### PR TITLE
Export holiday-stop results to Salesforce

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Failures.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Failures.scala
@@ -1,0 +1,7 @@
+package com.gu.holidaystopprocessor
+
+// A failure to process an individual holiday stop
+case class HolidayStopFailure(reason: String)
+
+// A general failure during the processing of holiday stops, but not caused by any particular holiday stop
+case class OverallFailure(reason: String)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
@@ -3,22 +3,27 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.holiday_stops.ActionCalculator
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId}
 
 case class HolidayStop(
+  requestId: HolidayStopRequestId,
   subscriptionName: String,
   stoppedPublicationDate: LocalDate
 )
 
 object HolidayStop {
 
-  def holidayStopsToApply(config: Config): Either[String, List[HolidayStop]] =
-    Salesforce.holidayStopRequests(config, "Guardian Weekly") map {
+  def holidayStopsToApply(getRequests: String => Either[String, Seq[HolidayStopRequest]]): Either[String, Seq[HolidayStop]] =
+    getRequests("Guardian Weekly") map {
       _ flatMap toHolidayStops
     }
 
-  private def toHolidayStops(request: HolidayStopRequest): List[HolidayStop] =
+  private def toHolidayStops(request: HolidayStopRequest): Seq[HolidayStop] =
     ActionCalculator.publicationDatesToBeStopped(request) map { date =>
-      HolidayStop(request.Subscription_Name__c.value, Time.toJavaDate(date))
+      HolidayStop(
+        requestId = request.Id,
+        subscriptionName = request.Subscription_Name__c.value,
+        stoppedPublicationDate = Time.toJavaDate(date)
+      )
     }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
@@ -13,7 +13,7 @@ case class HolidayStop(
 
 object HolidayStop {
 
-  def holidayStopsToApply(getRequests: String => Either[String, Seq[HolidayStopRequest]]): Either[String, Seq[HolidayStop]] =
+  def holidayStopsToApply(getRequests: String => Either[OverallFailure, Seq[HolidayStopRequest]]): Either[OverallFailure, Seq[HolidayStop]] =
     getRequests("Guardian Weekly") map {
       _ flatMap toHolidayStops
     }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -1,18 +1,46 @@
 package com.gu.holidaystopprocessor
 
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice}
+
 object HolidayStopProcess {
 
   def apply(config: Config): Seq[Either[String, HolidayStopResponse]] = {
+    val sfCredentials = config.sfCredentials
     val zuoraCredentials = config.zuoraCredentials
-    val response = processHolidayStop(
+    processHolidayStops(
       config,
+      getRequests = Salesforce.holidayStopRequests(sfCredentials),
       getSubscription = Zuora.subscriptionGetResponse(zuoraCredentials),
       updateSubscription = Zuora.subscriptionUpdateResponse(zuoraCredentials),
-      getLastAmendment = Zuora.lastAmendmentGetResponse(zuoraCredentials)
+      getLastAmendment = Zuora.lastAmendmentGetResponse(zuoraCredentials),
+      exportAmendments = Salesforce.holidayStopUpdateResponse(sfCredentials)
+    )
+  }
+
+  def processHolidayStops(
+    config: Config,
+    getRequests: String => Either[String, Seq[HolidayStopRequest]],
+    getSubscription: String => Either[String, Subscription],
+    updateSubscription: (Subscription, SubscriptionUpdate) => Either[String, Unit],
+    getLastAmendment: Subscription => Either[String, Amendment],
+    exportAmendments: Seq[HolidayStopResponse] => Either[String, Unit]
+  ): Seq[Either[String, HolidayStopResponse]] = {
+    val response = processHolidayStop(
+      config,
+      getSubscription,
+      updateSubscription,
+      getLastAmendment
     ) _
-    HolidayStop.holidayStopsToApply(config) match {
+    HolidayStop.holidayStopsToApply(getRequests) match {
       case Left(msg) => Seq(Left(msg))
-      case Right(holidayStops) => holidayStops map response
+      case Right(holidayStops) =>
+        val responses = holidayStops.map(response)
+        val exportResult = exportAmendments(responses.collect { case Right(successes) => successes })
+        exportResult match {
+          case Left(msg) => Seq(Left(msg))
+          case _ => responses
+        }
     }
   }
 
@@ -28,5 +56,9 @@ object HolidayStopProcess {
       update <- Right(SubscriptionUpdate.holidayCreditToAdd(config, subscription, stop.stoppedPublicationDate))
       _ <- updateSubscription(subscription, update)
       amendment <- getLastAmendment(subscription)
-    } yield HolidayStopResponse(amendment.code, update.price)
+    } yield HolidayStopResponse(
+      stop.requestId,
+      HolidayStopRequestActionedZuoraAmendmentCode(amendment.code),
+      HolidayStopRequestActionedZuoraAmendmentPrice(update.price)
+    )
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
@@ -1,3 +1,10 @@
 package com.gu.holidaystopprocessor
 
-case class HolidayStopResponse(code: String, price: Double)
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequestId
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice}
+
+case class HolidayStopResponse(
+  requestId: HolidayStopRequestId,
+  amendmentCode: HolidayStopRequestActionedZuoraAmendmentCode,
+  price: HolidayStopRequestActionedZuoraAmendmentPrice
+)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
@@ -1,0 +1,6 @@
+package com.gu.holidaystopprocessor
+
+case class ProcessResult(
+  overallFailure: Option[OverallFailure],
+  holidayStopResults: Seq[Either[HolidayStopFailure, HolidayStopResponse]]
+)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -16,17 +16,17 @@ object Salesforce {
 
   private def thresholdDate: LocalDate = LocalDate.now.plusDays(14)
 
-  def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: String): Either[String, Seq[HolidayStopRequest]] =
+  def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: String): Either[OverallFailure, Seq[HolidayStopRequest]] =
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>
       val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
       val fetchOp = SalesforceHolidayStopRequest.LookupByDateAndProductNamePrefix(sfGet)
       fetchOp(thresholdDate, SalesforceHolidayStopRequest.ProductName(productNamePrefix))
     }.toDisjunction match {
-      case -\/(failure) => Left(failure.toString)
+      case -\/(failure) => Left(OverallFailure(failure.toString))
       case \/-(requests) => Right(requests)
     }
 
-  def holidayStopUpdateResponse(sfCredentials: SFAuthConfig)(responses: Seq[HolidayStopResponse]): Either[String, Unit] = {
+  def holidayStopUpdateResponse(sfCredentials: SFAuthConfig)(responses: Seq[HolidayStopResponse]): Either[OverallFailure, Unit] = {
 
     def send(
       sendOp: HolidayStopRequestActionedZuoraRef => ClientFailableOp[JsValue]
@@ -44,7 +44,7 @@ object Salesforce {
       val sendOp = CreateHolidayStopRequestActionedZuoraRef(sfGet)
       responses.map(send(sendOp)).find(_.isFailure)
     }.toDisjunction match {
-      case -\/(failure) => Left(failure.toString)
+      case -\/(failure) => Left(OverallFailure(failure.toString))
       case _ => Right(())
     }
   }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -1,22 +1,23 @@
 package com.gu.holidaystopprocessor
 
 import com.gu.effects.RawEffects
+import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef._
 import com.gu.util.resthttp.JsonHttp
+import com.gu.util.resthttp.Types.ClientFailableOp
 import org.joda.time.LocalDate
+import play.api.libs.json.JsValue
 import scalaz.{-\/, \/-}
 
 object Salesforce {
 
   private def thresholdDate: LocalDate = LocalDate.now.plusDays(14)
 
-  def holidayStopRequests(
-    config: Config,
-    productNamePrefix: String
-  ): Either[String, List[HolidayStopRequest]] =
-    SalesforceClient(RawEffects.response, config.sfCredentials).value.flatMap { sfAuth =>
+  def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: String): Either[String, Seq[HolidayStopRequest]] =
+    SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>
       val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
       val fetchOp = SalesforceHolidayStopRequest.LookupByDateAndProductNamePrefix(sfGet)
       fetchOp(thresholdDate, SalesforceHolidayStopRequest.ProductName(productNamePrefix))
@@ -24,4 +25,27 @@ object Salesforce {
       case -\/(failure) => Left(failure.toString)
       case \/-(requests) => Right(requests)
     }
+
+  def holidayStopUpdateResponse(sfCredentials: SFAuthConfig)(responses: Seq[HolidayStopResponse]): Either[String, Unit] = {
+
+    def send(
+      sendOp: HolidayStopRequestActionedZuoraRef => ClientFailableOp[JsValue]
+    )(response: HolidayStopResponse): ClientFailableOp[JsValue] =
+      sendOp(
+        HolidayStopRequestActionedZuoraRef(
+          response.requestId,
+          response.amendmentCode,
+          response.price
+        )
+      )
+
+    SalesforceClient(RawEffects.response, sfCredentials).value.map { sfAuth =>
+      val sfGet = sfAuth.wrapWith(JsonHttp.post)
+      val sendOp = CreateHolidayStopRequestActionedZuoraRef(sfGet)
+      responses.map(send(sendOp)).find(_.isFailure)
+    }.toDisjunction match {
+      case -\/(failure) => Left(failure.toString)
+      case _ => Right(())
+    }
+  }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/StandaloneApp.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/StandaloneApp.scala
@@ -6,8 +6,12 @@ object StandaloneApp extends App {
   Config() match {
     case Left(msg) => println(s"Config failure: $msg")
     case Right(config) =>
-      HolidayStopProcess(config) foreach {
-        case Left(msg) => println(s"Failed: $msg")
+      val processResult = HolidayStopProcess(config)
+      processResult.overallFailure foreach { failure =>
+        println(s"Overall failure: ${failure.reason}")
+      }
+      processResult.holidayStopResults foreach {
+        case Left(failure) => println(s"Failed: ${failure.reason}")
         case Right(response) => println(s"Success: $response")
       }
   }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Time.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Time.scala
@@ -1,10 +1,14 @@
 package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
+
 import org.joda.time.{LocalDate => JodaLocalDate}
 
 object Time {
 
   def toJavaDate(joda: JodaLocalDate): LocalDate =
     LocalDate.of(joda.getYear, joda.getMonthOfYear, joda.getDayOfMonth)
+
+  def toJodaDate(date: LocalDate): JodaLocalDate =
+    new JodaLocalDate(date.getYear, date.getMonth.getValue, date.getDayOfMonth)
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -3,7 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestActionedCount, HolidayStopRequestEndDate, HolidayStopRequestId, HolidayStopRequestStartDate, ProductName, SubscriptionName}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 
 object Fixtures {
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -3,6 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestActionedCount, HolidayStopRequestEndDate, HolidayStopRequestId, HolidayStopRequestStartDate, ProductName, SubscriptionName}
 
 object Fixtures {
 
@@ -26,6 +27,15 @@ object Fixtures {
         )
       )
     )
+
+  def mkHolidayStopRequest(id: String) = HolidayStopRequest(
+    Id = HolidayStopRequestId(id),
+    Start_Date__c = HolidayStopRequestStartDate(Time.toJodaDate(LocalDate.of(2019, 1, 1))),
+    End_Date__c = HolidayStopRequestEndDate(Time.toJodaDate(LocalDate.of(2019, 2, 15))),
+    Actioned_Count__c = HolidayStopRequestActionedCount(3),
+    Subscription_Name__c = SubscriptionName("subName"),
+    Product_Name__c = ProductName("Guardian Weekly")
+  )
 
   val config = Config(
     zuoraCredentials = ZuoraAccess(baseUrl = "", username = "", password = ""),


### PR DESCRIPTION
This change writes the details of amendments to subscriptions made by Zuora back to Salesforce.

Implementation details:
* There's a [new method](https://github.com/guardian/support-service-lambdas/compare/kc-sf-write?expand=1#diff-c5ebc37fd50df1a8bbff179733bf2ffcR29) to write holiday-stop responses back to Salesforce
* `HolidayStops` and `HolidayStopResponses` now keep the original request ID from Salesforce so that it can be passed back after the update

That's about it.

