### PR TITLE
Fetch Holiday-stop requests from Salesforce with outer join

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -28,7 +28,7 @@ object HolidayStopProcess {
     val result = for {
       requests <- getRequests(ProductName("Guardian Weekly"))
       holidayStops <- Right(requests.map(_.request).distinct.flatMap(HolidayStop(_)))
-      alreadyExportedChargeCodes <- Right(requests.map(_.chargeCode).distinct)
+      alreadyExportedChargeCodes <- Right(requests.flatMap(_.zuoraRefs.getOrElse(Nil).map(_.chargeCode)).distinct)
     } yield {
       val responses = holidayStops map {
         processHolidayStop(

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{HolidayStopRequestActionedZuoraChargeCode, HolidayStopRequestDetails, StoppedPublicationDate}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestActionedZuoraRef.{ZuoraRef, HolidayStopRequestActionedZuoraChargeCode, HolidayStopRequestDetails, StoppedPublicationDate}
 import com.gu.util.Time
 
 object Fixtures {
@@ -146,8 +146,10 @@ object Fixtures {
 
   def mkHolidayStopRequestDetails(request: HolidayStopRequest, chargeCode: String) = HolidayStopRequestDetails(
     request,
-    chargeCode = HolidayStopRequestActionedZuoraChargeCode(chargeCode),
-    stoppedPublicationDate = StoppedPublicationDate(Time.toJavaDate(request.Start_Date__c.value))
+    zuoraRefs = Some(Seq(ZuoraRef(
+      chargeCode = HolidayStopRequestActionedZuoraChargeCode(chargeCode),
+      stoppedPublicationDate = StoppedPublicationDate(Time.toJavaDate(request.Start_Date__c.value))
+    )))
   )
 
   def mkHolidayStop(date: LocalDate) = HolidayStop(

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -15,7 +15,7 @@ object SalesforceHolidayStopRequest extends Logging {
 
   val SALESFORCE_DATE_FORMAT = "yyyy-MM-dd"
 
-  private val holidayStopRequestSfObjectRef = "Holiday_Stop_Request__c"
+  val holidayStopRequestSfObjectRef = "Holiday_Stop_Request__c"
   private val holidayStopRequestSfObjectsBaseUrl = sfObjectsBaseUrl + holidayStopRequestSfObjectRef
 
   implicit val formatLocalDateAsSalesforceDate: Format[LocalDate] = new Format[LocalDate] {


### PR DESCRIPTION
This changes the model that we fetch from Salesforce so that it now looks like:
```
  case class HolidayStopRequestDetails(
    request: HolidayStopRequest,
    zuoraRefs: Option[Seq[ZuoraRef]]
  )
```

This fixes a bug I introduced in #341 where a holiday stop that had no existing Zuora refs would not be fetched from Salesforce to be processed.
