### PR TITLE
Add description to holiday-stop processor lambda

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -48,7 +48,7 @@ Resources:
     Properties:
       FunctionName:
         !Sub holiday-stop-processor-${Stage}
-      Description: Updates subscriptions with outstanding holiday stops.  Source - https://github.com/guardian/support-service-lambdas/tree/master/handlers/holiday-stop-processor
+      Description: Updates subscriptions with outstanding holiday stops. Source - https://github.com/guardian/support-service-lambdas/tree/master/handlers/holiday-stop-processor
       Code:
         S3Bucket: support-service-lambdas-dist
         S3Key: !Sub membership/${Stage}/holiday-stop-processor/holiday-stop-processor.jar

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -48,6 +48,7 @@ Resources:
     Properties:
       FunctionName:
         !Sub holiday-stop-processor-${Stage}
+      Description: Updates subscriptions with outstanding holiday stops.  Source - https://github.com/guardian/support-service-lambdas/tree/master/handlers/holiday-stop-processor
       Code:
         S3Bucket: support-service-lambdas-dist
         S3Key: !Sub membership/${Stage}/holiday-stop-processor/holiday-stop-processor.jar


### PR DESCRIPTION
This is to clarify the purpose of the lambda in the AWS UI.