### PR TITLE
Use sttp out-of-the-box deserialiser response(asJson[T])

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Zuora.scala
@@ -4,60 +4,49 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.Subsc
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 import io.circe.generic.auto._
-import io.circe.parser._
 
 object Zuora {
 
   implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
 
-  private def normalised[E <: io.circe.Error, R](
-    body: String, result: String => Either[E, R]
-  ): Either[String, R] =
-    result(body).left.map(e => s"Failed to decode '$body': ${e.toString}")
-
   def accessTokenGetResponse(config: ZuoraConfig): Either[OverallFailure, AccessToken] = {
-    val authBaseUrl = config.baseUrl.stripSuffix("/v1")
-    val url = uri"$authBaseUrl/oauth/token"
-    val request = sttp.post(url)
+    sttp.post(uri"${config.baseUrl.stripSuffix("/v1")}/oauth/token")
       .body(
         "grant_type" -> "client_credentials",
         "client_id" -> s"${config.holidayStopProcessor.oauth.clientId}",
         "client_secret" -> s"${config.holidayStopProcessor.oauth.clientSecret}"
       )
-    val response = request.send()
-    for {
-      body <- response.body.left.map(OverallFailure)
-      token <- normalised(body, decode[AccessToken]).left.map(OverallFailure)
-    } yield token
+      .response(asJson[AccessToken])
+      .mapResponse(_.left.map(e => OverallFailure(e.message)))
+      .send()
+      .body.left.map(OverallFailure)
+      .joinRight
   }
 
   def subscriptionGetResponse(config: Config, accessToken: AccessToken)(subscriptionName: SubscriptionName): Either[HolidayStopFailure, Subscription] = {
-    val url = uri"${config.zuoraConfig.baseUrl}/subscriptions/${subscriptionName.value}"
-    val request = sttp.get(url)
+    sttp.get(uri"${config.zuoraConfig.baseUrl}/subscriptions/${subscriptionName.value}")
       .header("Authorization", s"Bearer ${accessToken.access_token}")
-    val response = request.send()
-    for {
-      body <- response.body.left.map(HolidayStopFailure)
-      subscription <- normalised(body, decode[Subscription]).left.map(HolidayStopFailure)
-    } yield subscription
+      .response(asJson[Subscription])
+      .mapResponse(_.left.map(e => HolidayStopFailure(e.message)))
+      .send()
+      .body.left.map(HolidayStopFailure)
+      .joinRight
   }
 
   def subscriptionUpdateResponse(config: Config, accessToken: AccessToken)(subscription: Subscription, update: SubscriptionUpdate): Either[HolidayStopFailure, Unit] = {
-    val url = uri"${config.zuoraConfig.baseUrl}/subscriptions/${subscription.subscriptionNumber}"
-    val request = sttp.put(url)
+    val errMsg = (reason: String) => s"Failed to update subscription '${subscription.subscriptionNumber}' with $update. Reason: $reason"
+    sttp.put(uri"${config.zuoraConfig.baseUrl}/subscriptions/${subscription.subscriptionNumber}")
       .header("Authorization", s"Bearer ${accessToken.access_token}")
       .body(update)
-    val response = request.send()
-    response.body.left map { e => HolidayStopFailure(e) } flatMap { body =>
-      def failureMsg(wrappedMsg: String) =
-        s"Update '$update' to subscription '${subscription.subscriptionNumber}' failed: $wrappedMsg"
-      normalised(body, decode[ZuoraStatusResponse]) match {
-        case Left(e) => Left(HolidayStopFailure(failureMsg(e)))
+      .response(asJson[ZuoraStatusResponse])
+      .mapResponse {
+        case Left(e) => Left(HolidayStopFailure(errMsg(e.message)))
         case Right(status) =>
-          if (!status.success)
-            Left(HolidayStopFailure(failureMsg(status.reasons.map(_.mkString).getOrElse(""))))
-          else Right(())
+          if (status.success) Right(())
+          else Left(HolidayStopFailure(errMsg(status.reasons.map(_.mkString).getOrElse(""))))
       }
-    }
+      .send()
+      .body.left.map(reason => HolidayStopFailure(errMsg(reason)))
+      .joinRight
   }
 }


### PR DESCRIPTION
This PR tries to handle the following [return type of sttp](https://sttp.readthedocs.io/en/latest/responses/basics.html#obtaining-the-response-body)

``` 
Either[String, Either[DeserializationError[Error], T]]
```

by converting it to

```
Either[A, Either[A, T]]
```

and finally

```
Either[A, T]
```

using out-of-the-box APIs, namely

* [`response(asJson[T])`](https://sttp.readthedocs.io/en/latest/json.html#circe)
* [`Either.joinRight`](https://www.scala-lang.org/api/2.12.0/scala/util/Either.html#joinRight[A1%3E:A,B1%3E:B,C](implicitev:%3C:%3C[B1,scala.util.Either[A1,C]]):scala.util.Either[A1,C]) is similar to `Option.flatten`, for example

```
val e1: Either[String, Either[String, Int]] = Left("boom!")
val e2: Either[String, Either[String, Int]] = Right(Left("boom!"))
val e3: Either[String, Either[String, Int]] = Right(Right(42))

e1.joinRight
e2.joinRight
e3.joinRight
```
outputs

```
res0: scala.util.Either[String,Int] = Left(boom!)
res1: scala.util.Either[String,Int] = Left(boom!)
res2: scala.util.Either[String,Int] = Right(42)
```