### PR TITLE
 Read holiday stop requests from Salesforce

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -239,6 +239,7 @@ lazy val `braze-to-salesforce-file-upload` = all(project in file("handlers/braze
 
 lazy val `holiday-stop-processor` = all(project in file("handlers/holiday-stop-processor"))
   .enablePlugins(RiffRaffArtifact)
+  .dependsOn(`holiday-stops`, effects)
   
 // ==== END handlers ====
 

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
@@ -2,29 +2,38 @@ package com.gu.holidaystopprocessor
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions.EU_WEST_1
-import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.AmazonS3Client
+import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
+import io.circe.Decoder
 import io.circe.generic.auto._
 import io.circe.parser.decode
 
 import scala.io.Source
 
 case class Config(
-  zuoraAccess: ZuoraAccess,
+  zuoraCredentials: ZuoraAccess,
+  sfCredentials: SFAuthConfig,
   holidayCreditProductRatePlanId: String,
   holidayCreditProductRatePlanChargeId: String
 )
 
 object Config {
 
-  private def configFromS3(stage: String): Either[String, ZuoraAccess] = {
+  private def zuoraCredentials(stage: String): Either[String, ZuoraAccess] =
+    credentials[ZuoraAccess](stage, "zuoraRest")
+
+  private def salesforceCredentials(stage: String): Either[String, SFAuthConfig] =
+    credentials[SFAuthConfig](stage, "sfAuth")
+
+  private def credentials[T](stage: String, filePrefix: String)(implicit evidence: Decoder[T]): Either[String, T] = {
     val profileName = "membership"
     val bucketName = "gu-reader-revenue-private"
     val key =
       if (stage == "DEV")
-        s"membership/support-service-lambdas/$stage/zuoraRest-$stage.json"
+        s"membership/support-service-lambdas/$stage/$filePrefix-$stage.json"
       else
-        s"membership/support-service-lambdas/$stage/zuoraRest-$stage.v1.json"
-    val builder: AmazonS3ClientBuilder =
+        s"membership/support-service-lambdas/$stage/$filePrefix-$stage.v1.json"
+    val builder =
       if (stage == "DEV")
         AmazonS3Client.builder
           .withCredentials(new ProfileCredentialsProvider(profileName))
@@ -33,32 +42,38 @@ object Config {
     val inputStream =
       builder.build().getObject(bucketName, key).getObjectContent
     val rawJson = Source.fromInputStream(inputStream).mkString
-    decode[ZuoraAccess](rawJson).left map { e =>
+    decode[T](rawJson).left map { e =>
       s"Could not read secret config file from S3://$bucketName/$key: ${e.toString}"
     }
   }
 
   def apply(): Either[String, Config] = {
     val stage = Option(System.getenv("Stage")).getOrElse("DEV")
-    configFromS3(stage) map { secretConfig =>
+    for {
+      zuoraCreds <- zuoraCredentials(stage)
+      sfCreds <- salesforceCredentials(stage)
+    } yield {
       stage match {
         case "PROD" =>
           Config(
-            secretConfig,
+            zuoraCreds,
+            sfCreds,
             holidayCreditProductRatePlanId = "2c92a0fc5b42d2c9015b6259f7f40040",
             holidayCreditProductRatePlanChargeId =
               "2c92a00e6ad50f58016ad9ca59962c8c"
           )
         case "CODE" =>
           Config(
-            secretConfig,
+            zuoraCreds,
+            sfCreds,
             holidayCreditProductRatePlanId = "2c92c0f96abaa1b5016abac99075461f",
             holidayCreditProductRatePlanChargeId =
               "2c92c0f96abc17d2016ac0da404d456c"
           )
         case "DEV" =>
           Config(
-            secretConfig,
+            zuoraCreds,
+            sfCreds,
             holidayCreditProductRatePlanId = "2c92c0f9671686a201671d14b5e5771e",
             holidayCreditProductRatePlanChargeId =
               "2c92c0f96abb85c3016abbe5771b04cc"

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
@@ -1,5 +1,6 @@
 package com.gu.holidaystopprocessor
 
+import cats.implicits._
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.util.Logging
 import io.circe.generic.auto._
@@ -25,10 +26,7 @@ object Handler
           case Right(response) => logger.info(response)
         }
 
-        responses collectFirst {
-          case Left(msg) => Left(new RuntimeException(msg))
-        } getOrElse
-          Right(responses collect { case Right(response) => response })
+        responses.toList.sequence.leftMap(new RuntimeException(_))
     }
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
@@ -1,23 +1,34 @@
 package com.gu.holidaystopprocessor
 
 import com.amazonaws.services.lambda.runtime.Context
+import com.gu.util.Logging
 import io.circe.generic.auto._
 import io.github.mkotsur.aws.handler.Lambda
 import io.github.mkotsur.aws.handler.Lambda._
 
-object Handler extends Lambda[HolidayStop, HolidayStopResponse] {
+object Handler
+  extends Lambda[HolidayStop, Seq[HolidayStopResponse]]
+  with Logging {
 
   override protected def handle(
     holidayStop: HolidayStop,
     context: Context
-  ): Either[Throwable, HolidayStopResponse] = {
+  ): Either[Throwable, Seq[HolidayStopResponse]] = {
+
     Config() match {
       case Left(msg) => Left(new RuntimeException(s"Config failure: $msg"))
       case Right(config) =>
-        HolidayStopProcess(config, holidayStop) match {
-          case Left(msg) => Left(new RuntimeException(msg))
-          case Right(response) => Right(response)
+        val responses = HolidayStopProcess(config)
+
+        responses foreach {
+          case Left(msg) => logger.error(msg)
+          case Right(response) => logger.info(response)
         }
+
+        responses collectFirst {
+          case Left(msg) => Left(new RuntimeException(msg))
+        } getOrElse
+          Right(responses collect { case Right(response) => response })
     }
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
@@ -2,9 +2,23 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.ActionCalculator
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
+
 case class HolidayStop(
   subscriptionName: String,
   stoppedPublicationDate: LocalDate
 )
 
-case class HolidayStopResponse(code: String, price: Double)
+object HolidayStop {
+
+  def holidayStopsToApply(config: Config): Either[String, List[HolidayStop]] =
+    Salesforce.holidayStopRequests(config, "Guardian Weekly") map {
+      _ flatMap toHolidayStops
+    }
+
+  private def toHolidayStops(request: HolidayStopRequest): List[HolidayStop] =
+    ActionCalculator.publicationDatesToBeStopped(request) map { date =>
+      HolidayStop(request.Subscription_Name__c.value, Time.toJavaDate(date))
+    }
+}

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
@@ -1,0 +1,3 @@
+package com.gu.holidaystopprocessor
+
+case class HolidayStopResponse(code: String, price: Double)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -1,0 +1,27 @@
+package com.gu.holidaystopprocessor
+
+import com.gu.effects.RawEffects
+import com.gu.salesforce.SalesforceClient
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
+import com.gu.util.resthttp.JsonHttp
+import org.joda.time.LocalDate
+import scalaz.{-\/, \/-}
+
+object Salesforce {
+
+  private def thresholdDate: LocalDate = LocalDate.now.plusDays(14)
+
+  def holidayStopRequests(
+    config: Config,
+    productNamePrefix: String
+  ): Either[String, List[HolidayStopRequest]] =
+    SalesforceClient(RawEffects.response, config.sfCredentials).value.flatMap { sfAuth =>
+      val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
+      val fetchOp = SalesforceHolidayStopRequest.LookupByDateAndProductNamePrefix(sfGet)
+      fetchOp(thresholdDate, SalesforceHolidayStopRequest.ProductName(productNamePrefix))
+    }.toDisjunction match {
+      case -\/(failure) => Left(failure.toString)
+      case \/-(requests) => Right(requests)
+    }
+}

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/StandaloneApp.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/StandaloneApp.scala
@@ -1,17 +1,12 @@
 package com.gu.holidaystopprocessor
 
-import java.time.LocalDate
-
 // This is just for functional testing locally.
 object StandaloneApp extends App {
-
-  val subscriptionName = "A-S00050605"
-  val stoppedPublicationDate = LocalDate.of(2019, 7, 11)
 
   Config() match {
     case Left(msg) => println(s"Config failure: $msg")
     case Right(config) =>
-      HolidayStopProcess(config, HolidayStop(subscriptionName, stoppedPublicationDate)) match {
+      HolidayStopProcess(config) foreach {
         case Left(msg) => println(s"Failed: $msg")
         case Right(response) => println(s"Success: $response")
       }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
@@ -35,10 +35,12 @@ case class RatePlanCharge(
 ) {
 
   val weekCountApprox: Int = {
+    val default = 52
     billingPeriod map {
       case "Month" => 4
       case "Quarter" => 13
       case "Annual" => 52
-    } getOrElse 52
+      case _ => default
+    } getOrElse default
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Time.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Time.scala
@@ -1,0 +1,10 @@
+package com.gu.holidaystopprocessor
+
+import java.time.LocalDate
+import org.joda.time.{LocalDate => JodaLocalDate}
+
+object Time {
+
+  def toJavaDate(joda: JodaLocalDate): LocalDate =
+    LocalDate.of(joda.getYear, joda.getMonthOfYear, joda.getDayOfMonth)
+}

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
@@ -41,7 +41,7 @@ object Zuora {
         case Right(status) =>
           if (!status.success)
             Left(failureMsg(status.reasons.map(_.mkString).getOrElse("")))
-          else Right(Unit)
+          else Right(())
       }
     }
   }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -2,6 +2,8 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
+import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
+
 object Fixtures {
 
   def mkSubscription(
@@ -24,4 +26,11 @@ object Fixtures {
         )
       )
     )
+
+  val config = Config(
+    zuoraCredentials = ZuoraAccess(baseUrl = "", username = "", password = ""),
+    sfCredentials = SFAuthConfig("", "", "", "", "", ""),
+    holidayCreditProductRatePlanId = "ratePlanId",
+    holidayCreditProductRatePlanChargeId = "ratePlanChargeId"
+  )
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -36,7 +36,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription)),
-      updateSubscription(Right(Unit)),
+      updateSubscription(Right(())),
       getLastAmendment(Right(amendment))
     )(holidayStop)
     response.right.value shouldBe HolidayStopResponse(
@@ -59,7 +59,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Left("get went wrong")),
-      updateSubscription(Right(Unit)),
+      updateSubscription(Right(())),
       getLastAmendment(Right(amendment))
     )(holidayStop)
     response.left.value shouldBe "get went wrong"
@@ -69,7 +69,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription)),
-      updateSubscription(Right(Unit)),
+      updateSubscription(Right(())),
       getLastAmendment(Left("amendment gone bad"))
     )(holidayStop)
     response.left.value shouldBe "amendment gone bad"
@@ -79,7 +79,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription.copy(autoRenew = false))),
-      updateSubscription(Right(Unit)),
+      updateSubscription(Right(())),
       getLastAmendment(Right(amendment))
     )(holidayStop)
     response.left.value shouldBe "Cannot currently process non-auto-renewing subscription"

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -2,11 +2,12 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
+import com.gu.holidaystopprocessor.Fixtures.{config, mkSubscription}
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
 
-  private val subscription = Fixtures.mkSubscription(
+  private val subscription = mkSubscription(
     LocalDate.of(2019, 1, 1),
     75.5,
     "Quarter",
@@ -17,11 +18,6 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
 
   private val holidayStop = HolidayStop("", LocalDate.of(2019, 1, 1))
 
-  private val config = Config(
-    zuoraAccess = ZuoraAccess(baseUrl = "", username = "", password = ""),
-    holidayCreditProductRatePlanId = "",
-    holidayCreditProductRatePlanChargeId = ""
-  )
   private def getSubscription(subscriptionGet: Either[String, Subscription]) = {
     _: String =>
       subscriptionGet
@@ -37,13 +33,12 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
   }
 
   "HolidayStopProcess" should "give correct amendment" in {
-    val response = HolidayStopProcess.process(
+    val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription)),
       updateSubscription(Right(Unit)),
-      getLastAmendment(Right(amendment)),
-      holidayStop
-    )
+      getLastAmendment(Right(amendment))
+    )(holidayStop)
     response.right.value shouldBe HolidayStopResponse(
       code = "A1",
       price = -5.81
@@ -51,46 +46,42 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues {
   }
 
   it should "give an exception message if update fails" in {
-    val response = HolidayStopProcess.process(
+    val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription)),
       updateSubscription(Left("update went wrong")),
-      getLastAmendment(Right(amendment)),
-      holidayStop
-    )
+      getLastAmendment(Right(amendment))
+    )(holidayStop)
     response.left.value shouldBe "update went wrong"
   }
 
   it should "give an exception message if getting subscription details fails" in {
-    val response = HolidayStopProcess.process(
+    val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Left("get went wrong")),
       updateSubscription(Right(Unit)),
-      getLastAmendment(Right(amendment)),
-      holidayStop
-    )
+      getLastAmendment(Right(amendment))
+    )(holidayStop)
     response.left.value shouldBe "get went wrong"
   }
 
   it should "give an exception message if getting amendment code fails" in {
-    val response = HolidayStopProcess.process(
+    val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription)),
       updateSubscription(Right(Unit)),
-      getLastAmendment(Left("amendment gone bad")),
-      holidayStop
-    )
+      getLastAmendment(Left("amendment gone bad"))
+    )(holidayStop)
     response.left.value shouldBe "amendment gone bad"
   }
 
   it should "give an exception message if subscription isn't auto-renewing" in {
-    val response = HolidayStopProcess.process(
+    val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription.copy(autoRenew = false))),
       updateSubscription(Right(Unit)),
