### PR TITLE
Add Amendment to zuora-datalake-export

### DIFF
--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -143,6 +143,12 @@ object Query extends Enum[Query] {
     "ophan-raw-zuora-increment-paymentmethod",
     "PaymentMethod.csv"
   )
+  case object Amendment extends Query(
+    "Amendment",
+    "SELECT CreatedDate, Status, SubscriptionID, ID FROM Amendment",
+    "ophan-raw-zuora-increment-amendment",
+    "Amendment.csv"
+  )
 }
 
 object ZuoraApiHost {


### PR DESCRIPTION
`Amendment` is not pre-joined with `Account` on Zuora side, so we will apply GDPR on datalake side by joining with `clean.zuora_subscription` to add `accountId` column.