### PR TITLE
Modify Zuora holiday-stop response model

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.gu.holiday_stops.ActionCalculator
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId}
+import com.gu.util.Time
 
 case class HolidayStop(
   requestId: HolidayStopRequestId,

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -1,7 +1,9 @@
 package com.gu.holidaystopprocessor
 
+import java.time.LocalDate
+
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice, StoppedPublicationDate}
 
 object HolidayStopProcess {
 
@@ -64,7 +66,8 @@ object HolidayStopProcess {
       HolidayStopResponse(
         stop.requestId,
         HolidayStopRequestActionedZuoraAmendmentCode(addedCharge.number),
-        HolidayStopRequestActionedZuoraAmendmentPrice(addedCharge.price)
+        HolidayStopRequestActionedZuoraAmendmentPrice(addedCharge.price),
+        StoppedPublicationDate(addedCharge.HolidayStart__c.getOrElse(LocalDate.MIN))
       )
     }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -3,7 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice, StoppedPublicationDate}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraChargeCode, HolidayStopRequestActionedZuoraChargePrice, StoppedPublicationDate}
 
 object HolidayStopProcess {
 
@@ -65,8 +65,8 @@ object HolidayStopProcess {
     } yield {
       HolidayStopResponse(
         stop.requestId,
-        HolidayStopRequestActionedZuoraAmendmentCode(addedCharge.number),
-        HolidayStopRequestActionedZuoraAmendmentPrice(addedCharge.price),
+        HolidayStopRequestActionedZuoraChargeCode(addedCharge.number),
+        HolidayStopRequestActionedZuoraChargePrice(addedCharge.price),
         StoppedPublicationDate(addedCharge.HolidayStart__c.getOrElse(LocalDate.MIN))
       )
     }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
@@ -1,11 +1,11 @@
 package com.gu.holidaystopprocessor
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequestId
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice, StoppedPublicationDate}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraChargeCode, HolidayStopRequestActionedZuoraChargePrice, StoppedPublicationDate}
 
 case class HolidayStopResponse(
   requestId: HolidayStopRequestId,
-  amendmentCode: HolidayStopRequestActionedZuoraAmendmentCode,
-  price: HolidayStopRequestActionedZuoraAmendmentPrice,
+  amendmentCode: HolidayStopRequestActionedZuoraChargeCode,
+  price: HolidayStopRequestActionedZuoraChargePrice,
   pubDate: StoppedPublicationDate
 )

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
@@ -5,7 +5,7 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuora
 
 case class HolidayStopResponse(
   requestId: HolidayStopRequestId,
-  amendmentCode: HolidayStopRequestActionedZuoraChargeCode,
+  chargeCode: HolidayStopRequestActionedZuoraChargeCode,
   price: HolidayStopRequestActionedZuoraChargePrice,
   pubDate: StoppedPublicationDate
 )

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopResponse.scala
@@ -1,10 +1,11 @@
 package com.gu.holidaystopprocessor
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequestId
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice, StoppedPublicationDate}
 
 case class HolidayStopResponse(
   requestId: HolidayStopRequestId,
   amendmentCode: HolidayStopRequestActionedZuoraAmendmentCode,
-  price: HolidayStopRequestActionedZuoraAmendmentPrice
+  price: HolidayStopRequestActionedZuoraAmendmentPrice,
+  pubDate: StoppedPublicationDate
 )

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -34,7 +34,7 @@ object Salesforce {
       sendOp(
         HolidayStopRequestActionedZuoraRef(
           response.requestId,
-          response.amendmentCode,
+          response.chargeCode,
           response.price,
           response.pubDate
         )

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -35,7 +35,8 @@ object Salesforce {
         HolidayStopRequestActionedZuoraRef(
           response.requestId,
           response.amendmentCode,
-          response.price
+          response.price,
+          response.pubDate
         )
       )
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
+import com.gu.util.Time
 
 object Fixtures {
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 import com.gu.holidaystopprocessor.Fixtures.{config, mkSubscription}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId}
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice, StoppedPublicationDate}
 import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
 
 class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues with OptionValues {
@@ -47,7 +47,8 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     response.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("HSR1"),
       amendmentCode = HolidayStopRequestActionedZuoraAmendmentCode("C2"),
-      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27)
+      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27),
+      pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )
   }
 