-      getLastAmendment(Right(amendment)),
-      holidayStop
-    )
+      getLastAmendment(Right(amendment))
+    )(holidayStop)
     response.left.value shouldBe "Cannot currently process non-auto-renewing subscription"
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -2,12 +2,11 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
+import com.gu.holidaystopprocessor.Fixtures.config
 import com.gu.holidaystopprocessor.SubscriptionUpdate.holidayCreditToAdd
 import org.scalatest.{FlatSpec, Matchers}
 
 class SubscriptionUpdateTest extends FlatSpec with Matchers {
-
-  private val config = Config(ZuoraAccess("", "", ""), "ratePlanId", "ratePlanChargeId")
 
   "holidayCreditToAdd" should "generate update correctly" in {
     val update = holidayCreditToAdd(

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
@@ -28,7 +28,7 @@ object ActionCalculator {
     val from = hsr.Start_Date__c.value
     val to = hsr.End_Date__c.value
     val dayOfWeekForProduct = productNameToDayOfWeek(hsr.Product_Name__c)
-    applicableDates(from, to, { _.dayOfWeek.get == dayOfWeekForProduct })
+    applicableDates(from, to, { _.getDayOfWeek == dayOfWeekForProduct })
   }
 
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
@@ -13,22 +13,24 @@ object ActionCalculator {
   def publicationDatesToBeStopped(hsr: HolidayStopRequest): List[LocalDate] = {
 
     def applicableDates(
-      from: LocalDate,
-      to: LocalDate,
+      fromInclusive: LocalDate,
+      toInclusive: LocalDate,
       p: LocalDate => Boolean
     ): List[LocalDate] = {
-      val dateRange = 0 to Days.daysBetween(from, to).getDays
+      val dateRange = 0 to Days.daysBetween(fromInclusive, toInclusive).getDays
       dateRange.foldLeft(List.empty[LocalDate]) { (acc, i) =>
-        val d = from.plusDays(i)
+        val d = fromInclusive.plusDays(i)
         if (p(d)) acc :+ d
         else acc
       }
     }
 
-    val from = hsr.Start_Date__c.value
-    val to = hsr.End_Date__c.value
     val dayOfWeekForProduct = productNameToDayOfWeek(hsr.Product_Name__c)
-    applicableDates(from, to, { _.getDayOfWeek == dayOfWeekForProduct })
+    applicableDates(
+      fromInclusive = hsr.Start_Date__c.value,
+      toInclusive = hsr.End_Date__c.value,
+      { _.getDayOfWeek == dayOfWeekForProduct }
+    )
   }
 
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
@@ -1,9 +1,6 @@
 package com.gu.holiday_stops
 
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{
-  HolidayStopRequest,
-  ProductName
-}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, ProductName}
 import org.joda.time.{DateTimeConstants, Days, LocalDate}
 
 object ActionCalculator {


### PR DESCRIPTION
This is the first step in integrating the holiday-stop processing lambda with Salesforce.  Salesforce holds a table of holiday-stop requests.  This PR reads those requests and sends them to Zuora to be processed.

There will be a separate PR to write the amendment details made by Zuora back to Salesforce.
