### PR TITLE
Use correct effective date for GW holiday stops

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
@@ -22,7 +22,7 @@ object Config {
   /**
    * Min number of days ahead that a holiday stop can be applied
    */
-  val daysInAdvance = 10
+  val daysInAdvance = 14
 
   private def zuoraCredentials(stage: String): Either[String, ZuoraAccess] =
     credentials[ZuoraAccess](stage, "zuoraRest")

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
@@ -19,6 +19,11 @@ case class Config(
 
 object Config {
 
+  /**
+   * Min number of days ahead that a holiday stop can be applied
+   */
+  val daysInAdvance = 10
+
   private def zuoraCredentials(stage: String): Either[String, ZuoraAccess] =
     credentials[ZuoraAccess](stage, "zuoraRest")
 

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCredit.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCredit.scala
@@ -4,13 +4,10 @@ import scala.math.BigDecimal.RoundingMode
 
 object HolidayCredit {
 
-  def apply(subscription: Subscription): Double = {
-    def roundUp(d: Double): Double =
-      BigDecimal(d).setScale(2, RoundingMode.UP).toDouble
-    subscription.originalRatePlanCharge map { charge =>
-      val recurringPayment = charge.price
-      val numPublicationsInPeriod = charge.weekCountApprox
-      -roundUp(recurringPayment / numPublicationsInPeriod)
-    } getOrElse 0
+  def apply(charge: RatePlanCharge): Double = {
+    def roundUp(d: Double): Double = BigDecimal(d).setScale(2, RoundingMode.UP).toDouble
+    val recurringPayment = charge.price
+    val numPublicationsInPeriod = charge.weekCountApprox
+    -roundUp(recurringPayment / numPublicationsInPeriod)
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -62,7 +62,7 @@ object HolidayStopProcess {
     for {
       subscription <- getSubscription(stop.subscriptionName)
       _ <- if (subscription.autoRenew) Right(()) else Left(HolidayStopFailure("Cannot currently process non-auto-renewing subscription"))
-      update <- Right(SubscriptionUpdate.holidayCreditToAdd(config, subscription, stop.stoppedPublicationDate))
+      update <- SubscriptionUpdate.holidayCreditToAdd(config, subscription, stop.stoppedPublicationDate)
       _ <- updateSubscription(subscription, update)
       amendment <- getLastAmendment(subscription)
     } yield HolidayStopResponse(

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -14,7 +14,7 @@ import scalaz.{-\/, \/-}
 
 object Salesforce {
 
-  private def thresholdDate: LocalDate = LocalDate.now.plusDays(14)
+  private def thresholdDate: LocalDate = LocalDate.now.plusDays(Config.daysInAdvance)
 
   def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: String): Either[OverallFailure, Seq[HolidayStopRequest]] =
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
@@ -31,7 +31,7 @@ case class RatePlanCharge(
   price: Double,
   billingPeriod: Option[String],
   effectiveStartDate: LocalDate,
-  effectiveEndDate: LocalDate
+  chargedThroughDate: Option[LocalDate]
 ) {
 
   val weekCountApprox: Int = {

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
@@ -2,7 +2,7 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-case class SubscriptionUpdate(currentTerm: Option[Int], add: Seq[Add]) {
+case class SubscriptionUpdate(add: Seq[Add]) {
 
   val price: Double = {
     val optPrice = for {
@@ -15,42 +15,32 @@ case class SubscriptionUpdate(currentTerm: Option[Int], add: Seq[Add]) {
 
 object SubscriptionUpdate {
 
-  // In Zuora, the current term has to be extended beyond the effective date of any update
-  private def extendedTerm(subscription: Subscription, effectiveDate: LocalDate): Option[Int] =
-    if (effectiveDate.isAfter(subscription.termEndDate)) {
-      subscription.currentTermPeriodType match {
-        case "Month" => Some(24)
-        case _ => None
-      }
-    } else None
-
   def holidayCreditToAdd(
     config: Config,
     subscription: Subscription,
     stoppedPublicationDate: LocalDate
-  ): SubscriptionUpdate = {
-    val effectiveDate = subscription.originalRatePlanCharge map {
-      _.effectiveEndDate.plusDays(1)
-    } getOrElse stoppedPublicationDate
-    SubscriptionUpdate(
-      currentTerm = extendedTerm(subscription, effectiveDate),
-      Seq(
-        Add(
-          productRatePlanId = config.holidayCreditProductRatePlanId,
-          contractEffectiveDate = effectiveDate,
-          customerAcceptanceDate = effectiveDate,
-          serviceActivationDate = effectiveDate,
-          chargeOverrides = Seq(
-            ChargeOverride(
-              productRatePlanChargeId = config.holidayCreditProductRatePlanChargeId,
-              HolidayStart__c = stoppedPublicationDate,
-              HolidayEnd__c = stoppedPublicationDate,
-              price = HolidayCredit(subscription)
+  ): Either[HolidayStopFailure, SubscriptionUpdate] = {
+    subscription.originalRatePlanCharge.flatMap(_.chargedThroughDate)
+      .toRight(HolidayStopFailure("No effective date for amendment")).map { effectiveDate =>
+        SubscriptionUpdate(
+          Seq(
+            Add(
+              productRatePlanId = config.holidayCreditProductRatePlanId,
+              contractEffectiveDate = effectiveDate,
+              customerAcceptanceDate = effectiveDate,
+              serviceActivationDate = effectiveDate,
+              chargeOverrides = Seq(
+                ChargeOverride(
+                  productRatePlanChargeId = config.holidayCreditProductRatePlanChargeId,
+                  HolidayStart__c = stoppedPublicationDate,
+                  HolidayEnd__c = stoppedPublicationDate,
+                  price = subscription.originalRatePlanCharge.map(HolidayCredit(_)).getOrElse(0)
+                )
+              )
             )
           )
         )
-      )
-    )
+      }
   }
 }
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -7,11 +7,22 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 
 object Fixtures {
 
+  def mkRatePlanCharge(
+    price: Double,
+    billingPeriod: String,
+    chargedThroughDate: Option[LocalDate] = Some(LocalDate.of(2019, 9, 2))
+  ) = RatePlanCharge(
+    price,
+    Some(billingPeriod),
+    effectiveStartDate = LocalDate.of(2019, 6, 10),
+    chargedThroughDate
+  )
+
   def mkSubscription(
     termEndDate: LocalDate,
     price: Double,
     billingPeriod: String,
-    effectiveEndDate: LocalDate
+    chargedThroughDate: Option[LocalDate]
   ) =
     Subscription(
       subscriptionNumber = "S1",
@@ -22,8 +33,7 @@ object Fixtures {
       ratePlans = Seq(
         RatePlan(
           productName = "Guardian Weekly",
-          ratePlanCharges =
-            Seq(RatePlanCharge(price, Some(billingPeriod), LocalDate.of(2019, 1, 1), effectiveEndDate))
+          ratePlanCharges = Seq(mkRatePlanCharge(price, billingPeriod, chargedThroughDate))
         )
       )
     )

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditSpec.scala
@@ -8,21 +8,21 @@ import org.scalatest.OptionValues
 
 object HolidayCreditSpec extends Properties("HolidayCredit") with OptionValues {
 
-  private val subscriptionGen = for {
+  private val ratePlanChargeGen = for {
     price <- Gen.choose(0.01, 10000)
     billingPeriod <- Gen.oneOf(Seq("Month", "Quarter", "Annual"))
-  } yield Fixtures.mkSubscription(
-    termEndDate = LocalDate.of(2019, 1, 1),
+  } yield RatePlanCharge(
     price,
-    billingPeriod,
-    effectiveEndDate = LocalDate.of(2020, 1, 1)
+    Some(billingPeriod),
+    effectiveStartDate = LocalDate.of(2019, 7, 10),
+    chargedThroughDate = Some(LocalDate.of(2020, 1, 1))
   )
 
-  property("should never be positive") = forAll(subscriptionGen) { subscription: Subscription =>
-    HolidayCredit(subscription) <= 0
+  property("should never be positive") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
+    HolidayCredit(charge) <= 0
   }
 
-  property("should never be overwhelmingly negative") = forAll(subscriptionGen) { subscription: Subscription =>
-    HolidayCredit(subscription) > -subscription.originalRatePlanCharge.value.price
+  property("should never be overwhelmingly negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
+    HolidayCredit(charge) > -charge.price
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditTest.scala
@@ -1,41 +1,24 @@
 package com.gu.holidaystopprocessor
 
-import java.time.LocalDate
-
 import org.scalatest.{FlatSpec, Matchers}
 
 class HolidayCreditTest extends FlatSpec with Matchers {
 
   "HolidayCredit" should "be correct for a quarterly billing period" in {
-    val subscription = Fixtures.mkSubscription(
-      termEndDate = LocalDate.now,
-      price = 30,
-      billingPeriod = "Quarter",
-      effectiveEndDate = LocalDate.of(2019, 5, 15)
-    )
-    val credit = HolidayCredit(subscription)
+    val charge = Fixtures.mkRatePlanCharge(price = 30, billingPeriod = "Quarter")
+    val credit = HolidayCredit(charge)
     credit shouldBe -2.31
   }
 
   it should "be correct for another quarterly billing period" in {
-    val subscription = Fixtures.mkSubscription(
-      termEndDate = LocalDate.now,
-      price = 37.5,
-      billingPeriod = "Quarter",
-      effectiveEndDate = LocalDate.of(2019, 5, 15)
-    )
-    val credit = HolidayCredit(subscription)
+    val charge = Fixtures.mkRatePlanCharge(price = 37.5, billingPeriod = "Quarter")
+    val credit = HolidayCredit(charge)
     credit shouldBe -2.89
   }
 
   it should "be correct for an annual billing period" in {
-    val subscription = Fixtures.mkSubscription(
-      termEndDate = LocalDate.now,
-      price = 120,
-      billingPeriod = "Annual",
-      effectiveEndDate = LocalDate.of(2019, 5, 15)
-    )
-    val credit = HolidayCredit(subscription)
+    val charge = Fixtures.mkRatePlanCharge(price = 120, billingPeriod = "Annual")
+    val credit = HolidayCredit(charge)
     credit shouldBe -2.31
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -10,10 +10,10 @@ import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
 class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues with OptionValues {
 
   private val subscription = mkSubscription(
-    LocalDate.of(2019, 1, 1),
-    75.5,
-    "Quarter",
-    LocalDate.of(2020, 1, 1)
+    termEndDate = LocalDate.of(2019, 1, 1),
+    price = 75.5,
+    billingPeriod = "Quarter",
+    chargedThroughDate = Some(LocalDate.of(2019, 8, 11))
   )
 
   private val amendment = Amendment("A1")


### PR DESCRIPTION
This change ensures that the negative charge is applied to the next invoice by using the charge-through date (the first day of the next service period) as the effective date.
