### PR TITLE
Only export unique holiday-stop Zuora refs to Salesforce

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/HolidayStopDetail.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/HolidayStopDetail.scala
@@ -108,7 +108,7 @@ object SalesforceHolidayStop {
      * is actually the same as a Zuora ref recorded in Salesforce.
      */
     def isSame(z: ZuoraHolidayStop, sf: HolidayStopRequestDetails): Boolean =
-      z.subscriptionName == sf.subscriptionName.value &&
+      z.subscriptionName == sf.request.Subscription_Name__c.value &&
         z.chargeNumber == sf.chargeCode.value &&
         z.startDate == sf.stoppedPublicationDate.value
 
@@ -118,7 +118,7 @@ object SalesforceHolidayStop {
      * as in the first pass the parent holiday requests will have been populated.
      */
     val sfRequestIds = inSalesforce
-      .map { sfStop => (sfStop.subscriptionName, sfStop.stoppedPublicationDate) -> sfStop.requestId }
+      .map { sfStop => (sfStop.request.Subscription_Name__c, sfStop.stoppedPublicationDate) -> sfStop.request.Id }
       .toMap
 
     stoppedPublications

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
@@ -14,7 +14,7 @@ case class HolidayStop(
 
 object HolidayStop {
 
-  def toHolidayStop(request: HolidayStopRequest): Seq[HolidayStop] =
+  def apply(request: HolidayStopRequest): Seq[HolidayStop] =
     ActionCalculator.publicationDatesToBeStopped(request) map { date =>
       HolidayStop(
         requestId = request.Id,

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStop.scala
@@ -14,12 +14,7 @@ case class HolidayStop(
 
 object HolidayStop {
 
-  def holidayStopsToApply(getRequests: String => Either[OverallFailure, Seq[HolidayStopRequest]]): Either[OverallFailure, Seq[HolidayStop]] =
-    getRequests("Guardian Weekly") map {
-      _ flatMap toHolidayStops
-    }
-
-  private def toHolidayStops(request: HolidayStopRequest): Seq[HolidayStop] =
+  def toHolidayStop(request: HolidayStopRequest): Seq[HolidayStop] =
     ActionCalculator.publicationDatesToBeStopped(request) map { date =>
       HolidayStop(
         requestId = request.Id,

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -27,7 +27,7 @@ object HolidayStopProcess {
   ): ProcessResult = {
     val result = for {
       requests <- getRequests(ProductName("Guardian Weekly"))
-      holidayStops <- Right(requests.map(_.request).distinct.flatMap(HolidayStop.toHolidayStop))
+      holidayStops <- Right(requests.map(_.request).distinct.flatMap(HolidayStop(_)))
       alreadyExportedChargeCodes <- Right(requests.map(_.chargeCode).distinct)
     } yield {
       val responses = holidayStops map {

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
@@ -3,9 +3,10 @@ package com.gu.holidaystopprocessor
 case class ProcessResult(
   holidayStopsToApply: Seq[HolidayStop],
   holidayStopResults: Seq[Either[HolidayStopFailure, HolidayStopResponse]],
+  resultsToExport: Seq[HolidayStopResponse],
   overallFailure: Option[OverallFailure]
 )
 
 object ProcessResult {
-  def fromOverallFailure(failure: OverallFailure) = ProcessResult(Nil, Nil, Some(failure))
+  def fromOverallFailure(failure: OverallFailure) = ProcessResult(Nil, Nil, Nil, Some(failure))
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -1,14 +1,15 @@
 package com.gu.holidaystopprocessor
 
+import java.time.LocalDate
+
 import com.gu.effects.RawEffects
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.SalesforceClient
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.ProductName
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef._
 import com.gu.util.resthttp.JsonHttp
 import com.gu.util.resthttp.Types.ClientFailableOp
-import org.joda.time.LocalDate
 import play.api.libs.json.JsValue
 import scalaz.{-\/, \/-}
 
@@ -16,14 +17,14 @@ object Salesforce {
 
   private def thresholdDate: LocalDate = LocalDate.now.plusDays(Config.daysInAdvance)
 
-  def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: String): Either[OverallFailure, Seq[HolidayStopRequest]] =
+  def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName): Either[OverallFailure, Seq[HolidayStopRequestDetails]] =
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>
       val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
-      val fetchOp = SalesforceHolidayStopRequest.LookupByDateAndProductNamePrefix(sfGet)
-      fetchOp(thresholdDate, SalesforceHolidayStopRequest.ProductName(productNamePrefix))
+      val fetchOp = SalesforceHolidayStopRequestActionedZuoraRef.LookupByProductNamePrefixAndDate(sfGet)
+      fetchOp(productNamePrefix, thresholdDate)
     }.toDisjunction match {
       case -\/(failure) => Left(OverallFailure(failure.toString))
-      case \/-(requests) => Right(requests)
+      case \/-(details) => Right(details)
     }
 
   def holidayStopUpdateResponse(sfCredentials: SFAuthConfig)(responses: Seq[HolidayStopResponse]): Either[OverallFailure, Unit] = {

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraChargeCode, HolidayStopRequestDetails, StoppedPublicationDate}
 import com.gu.util.Time
 
 object Fixtures {
@@ -141,6 +142,12 @@ object Fixtures {
     Actioned_Count__c = HolidayStopRequestActionedCount(3),
     Subscription_Name__c = SubscriptionName("subName"),
     Product_Name__c = ProductName("Guardian Weekly")
+  )
+
+  def mkHolidayStopRequestDetails(request: HolidayStopRequest, chargeCode: String) = HolidayStopRequestDetails(
+    request,
+    chargeCode = HolidayStopRequestActionedZuoraChargeCode(chargeCode),
+    stoppedPublicationDate = StoppedPublicationDate(Time.toJavaDate(request.Start_Date__c.value))
   )
 
   def mkHolidayStop(date: LocalDate) = HolidayStop(

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 import ai.x.play.json.Jsonx
 import com.gu.salesforce.SalesforceConstants._
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequestId, ProductName, SubscriptionName}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestId, ProductName}
 import com.gu.util.Logging
 import com.gu.util.resthttp.RestOp._
 import com.gu.util.resthttp.RestRequestMaker._
@@ -43,22 +43,42 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
   }
 
   case class HolidayStopRequestDetails(
-    requestId: HolidayStopRequestId,
-    subscriptionName: SubscriptionName,
+    request: HolidayStopRequest,
     chargeCode: HolidayStopRequestActionedZuoraChargeCode,
     stoppedPublicationDate: StoppedPublicationDate
   )
   implicit val reads: Reads[HolidayStopRequestDetails] = { json =>
     for {
-      requestId <- (json \ "Holiday_Stop_Request__r" \ "Id").validate[HolidayStopRequestId]
-      subscriptionName <- (json \ "Holiday_Stop_Request__r" \ "Subscription_Name__c").validate[SubscriptionName]
+      request <- (json \ "Holiday_Stop_Request__r").validate[HolidayStopRequest]
       chargeCode <- (json \ "Charge_Code__c").validate[HolidayStopRequestActionedZuoraChargeCode]
       stoppedPublicationDate <- (json \ "Stopped_Publication_Date__c").validate[StoppedPublicationDate]
-    } yield HolidayStopRequestDetails(requestId, subscriptionName, chargeCode, stoppedPublicationDate)
+    } yield HolidayStopRequestDetails(request, chargeCode, stoppedPublicationDate)
   }
 
   private case class HolidayStopRequestActionedZuoraRefSearchQueryResponse(records: List[HolidayStopRequestDetails])
   private implicit val readsIds = Json.reads[HolidayStopRequestActionedZuoraRefSearchQueryResponse]
+
+  object LookupByProductNamePrefixAndDate {
+
+    def apply(sfGet: HttpOp[RestRequestMaker.GetRequestWithParams, JsValue]): (ProductName, LocalDate) => ClientFailableOp[List[HolidayStopRequestDetails]] =
+      sfGet.setupRequestMultiArg(toRequest _).parse[HolidayStopRequestActionedZuoraRefSearchQueryResponse].map(_.records).runRequestMultiArg
+
+    def toRequest(productNamePrefix: ProductName, date: LocalDate): GetRequestWithParams = {
+      val soqlQuery =
+        s"""
+          |select Holiday_Stop_Request__r.Id, Holiday_Stop_Request__r.Start_Date__c,
+          |  Holiday_Stop_Request__r.End_Date__c, Holiday_Stop_Request__r.Actioned_Count__c,
+          |  Holiday_Stop_Request__r.Subscription_Name__c, Holiday_Stop_Request__r.Product_Name__c,
+          |  Charge_Code__c, Stopped_Publication_Date__c
+          |from $holidayStopRequestActionedZuoraRefSfObjectRef
+          |where Holiday_Stop_Request__r.Product_Name__c LIKE '${productNamePrefix.value}%'
+          |and Holiday_Stop_Request__r.Start_Date__c >= ${date.toString}
+          |and Holiday_Stop_Request__r.Start_Date__c <= ${date.toString}
+        """.stripMargin
+      logger.info(s"using SF query : $soqlQuery")
+      RestRequestMaker.GetRequestWithParams(RelativePath(soqlQueryBaseUrl), UrlParams(Map("q" -> soqlQuery)))
+    }
+  }
 
   object LookupByProductNamePrefixAndDateRange {
 
@@ -68,7 +88,9 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
     def toRequest(productNamePrefix: ProductName, startThreshold: LocalDate, endThreshold: LocalDate): GetRequestWithParams = {
       val soqlQuery =
         s"""
-          |select Holiday_Stop_Request__r.Id, Holiday_Stop_Request__r.Subscription_Name__c,
+          |select Holiday_Stop_Request__r.Id, Holiday_Stop_Request__r.Start_Date__c,
+          |  Holiday_Stop_Request__r.End_Date__c, Holiday_Stop_Request__r.Actioned_Count__c,
+          |  Holiday_Stop_Request__r.Subscription_Name__c, Holiday_Stop_Request__r.Product_Name__c,
           |  Charge_Code__c, Stopped_Publication_Date__c
           |from $holidayStopRequestActionedZuoraRefSfObjectRef
           |where Holiday_Stop_Request__r.Product_Name__c LIKE '${productNamePrefix.value}%'

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
@@ -16,6 +16,14 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
 
   private val holidayStopRequestActionedZuoraRefSfObjectRef = "Holiday_Stop_Request_Actioned_Zuora_Ref__c"
 
+  val baseQuery = s"""
+    |SELECT Holiday_Stop_Request__r.Id, Holiday_Stop_Request__r.Start_Date__c,
+    |  Holiday_Stop_Request__r.End_Date__c, Holiday_Stop_Request__r.Actioned_Count__c,
+    |  Holiday_Stop_Request__r.Subscription_Name__c, Holiday_Stop_Request__r.Product_Name__c,
+    |  Charge_Code__c, Stopped_Publication_Date__c
+    |FROM $holidayStopRequestActionedZuoraRefSfObjectRef
+    |""".stripMargin
+
   case class HolidayStopRequestActionedZuoraChargeCode(value: String) extends AnyVal
   implicit val formatHolidayStopRequestActionedZuoraChargeCode = Jsonx.formatInline[HolidayStopRequestActionedZuoraChargeCode]
 
@@ -64,17 +72,12 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
       sfGet.setupRequestMultiArg(toRequest _).parse[HolidayStopRequestActionedZuoraRefSearchQueryResponse].map(_.records).runRequestMultiArg
 
     def toRequest(productNamePrefix: ProductName, date: LocalDate): GetRequestWithParams = {
-      val soqlQuery =
-        s"""
-          |select Holiday_Stop_Request__r.Id, Holiday_Stop_Request__r.Start_Date__c,
-          |  Holiday_Stop_Request__r.End_Date__c, Holiday_Stop_Request__r.Actioned_Count__c,
-          |  Holiday_Stop_Request__r.Subscription_Name__c, Holiday_Stop_Request__r.Product_Name__c,
-          |  Charge_Code__c, Stopped_Publication_Date__c
-          |from $holidayStopRequestActionedZuoraRefSfObjectRef
-          |where Holiday_Stop_Request__r.Product_Name__c LIKE '${productNamePrefix.value}%'
-          |and Holiday_Stop_Request__r.Start_Date__c <= ${date.toString}
-          |and Holiday_Stop_Request__r.End_Date__c >= ${date.toString}
-        """.stripMargin
+      val soqlQuery = s"""
+        |$baseQuery
+        |WHERE Holiday_Stop_Request__r.Product_Name__c LIKE '${productNamePrefix.value}%'
+        |AND Holiday_Stop_Request__r.Start_Date__c <= ${date.toString}
+        |AND Holiday_Stop_Request__r.End_Date__c >= ${date.toString}
+        |""".stripMargin
       logger.info(s"using SF query : $soqlQuery")
       RestRequestMaker.GetRequestWithParams(RelativePath(soqlQueryBaseUrl), UrlParams(Map("q" -> soqlQuery)))
     }
@@ -86,17 +89,12 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
       sfGet.setupRequestMultiArg(toRequest _).parse[HolidayStopRequestActionedZuoraRefSearchQueryResponse].map(_.records).runRequestMultiArg
 
     def toRequest(productNamePrefix: ProductName, startThreshold: LocalDate, endThreshold: LocalDate): GetRequestWithParams = {
-      val soqlQuery =
-        s"""
-          |select Holiday_Stop_Request__r.Id, Holiday_Stop_Request__r.Start_Date__c,
-          |  Holiday_Stop_Request__r.End_Date__c, Holiday_Stop_Request__r.Actioned_Count__c,
-          |  Holiday_Stop_Request__r.Subscription_Name__c, Holiday_Stop_Request__r.Product_Name__c,
-          |  Charge_Code__c, Stopped_Publication_Date__c
-          |from $holidayStopRequestActionedZuoraRefSfObjectRef
-          |where Holiday_Stop_Request__r.Product_Name__c LIKE '${productNamePrefix.value}%'
-          |and Stopped_Publication_Date__c >= ${startThreshold.toString}
-          |and Stopped_Publication_Date__c <= ${endThreshold.toString}
-        """.stripMargin
+      val soqlQuery = s"""
+        |$baseQuery
+        |WHERE Holiday_Stop_Request__r.Product_Name__c LIKE '${productNamePrefix.value}%'
+        |AND Stopped_Publication_Date__c >= ${startThreshold.toString}
+        |AND Stopped_Publication_Date__c <= ${endThreshold.toString}
+        |""".stripMargin
       logger.info(s"using SF query : $soqlQuery")
       RestRequestMaker.GetRequestWithParams(RelativePath(soqlQueryBaseUrl), UrlParams(Map("q" -> soqlQuery)))
     }

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestActionedZuoraRef.scala
@@ -72,8 +72,8 @@ object SalesforceHolidayStopRequestActionedZuoraRef extends Logging {
           |  Charge_Code__c, Stopped_Publication_Date__c
           |from $holidayStopRequestActionedZuoraRefSfObjectRef
           |where Holiday_Stop_Request__r.Product_Name__c LIKE '${productNamePrefix.value}%'
-          |and Holiday_Stop_Request__r.Start_Date__c >= ${date.toString}
           |and Holiday_Stop_Request__r.Start_Date__c <= ${date.toString}
+          |and Holiday_Stop_Request__r.End_Date__c >= ${date.toString}
         """.stripMargin
       logger.info(s"using SF query : $soqlQuery")
       RestRequestMaker.GetRequestWithParams(RelativePath(soqlQueryBaseUrl), UrlParams(Map("q" -> soqlQuery)))


### PR DESCRIPTION
Currently if the holiday-stop processor is run twice the same result set from Zuora will be exported to Salesforce so there will be a duplicate set of Zuora refs for every stop request in Salesforce.

This change should stop that from happening by fetching the pre-existing Zuora refs with each holiday request from Salesforce.  This way the processor can inspect and dedup the Zuora refs before exporting them to Salesforce.
