### PR TITLE
Recognise holiday-stop rate plan charges as duplicates if dates overlap

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
@@ -27,8 +27,12 @@ case class Subscription(
 
     def isMatchingCharge(charge: RatePlanCharge): Boolean =
       charge.name == "Holiday Credit" &&
-        charge.HolidayStart__c.contains(stop.stoppedPublicationDate) &&
-        charge.HolidayEnd__c.contains(stop.stoppedPublicationDate)
+        charge.HolidayStart__c.exists { start =>
+          start.isEqual(stop.stoppedPublicationDate) || start.isBefore(stop.stoppedPublicationDate)
+        } &&
+        charge.HolidayEnd__c.exists { end =>
+          end.isEqual(stop.stoppedPublicationDate) || end.isAfter(stop.stoppedPublicationDate)
+        }
 
     val charges = for {
       plan <- ratePlans if isMatchingPlan(plan)

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -17,7 +17,7 @@ object Fixtures {
     number = "C1",
     price,
     Some(billingPeriod),
-    effectiveStartDate = LocalDate.of(2019, 6, 10),
+    effectiveStartDate = LocalDate.of(2018, 6, 10),
     chargedThroughDate,
     HolidayStart__c = None,
     HolidayEnd__c = None
@@ -105,6 +105,19 @@ object Fixtures {
           chargedThroughDate = None,
           HolidayStart__c = Some(LocalDate.of(2019, 8, 2)),
           HolidayEnd__c = Some(LocalDate.of(2019, 8, 2))
+        ))
+      ),
+      RatePlan(
+        productName = "Discounts",
+        ratePlanCharges = Seq(RatePlanCharge(
+          name = "Holiday Credit",
+          number = "C987",
+          price = -4.92,
+          billingPeriod = None,
+          effectiveStartDate = LocalDate.of(2018, 11, 16),
+          chargedThroughDate = None,
+          HolidayStart__c = Some(LocalDate.of(2018, 11, 16)),
+          HolidayEnd__c = Some(LocalDate.of(2019, 1, 4))
         ))
       ),
       RatePlan(

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionTest.scala
@@ -64,4 +64,19 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
     val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 11))
     subscription.ratePlanCharge(stop) shouldBe None
   }
+
+  it should "give RatePlanCharge when dates overlap but don't match precisely" in {
+    val subscription = Fixtures.mkSubscriptionWithHolidayStops()
+    val stop = Fixtures.mkHolidayStop(LocalDate.of(2018, 12, 22))
+    subscription.ratePlanCharge(stop).value shouldBe RatePlanCharge(
+      name = "Holiday Credit",
+      number = "C987",
+      price = -4.92,
+      billingPeriod = None,
+      effectiveStartDate = LocalDate.of(2018, 11, 16),
+      chargedThroughDate = None,
+      HolidayStart__c = Some(LocalDate.of(2018, 11, 16)),
+      HolidayEnd__c = Some(LocalDate.of(2019, 1, 4))
+    )
+  }
 }


### PR DESCRIPTION
Previously holiday start and end dates had to match precisely to identify duplicates.  But this will fail if a holiday stop has already been applied manually and there's an attempt to add the same holiday stop automatically.  The rules for adding stops manually were slightly different and covered a range of dates rather than a single date.