### PR TITLE
Kougios/417 add i movo contract salesforce data to the lake

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -485,13 +485,6 @@ Resources:
              "objectName": "CardExpiry"
             }
           RoleArn: !GetAtt [ TriggerRole, Arn ]
-        - Arn: !Ref StateMachine
-          Id: !Sub trigger_sf_export-ImovoContract-${Stage}
-          Input: |
-            {
-             "objectName": "ImovoContract"
-            }
-          RoleArn: !GetAtt [ TriggerRole, Arn ]
   ScheduleRule2:
     Type: "AWS::Events::Rule"
     Condition: IsProd
@@ -538,5 +531,20 @@ Resources:
           Input: |
             {
              "objectName": "CancellationSurvey"
+            }
+          RoleArn: !GetAtt [ TriggerRole, Arn ]
+  ScheduleRule3:
+    Type: "AWS::Events::Rule"
+    Condition: IsProd
+    Properties:
+      Description: "trigger salesforce export every day at 01:00 GMT"
+      ScheduleExpression: "cron(0 1 ? * * *)"
+      State: "ENABLED"
+      Targets:
+        - Arn: !Ref StateMachine
+          Id: !Sub trigger_sf_export-ImovoContract-${Stage}
+          Input: |
+            {
+             "objectName": "ImovoContract"
             }
           RoleArn: !GetAtt [ TriggerRole, Arn ]

--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -485,6 +485,13 @@ Resources:
              "objectName": "CardExpiry"
             }
           RoleArn: !GetAtt [ TriggerRole, Arn ]
