### PR TITLE
Make holiday-stop backfiller stage configurable

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Backfiller.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Backfiller.scala
@@ -13,9 +13,9 @@ object Backfiller {
    * If any call fails it should leave Salesforce in a consistent state.
    * First, the holiday request table is updated, and then the zuora refs child table.
    */
-  def backfill(src: File, startThreshold: LocalDate, endThreshold: Option[LocalDate], dryRun: Boolean): Either[BackfillFailure, BackfillResult] = {
+  def backfill(src: File, startThreshold: LocalDate, endThreshold: Option[LocalDate], dryRun: Boolean, stage: String): Either[BackfillFailure, BackfillResult] = {
     for {
-      config <- Config()
+      config <- Config(stage)
       stopsInZuora <- Right(holidayStopsAlreadyInZuora(src))
       requestsInSf <- holidayStopRequestsAlreadyInSalesforce(config)(startThreshold, endThreshold)
       requestsToAddToSf = holidayStopRequestsToBeBackfilled(stopsInZuora, requestsInSf)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/BackfillingApp.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/BackfillingApp.scala
@@ -18,6 +18,7 @@ import java.time.LocalDate
  *     <li>Credit price.</ol></li>
  *   <li>Earliest date of start of holiday-stops to find.</li>
  *   <li>Latest date of end of holiday-stops to find.</li>
+ *   <li>Salesforce stage to backfill.  Defaults to DEV.</li>
  * </ol>
  * </p>
  */
@@ -27,8 +28,9 @@ object BackfillingApp extends App {
   val src = new File(args(1))
   val start = LocalDate.parse(args(2))
   val end = args.lift(3).map(LocalDate.parse)
+  val stage = args.lift(4).getOrElse("DEV")
 
-  Backfiller.backfill(src, start, end, dryRun) match {
+  Backfiller.backfill(src, start, end, dryRun, stage) match {
     case Left(failure) => println(s"Failed: $failure")
     case Right(result) =>
       println("Success!")

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Config.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Config.scala
@@ -20,11 +20,9 @@ object Config {
       else
         s"membership/support-service-lambdas/$stage/sfAuth-$stage.v1.json"
     val builder =
-      if (stage == "DEV")
-        AmazonS3Client.builder
-          .withCredentials(new ProfileCredentialsProvider(profileName))
-          .withRegion(EU_WEST_1)
-      else AmazonS3Client.builder
+      AmazonS3Client.builder
+        .withCredentials(new ProfileCredentialsProvider(profileName))
+        .withRegion(EU_WEST_1)
     val inputStream =
       builder.build().getObject(bucketName, key).getObjectContent
     val rawJson = Source.fromInputStream(inputStream).mkString
@@ -33,10 +31,5 @@ object Config {
     }
   }
 
-  def apply(): Either[ConfigFailure, SFAuthConfig] = {
-    val stage = Option(System.getenv("Stage")).getOrElse("DEV")
-    for {
-      sfConfig <- salesforceCredentials(stage)
-    } yield sfConfig
-  }
+  def apply(stage: String): Either[ConfigFailure, SFAuthConfig] = salesforceCredentials(stage)
 }


### PR DESCRIPTION
As the backfilling script is only designed to run on a dev machine it makes sense to make the staging environment it's going to backfill configurable.

(The script will need to amended once the holiday stop model has changed in Salesforce.)
