### PR TITLE
Log log4j messages through logback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val zuora = all(project in file("lib/zuora"))
     effects % "test->test"
   )
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, jacksonDatabind)
+    libraryDependencies ++= Seq(okhttp3, scalaz, playJson, scalatest, jacksonDatabind) ++ logging
   )
 
 lazy val salesforce = all(project in file("lib/salesforce"))
@@ -85,7 +85,7 @@ lazy val salesforce = all(project in file("lib/salesforce"))
     testDep
   )
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
+    libraryDependencies ++= Seq(okhttp3, scalaz, playJson, scalatest) ++ logging
   )
 
 lazy val `holiday-stops` = all(project in file("lib/holiday-stops"))
@@ -95,12 +95,12 @@ lazy val `holiday-stops` = all(project in file("lib/holiday-stops"))
     testDep
   )
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, playJsonExtensions)
+    libraryDependencies ++= Seq(okhttp3, scalaz, playJson, scalatest, playJsonExtensions) ++ logging
 )
 
 lazy val restHttp = all(project in file("lib/restHttp"))
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
+    libraryDependencies ++= Seq(okhttp3, scalaz, playJson, scalatest) ++ logging
   )
 
 lazy val s3ConfigValidator = all(project in file("lib/s3ConfigValidator"))
@@ -120,25 +120,25 @@ lazy val s3ConfigValidator = all(project in file("lib/s3ConfigValidator"))
 
 lazy val handler = all(project in file("lib/handler"))
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, awsLambda, awsS3)
+    libraryDependencies ++= Seq(okhttp3, scalaz, playJson, scalatest, awsLambda, awsS3) ++ logging
   )
 
 // to aid testability, only the actual handlers called as a lambda can depend on this
 lazy val effects = all(project in file("lib/effects"))
   .dependsOn(handler)
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, awsS3, jacksonDatabind)
+    libraryDependencies ++= Seq(okhttp3, scalaz, playJson, scalatest, awsS3, jacksonDatabind) ++ logging
   )
 lazy val `effects-sqs` = all(project in file("lib/effects-sqs"))
   .dependsOn(testDep)
   .settings(
-    libraryDependencies ++= Seq(logging, awsSQS)
+    libraryDependencies ++= Seq(awsSQS) ++ logging
   )
 
 lazy val `effects-ses` = all(project in file("lib/effects-ses"))
   .dependsOn(testDep)
   .settings(
-    libraryDependencies ++= Seq(logging, awsSES)
+    libraryDependencies ++= Seq(awsSES) ++ logging
   )
 
 val effectsDepIncludingTestFolder: ClasspathDependency = effects % "compile->compile;test->test"

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ val scalaSettings = Seq(
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard"
   ),
