### PR TITLE
Use oauth2 for authorising holiday-stop processing

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/AccessToken.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/AccessToken.scala
@@ -1,0 +1,3 @@
+package com.gu.holidaystopprocessor
+
+case class AccessToken(access_token: String)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
@@ -5,3 +5,7 @@ case class ProcessResult(
   holidayStopResults: Seq[Either[HolidayStopFailure, HolidayStopResponse]],
   overallFailure: Option[OverallFailure]
 )
+
+object ProcessResult {
+  def fromOverallFailure(failure: OverallFailure) = ProcessResult(Nil, Nil, Some(failure))
+}

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
@@ -11,35 +11,50 @@ object Zuora {
 
   private def normalised[E <: io.circe.Error, R](
     body: String, result: String => Either[E, R]
-  ): Either[HolidayStopFailure, R] =
-    result(body).left.map(e => HolidayStopFailure(s"Failed to decode '$body': ${e.toString}"))
+  ): Either[String, R] =
+    result(body).left.map(e => s"Failed to decode '$body': ${e.toString}")
 
-  def subscriptionGetResponse(
-    zuoraAccess: ZuoraAccess
-  )(subscriptionName: String): Either[HolidayStopFailure, Subscription] = {
-    val request = sttp.auth
-      .basic(zuoraAccess.username, zuoraAccess.password)
-      .get(uri"${zuoraAccess.baseUrl}/subscriptions/$subscriptionName")
+  def accessTokenGetResponse(config: ZuoraConfig): Either[OverallFailure, AccessToken] = {
+    val authBaseUrl = config.baseUrl.stripSuffix("/v1")
+    val url = uri"$authBaseUrl/oauth/token"
+    val request = sttp.post(url)
+      .body(
+        "grant_type" -> "client_credentials",
+        "client_id" -> s"${config.holidayStopProcessor.oauth.clientId}",
+        "client_secret" -> s"${config.holidayStopProcessor.oauth.clientSecret}"
+      )
     val response = request.send()
-    response.body.left map { e => HolidayStopFailure(e) } flatMap { body =>
-      normalised(body, decode[Subscription])
-    }
+    for {
+      body <- response.body.left.map(OverallFailure)
+      token <- normalised(body, decode[AccessToken]).left.map(OverallFailure)
+    } yield token
   }
 
-  def subscriptionUpdateResponse(zuoraAccess: ZuoraAccess)(
-    subscription: Subscription,
-    update: SubscriptionUpdate
-  ): Either[HolidayStopFailure, Unit] = {
-    val request = sttp.auth
-      .basic(zuoraAccess.username, zuoraAccess.password)
-      .put(uri"${zuoraAccess.baseUrl}/subscriptions/${subscription.subscriptionNumber}")
+  def subscriptionGetResponse(config: Config, accessToken: AccessToken)(subscriptionName: String): Either[HolidayStopFailure, Subscription] = {
+    val url = uri"${config.zuoraConfig.baseUrl}/subscriptions/$subscriptionName"
+    val request = sttp.get(url)
+      .header("Authorization", s"Bearer $accessToken")
+    val response = request.send()
+    response.body.left map { e => HolidayStopFailure(e) } flatMap { body =>
+      normalised(body, decode[Subscription]).left.map(HolidayStopFailure)
+    }
+    for {
+      body <- response.body.left.map(HolidayStopFailure)
+      subscription <- normalised(body, decode[Subscription]).left.map(HolidayStopFailure)
+    } yield subscription
+  }
+
+  def subscriptionUpdateResponse(config: Config, accessToken: AccessToken)(subscription: Subscription, update: SubscriptionUpdate): Either[HolidayStopFailure, Unit] = {
+    val url = uri"${config.zuoraConfig.baseUrl}/subscriptions/${subscription.subscriptionNumber}"
+    val request = sttp.put(url)
+      .header("Authorization", s"Bearer $accessToken")
       .body(update)
     val response = request.send()
     response.body.left map { e => HolidayStopFailure(e) } flatMap { body =>
       def failureMsg(wrappedMsg: String) =
         s"Update '$update' to subscription '${subscription.subscriptionNumber}' failed: $wrappedMsg"
       normalised(body, decode[ZuoraStatusResponse]) match {
-        case Left(e) => Left(HolidayStopFailure(failureMsg(e.reason)))
+        case Left(e) => Left(HolidayStopFailure(failureMsg(e)))
         case Right(status) =>
           if (!status.success)
             Left(HolidayStopFailure(failureMsg(status.reasons.map(_.mkString).getOrElse(""))))

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ZuoraAccess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ZuoraAccess.scala
@@ -1,3 +1,0 @@
-package com.gu.holidaystopprocessor
-
-case class ZuoraAccess(baseUrl: String, username: String, password: String)

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -136,8 +136,8 @@ object Fixtures {
   )
 
   val config = Config(
-    zuoraCredentials = ZuoraAccess(baseUrl = "", username = "", password = ""),
-    sfCredentials = SFAuthConfig("", "", "", "", "", ""),
+    zuoraConfig = ZuoraConfig(baseUrl = "", holidayStopProcessor = HolidayStopProcessor(Oauth(clientId = "", clientSecret = ""))),
+    sfConfig = SFAuthConfig("", "", "", "", "", ""),
     holidayCreditProductRatePlanId = "ratePlanId",
     holidayCreditProductRatePlanChargeId = "ratePlanChargeId"
   )

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -22,12 +22,10 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     LocalDate.of(2019, 8, 9)
   )
 
-  private def getRequests(requestsGet: Either[OverallFailure, Seq[HolidayStopRequest]]): String
-    => Either[OverallFailure, Seq[HolidayStopRequest]] =
+  private def getRequests(requestsGet: Either[OverallFailure, Seq[HolidayStopRequest]]): String => Either[OverallFailure, Seq[HolidayStopRequest]] =
     _ => requestsGet
 
-  private def getSubscription(subscriptionGet: Either[HolidayStopFailure, Subscription]): String
-    => Either[HolidayStopFailure, Subscription] = {
+  private def getSubscription(subscriptionGet: Either[HolidayStopFailure, Subscription]): String => Either[HolidayStopFailure, Subscription] = {
     _ => subscriptionGet
   }
 
@@ -37,15 +35,14 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     case (_, _) => subscriptionUpdate
   }
 
-  private def exportAmendments(amendmentExport: Either[OverallFailure, Unit])
-  : Seq[HolidayStopResponse] => Either[OverallFailure, Unit] =
+  private def exportAmendments(amendmentExport: Either[OverallFailure, Unit]): Seq[HolidayStopResponse] => Either[OverallFailure, Unit] =
     _ => amendmentExport
 
   "HolidayStopProcess" should "give correct added charge" in {
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(Fixtures.mkSubscriptionWithHolidayStops())),
-      updateSubscription(Right(())),
+      updateSubscription(Right(()))
     )(holidayStop)
     response.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("HSR1"),
@@ -58,7 +55,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription)),
-      updateSubscription(Left(HolidayStopFailure("update went wrong"))),
+      updateSubscription(Left(HolidayStopFailure("update went wrong")))
     )(holidayStop)
     response.left.value shouldBe HolidayStopFailure("update went wrong")
   }
