### PR TITLE
 Enable fetching holiday-stop details from Salesforce

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
@@ -3,19 +3,19 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.holiday_stops.ActionCalculator
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId, ProductName, SubscriptionName}
 import com.gu.util.Time
 
 case class HolidayStop(
   requestId: HolidayStopRequestId,
-  subscriptionName: String,
+  subscriptionName: SubscriptionName,
   stoppedPublicationDate: LocalDate
 )
 
 object HolidayStop {
 
-  def holidayStopsToApply(getRequests: String => Either[OverallFailure, Seq[HolidayStopRequest]]): Either[OverallFailure, Seq[HolidayStop]] =
-    getRequests("Guardian Weekly") map {
+  def holidayStopsToApply(getRequests: ProductName => Either[OverallFailure, Seq[HolidayStopRequest]]): Either[OverallFailure, Seq[HolidayStop]] =
+    getRequests(ProductName("Guardian Weekly")) map {
       _ flatMap toHolidayStops
     }
 
@@ -23,7 +23,7 @@ object HolidayStop {
     ActionCalculator.publicationDatesToBeStopped(request) map { date =>
       HolidayStop(
         requestId = request.Id,
-        subscriptionName = request.Subscription_Name__c.value,
+        subscriptionName = request.Subscription_Name__c,
         stoppedPublicationDate = Time.toJavaDate(date)
       )
     }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -2,7 +2,7 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, ProductName, SubscriptionName}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraChargeCode, HolidayStopRequestActionedZuoraChargePrice, StoppedPublicationDate}
 
 object HolidayStopProcess {
@@ -20,8 +20,8 @@ object HolidayStopProcess {
 
   def processHolidayStops(
     config: Config,
-    getRequests: String => Either[OverallFailure, Seq[HolidayStopRequest]],
-    getSubscription: String => Either[HolidayStopFailure, Subscription],
+    getRequests: ProductName => Either[OverallFailure, Seq[HolidayStopRequest]],
+    getSubscription: SubscriptionName => Either[HolidayStopFailure, Subscription],
     updateSubscription: (Subscription, SubscriptionUpdate) => Either[HolidayStopFailure, Unit],
     exportAddedCharges: Seq[HolidayStopResponse] => Either[OverallFailure, Unit]
   ): ProcessResult = {
@@ -52,7 +52,7 @@ object HolidayStopProcess {
 
   def processHolidayStop(
     config: Config,
-    getSubscription: String => Either[HolidayStopFailure, Subscription],
+    getSubscription: SubscriptionName => Either[HolidayStopFailure, Subscription],
     updateSubscription: (Subscription, SubscriptionUpdate) => Either[HolidayStopFailure, Unit]
   )(stop: HolidayStop): Either[HolidayStopFailure, HolidayStopResponse] =
     for {

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
@@ -1,5 +1,6 @@
 package com.gu.holidaystopprocessor
 
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.SubscriptionName
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 import io.circe.generic.auto._
@@ -30,7 +31,7 @@ object Zuora {
     } yield token
   }
 
-  def subscriptionGetResponse(config: Config, accessToken: AccessToken)(subscriptionName: String): Either[HolidayStopFailure, Subscription] = {
+  def subscriptionGetResponse(config: Config, accessToken: AccessToken)(subscriptionName: SubscriptionName): Either[HolidayStopFailure, Subscription] = {
     val url = uri"${config.zuoraConfig.baseUrl}/subscriptions/$subscriptionName"
     val request = sttp.get(url)
       .header("Authorization", s"Bearer ${accessToken.access_token}")

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -145,7 +145,7 @@ object Fixtures {
 
   def mkHolidayStop(date: LocalDate) = HolidayStop(
     requestId = HolidayStopRequestId("R1"),
-    subscriptionName = "S1",
+    subscriptionName = SubscriptionName("S1"),
     stoppedPublicationDate = date
   )
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -3,7 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.holidaystopprocessor.Fixtures.{config, mkSubscription}
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId, ProductName, SubscriptionName}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraChargeCode, HolidayStopRequestActionedZuoraChargePrice, StoppedPublicationDate}
 import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
 
@@ -18,14 +18,14 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
 
   private val holidayStop = HolidayStop(
     HolidayStopRequestId("HSR1"),
-    "subscriptionName",
+    SubscriptionName("subscriptionName"),
     LocalDate.of(2019, 8, 9)
   )
 
-  private def getRequests(requestsGet: Either[OverallFailure, Seq[HolidayStopRequest]]): String => Either[OverallFailure, Seq[HolidayStopRequest]] =
+  private def getRequests(requestsGet: Either[OverallFailure, Seq[HolidayStopRequest]]): ProductName => Either[OverallFailure, Seq[HolidayStopRequest]] =
     _ => requestsGet
 
-  private def getSubscription(subscriptionGet: Either[HolidayStopFailure, Subscription]): String => Either[HolidayStopFailure, Subscription] = {
+  private def getSubscription(subscriptionGet: Either[HolidayStopFailure, Subscription]): SubscriptionName => Either[HolidayStopFailure, Subscription] = {
     _ => subscriptionGet
   }
 

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
@@ -4,13 +4,13 @@ import java.time.LocalDate
 
 import ai.x.play.json.Jsonx
 import com.gu.salesforce.SalesforceConstants._
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequestId
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequestId, ProductName, SubscriptionName}
 import com.gu.util.Logging
 import com.gu.util.resthttp.RestOp._
 import com.gu.util.resthttp.RestRequestMaker._
 import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.resthttp.{HttpOp, RestRequestMaker}
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsValue, Json, Reads}
 
 object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
 
@@ -42,4 +42,38 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
 
   }
 
+  case class HolidayStopRequestDetails(
+    subscriptionName: SubscriptionName,
+    chargeCode: HolidayStopRequestActionedZuoraChargeCode,
+    stoppedPublicationDate: StoppedPublicationDate
+  )
+  implicit val reads: Reads[HolidayStopRequestDetails] = { json =>
+    for {
+      subscriptionName <- (json \ "Holiday_Stop_Request__r" \ "Subscription_Name__c").validate[SubscriptionName]
+      chargeCode <- (json \ "Charge_Code__c").validate[HolidayStopRequestActionedZuoraChargeCode]
+      stoppedPublicationDate <- (json \ "Stopped_Publication_Date__c").validate[StoppedPublicationDate]
+    } yield HolidayStopRequestDetails(subscriptionName, chargeCode, stoppedPublicationDate)
+  }
+
+  private case class HolidayStopRequestActionedZuoraRefSearchQueryResponse(records: List[HolidayStopRequestDetails])
+  private implicit val readsIds = Json.reads[HolidayStopRequestActionedZuoraRefSearchQueryResponse]
+
+  object LookupByProductNamePrefixAndDateRange {
+
+    def apply(sfGet: HttpOp[RestRequestMaker.GetRequestWithParams, JsValue]): (ProductName, LocalDate, LocalDate) => ClientFailableOp[List[HolidayStopRequestDetails]] =
+      sfGet.setupRequestMultiArg(toRequest _).parse[HolidayStopRequestActionedZuoraRefSearchQueryResponse].map(_.records).runRequestMultiArg
+
+    def toRequest(productNamePrefix: ProductName, startThreshold: LocalDate, endThreshold: LocalDate): GetRequestWithParams = {
+      val soqlQuery =
+        s"""
+          |select Holiday_Stop_Request__r.Subscription_Name__c, Charge_Code__c, Stopped_Publication_Date__c
+          |from $holidayStopRequestActionedZuoraRefSfObjectRef
+          |where Holiday_Stop_Request__r.Product_Name__c LIKE '${productNamePrefix.value}%'
+          |and Stopped_Publication_Date__c >= ${startThreshold.toString}
+          |and Stopped_Publication_Date__c <= ${endThreshold.toString}
+        """.stripMargin
+      logger.info(s"using SF query : $soqlQuery")
+      RestRequestMaker.GetRequestWithParams(RelativePath(soqlQueryBaseUrl), UrlParams(Map("q" -> soqlQuery)))
+    }
+  }
 }


### PR DESCRIPTION
This will allow us to see what has already been written to Salesforce so that by comparing it with what's in Zuora we can see what needs to be backfilled.

The fetch method takes start and end threshold dates so that we can backfill in batches and then run on a schedule to pick up any holiday stops that have been manually applied in Zuora since a given date.

The data required for the comparison comes from across the holiday-stop table and the holiday-stop-zuora-action-refs table.  We need the subscription name and its child results.
