### PR TITLE
Implement holiday-stop backfill with new detail model

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/BackfillResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/BackfillResult.scala
@@ -1,6 +1,9 @@
 package com.gu.holidaystopbackfill
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.NewHolidayStopRequest
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.HolidayStopRequestsDetailPending
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.ActionedHolidayStopRequestsDetailToBackfill
 
-case class BackfillResult(requests: Seq[NewHolidayStopRequest], zuoraRefs: Seq[HolidayStopRequestsDetailPending])
+case class BackfillResult(
+  requests: Seq[NewHolidayStopRequest],
+  zuoraRefs: Seq[ActionedHolidayStopRequestsDetailToBackfill]
+)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/BackfillingApp.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/BackfillingApp.scala
@@ -1,7 +1,6 @@
 package com.gu.holidaystopbackfill
 
 import java.io.File
-import java.time.LocalDate
 
 /**
  * <p>Backfill app, to be run from a dev machine.</p>
@@ -16,8 +15,6 @@ import java.time.LocalDate
  *     <li>Holiday start date.</li>
  *     <li>Holiday end date.</li>
  *     <li>Credit price.</ol></li>
- *   <li>Earliest date of start of holiday-stops to find.</li>
- *   <li>Latest date of end of holiday-stops to find.</li>
  *   <li>Salesforce stage to backfill.  Defaults to DEV.</li>
  * </ol>
  * </p>
@@ -26,11 +23,9 @@ object BackfillingApp extends App {
 
   val dryRun = args(0).toBoolean
   val src = new File(args(1))
-  val start = LocalDate.parse(args(2))
-  val end = args.lift(3).map(LocalDate.parse)
-  val stage = args.lift(4).getOrElse("DEV")
+  val stage = args.lift(2).getOrElse("DEV")
 
-  Backfiller.backfill(src, start, end, dryRun, stage) match {
+  Backfiller.backfill(src, dryRun, stage) match {
     case Left(failure) => println(s"Failed: $failure")
     case Right(result) =>
       println("Success!")

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Salesforce.scala
@@ -1,43 +1,30 @@
 package com.gu.holidaystopbackfill
 
-import java.time.LocalDate
-
 import com.gu.effects.RawEffects
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.SalesforceClient
-import com.gu.salesforce.holiday_stops.{SalesforceHolidayStopRequest, SalesforceHolidayStopRequestsDetail}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{CreateHolidayStopRequest, HolidayStopRequest, NewHolidayStopRequest}
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, HolidayStopRequestsDetailPending, ProductName}
-import com.gu.util.Time
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{ActionedHolidayStopRequestsDetailToBackfill, ProductName}
+import com.gu.salesforce.holiday_stops.{SalesforceHolidayStopRequest, SalesforceHolidayStopRequestsDetail}
 import com.gu.util.resthttp.JsonHttp
 import scalaz.{-\/, \/-}
 
 object Salesforce {
 
-  def holidayStopRequestsByProductAndDateRange(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName, start: LocalDate, end: LocalDate): Either[SalesforceFetchFailure, Seq[HolidayStopRequest]] =
+  def holidayStopRequestsByProduct(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName): Either[SalesforceFetchFailure, Seq[HolidayStopRequest]] =
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>
       val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
-      val fetchOp = SalesforceHolidayStopRequest.LookupByDateRangeAndProductNamePrefix(sfGet)
-      fetchOp(Time.toJodaDate(start), Time.toJodaDate(end), productNamePrefix)
+      val fetchOp = SalesforceHolidayStopRequest.LookupByProductNamePrefix(sfGet)
+      fetchOp(productNamePrefix)
     }.toDisjunction match {
       case -\/(failure) => Left(SalesforceFetchFailure(failure.toString))
       case \/-(requests) => Right(requests)
     }
 
-  def holidayStopRequestDetails(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName, startThreshold: LocalDate, endThreshold: LocalDate): Either[SalesforceFetchFailure, Seq[HolidayStopRequestsDetail]] =
-    SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>
-      val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
-      val fetchOp = SalesforceHolidayStopRequestsDetail.LookupActionedByProductNamePrefixAndDateRange(sfGet)
-      fetchOp(productNamePrefix, startThreshold, endThreshold)
-    }.toDisjunction match {
-      case -\/(failure) => Left(SalesforceFetchFailure(failure.toString))
-      case \/-(details) => Right(details)
-    }
-
-  def holidayStopDetailsCreateResponse(sfCredentials: SFAuthConfig)(details: Seq[HolidayStopRequestsDetailPending]): Either[SalesforceUpdateFailure, Unit] =
+  def holidayStopDetailsCreateResponse(sfCredentials: SFAuthConfig)(details: Seq[ActionedHolidayStopRequestsDetailToBackfill]): Either[SalesforceUpdateFailure, Unit] =
     SalesforceClient(RawEffects.response, sfCredentials).value.map { sfAuth =>
       val sfPost = sfAuth.wrapWith(JsonHttp.post)
-      val sendOp = SalesforceHolidayStopRequestsDetail.CreatePendingSalesforceHolidayStopRequestsDetail(sfPost)
+      val sendOp = SalesforceHolidayStopRequestsDetail.BackfillActionedSalesforceHolidayStopRequestsDetail(sfPost)
       details.map(sendOp).find(_.isFailure)
     }.toDisjunction match {
       case -\/(failure) => Left(SalesforceUpdateFailure(failure.toString))

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -3,8 +3,8 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestActionedCount, HolidayStopRequestEndDate, HolidayStopRequestId, HolidayStopRequestStartDate}
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailId, ProductName, StoppedPublicationDate, SubscriptionName}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestActionedCount, HolidayStopRequestEndDate, HolidayStopRequestStartDate}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestId, HolidayStopRequestsDetail, HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailId, ProductName, StoppedPublicationDate, SubscriptionName}
 import com.gu.util.Time
 
 object Fixtures {

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
@@ -1,7 +1,7 @@
 package com.gu.holiday_stops
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{ProductName, SubscriptionName}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestId, ProductName, SubscriptionName}
 import org.joda.time.{DateTimeConstants, LocalDate}
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -16,7 +16,7 @@ import scalaz.{-\/, \/-}
 class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matchers {
 
   case class EndToEndResults(
-    createResult: SalesforceHolidayStopRequest.HolidayStopRequestId,
+    createResult: HolidayStopRequestId,
     preProcessingFetchResult: List[SalesforceHolidayStopRequest.HolidayStopRequest],
     postProcessingFetchResult: List[SalesforceHolidayStopRequest.HolidayStopRequest],
     deleteResult: String


### PR DESCRIPTION
This fixes some problems introduced to the backfiller by the changes to the holiday-stop detail model in #349.
The main changes here are:
* Fetching the holiday-stop request with its child details rather than the detail records with their parent
* There's a new  `BackfillActionedSalesforceHolidayStopRequestsDetail` object specifically for the backfiller to use to create a new actioned holiday-stop detail
* Removed the date ranges because that was getting quite confusing and there's only about 2000 legacy holiday stops to add (will need to consider a batching operation when backfilling other products).