@@ -88,7 +89,8 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     response.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("HSR1"),
       amendmentCode = HolidayStopRequestActionedZuoraAmendmentCode("C2"),
-      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27)
+      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27),
+      pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )
   }
 
@@ -116,12 +118,14 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     responses.holidayStopResults.headOption.value.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("R1"),
       amendmentCode = HolidayStopRequestActionedZuoraAmendmentCode("C3"),
-      price = HolidayStopRequestActionedZuoraAmendmentPrice(-5.81)
+      price = HolidayStopRequestActionedZuoraAmendmentPrice(-5.81),
+      pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 2))
     )
     responses.holidayStopResults.lastOption.value.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("R3"),
       amendmentCode = HolidayStopRequestActionedZuoraAmendmentCode("C2"),
-      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27)
+      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27),
+      pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )
   }
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 import com.gu.holidaystopprocessor.Fixtures.{config, mkSubscription}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId}
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraAmendmentCode, HolidayStopRequestActionedZuoraAmendmentPrice, StoppedPublicationDate}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraChargeCode, HolidayStopRequestActionedZuoraChargePrice, StoppedPublicationDate}
 import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
 
 class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues with OptionValues {
@@ -46,8 +46,8 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     )(holidayStop)
     response.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("HSR1"),
-      amendmentCode = HolidayStopRequestActionedZuoraAmendmentCode("C2"),
-      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27),
+      amendmentCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
+      price = HolidayStopRequestActionedZuoraChargePrice(-3.27),
       pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )
   }
@@ -88,8 +88,8 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     )(holidayStop)
     response.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("HSR1"),
-      amendmentCode = HolidayStopRequestActionedZuoraAmendmentCode("C2"),
-      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27),
+      amendmentCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
+      price = HolidayStopRequestActionedZuoraChargePrice(-3.27),
       pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )
   }
@@ -117,14 +117,14 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     )
     responses.holidayStopResults.headOption.value.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("R1"),
-      amendmentCode = HolidayStopRequestActionedZuoraAmendmentCode("C3"),
-      price = HolidayStopRequestActionedZuoraAmendmentPrice(-5.81),
+      amendmentCode = HolidayStopRequestActionedZuoraChargeCode("C3"),
+      price = HolidayStopRequestActionedZuoraChargePrice(-5.81),
       pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 2))
     )
     responses.holidayStopResults.lastOption.value.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("R3"),
-      amendmentCode = HolidayStopRequestActionedZuoraAmendmentCode("C2"),
-      price = HolidayStopRequestActionedZuoraAmendmentPrice(-3.27),
+      amendmentCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
+      price = HolidayStopRequestActionedZuoraChargePrice(-3.27),
       pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )
   }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -46,7 +46,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     )(holidayStop)
     response.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("HSR1"),
-      amendmentCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
+      chargeCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
       price = HolidayStopRequestActionedZuoraChargePrice(-3.27),
       pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )
@@ -88,7 +88,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     )(holidayStop)
     response.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("HSR1"),
-      amendmentCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
+      chargeCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
       price = HolidayStopRequestActionedZuoraChargePrice(-3.27),
       pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )
@@ -117,13 +117,13 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     )
     responses.holidayStopResults.headOption.value.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("R1"),