@@ -67,7 +64,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Left(HolidayStopFailure("get went wrong"))),
-      updateSubscription(Right(())),
+      updateSubscription(Right(()))
     )(holidayStop)
     response.left.value shouldBe HolidayStopFailure("get went wrong")
   }
@@ -76,7 +73,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription.copy(autoRenew = false))),
-      updateSubscription(Right(())),
+      updateSubscription(Right(()))
     )(holidayStop)
     response.left.value shouldBe
       HolidayStopFailure("Cannot currently process non-auto-renewing subscription")
@@ -86,7 +83,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(Fixtures.mkSubscriptionWithHolidayStops())),
-      updateSubscription(Left(HolidayStopFailure("shouldn't need to apply an update"))),
+      updateSubscription(Left(HolidayStopFailure("shouldn't need to apply an update")))
     )(holidayStop)
     response.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("HSR1"),
@@ -99,7 +96,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val response = HolidayStopProcess.processHolidayStop(
       config,
       getSubscription(Right(subscription)),
-      updateSubscription(Left(HolidayStopFailure("shouldn't need to apply an update"))),
+      updateSubscription(Left(HolidayStopFailure("shouldn't need to apply an update")))
     )(holidayStop)
     response.left.value shouldBe HolidayStopFailure("shouldn't need to apply an update")
   }
@@ -108,9 +105,9 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val responses = HolidayStopProcess.processHolidayStops(
       config,
       getRequests(Right(Seq(
-        Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019,8,2)),
-        Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019,9,1)),
-        Fixtures.mkHolidayStopRequest("R3", LocalDate.of(2019,8,9))
+        Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)),
+        Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)),
+        Fixtures.mkHolidayStopRequest("R3", LocalDate.of(2019, 8, 9))
       ))),
       getSubscription(Right(Fixtures.mkSubscriptionWithHolidayStops())),
       updateSubscription(Right(())),


### PR DESCRIPTION
Zuora considers the use of username and password to be a legacy means of authentication.
This PR changes to use an oauth2 access token instead.