+        - Arn: !Ref StateMachine
+          Id: !Sub trigger_sf_export-ImovoContract-${Stage}
+          Input: |
+            {
+             "objectName": "ImovoContract"
+            }
+          RoleArn: !GetAtt [ TriggerRole, Arn ]
   ScheduleRule2:
     Type: "AWS::Events::Rule"
     Condition: IsProd

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndToEndManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndToEndManualTest.scala
@@ -2,28 +2,48 @@ package com.manual_test
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
-import com.gu.sf_datalake_export.handlers.GetBatchesHandler
+import com.gu.sf_datalake_export.handlers.{GetBatchesHandler, StartJobHandler}
+import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams
+import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.SfQueryInfo
 import play.api.libs.json._
 
 object EndToEndManualTest extends App {
+
+  case class Job(jobId: String, jobName: String, objectName: String, uploadToDataLake: Boolean)
 
   case class Batch(batchId: String, state: String)
 
   case class Batches(jobId: String, jobName: String, objectName: String, jobStatus: String, batches: Seq[Batch])
 
+  implicit val jobFormat = Json.format[Job]
   implicit val batchFormat = Json.format[Batch]
   implicit val batchesWrites = Json.format[Batches]
 
+  val job = startJob(BulkApiParams.contact)
+  msg(job)
+  val batches = getBatches(job)
+  msg(batches)
 
-  def getBatches = {
+  def startJob(sfObject: SfQueryInfo): Job = {
+
     val request =
-      """{
-        |"jobId" : "7503E0000063jW3QAI",
-        |"jobName" : "Contact_2019-06-30",
-        |"objectName" : "Contact",
-        |"uploadToDataLake" : false
-        |}
-      """.stripMargin
+      s"""{
+         |"objectName" : "${sfObject.objectName.value}"
+         |}
+    """.stripMargin
+
+    println(s"sending request..")
+    println(request)
+
+    val testInputStream = new ByteArrayInputStream(request.getBytes)
+    val testOutput = new ByteArrayOutputStream()
+    StartJobHandler(testInputStream, testOutput, null)
+
+    Json.parse(testOutput.toByteArray).as[Job]
+  }
+
+  def getBatches(job: Job) = {
+    val request = Json.prettyPrint(Json.toJson(job))
 
     println(s"sending request..")
     println(request)
@@ -33,5 +53,14 @@ object EndToEndManualTest extends App {
     GetBatchesHandler(testInputStream, testOutput, null)
 
     Json.parse(testOutput.toByteArray).as[Batches]
+  }
+
+  def msg(s: Any): Unit = {
+    println(
+      s"""
+         |----------------------------------------------------------------------
+         |$s
+         |----------------------------------------------------------------------
+      """.stripMargin)
   }
 }

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndToEndManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndToEndManualTest.scala
@@ -13,7 +13,9 @@ object EndToEndManualTest extends App {
 
   case class Batch(batchId: String, state: String)
 
-  case class Batches(jobId: String, jobName: String, objectName: String, jobStatus: String, batches: Seq[Batch])
+  case class Batches(jobId: String, jobName: String, objectName: String, jobStatus: String, batches: Seq[Batch]) {
+    def isCompleted = jobStatus == "Completed"
+  }
 
   implicit val jobFormat = Json.format[Job]
   implicit val batchFormat = Json.format[Batch]
@@ -21,7 +23,7 @@ object EndToEndManualTest extends App {
 
   val job = startJob(BulkApiParams.contact)
   msg(job)
-  val batches = getBatches(job)
+  val batches = waitBatchesToComplete(job)
   msg(batches)
 
   def startJob(sfObject: SfQueryInfo): Job = {
@@ -32,24 +34,29 @@ object EndToEndManualTest extends App {
          |}
     """.stripMargin
 
-    println(s"sending request..")
-    println(request)
-
     val testInputStream = new ByteArrayInputStream(request.getBytes)
-    val testOutput = new ByteArrayOutputStream()
+    val testOutput = new ByteArrayOutputStream
     StartJobHandler(testInputStream, testOutput, null)
 
     Json.parse(testOutput.toByteArray).as[Job]
   }
 
+  def waitBatchesToComplete(job: Job): Batches = {
+    val batches = getBatches(job)
+
+    if (batches.isCompleted) batches else {
+      println("Batches not complete: " + batches)
+
+      Thread.sleep(2000)
+      waitBatchesToComplete(job)
+    }
+  }
+
   def getBatches(job: Job) = {
     val request = Json.prettyPrint(Json.toJson(job))
 
-    println(s"sending request..")
-    println(request)
-
     val testInputStream = new ByteArrayInputStream(request.getBytes)
-    val testOutput = new ByteArrayOutputStream()
+    val testOutput = new ByteArrayOutputStream
     GetBatchesHandler(testInputStream, testOutput, null)
 
     Json.parse(testOutput.toByteArray).as[Batches]

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndToEndManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndToEndManualTest.scala
@@ -1,0 +1,37 @@
+package com.manual_test
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+import com.gu.sf_datalake_export.handlers.GetBatchesHandler
+import play.api.libs.json._
+
+object EndToEndManualTest extends App {
+
+  case class Batch(batchId: String, state: String)
+
+  case class Batches(jobId: String, jobName: String, objectName: String, jobStatus: String, batches: Seq[Batch])
+
+  implicit val batchFormat = Json.format[Batch]
+  implicit val batchesWrites = Json.format[Batches]
+
+
+  def getBatches = {
+    val request =
+      """{
+        |"jobId" : "7503E0000063jW3QAI",
+        |"jobName" : "Contact_2019-06-30",
+        |"objectName" : "Contact",
+        |"uploadToDataLake" : false
+        |}
+      """.stripMargin
+
+    println(s"sending request..")
+    println(request)
+
+    val testInputStream = new ByteArrayInputStream(request.getBytes)
+    val testOutput = new ByteArrayOutputStream()
+    GetBatchesHandler(testInputStream, testOutput, null)
+
+    Json.parse(testOutput.toByteArray).as[Batches]
+  }
+}

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/StartJobManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/StartJobManualTest.scala
@@ -1,15 +1,14 @@
-package manualTest
+package com.manual_test
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.gu.sf_datalake_export.handlers.StartJobHandler
-import com.gu.sf_datalake_export.salesforce_bulk_api.{BulkApiParams, SfQueries}
+import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams
 
 //This is just a way to locally run the lambda in dev
 object StartJobManualTest extends App {
 
   val sfObject = BulkApiParams.contact
-  val queryStr = sfObject.soql.value.replace("\n", " ")
 
   val request =
     s"""{


### PR DESCRIPTION
PR to download the imovo contract csv from salesforce.

The important changes are in cfn.yaml where I changed the statemachine to trigger the imovo-contract csv export too.

The other changes include EndToEndManualTest which is similar to other manual tests and does the whole salesforce-job --> wait ---> export csv to s3. I used that to get data.

I am not sure for the whole end to end wiring of this reg. bucket names.