-  javaOptions in Test += s"""-Dlog4j.configuration=file:${new File(".").getCanonicalPath}/test_log4j.properties""",
+  
+  javaOptions in Test += s"""-Dlogback.configurationFile=${new File(".").getCanonicalPath}/logback-test.xml""",
   fork in Test := true,
   {
     import scalariform.formatter.preferences._

--- a/handlers/batch-email-sender/src/main/resources/log4j.properties
+++ b/handlers/batch-email-sender/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/batch-email-sender/src/main/resources/logback.xml
+++ b/handlers/batch-email-sender/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/batch-email-sender/src/main/resources/logback.xml
+++ b/handlers/batch-email-sender/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/cancellation-sf-cases/src/main/resources/log4j.properties
+++ b/handlers/cancellation-sf-cases/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/cancellation-sf-cases/src/main/resources/logback.xml
+++ b/handlers/cancellation-sf-cases/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/cancellation-sf-cases/src/main/resources/logback.xml
+++ b/handlers/cancellation-sf-cases/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/catalog-service/src/main/resources/log4j.properties
+++ b/handlers/catalog-service/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/catalog-service/src/main/resources/logback.xml
+++ b/handlers/catalog-service/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/catalog-service/src/main/resources/logback.xml
+++ b/handlers/catalog-service/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/digital-subscription-expiry/src/main/resources/log4j.properties
+++ b/handlers/digital-subscription-expiry/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/digital-subscription-expiry/src/main/resources/logback.xml
+++ b/handlers/digital-subscription-expiry/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/digital-subscription-expiry/src/main/resources/logback.xml
+++ b/handlers/digital-subscription-expiry/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/holiday-stop-processor/build.sbt
+++ b/handlers/holiday-stop-processor/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp" %% "circe" % sttpVersion,
   "io.circe" %% "circe-generic" % "0.11.1",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.566",
-  "org.slf4j" % "slf4j-api" % "1.7.25",
+  "org.slf4j" % "log4j-over-slf4j" % "1.7.26",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "org.scalatest" %% "scalatest" % "3.0.7" % Test,

--- a/handlers/holiday-stop-processor/build.sbt
+++ b/handlers/holiday-stop-processor/build.sbt
@@ -20,7 +20,6 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp" %% "circe" % sttpVersion,
   "io.circe" %% "circe-generic" % "0.11.1",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.566",
-  "org.slf4j" % "log4j-over-slf4j" % "1.7.26",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "org.scalatest" %% "scalatest" % "3.0.7" % Test,

--- a/handlers/identity-backfill/src/main/resources/log4j.properties
+++ b/handlers/identity-backfill/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/identity-backfill/src/main/resources/logback.xml
+++ b/handlers/identity-backfill/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/identity-backfill/src/main/resources/logback.xml
+++ b/handlers/identity-backfill/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/identity-retention/src/main/resources/log4j.properties
+++ b/handlers/identity-retention/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/identity-retention/src/main/resources/logback.xml
+++ b/handlers/identity-retention/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/identity-retention/src/main/resources/logback.xml
+++ b/handlers/identity-retention/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/new-product-api/src/main/resources/log4j.properties
+++ b/handlers/new-product-api/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/new-product-api/src/main/resources/logback.xml
+++ b/handlers/new-product-api/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/new-product-api/src/main/resources/logback.xml
+++ b/handlers/new-product-api/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/sf-contact-merge/src/main/resources/log4j.properties
+++ b/handlers/sf-contact-merge/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/sf-contact-merge/src/main/resources/logback.xml
+++ b/handlers/sf-contact-merge/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/sf-contact-merge/src/main/resources/logback.xml
+++ b/handlers/sf-contact-merge/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/sf-datalake-export/src/main/resources/log4j.properties
+++ b/handlers/sf-datalake-export/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/sf-datalake-export/src/main/resources/logback.xml
+++ b/handlers/sf-datalake-export/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/sf-datalake-export/src/main/resources/logback.xml
+++ b/handlers/sf-datalake-export/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/sf-gocardless-sync/src/main/resources/log4j.properties
+++ b/handlers/sf-gocardless-sync/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/sf-gocardless-sync/src/main/resources/logback.xml
+++ b/handlers/sf-gocardless-sync/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/sf-gocardless-sync/src/main/resources/logback.xml
+++ b/handlers/sf-gocardless-sync/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/handlers/zuora-retention/src/main/resources/log4j.properties
+++ b/handlers/zuora-retention/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/zuora-retention/src/main/resources/logback.xml
+++ b/handlers/zuora-retention/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/handlers/zuora-retention/src/main/resources/logback.xml
+++ b/handlers/zuora-retention/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/lib/effects-ses/src/main/scala/com/gu/effects/ses/AWSAsyncHandler.scala
+++ b/lib/effects-ses/src/main/scala/com/gu/effects/ses/AWSAsyncHandler.scala
@@ -4,14 +4,14 @@ import java.util.concurrent.{Future => JFuture}
 
 import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.{Future, Promise}
 
 class AwsAsyncHandler[Request <: AmazonWebServiceRequest, Response](f: (Request, AsyncHandler[Request, Response]) => JFuture[Response], request: Request)
   extends AsyncHandler[Request, Response] {
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LoggerFactory.getLogger(getClass)
 
   f(request, this)
 

--- a/lib/effects-ses/src/main/scala/com/gu/effects/ses/AwsSESSend.scala
+++ b/lib/effects-ses/src/main/scala/com/gu/effects/ses/AwsSESSend.scala
@@ -5,7 +5,7 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceAsyncClientBuilder
 import com.amazonaws.services.simpleemail.model._
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success}
 
 object AwsSESSend {
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LoggerFactory.getLogger(getClass)
 
   case class EmailAddress(value: String) extends AnyVal
 

--- a/lib/effects-sqs/src/main/scala/com/gu/effects/sqs/AWSAsyncHandler.scala
+++ b/lib/effects-sqs/src/main/scala/com/gu/effects/sqs/AWSAsyncHandler.scala
@@ -4,14 +4,14 @@ import java.util.concurrent.{Future => JFuture}
 
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.AmazonWebServiceRequest
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.{Future, Promise}
 
 class AwsAsyncHandler[Request <: AmazonWebServiceRequest, Response](f: (Request, AsyncHandler[Request, Response]) => JFuture[Response], request: Request)
   extends AsyncHandler[Request, Response] {
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LoggerFactory.getLogger(getClass)
 
   f(request, this)
 

--- a/lib/effects-sqs/src/main/scala/com/gu/effects/sqs/AwsSQSSend.scala
+++ b/lib/effects-sqs/src/main/scala/com/gu/effects/sqs/AwsSQSSend.scala
@@ -5,14 +5,15 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.sqs.{AmazonSQSAsync, AmazonSQSAsyncClientBuilder}
 import com.amazonaws.services.sqs.model.{SendMessageRequest, SendMessageResult}
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 object AwsSQSSend {
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LoggerFactory.getLogger(getClass)
 
   case class QueueName(value: String) extends AnyVal
 

--- a/lib/effects-sqs/src/test/scala/com/gu/effects/sqs/AWSSQSSendTest.scala
+++ b/lib/effects-sqs/src/test/scala/com/gu/effects/sqs/AWSSQSSendTest.scala
@@ -5,8 +5,8 @@ import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.gu.effects.sqs.AwsSQSSend.{Payload, QueueName}
 import com.gu.test.EffectsTest
-import org.apache.log4j.Logger
 import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Random, Success, Try}
@@ -33,7 +33,7 @@ class AWSSQSSendTest extends AsyncFlatSpec with Matchers {
 
 object SQSRead {
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LoggerFactory.getLogger(getClass)
 
   def apply(queueName: AwsSQSSend.QueueName): List[String] = {
     val sqsClient = AmazonSQSAsyncClientBuilder

--- a/lib/handler/src/main/scala/com/gu/util/Logging.scala
+++ b/lib/handler/src/main/scala/com/gu/util/Logging.scala
@@ -1,9 +1,9 @@
 package com.gu.util
 
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 trait Logging {
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LoggerFactory.getLogger(getClass)
 
 }

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/ClientFailableOpLogging.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/ClientFailableOpLogging.scala
@@ -1,11 +1,11 @@
 package com.gu.util.resthttp
 
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientFailure, ClientSuccess}
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 object ClientFailableOpLogging { // in future maybe put logging into a context so the messages stack together like a stack trace
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LoggerFactory.getLogger(getClass.getName)
 
   implicit class LogImplicit2[A](apiGatewayOp: ClientFailableOp[A]) {
 

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/Logging.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/Logging.scala
@@ -1,9 +1,9 @@
 package com.gu.util.resthttp
 
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 trait Logging { // in future maybe put logging into a context so the messages stack together like a stack trace
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LoggerFactory.getLogger(getClass)
 
 }

--- a/logback-test.xml
+++ b/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="A1" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-4r [%t] %-5p %c %x - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="A1"/>
+    </root>
+
+</configuration>

--- a/logback-test.xml
+++ b/logback-test.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="A1" class="ch.qos.logback.core.ConsoleAppender">

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val awsVersion = "1.11.574"
 
   val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.9.1"
-  val logging = "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0"
+  val logging = "org.slf4j" % "log4j-over-slf4j" % "1.7.26"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.18"
   val playJson = "com.typesafe.play" %% "play-json" % "2.6.9"
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.30.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,8 @@ object Dependencies {
   val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.9.1"
   val logging = Seq(
     ("com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0").exclude("log4j", "log4j"),
-    "org.slf4j" % "log4j-over-slf4j" % "1.7.26"
+    "org.slf4j" % "log4j-over-slf4j" % "1.7.26",
+    "ch.qos.logback" % "logback-classic" % "1.2.3"
   )
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.18"
   val playJson = "com.typesafe.play" %% "play-json" % "2.6.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,10 @@ object Dependencies {
   val awsVersion = "1.11.574"
 
   val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.9.1"
-  val logging = "org.slf4j" % "log4j-over-slf4j" % "1.7.26"
+  val logging = Seq(
+    ("com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0").exclude("log4j", "log4j"),
+    "org.slf4j" % "log4j-over-slf4j" % "1.7.26"
+  )
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.18"
   val playJson = "com.typesafe.play" %% "play-json" % "2.6.9"
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.30.1"

--- a/root.sbt
+++ b/root.sbt
@@ -12,6 +12,8 @@ riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Auto Cancel"
 addCommandAlias("dist", ";riffRaffArtifact")
 
 libraryDependencies ++= Seq(
+  ("com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0").exclude("log4j", "log4j"),
+  "org.slf4j" % "log4j-over-slf4j" % "1.7.26",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.squareup.okhttp3" % "okhttp" % "3.9.1",
   "org.scalaz" %% "scalaz-core" % "7.2.18",

--- a/root.sbt
+++ b/root.sbt
@@ -14,6 +14,7 @@ addCommandAlias("dist", ";riffRaffArtifact")
 libraryDependencies ++= Seq(
   ("com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0").exclude("log4j", "log4j"),
   "org.slf4j" % "log4j-over-slf4j" % "1.7.26",
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.squareup.okhttp3" % "okhttp" % "3.9.1",
   "org.scalaz" %% "scalaz-core" % "7.2.18",

--- a/root.sbt
+++ b/root.sbt
@@ -12,9 +12,7 @@ riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Auto Cancel"
 addCommandAlias("dist", ";riffRaffArtifact")
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "log4j" % "log4j" % "1.2.17",
   "com.squareup.okhttp3" % "okhttp" % "3.9.1",
   "org.scalaz" %% "scalaz-core" % "7.2.18",
   "com.typesafe.play" %% "play-json" % "2.6.9",

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log = .
-log4j.rootLogger = INFO, LAMBDA
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- For assistance related to logback-translator or configuration  -->
-<!-- files in general, please contact the logback user mailing list -->
-<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
-<!--                                                                -->
-<!-- For professional support please see                            -->
-<!--    http://www.qos.ch/shop/products/professionalSupport         -->
-<!--                                                                -->
 <configuration>
 
     <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For assistance related to logback-translator or configuration  -->
+<!-- files in general, please contact the logback user mailing list -->
+<!-- at http://www.qos.ch/mailman/listinfo/logback-user             -->
+<!--                                                                -->
+<!-- For professional support please see                            -->
+<!--    http://www.qos.ch/shop/products/professionalSupport         -->
+<!--                                                                -->
+<configuration>
+
+    <appender name="LAMBDA" class="com.amazonaws.services.lambda.runtime.log4j.LambdaAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LAMBDA"/>
+    </root>
+
+</configuration>

--- a/test_log4j.properties
+++ b/test_log4j.properties
@@ -1,9 +1,0 @@
-# Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=DEBUG, A1
-
-# A1 is set to be a ConsoleAppender.
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-
-# A1 uses PatternLayout.
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
This makes the logback configuration work correctly and avoids the warning message:
```
log4j:WARN No appenders could be found for logger (com.amazonaws.AmazonWebServiceClient).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```


[Difference between slf4j-log4j12 and log4j-over-slf4j:](https://stackoverflow.com/a/31044844/5205022)

> **log4j-over-slf4j**
> 
> Use this if your code or some libraries you are using uses Log4j directly, but you want to use a different SLF4J binding than Log4j. It will route the Log4j API calls to SLF4J to the binding you choose. You need to remove the Log4j library from your classpath and replace it with this dependency.