### PR TITLE
Fix regression in GoCardless-SalesForce sync

### DIFF
--- a/handlers/sf-gocardless-sync/cfn.yaml
+++ b/handlers/sf-gocardless-sync/cfn.yaml
@@ -132,11 +132,6 @@ Resources:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
       AlarmName: !Sub "GenericError observed on ${LogGroupNamePrefix}-${Stage}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: LogGroup
-          Value: !Sub "${LogGroupNamePrefix}-${Stage}"
-        - Name: Stage
-          Value: !Sub ${Stage}
       EvaluationPeriods: 1
       MetricName: "GenericError Count"
       Namespace: "GoCardlessSalesForceSync"

--- a/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandate.scala
+++ b/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandate.scala
@@ -13,7 +13,7 @@ import play.api.libs.json.{JsValue, Json}
 
 object SalesforceDDMandate extends Logging {
 
-  private val mandateSfObjectsBaseUrl = sfApiBaseUrl + "DD_Mandate__c"
+  private val mandateSfObjectsBaseUrl = sfObjectsBaseUrl + "DD_Mandate__c"
 
   case class BillingAccountSfId(value: String) extends AnyVal
   implicit val formatBillingAccountSfId = Jsonx.formatInline[BillingAccountSfId]

--- a/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceConstants.scala
+++ b/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceConstants.scala
@@ -2,10 +2,10 @@ package com.gu.salesforce
 
 object SalesforceConstants {
 
-  val sfApiBaseUrl = "/services/data/v29.0"
+  private val sfApiBaseUrl = "/services/data/v29.0"
 
-  val soqlQueryBaseUrl = sfApiBaseUrl + "/query/"
+  val soqlQueryBaseUrl: String = sfApiBaseUrl + "/query/"
 
-  val sfObjectsBaseUrl = sfApiBaseUrl + "/sobjects/"
+  val sfObjectsBaseUrl: String = sfApiBaseUrl + "/sobjects/"
 
 }


### PR DESCRIPTION
Silly mistake in https://github.com/guardian/support-service-lambdas/pull/294, which caused the GoCardless-SalesForce sync to break.

This break went undetected for 19 days, as the resulting `NOT_FOUND` error was not picked up with the alarm, so corrected the alarm definition in the CloudFormation in this PR alongside the necessary fix.