### PR TITLE
Fix zuora-datalake-export trigger input

### DIFF
--- a/handlers/zuora-datalake-export/cfn.yaml
+++ b/handlers/zuora-datalake-export/cfn.yaml
@@ -87,7 +87,7 @@ Resources:
           - Arn: !Sub ${ExportLambda.Arn}
             Id: TriggerLambda
             Input: |
-              null
+              {"exportFromDate": "yesterday"}
 
     TriggerStartExportJobPermission:
       Type: AWS::Lambda::Permission


### PR DESCRIPTION
Fix https://github.com/guardian/support-service-lambdas/pull/297

Lambda trigger input changed from `null` to `{"exportFromDate": "yesterday"}` but the cloudformation was not updated.