### PR TITLE
Add RatePlanChargeTier to zuora-datalake-export

### DIFF
--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -82,14 +82,18 @@ object RatePlanChargeQuery extends Query(
   "ophan-raw-zuora-increment-rateplancharge",
   "RatePlanCharge.csv"
 )
+// https://knowledgecenter.zuora.com/CD_Reporting/D_Data_Sources_and_Exports/C_Data_Source_Reference/Rate_Plan_Charge_Tier_Data_Source
 object RatePlanChargeTierQuery extends Query(
   "RatePlanChargeTier",
   """
     |SELECT
     |  RatePlanChargeTier.Price,
+    |  RatePlanChargeTier.Currency,
     |  RatePlanChargeTier.DiscountAmount,
     |  RatePlanChargeTier.DiscountPercentage,
-    |  RatePlanCharge.ID
+    |  RatePlanChargeTier.ID,
+    |  RatePlanCharge.ID,
+    |  Subscription.ID
     |FROM
     |  RatePlanChargeTier
   """.stripMargin,

--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -82,10 +82,25 @@ object RatePlanChargeQuery extends Query(
   "ophan-raw-zuora-increment-rateplancharge",
   "RatePlanCharge.csv"
 )
+object RatePlanChargeTierQuery extends Query(
+  "RatePlanChargeTier",
+  """
+    |SELECT
+    |  RatePlanChargeTier.Price,
+    |  RatePlanChargeTier.DiscountAmount,
+    |  RatePlanChargeTier.DiscountPercentage,
+    |  RatePlanCharge.ID
+    |FROM
+    |  RatePlanChargeTier
+  """.stripMargin,
+  "ophan-raw-zuora-increment-rateplanchargetier",
+  "RatePlanChargeTier.csv"
+)
 object Query {
   def apply(batchName: String): Query = batchName match {
     case AccountQuery.batchName => AccountQuery
     case RatePlanChargeQuery.batchName => RatePlanChargeQuery
+    case RatePlanChargeTierQuery.batchName => RatePlanChargeTierQuery
     case _ => throw new RuntimeException(s"Failed to create Query object due to unexpected batch name: $batchName")
   }
 }
@@ -216,7 +231,13 @@ object StartAquaJob {
         |			"query" : "${RatePlanChargeQuery.zoql}",
         |			"type" : "zoqlexport",
         |			"deleted" : ${DeletedColumn()}
-        |		}
+        |		},
+        |		{
+        |			"name" : "${RatePlanChargeTierQuery.batchName}",
+        |			"query" : "${RatePlanChargeTierQuery.zoql}",
+        |			"type" : "zoqlexport",
+        |			"deleted" : ${DeletedColumn()}
+        |		},
         |	]
         |}
       """.stripMargin


### PR DESCRIPTION
Regarding GDPR, `RatePlanChargeTier` is [not pre-joined](https://knowledgecenter.zuora.com/CD_Reporting/D_Data_Sources_and_Exports/C_Data_Source_Reference/Rate_Plan_Charge_Tier_Data_Source#Data_Source_Diagram) with `Account` so we have to join on `RatePlanCharge.ID` on data lake side to apply GDPR.