### PR TITLE
Enable holiday-stop amendments to be applied to annual subscriptions

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ExtendedTerm.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ExtendedTerm.scala
@@ -1,0 +1,23 @@
+package com.gu.holidaystopprocessor
+
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit.DAYS
+
+case class ExtendedTerm(length: Int, unit: String)
+
+/**
+  * Applies term extension if next invoice start date (chargedThroughDate) falls outside the termEndDate.
+  *
+  * Addresses API error:
+  *   "The Contract effective date should not be later than the term end date of the basic subscription"
+  */
+object ExtendedTerm {
+  def apply(chargedThroughDate: LocalDate, subscription: Subscription): Option[ExtendedTerm] = {
+    if (chargedThroughDate.isAfter(subscription.termEndDate)) {
+      Some(ExtendedTerm(
+        length = DAYS.between(subscription.termStartDate, chargedThroughDate).toInt,
+        unit = "Day"
+      ))
+    } else None
+  }
+}

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 case class Subscription(
   subscriptionNumber: String,
+  termStartDate: LocalDate,
   termEndDate: LocalDate,
   currentTerm: Int,
   currentTermPeriodType: String,

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SubscriptionUpdate.scala
@@ -1,6 +1,7 @@
 package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit.DAYS
 
 case class SubscriptionUpdate(
   currentTerm: Option[Int],
@@ -31,8 +32,12 @@ object SubscriptionUpdate {
       .toRight(HolidayStopFailure("Original rate plan charge has no charged through date.  A bill run is needed to fix this.")).map { effectiveDate =>
 
         val extendedTerm: Option[ExtendedTerm] =
-          if (effectiveDate.isAfter(subscription.termEndDate)) Some(ExtendedTerm(366, "Day"))
-          else None
+          if (effectiveDate.isAfter(subscription.termEndDate)) {
+            Some(ExtendedTerm(
+              length = DAYS.between(subscription.termStartDate, effectiveDate).toInt,
+              unit = "Day"
+            ))
+          } else None
 
         SubscriptionUpdate(
           currentTerm = extendedTerm.map(_.length),

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -25,6 +25,7 @@ object Fixtures {
   )
 
   def mkSubscription(
+    termStartDate: LocalDate,
     termEndDate: LocalDate,
     price: Double,
     billingPeriod: String,
@@ -32,6 +33,7 @@ object Fixtures {
   ) =
     Subscription(
       subscriptionNumber = "S1",
+      termStartDate,
       termEndDate,
       currentTerm = 12,
       currentTermPeriodType = "Month",
@@ -51,6 +53,7 @@ object Fixtures {
 
   def mkSubscriptionWithHolidayStops() = Subscription(
     subscriptionNumber = "S1",
+    termStartDate = LocalDate.of(2019, 3, 1),
     termEndDate = LocalDate.of(2020, 3, 1),
     currentTerm = 12,
     currentTermPeriodType = "Month",

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
 class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues with OptionValues {
 
   private val subscription = mkSubscription(
+    termStartDate = LocalDate.of(2018, 1, 1),
     termEndDate = LocalDate.of(2019, 1, 1),
     price = 75.5,
     billingPeriod = "Quarter",

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionTest.scala
@@ -44,6 +44,7 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
 
   it should "give no ratePlanCharge when subscription has no holiday stops applied" in {
     val subscription = Fixtures.mkSubscription(
+      termStartDate = LocalDate.of(2018, 1, 1),
       termEndDate = LocalDate.of(2019, 1, 1),
       price = 123,
       billingPeriod = "Quarter",

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -12,6 +12,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     val update = holidayCreditToAdd(
       config,
       subscription = Fixtures.mkSubscription(
+        termStartDate = LocalDate.of(2019, 7, 12),
         termEndDate = LocalDate.of(2020, 7, 12),
         price = 42.1,
         billingPeriod = "Quarter",
@@ -45,6 +46,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     val update = holidayCreditToAdd(
       config,
       subscription = Fixtures.mkSubscription(
+        termStartDate = LocalDate.of(2019, 7, 12),
         termEndDate = LocalDate.of(2020, 7, 12),
         price = 42.1,
         billingPeriod = "Quarter",
@@ -61,6 +63,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     val update = holidayCreditToAdd(
       config,
       subscription = Fixtures.mkSubscription(
+        termStartDate = LocalDate.of(2019, 7, 23),
         termEndDate = LocalDate.of(2020, 7, 23),
         price = 150,
         billingPeriod = "Annual",
@@ -69,7 +72,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       stoppedPublicationDate = LocalDate.of(2019, 8, 6)
     )
     update shouldBe Right(SubscriptionUpdate(
-      currentTerm = Some(366),
+      currentTerm = Some(376),
       currentTermPeriodType = Some("Day"),
       List(Add(
         productRatePlanId = "ratePlanId",
@@ -92,6 +95,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     val update = holidayCreditToAdd(
       config,
       subscription = Fixtures.mkSubscription(
+        termStartDate = LocalDate.of(2019, 7, 23),
         termEndDate = LocalDate.of(2020, 7, 23),
         price = 150,
         billingPeriod = "Annual",


### PR DESCRIPTION
This fixes a bug where amendments could not be applied to annual subscriptions because their term-end date falls before the first day of their next billing period, which is the effective date of the amendment.  Zuora will not allow an amendment to be effective after the term of the subscription ends.

In these cases, the subscription is now updated to extend the term by the number of days needed to fit the effective date into the current term of the subscription.

This is an example of the amendment that's applied:

```
{
	"currentTerm": "376",
	"currentTermPeriodType": "Day",
        "add": [
        {
            "productRatePlanId": "{{productRatePlanId}}",
            "contractEffectiveDate": "2020-08-02",
            "customerAcceptanceDate": "2020-08-02",
            "serviceActivationDate": "2020-08-02",
            "chargeOverrides": [
                {
                    "productRatePlanChargeId": "{{productRatePlanChargeId}}",
                    "HolidayStart__c": "2019-08-06",
                    "HolidayEnd__c": "2019-08-06",
                    "price": "-12.34"
                }
            ]
        }
    ]
}
```
