### PR TITLE
Return amendment details from Holiday Stop processor instead of subscription ID

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Amendment.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Amendment.scala
@@ -1,0 +1,3 @@
+package com.gu.holidaystopprocessor
+
+case class Amendment(code: String)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
@@ -9,9 +9,7 @@ import io.circe.parser.decode
 import scala.io.Source
 
 case class Config(
-  getSubscription: String => Either[String, Subscription],
-  updateSubscription: (Subscription, SubscriptionUpdate) => Either[String, Unit],
-  getLastAmendment: Subscription => Either[String, Amendment],
+  zuoraAccess: ZuoraAccess,
   holidayCreditProductRatePlanId: String,
   holidayCreditProductRatePlanChargeId: String
 )
@@ -43,33 +41,24 @@ object Config {
   def apply(): Either[String, Config] = {
     val stage = Option(System.getenv("Stage")).getOrElse("DEV")
     configFromS3(stage) map { secretConfig =>
-      val getSubscription = Zuora.subscriptionGetResponse(secretConfig) _
-      val updateSubscription = Zuora.subscriptionUpdateResponse(secretConfig) _
-      val getAmendment = Zuora.lastAmendmentGetResponse(secretConfig) _
       stage match {
         case "PROD" =>
           Config(
-            getSubscription,
-            updateSubscription,
-            getAmendment,
+            secretConfig,
             holidayCreditProductRatePlanId = "2c92a0fc5b42d2c9015b6259f7f40040",
             holidayCreditProductRatePlanChargeId =
               "2c92a00e6ad50f58016ad9ca59962c8c"
           )
         case "CODE" =>
           Config(
-            getSubscription,
-            updateSubscription,
-            getAmendment,
+            secretConfig,
             holidayCreditProductRatePlanId = "2c92c0f96abaa1b5016abac99075461f",
             holidayCreditProductRatePlanChargeId =
               "2c92c0f96abc17d2016ac0da404d456c"
           )
         case "DEV" =>
           Config(
-            getSubscription,
-            updateSubscription,
-            getAmendment,
+            secretConfig,
             holidayCreditProductRatePlanId = "2c92c0f9671686a201671d14b5e5771e",
             holidayCreditProductRatePlanChargeId =
               "2c92c0f96abb85c3016abbe5771b04cc"

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
@@ -5,18 +5,18 @@ import io.circe.generic.auto._
 import io.github.mkotsur.aws.handler.Lambda
 import io.github.mkotsur.aws.handler.Lambda._
 
-object Handler extends Lambda[HolidayStop, String] {
+object Handler extends Lambda[HolidayStop, HolidayStopResponse] {
 
   override protected def handle(
     holidayStop: HolidayStop,
     context: Context
-  ): Either[Throwable, String] = {
+  ): Either[Throwable, HolidayStopResponse] = {
     Config() match {
       case Left(msg) => Left(new RuntimeException(s"Config failure: $msg"))
       case Right(config) =>
-        HolidayStopProcess(config)(holidayStop) match {
+        HolidayStopProcess(config, holidayStop) match {
           case Left(msg) => Left(new RuntimeException(msg))
-          case Right(r) => Right(r.toString)
+          case Right(response) => Right(response)
         }
     }
   }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
@@ -6,3 +6,5 @@ case class HolidayStop(
   subscriptionName: String,
   stoppedPublicationDate: LocalDate
 )
+
+case class HolidayStopResponse(code: String, price: Double)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -6,21 +6,37 @@ object HolidayStopProcess {
     config: Config,
     stop: HolidayStop
   ): Either[String, HolidayStopResponse] = {
-    config.getSubscription(stop.subscriptionName) flatMap {
-      subscription =>
-        if (subscription.autoRenew) {
-          val update = SubscriptionUpdate.holidayCreditToAdd(
-            config.holidayCreditProductRatePlanId,
-            config.holidayCreditProductRatePlanChargeId,
-            subscription,
-            stop.stoppedPublicationDate
-          )
-          config.updateSubscription(subscription, update) flatMap { _ =>
-            config.getLastAmendment(subscription) map { amendment =>
-              HolidayStopResponse(amendment.code, update.price)
-            }
+    val secretConfig = config.zuoraAccess
+    process(
+      config,
+      getSubscription = Zuora.subscriptionGetResponse(secretConfig),
+      updateSubscription = Zuora.subscriptionUpdateResponse(secretConfig),
+      getLastAmendment = Zuora.lastAmendmentGetResponse(secretConfig),
+      stop
+    )
+  }
+
+  def process(
+    config: Config,
+    getSubscription: String => Either[String, Subscription],
+    updateSubscription: (Subscription, SubscriptionUpdate) => Either[String, Unit],
+    getLastAmendment: Subscription => Either[String, Amendment],
+    stop: HolidayStop
+  ): Either[String, HolidayStopResponse] = {
+    getSubscription(stop.subscriptionName) flatMap { subscription =>
+      if (subscription.autoRenew) {
+        val update = SubscriptionUpdate.holidayCreditToAdd(
+          config.holidayCreditProductRatePlanId,
+          config.holidayCreditProductRatePlanChargeId,
+          subscription,
+          stop.stoppedPublicationDate
+        )
+        updateSubscription(subscription, update) flatMap { _ =>
+          getLastAmendment(subscription) map { amendment =>
+            HolidayStopResponse(amendment.code, update.price)
           }
-        } else Left("Cannot currently process non-auto-renewing subscription")
+        }
+      } else Left("Cannot currently process non-auto-renewing subscription")
     }
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -28,8 +28,7 @@ object HolidayStopProcess {
       subscription: Subscription
     ): Either[String, HolidayStopResponse] = {
       val update = SubscriptionUpdate.holidayCreditToAdd(
-        config.holidayCreditProductRatePlanId,
-        config.holidayCreditProductRatePlanChargeId,
+        config,
         subscription,
         stop.stoppedPublicationDate
       )

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/StandaloneApp.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/StandaloneApp.scala
@@ -11,11 +11,9 @@ object StandaloneApp extends App {
   Config() match {
     case Left(msg) => println(s"Config failure: $msg")
     case Right(config) =>
-      HolidayStopProcess(config)(
-        HolidayStop(subscriptionName, stoppedPublicationDate)
-      ) match {
-          case Left(msg) => println(s"Failed: $msg")
-          case Right(r) => println(s"Success: $r")
-        }
+      HolidayStopProcess(config, HolidayStop(subscriptionName, stoppedPublicationDate)) match {
+        case Left(msg) => println(s"Failed: $msg")
+        case Right(response) => println(s"Success: $response")
+      }
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
@@ -3,6 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 case class Subscription(
+  subscriptionNumber: String,
   termEndDate: LocalDate,
   currentTerm: Int,
   currentTermPeriodType: String,
@@ -32,6 +33,7 @@ case class RatePlanCharge(
   effectiveStartDate: LocalDate,
   effectiveEndDate: LocalDate
 ) {
+
   val weekCountApprox: Int = {
     billingPeriod map {
       case "Month" => 4

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
@@ -2,7 +2,9 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-case class SubscriptionUpdate(currentTerm: Option[Int], add: Seq[Add])
+case class SubscriptionUpdate(currentTerm: Option[Int], add: Seq[Add]) {
+  val price: Double = add.headOption.map(_.chargeOverrides.headOption.map(_.price).getOrElse(0d)).getOrElse(0d)
+}
 
 object SubscriptionUpdate {
 
@@ -15,7 +17,9 @@ object SubscriptionUpdate {
       }
     } else None
 
-  def holidayCreditToAdd(config: Config)(
+  def holidayCreditToAdd(
+    holidayCreditProductRatePlanId: String,
+    holidayCreditProductRatePlanChargeId: String,
     subscription: Subscription,
     stoppedPublicationDate: LocalDate
   ): SubscriptionUpdate = {
@@ -26,13 +30,13 @@ object SubscriptionUpdate {
       currentTerm = extendedTerm(subscription, effectiveDate),
       Seq(
         Add(
-          productRatePlanId = config.holidayCreditProductRatePlanId,
+          productRatePlanId = holidayCreditProductRatePlanId,
           contractEffectiveDate = effectiveDate,
           customerAcceptanceDate = effectiveDate,
           serviceActivationDate = effectiveDate,
           chargeOverrides = Seq(
             ChargeOverride(
-              config.holidayCreditProductRatePlanChargeId,
+              holidayCreditProductRatePlanChargeId,
               HolidayStart__c = stoppedPublicationDate,
               HolidayEnd__c = stoppedPublicationDate,
               price = HolidayCredit(subscription)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
@@ -25,8 +25,7 @@ object SubscriptionUpdate {
     } else None
 
   def holidayCreditToAdd(
-    holidayCreditProductRatePlanId: String,
-    holidayCreditProductRatePlanChargeId: String,
+    config: Config,
     subscription: Subscription,
     stoppedPublicationDate: LocalDate
   ): SubscriptionUpdate = {
@@ -37,13 +36,13 @@ object SubscriptionUpdate {
       currentTerm = extendedTerm(subscription, effectiveDate),
       Seq(
         Add(
-          productRatePlanId = holidayCreditProductRatePlanId,
+          productRatePlanId = config.holidayCreditProductRatePlanId,
           contractEffectiveDate = effectiveDate,
           customerAcceptanceDate = effectiveDate,
           serviceActivationDate = effectiveDate,
           chargeOverrides = Seq(
             ChargeOverride(
-              holidayCreditProductRatePlanChargeId,
+              productRatePlanChargeId = config.holidayCreditProductRatePlanChargeId,
               HolidayStart__c = stoppedPublicationDate,
               HolidayEnd__c = stoppedPublicationDate,
               price = HolidayCredit(subscription)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
@@ -24,7 +24,7 @@ object SubscriptionUpdate {
     stoppedPublicationDate: LocalDate
   ): SubscriptionUpdate = {
     val effectiveDate = subscription.originalRatePlanCharge map {
-      _.effectiveEndDate.plusDays(1)
+      _.effectiveEndDate
     } getOrElse stoppedPublicationDate
     SubscriptionUpdate(
       currentTerm = extendedTerm(subscription, effectiveDate),

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
@@ -3,7 +3,14 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 case class SubscriptionUpdate(currentTerm: Option[Int], add: Seq[Add]) {
-  val price: Double = add.headOption.map(_.chargeOverrides.headOption.map(_.price).getOrElse(0d)).getOrElse(0d)
+
+  val price: Double = {
+    val optPrice = for {
+      firstAdd <- add.headOption
+      charge <- firstAdd.chargeOverrides.headOption
+    } yield charge.price
+    optPrice.getOrElse(0)
+  }
 }
 
 object SubscriptionUpdate {

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
@@ -30,7 +30,7 @@ object SubscriptionUpdate {
     stoppedPublicationDate: LocalDate
   ): SubscriptionUpdate = {
     val effectiveDate = subscription.originalRatePlanCharge map {
-      _.effectiveEndDate
+      _.effectiveEndDate.plusDays(1)
     } getOrElse stoppedPublicationDate
     SubscriptionUpdate(
       currentTerm = extendedTerm(subscription, effectiveDate),

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ZuoraAccess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ZuoraAccess.scala
@@ -1,0 +1,3 @@
+package com.gu.holidaystopprocessor
+
+case class ZuoraAccess(baseUrl: String, username: String, password: String)

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -11,6 +11,7 @@ object Fixtures {
     effectiveEndDate: LocalDate
   ) =
     Subscription(
+      subscriptionNumber = "S1",
       termEndDate,
       currentTerm = 12,
       currentTermPeriodType = "Month",

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -1,0 +1,71 @@
+package com.gu.holidaystopprocessor
+
+import java.time.LocalDate
+
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+
+class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
+
+  private val subscription = Fixtures.mkSubscription(
+    LocalDate.of(2019, 1, 1),
+    75.5,
+    "Quarter",
+    LocalDate.of(2020, 1, 1)
+  )
+
+  private val amendment = Amendment("A1")
+
+  private val holidayStop = HolidayStop("", LocalDate.of(2019, 1, 1))
+
+  private def mkConfig(
+    subscriptionGet: Either[String, Subscription],
+    subscriptionUpdate: Either[String, Unit],
+    amendmentGet: Either[String, Amendment]
+  ) = Config(
+    getSubscription = { _ =>
+      subscriptionGet
+    },
+    updateSubscription = { case (_, _) => subscriptionUpdate },
+    getLastAmendment = { _ =>
+      amendmentGet
+    },
+    holidayCreditProductRatePlanId = "",
+    holidayCreditProductRatePlanChargeId = ""
+  )
+
+  "HolidayStopProcess" should "give correct amendment" in {
+    val config = mkConfig(Right(subscription), Right(Unit), Right(amendment))
+    val response = HolidayStopProcess(config, holidayStop)
+    response.right.value shouldBe HolidayStopResponse(
+      code = "A1",
+      price = -5.81
+    )
+  }
+
+  it should "give an exception message if update fails" in {
+    val config =
+      mkConfig(Right(subscription), Left("update went wrong"), Right(amendment))
+    val response = HolidayStopProcess(config, holidayStop)
+    response.left.value shouldBe "update went wrong"
+  }
+
+  it should "give an exception message if getting subscription details fails" in {
+    val config = mkConfig(Left("get went wrong"), Right(Unit), Right(amendment))
+    val response = HolidayStopProcess(config, holidayStop)
+    response.left.value shouldBe "get went wrong"
+  }
+
+  it should "give an exception message if getting amendment code fails" in {
+    val config =
+      mkConfig(Right(subscription), Right(Unit), Left("amendment gone bad"))
+    val response = HolidayStopProcess(config, holidayStop)
+    response.left.value shouldBe "amendment gone bad"
+  }
+
+  it should "give an exception message if subscription isn't auto-renewing" in {
+    val config =
+      mkConfig(Right(subscription.copy(autoRenew = false)), Right(Unit), Right(amendment))
+    val response = HolidayStopProcess(config, holidayStop)
+    response.left.value shouldBe "Cannot currently process non-auto-renewing subscription"
+  }
+}

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -25,9 +25,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       Seq(
         Add(
           productRatePlanId = "ratePlanId",
-          contractEffectiveDate = LocalDate.of(2020, 5, 3),
-          customerAcceptanceDate = LocalDate.of(2020, 5, 3),
-          serviceActivationDate = LocalDate.of(2020, 5, 3),
+          contractEffectiveDate = LocalDate.of(2020, 5, 4),
+          customerAcceptanceDate = LocalDate.of(2020, 5, 4),
+          serviceActivationDate = LocalDate.of(2020, 5, 4),
           chargeOverrides = Seq(
             ChargeOverride(
               productRatePlanChargeId = "ratePlanChargeId",
@@ -57,9 +57,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       Seq(
         Add(
           productRatePlanId = "ratePlanId",
-          contractEffectiveDate = LocalDate.of(2020, 5, 3),
-          customerAcceptanceDate = LocalDate.of(2020, 5, 3),
-          serviceActivationDate = LocalDate.of(2020, 5, 3),
+          contractEffectiveDate = LocalDate.of(2020, 5, 4),
+          customerAcceptanceDate = LocalDate.of(2020, 5, 4),
+          serviceActivationDate = LocalDate.of(2020, 5, 4),
           chargeOverrides = Seq(
             ChargeOverride(
               productRatePlanChargeId = "ratePlanChargeId",

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -24,9 +24,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       Seq(
         Add(
           productRatePlanId = "ratePlanId",
-          contractEffectiveDate = LocalDate.of(2020, 5, 4),
-          customerAcceptanceDate = LocalDate.of(2020, 5, 4),
-          serviceActivationDate = LocalDate.of(2020, 5, 4),
+          contractEffectiveDate = LocalDate.of(2020, 5, 3),
+          customerAcceptanceDate = LocalDate.of(2020, 5, 3),
+          serviceActivationDate = LocalDate.of(2020, 5, 3),
           chargeOverrides = Seq(
             ChargeOverride(
               productRatePlanChargeId = "ratePlanChargeId",
@@ -57,9 +57,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       Seq(
         Add(
           productRatePlanId = "ratePlanId",
-          contractEffectiveDate = LocalDate.of(2020, 5, 4),
-          customerAcceptanceDate = LocalDate.of(2020, 5, 4),
-          serviceActivationDate = LocalDate.of(2020, 5, 4),
+          contractEffectiveDate = LocalDate.of(2020, 5, 3),
+          customerAcceptanceDate = LocalDate.of(2020, 5, 3),
+          serviceActivationDate = LocalDate.of(2020, 5, 3),
           chargeOverrides = Seq(
             ChargeOverride(
               productRatePlanChargeId = "ratePlanChargeId",

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -7,14 +7,10 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class SubscriptionUpdateTest extends FlatSpec with Matchers {
 
-  private val config = Config(
-    zuoraAccess = ZuoraAccess(baseUrl = "b", username = "u", password = "p"),
-    holidayCreditProductRatePlanId = "ratePlanId",
-    holidayCreditProductRatePlanChargeId = "ratePlanChargeId"
-  )
-
   "holidayCreditToAdd" should "generate update correctly" in {
-    val update = holidayCreditToAdd(config)(
+    val update = holidayCreditToAdd(
+      "ratePlanId",
+      "ratePlanChargeId",
       subscription = Fixtures.mkSubscription(
         termEndDate = LocalDate.of(2020, 7, 12),
         price = 42.1,
@@ -45,7 +41,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
   }
 
   it should "generate update correctly when current term too short" in {
-    val update = holidayCreditToAdd(config)(
+    val update = holidayCreditToAdd(
+      "ratePlanId",
+      "ratePlanChargeId",
       subscription = Fixtures.mkSubscription(
         termEndDate = LocalDate.of(2019, 12, 1),
         price = 42.1,

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -7,10 +7,11 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class SubscriptionUpdateTest extends FlatSpec with Matchers {
 
+  private val config = Config(ZuoraAccess("", "", ""), "ratePlanId", "ratePlanChargeId")
+
   "holidayCreditToAdd" should "generate update correctly" in {
     val update = holidayCreditToAdd(
-      "ratePlanId",
-      "ratePlanChargeId",
+      config,
       subscription = Fixtures.mkSubscription(
         termEndDate = LocalDate.of(2020, 7, 12),
         price = 42.1,
@@ -42,8 +43,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
 
   it should "generate update correctly when current term too short" in {
     val update = holidayCreditToAdd(
-      "ratePlanId",
-      "ratePlanChargeId",
+      config,
       subscription = Fixtures.mkSubscription(
         termEndDate = LocalDate.of(2019, 12, 1),
         price = 42.1,


### PR DESCRIPTION
This makes another call to Zuora to get amendment details after the subscription is updated.

There's also some refactoring to make the code more testable, which is why it's a bigger change than is strictly necessary.
