### PR TITLE
FIX recent bad refactor which was string concatenating a RelativePath

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -73,7 +73,7 @@ object SalesforceHolidayStopRequest extends Logging {
         s"AND Start_Date__c <= $sfDate " +
         s"AND End_Date__c >= $sfDate"
       logger.info(s"using SF query : $soqlQuery")
-      RestRequestMaker.GetRequestWithParams(soqlQueryBaseUrl, UrlParams(Map("q" -> soqlQuery)))
+      RestRequestMaker.GetRequestWithParams(RelativePath(soqlQueryBaseUrl), UrlParams(Map("q" -> soqlQuery)))
     }
 
   }
@@ -87,7 +87,7 @@ object SalesforceHolidayStopRequest extends Logging {
       val soqlQuery = getHolidayStopRequestPrefixSOQL(productNamePrefix) +
         s"AND IdentityID__c = '$identityId'"
       logger.info(s"using SF query : $soqlQuery")
-      RestRequestMaker.GetRequestWithParams(soqlQueryBaseUrl, UrlParams(Map("q" -> soqlQuery)))
+      RestRequestMaker.GetRequestWithParams(RelativePath(soqlQueryBaseUrl), UrlParams(Map("q" -> soqlQuery)))
     }
 
   }

--- a/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceConstants.scala
+++ b/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceConstants.scala
@@ -1,12 +1,10 @@
 package com.gu.salesforce
 
-import com.gu.util.resthttp.RestRequestMaker.RelativePath
-
 object SalesforceConstants {
 
   val sfApiBaseUrl = "/services/data/v29.0"
 
-  val soqlQueryBaseUrl = RelativePath(sfApiBaseUrl + "/query/")
+  val soqlQueryBaseUrl = sfApiBaseUrl + "/query/"
 
   val sfObjectsBaseUrl = sfApiBaseUrl + "/sobjects/"
 


### PR DESCRIPTION
Introduced in commit https://github.com/guardian/support-service-lambdas/pull/294/commits/5761a77d8d79e282495be630c24a9e5fd9b28413 as part of https://github.com/guardian/support-service-lambdas/pull/294

Caused the cancellation cases lambda and the GoCardless sync lambda to break for a short period, so old master was deployed to stabilise, but this is proper FIX.