### PR TITLE
Add Guardian Weekly offer field

### DIFF
--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -155,7 +155,8 @@ object SfQueries {
       |Promo_Type__c,
       |Version__c,
       |Zuora_Id__c,
-      |ReaderType__c
+      |ReaderType__c,
+      |GW_Offer__c
       |from SF_Subscription__c
       |where Buyer__r.Account.GDPR_Deletion_Pending__c = false
       |


### PR DESCRIPTION
https://eu7.salesforce.com/00N0J00000A2Wwz

Shows when the custom Guardian Weekly offer has been used; 6for6. Will show 12for12 if/when this is added. It's also used in SF to determin the correct fulfilment start date.