### PR TITLE
Don't allow Zuora to apply duplicate holiday-stop credits

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Amendment.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Amendment.scala
@@ -1,3 +1,0 @@
-package com.gu.holidaystopprocessor
-
-case class Amendment(code: String)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
@@ -20,6 +20,24 @@ case class Subscription(
       charge <- ratePlan.ratePlanCharges.headOption
     } yield charge
   }
+
+  def ratePlanCharge(stop: HolidayStop): Option[RatePlanCharge] = {
+
+    def isMatchingPlan(plan: RatePlan): Boolean = plan.productName == "Discounts"
+
+    def isMatchingCharge(charge: RatePlanCharge): Boolean =
+      charge.name == "Holiday Credit" &&
+        charge.HolidayStart__c.contains(stop.stoppedPublicationDate) &&
+        charge.HolidayEnd__c.contains(stop.stoppedPublicationDate)
+
+    val charges = for {
+      plan <- ratePlans if isMatchingPlan(plan)
+      charge <- plan.ratePlanCharges.find(isMatchingCharge)
+    } yield charge
+    charges.headOption
+  }
+
+  def hasHolidayStop(stop: HolidayStop): Boolean = ratePlanCharge(stop).isDefined
 }
 
 case class RatePlan(
@@ -28,10 +46,14 @@ case class RatePlan(
 )
 
 case class RatePlanCharge(
+  name: String,
+  number: String,
   price: Double,
   billingPeriod: Option[String],
   effectiveStartDate: LocalDate,
-  chargedThroughDate: Option[LocalDate]
+  chargedThroughDate: Option[LocalDate],
+  HolidayStart__c: Option[LocalDate],
+  HolidayEnd__c: Option[LocalDate]
 ) {
 
   val weekCountApprox: Int = {

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
@@ -47,14 +47,4 @@ object Zuora {
       }
     }
   }
-
-  def lastAmendmentGetResponse(zuoraAccess: ZuoraAccess)(subscription: Subscription): Either[HolidayStopFailure, Amendment] = {
-    val request = sttp.auth
-      .basic(zuoraAccess.username, zuoraAccess.password)
-      .get(uri"${zuoraAccess.baseUrl}/amendments/subscriptions/${subscription.subscriptionNumber}")
-    val response = request.send()
-    response.body.left map { e => HolidayStopFailure(e) } flatMap { body =>
-      normalised(body, decode[Amendment])
-    }
-  }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -12,10 +12,14 @@ object Fixtures {
     billingPeriod: String,
     chargedThroughDate: Option[LocalDate] = Some(LocalDate.of(2019, 9, 2))
   ) = RatePlanCharge(
+    name = "GW",
+    number = "C1",
     price,
     Some(billingPeriod),
     effectiveStartDate = LocalDate.of(2019, 6, 10),
-    chargedThroughDate
+    chargedThroughDate,
+    HolidayStart__c = None,
+    HolidayEnd__c = None
   )
 
   def mkSubscription(
@@ -33,18 +37,102 @@ object Fixtures {
       ratePlans = Seq(
         RatePlan(
           productName = "Guardian Weekly",
-          ratePlanCharges = Seq(mkRatePlanCharge(price, billingPeriod, chargedThroughDate))
+          ratePlanCharges =
+            Seq(mkRatePlanCharge(
+              price,
+              billingPeriod,
+              chargedThroughDate
+            ))
         )
       )
     )
 
-  def mkHolidayStopRequest(id: String) = HolidayStopRequest(
+  def mkSubscriptionWithHolidayStops() = Subscription(
+    subscriptionNumber = "S1",
+    termEndDate = LocalDate.of(2020, 3, 1),
+    currentTerm = 12,
+    currentTermPeriodType = "Month",
+    autoRenew = true,
+    ratePlans = Seq(
+      RatePlan(
+        productName = "Discounts",
+        ratePlanCharges = Seq(RatePlanCharge(
+          name = "Holiday Credit",
+          number = "C2",
+          price = -3.27,
+          billingPeriod = None,
+          effectiveStartDate = LocalDate.of(2019, 9, 7),
+          chargedThroughDate = None,
+          HolidayStart__c = Some(LocalDate.of(2019, 8, 9)),
+          HolidayEnd__c = Some(LocalDate.of(2019, 8, 9))
+        ))
+      ),
+      RatePlan(
+        productName = "Not a discount",
+        ratePlanCharges = Seq(RatePlanCharge(
+          name = "Holiday Credit",
+          number = "C29",
+          price = -3.27,
+          billingPeriod = None,
+          effectiveStartDate = LocalDate.of(2019, 9, 7),
+          chargedThroughDate = None,
+          HolidayStart__c = Some(LocalDate.of(2019, 8, 11)),
+          HolidayEnd__c = Some(LocalDate.of(2019, 8, 11))
+        ))
+      ),
+      RatePlan(
+        productName = "Discounts",
+        ratePlanCharges = Seq(RatePlanCharge(
+          name = "Some other discount",
+          number = "C73",
+          price = -5.81,
+          billingPeriod = None,
+          effectiveStartDate = LocalDate.of(2019, 9, 7),
+          chargedThroughDate = None,
+          HolidayStart__c = Some(LocalDate.of(2019, 8, 19)),
+          HolidayEnd__c = Some(LocalDate.of(2019, 8, 19))
+        ))
+      ),
+      RatePlan(
+        productName = "Discounts",
+        ratePlanCharges = Seq(RatePlanCharge(
+          name = "Holiday Credit",
+          number = "C3",
+          price = -5.81,
+          billingPeriod = None,
+          effectiveStartDate = LocalDate.of(2019, 9, 7),
+          chargedThroughDate = None,
+          HolidayStart__c = Some(LocalDate.of(2019, 8, 2)),
+          HolidayEnd__c = Some(LocalDate.of(2019, 8, 2))
+        ))
+      ),
+      RatePlan(
+        productName = "Guardian Weekly",
+        ratePlanCharges = Seq(mkRatePlanCharge(
+          price = 42.7,
+          billingPeriod = "Quarter",
+          chargedThroughDate = Some(LocalDate.of(2019, 9, 7))
+        ))
+      )
+    )
+  )
+
+  def mkHolidayStopRequest(
+    id: String,
+    stopDate: LocalDate = LocalDate.of(2019, 1, 1)
+  ) = HolidayStopRequest(
     Id = HolidayStopRequestId(id),
-    Start_Date__c = HolidayStopRequestStartDate(Time.toJodaDate(LocalDate.of(2019, 1, 1))),
-    End_Date__c = HolidayStopRequestEndDate(Time.toJodaDate(LocalDate.of(2019, 2, 15))),
+    Start_Date__c = HolidayStopRequestStartDate(Time.toJodaDate(stopDate)),
+    End_Date__c = HolidayStopRequestEndDate(Time.toJodaDate(stopDate)),
     Actioned_Count__c = HolidayStopRequestActionedCount(3),
     Subscription_Name__c = SubscriptionName("subName"),
     Product_Name__c = ProductName("Guardian Weekly")
+  )
+
+  def mkHolidayStop(date: LocalDate) = HolidayStop(
+    requestId = HolidayStopRequestId("R1"),
+    subscriptionName = "S1",
+    stoppedPublicationDate = date
   )
 
   val config = Config(

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditSpec.scala
@@ -12,10 +12,14 @@ object HolidayCreditSpec extends Properties("HolidayCredit") with OptionValues {
     price <- Gen.choose(0.01, 10000)
     billingPeriod <- Gen.oneOf(Seq("Month", "Quarter", "Annual"))
   } yield RatePlanCharge(
+    name = "GW",
+    number = "C5",
     price,
     Some(billingPeriod),
     effectiveStartDate = LocalDate.of(2019, 7, 10),
-    chargedThroughDate = Some(LocalDate.of(2020, 1, 1))
+    chargedThroughDate = Some(LocalDate.of(2020, 1, 1)),
+    HolidayStart__c = None,
+    HolidayEnd__c = None
   )
 
   property("should never be positive") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionTest.scala
@@ -1,0 +1,67 @@
+package com.gu.holidaystopprocessor
+
+import java.time.LocalDate
+
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+
+class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
+
+  "ratePlanCharge" should "give ratePlanCharge corresponding to holiday stop" in {
+    val subscription = Fixtures.mkSubscriptionWithHolidayStops()
+    val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 9))
+    subscription.ratePlanCharge(stop).value shouldBe RatePlanCharge(
+      name = "Holiday Credit",
+      number = "C2",
+      price = -3.27,
+      billingPeriod = None,
+      effectiveStartDate = LocalDate.of(2019, 9, 7),
+      chargedThroughDate = None,
+      HolidayStart__c = Some(LocalDate.of(2019, 8, 9)),
+      HolidayEnd__c = Some(LocalDate.of(2019, 8, 9))
+    )
+  }
+
+  it should "give another ratePlanCharge corresponding to another holiday stop" in {
+    val subscription = Fixtures.mkSubscriptionWithHolidayStops()
+    val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 2))
+    subscription.ratePlanCharge(stop).value shouldBe RatePlanCharge(
+      name = "Holiday Credit",
+      number = "C3",
+      price = -5.81,
+      billingPeriod = None,
+      effectiveStartDate = LocalDate.of(2019, 9, 7),
+      chargedThroughDate = None,
+      HolidayStart__c = Some(LocalDate.of(2019, 8, 2)),
+      HolidayEnd__c = Some(LocalDate.of(2019, 8, 2))
+    )
+  }
+
+  it should "give no ratePlanCharge when none correspond to holiday stop" in {
+    val subscription = Fixtures.mkSubscriptionWithHolidayStops()
+    val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 23))
+    subscription.ratePlanCharge(stop) shouldBe None
+  }
+
+  it should "give no ratePlanCharge when subscription has no holiday stops applied" in {
+    val subscription = Fixtures.mkSubscription(
+      termEndDate = LocalDate.of(2019, 1, 1),
+      price = 123,
+      billingPeriod = "Quarter",
+      chargedThroughDate = None
+    )
+    val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 23))
+    subscription.ratePlanCharge(stop) shouldBe None
+  }
+
+  it should "give no RatePlanCharge when dates correspond but it's not for a holiday credit" in {
+    val subscription = Fixtures.mkSubscriptionWithHolidayStops()
+    val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 19))
+    subscription.ratePlanCharge(stop) shouldBe None
+  }
+
+  it should "give no RatePlanCharge when dates correspond but it's not for a discount plan" in {
+    val subscription = Fixtures.mkSubscriptionWithHolidayStops()
+    val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 11))
+    subscription.ratePlanCharge(stop) shouldBe None
+  }
+}