-      amendmentCode = HolidayStopRequestActionedZuoraChargeCode("C3"),
+      chargeCode = HolidayStopRequestActionedZuoraChargeCode("C3"),
       price = HolidayStopRequestActionedZuoraChargePrice(-5.81),
       pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 2))
     )
     responses.holidayStopResults.lastOption.value.right.value shouldBe HolidayStopResponse(
       requestId = HolidayStopRequestId("R3"),
-      amendmentCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
+      chargeCode = HolidayStopRequestActionedZuoraChargeCode("C2"),
       price = HolidayStopRequestActionedZuoraChargePrice(-3.27),
       pubDate = StoppedPublicationDate(LocalDate.of(2019, 8, 9))
     )

--- a/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandateEvent.scala
+++ b/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandateEvent.scala
@@ -10,7 +10,6 @@ import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.resthttp.{HttpOp, RestRequestMaker}
 import play.api.libs.json.{JsValue, Json}
 
-
 object SalesforceDDMandateEvent extends Logging {
 
   private val mandateSfObjectsBaseUrl = sfObjectsBaseUrl + "DD_Mandate_Event__c"

--- a/lib/handler/src/main/scala/com/gu/util/Time.scala
+++ b/lib/handler/src/main/scala/com/gu/util/Time.scala
@@ -1,4 +1,4 @@
-package com.gu.holidaystopprocessor
+package com.gu.util
 
 import java.time.LocalDate
 

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
@@ -16,19 +16,19 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
 
   private val holidayStopRequestActionedZuoraRefSfObjectRef = "Holiday_Stop_Request_Actioned_Zuora_Ref__c"
 
-  case class HolidayStopRequestActionedZuoraAmendmentCode(value: String) extends AnyVal
-  implicit val formatHolidayStopRequestActionedZuoraAmendmentCode = Jsonx.formatInline[HolidayStopRequestActionedZuoraAmendmentCode]
+  case class HolidayStopRequestActionedZuoraChargeCode(value: String) extends AnyVal
+  implicit val formatHolidayStopRequestActionedZuoraChargeCode = Jsonx.formatInline[HolidayStopRequestActionedZuoraChargeCode]
 
-  case class HolidayStopRequestActionedZuoraAmendmentPrice(value: Double) extends AnyVal
-  implicit val formatHolidayStopRequestActionedZuoraAmendmentPrice = Jsonx.formatInline[HolidayStopRequestActionedZuoraAmendmentPrice]
+  case class HolidayStopRequestActionedZuoraChargePrice(value: Double) extends AnyVal
+  implicit val formatHolidayStopRequestActionedZuoraChargePrice = Jsonx.formatInline[HolidayStopRequestActionedZuoraChargePrice]
 
   case class StoppedPublicationDate(value: LocalDate) extends AnyVal
   implicit val formatStoppedPublicationDate = Jsonx.formatInline[StoppedPublicationDate]
 
   case class HolidayStopRequestActionedZuoraRef(
     Holiday_Stop_Request__c: HolidayStopRequestId,
-    Amendment_Code__c: HolidayStopRequestActionedZuoraAmendmentCode,
-    Price__c: HolidayStopRequestActionedZuoraAmendmentPrice,
+    Charge_Code__c: HolidayStopRequestActionedZuoraChargeCode,
+    Price__c: HolidayStopRequestActionedZuoraChargePrice,
     Stopped_Publication_Date__c: StoppedPublicationDate
   )
   implicit val writes = Json.writes[HolidayStopRequestActionedZuoraRef]

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
@@ -1,5 +1,7 @@
 package com.gu.salesforce.holiday_stops
 
+import java.time.LocalDate
+
 import ai.x.play.json.Jsonx
 import com.gu.salesforce.SalesforceConstants._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequestId
@@ -20,10 +22,14 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
   case class HolidayStopRequestActionedZuoraAmendmentPrice(value: Double) extends AnyVal
   implicit val formatHolidayStopRequestActionedZuoraAmendmentPrice = Jsonx.formatInline[HolidayStopRequestActionedZuoraAmendmentPrice]
 
+  case class StoppedPublicationDate(value: LocalDate) extends AnyVal
+  implicit val formatStoppedPublicationDate = Jsonx.formatInline[StoppedPublicationDate]
+
   case class HolidayStopRequestActionedZuoraRef(
     Holiday_Stop_Request__c: HolidayStopRequestId,
     Amendment_Code__c: HolidayStopRequestActionedZuoraAmendmentCode,
-    Price__c: HolidayStopRequestActionedZuoraAmendmentPrice
+    Price__c: HolidayStopRequestActionedZuoraAmendmentPrice,
+    Stopped_Publication_Date__c: StoppedPublicationDate
   )
   implicit val writes = Json.writes[HolidayStopRequestActionedZuoraRef]
 

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
@@ -30,11 +30,11 @@ class ActionCalculatorTest extends FlatSpec with Matchers {
         gwProductName
       )
     ) shouldEqual List(
-      new LocalDate(2019, 5, 24),
-      new LocalDate(2019, 5, 31),
-      new LocalDate(2019, 6, 7),
-      new LocalDate(2019, 6, 14)
-    )
+        new LocalDate(2019, 5, 24),
+        new LocalDate(2019, 5, 31),
+        new LocalDate(2019, 6, 7),
+        new LocalDate(2019, 6, 14)
+      )
 
     ActionCalculator.publicationDatesToBeStopped(
       HolidayStopRequest(
@@ -46,12 +46,12 @@ class ActionCalculatorTest extends FlatSpec with Matchers {
         gwProductName
       )
     ) shouldEqual List(
-      new LocalDate(2019, 5, 24),
-      new LocalDate(2019, 5, 31),
-      new LocalDate(2019, 6, 7),
-      new LocalDate(2019, 6, 14),
-      new LocalDate(2019, 6, 21)
-    )
+        new LocalDate(2019, 5, 24),
+        new LocalDate(2019, 5, 31),
+        new LocalDate(2019, 6, 7),
+        new LocalDate(2019, 6, 14),
+        new LocalDate(2019, 6, 21)
+      )
 
   }
 

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -51,8 +51,8 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
       )
       processedResult <- processOp(HolidayStopRequestActionedZuoraRef(
         Holiday_Stop_Request__c = createResult,
-        HolidayStopRequestActionedZuoraAmendmentCode("AM1234567"),
-        HolidayStopRequestActionedZuoraAmendmentPrice(-12.34),
+        HolidayStopRequestActionedZuoraChargeCode("C-1234567"),
+        HolidayStopRequestActionedZuoraChargePrice(-12.34),
         StoppedPublicationDate(Time.toJavaDate(LocalDate.now))
       )).toDisjunction
 

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -6,6 +6,7 @@ import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef._
 import com.gu.test.EffectsTest