### PR DESCRIPTION
There are some scenarios where we ask Zuora to apply the same holiday-stop twice.  This could be where sending the result of the amendment back to Salesforce fails for example.  In that case on the next run of the lambda the same amendment would be applied again and there would be nothing to stop it appearing as two or more credits for the same holiday stop on the next invoice.

This PR ensures that the same holiday stop cannot be applied twice.  It works on the assumption that a 'Holiday Credit' charge on a 'Discounts' plan for the same stopped publication date as the requested holiday stop means that the holiday stop has already been applied.

It's been easier to identify duplicates by inspecting the `Subscription` record, rather than by looking for relevant `Amendments`.  So I've changed the model a bit to avoid referring to `Amendments` at all.  This means that the lambda is sending `RatePlanCharge` IDs back to Salesforce rather than `Amendment` IDs.  Both uniquely identify the holiday-stop amendment to the original subscription.  So there'll be some follow-up work to change references in the service layer and the Salesforce UI from 'amendment' to 'charge'.

This is how the results look in Salesforce with the old amendment IDs and the new RatePlanCharge IDs:

![image](https://user-images.githubusercontent.com/1722550/59353959-0391d380-8d1c-11e9-9e16-6fb72a5db061.png)

It will be marginally more difficult to look these up in Zuora as RatePlanCharges don't exist as top-level objects.  They will have to be looked up by Subscription name instead to find the relevant charge in the subscription details.

I've tested this in Code.