+import com.gu.util.Time
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.resthttp.JsonHttp
 import org.joda.time.LocalDate
@@ -51,7 +52,8 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
       processedResult <- processOp(HolidayStopRequestActionedZuoraRef(
         Holiday_Stop_Request__c = createResult,
         HolidayStopRequestActionedZuoraAmendmentCode("AM1234567"),
-        HolidayStopRequestActionedZuoraAmendmentPrice(-12.34)
+        HolidayStopRequestActionedZuoraAmendmentPrice(-12.34),
+        StoppedPublicationDate(Time.toJavaDate(LocalDate.now))
       )).toDisjunction
 
       postProcessingFetchResult <- fetchOp(lookupDate, productName).toDisjunction

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -40,7 +40,7 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
       createResult <- createOp(NewHolidayStopRequest(
         startDate,
         endDate,
-        SubscriptionNameLookup(SubscriptionName("A-S00044269")) // must exist in DEV SalesForce
+        SubscriptionNameLookup(SubscriptionName("A-S00050817")) // must exist in DEV SalesForce
       )).toDisjunction
 
       fetchOp = SalesforceHolidayStopRequest.LookupByDateAndProductNamePrefix(sfAuth.wrapWith(JsonHttp.getWithParams))


### PR DESCRIPTION
Two changes:
* Now returning rate plan charge codes instead of amendment codes
* an extra field for the date of the stopped publication
