### PR TITLE
Model chargedThroughDate as NextBillingPeriodStartDate

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCreditUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCreditUpdate.scala
@@ -16,36 +16,32 @@ object HolidayCreditUpdate {
   def apply(
     config: Config,
     subscription: Subscription,
-    stoppedPublicationDate: LocalDate
+    stoppedPublicationDate: LocalDate,
+    nextInvoiceStartDate: LocalDate,
+    maybeExtendedTerm: Option[ExtendedTerm]
   ): Either[HolidayStopFailure, HolidayCreditUpdate] = {
-
-    subscription
-      .originalRatePlanCharge
-      .flatMap(_.chargedThroughDate)
-      .toRight(HolidayStopFailure("Original rate plan charge has no charged through date.  A bill run is needed to fix this."))
-      .map { chargedThroughDate =>
-        val extendedTerm = ExtendedTerm(chargedThroughDate, subscription)
-        HolidayCreditUpdate(
-          currentTerm = extendedTerm.map(_.length),
-          currentTermPeriodType = extendedTerm.map(_.unit),
-          Seq(
-            Add(
-              productRatePlanId = config.holidayCreditProductRatePlanId,
-              contractEffectiveDate = chargedThroughDate,
-              customerAcceptanceDate = chargedThroughDate,
-              serviceActivationDate = chargedThroughDate,
-              chargeOverrides = Seq(
-                ChargeOverride(
-                  productRatePlanChargeId = config.holidayCreditProductRatePlanChargeId,
-                  HolidayStart__c = stoppedPublicationDate,
-                  HolidayEnd__c = stoppedPublicationDate,
-                  price = subscription.originalRatePlanCharge.map(HolidayCredit(_)).getOrElse(0)
-                )
+    Right(
+      HolidayCreditUpdate(
+        currentTerm = maybeExtendedTerm.map(_.length),
+        currentTermPeriodType = maybeExtendedTerm.map(_.unit),
+        Seq(
+          Add(
+            productRatePlanId = config.holidayCreditProductRatePlanId,
+            contractEffectiveDate = nextInvoiceStartDate,
+            customerAcceptanceDate = nextInvoiceStartDate,
+            serviceActivationDate = nextInvoiceStartDate,
+            chargeOverrides = Seq(
+              ChargeOverride(
+                productRatePlanChargeId = config.holidayCreditProductRatePlanChargeId,
+                HolidayStart__c = stoppedPublicationDate,
+                HolidayEnd__c = stoppedPublicationDate,
+                price = subscription.originalRatePlanCharge.map(HolidayCredit(_)).getOrElse(0)
               )
             )
           )
         )
-      }
+      )
+    )
   }
 }
 

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -62,7 +62,7 @@ object HolidayStopProcess {
     for {
       subscription <- getSubscription(stop.subscriptionName)
       _ <- if (subscription.autoRenew) Right(()) else Left(HolidayStopFailure("Cannot currently process non-auto-renewing subscription"))
-      nextInvoiceStartDate <- NextInvoiceStartDate(subscription)
+      nextInvoiceStartDate <- NextBillingPeriodStartDate(subscription)
       maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
       holidayCreditUpdate <- HolidayCreditUpdate(config, subscription, stop.stoppedPublicationDate, nextInvoiceStartDate, maybeExtendedTerm)
       _ <- if (subscription.hasHolidayStop(stop)) Right(()) else updateSubscription(subscription, holidayCreditUpdate)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
@@ -3,18 +3,24 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 /**
- * Invoiced period is defined as [processedThroughDate, chargedThroughDate) meaning
+ * Holiday credit is applied to the next invoice on the first day of the next billing period.
+ *
+ * 'Invoiced period' or `billing period that has already been invoiced` is defined as
+ * [processedThroughDate, chargedThroughDate) meaning
  *   - from processedThroughDate inclusive
  *   - to chargedThroughDate exclusive
  *
- * Hence chargedThroughDate represents the first day of the next invoiced period. For quarterly
+ * Hence chargedThroughDate represents the first day of the next billing period. For quarterly
  * billing period this would be the first day of the next quarter, whilst for annual this would be
  * the first day of the next year.
  *
  * Note chargedThroughDate is an API concept. The UI and the actual invoice use the term 'Service Period'
  * where from and to dates are both inclusive.
+ *
+ * Note nextBillingPeriodStartDate represents a specific date yyyy-mm-dd unlike billingPeriod (quarterly)
+ * or billingPeriodStartDay (1st of month).
  */
-object NextInvoiceStartDate {
+object NextBillingPeriodStartDate {
   def apply(subscription: Subscription): Either[HolidayStopFailure, LocalDate] = {
     subscription
       .originalRatePlanCharge

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextInvoiceStartDate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextInvoiceStartDate.scala
@@ -1,0 +1,24 @@
+package com.gu.holidaystopprocessor
+
+import java.time.LocalDate
+
+/**
+ * Invoiced period is defined as [processedThroughDate, chargedThroughDate) meaning
+ *   - from processedThroughDate inclusive
+ *   - to chargedThroughDate exclusive
+ *
+ * Hence chargedThroughDate represents the first day of the next invoiced period. For quarterly
+ * billing period this would be the first day of the next quarter, whilst for annual this would be
+ * the first day of the next year.
+ *
+ * Note chargedThroughDate is an API concept. The UI and the actual invoice use the term 'Service Period'
+ * where from and to dates are both inclusive.
+ */
+object NextInvoiceStartDate {
+  def apply(subscription: Subscription): Either[HolidayStopFailure, LocalDate] = {
+    subscription
+      .originalRatePlanCharge
+      .flatMap(_.chargedThroughDate)
+      .toRight(HolidayStopFailure("Original rate plan charge has no charged through date. A bill run is needed to fix this."))
+  }
+}

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -8,16 +8,22 @@ import org.scalatest.{FlatSpec, Matchers}
 class SubscriptionUpdateTest extends FlatSpec with Matchers {
 
   "holidayCreditToAdd" should "generate update correctly" in {
+    val subscription = Fixtures.mkSubscription(
+      termStartDate = LocalDate.of(2019, 7, 12),
+      termEndDate = LocalDate.of(2020, 7, 12),
+      price = 42.1,
+      billingPeriod = "Quarter",
+      chargedThroughDate = Some(LocalDate.of(2019, 9, 12))
+    )
+    val nextInvoiceStartDate = NextInvoiceStartDate(subscription)
+    val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
+
     val update = HolidayCreditUpdate(
       config,
-      subscription = Fixtures.mkSubscription(
-        termStartDate = LocalDate.of(2019, 7, 12),
-        termEndDate = LocalDate.of(2020, 7, 12),
-        price = 42.1,
-        billingPeriod = "Quarter",
-        chargedThroughDate = Some(LocalDate.of(2019, 9, 12))
-      ),
-      stoppedPublicationDate = LocalDate.of(2019, 5, 18)
+      subscription = subscription,
+      stoppedPublicationDate = LocalDate.of(2019, 5, 18),
+      nextInvoiceStartDate = nextInvoiceStartDate.right.get,
+      maybeExtendedTerm = maybeExtendedTerm
     )
     update shouldBe Right(HolidayCreditUpdate(
       currentTerm = None,
@@ -42,33 +48,35 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
   }
 
   it should "fail to generate an update when there's no charged-through date" in {
-    val update = HolidayCreditUpdate(
-      config,
-      subscription = Fixtures.mkSubscription(
-        termStartDate = LocalDate.of(2019, 7, 12),
-        termEndDate = LocalDate.of(2020, 7, 12),
-        price = 42.1,
-        billingPeriod = "Quarter",
-        chargedThroughDate = None
-      ),
-      stoppedPublicationDate = LocalDate.of(2019, 5, 18)
+    val subscription = Fixtures.mkSubscription(
+      termStartDate = LocalDate.of(2019, 7, 12),
+      termEndDate = LocalDate.of(2020, 7, 12),
+      price = 42.1,
+      billingPeriod = "Quarter",
+      chargedThroughDate = None
     )
-    update shouldBe Left(HolidayStopFailure(
-      "Original rate plan charge has no charged through date.  A bill run is needed to fix this."
+    val nextInvoiceStartDate = NextInvoiceStartDate(subscription)
+    nextInvoiceStartDate shouldBe Left(HolidayStopFailure(
+      "Original rate plan charge has no charged through date. A bill run is needed to fix this."
     ))
   }
 
   it should "generate an update with an extended term when charged-through date of subscription is after its term-end date" in {
+    val subscription = Fixtures.mkSubscription(
+      termStartDate = LocalDate.of(2019, 7, 23),
+      termEndDate = LocalDate.of(2020, 7, 23),
+      price = 150,
+      billingPeriod = "Annual",
+      chargedThroughDate = Some(LocalDate.of(2020, 8, 2))
+    )
+    val nextInvoiceStartDate = NextInvoiceStartDate(subscription)
+    val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
     val update = HolidayCreditUpdate(
       config,
-      subscription = Fixtures.mkSubscription(
-        termStartDate = LocalDate.of(2019, 7, 23),
-        termEndDate = LocalDate.of(2020, 7, 23),
-        price = 150,
-        billingPeriod = "Annual",
-        chargedThroughDate = Some(LocalDate.of(2020, 8, 2))
-      ),
-      stoppedPublicationDate = LocalDate.of(2019, 8, 6)
+      subscription = subscription,
+      stoppedPublicationDate = LocalDate.of(2019, 8, 6),
+      nextInvoiceStartDate = nextInvoiceStartDate.right.get,
+      maybeExtendedTerm = maybeExtendedTerm
     )
     update shouldBe Right(HolidayCreditUpdate(
       currentTerm = Some(376),
@@ -91,16 +99,21 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
   }
 
   it should "generate an update without an extended term when charged-through date of subscription is on its term-end date" in {
+    val subscription = Fixtures.mkSubscription(
+      termStartDate = LocalDate.of(2019, 7, 23),
+      termEndDate = LocalDate.of(2020, 7, 23),
+      price = 150,
+      billingPeriod = "Annual",
+      chargedThroughDate = Some(LocalDate.of(2020, 7, 23))
+    )
+    val nextInvoiceStartDate = NextInvoiceStartDate(subscription)
+    val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
     val update = HolidayCreditUpdate(
       config,
-      subscription = Fixtures.mkSubscription(
-        termStartDate = LocalDate.of(2019, 7, 23),
-        termEndDate = LocalDate.of(2020, 7, 23),
-        price = 150,
-        billingPeriod = "Annual",
-        chargedThroughDate = Some(LocalDate.of(2020, 7, 23))
-      ),
-      stoppedPublicationDate = LocalDate.of(2019, 8, 6)
+      subscription = subscription,
+      stoppedPublicationDate = LocalDate.of(2019, 8, 6),
+      nextInvoiceStartDate = nextInvoiceStartDate.right.get,
+      maybeExtendedTerm = maybeExtendedTerm
     )
     update shouldBe Right(HolidayCreditUpdate(
       currentTerm = None,

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -15,7 +15,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Quarter",
       chargedThroughDate = Some(LocalDate.of(2019, 9, 12))
     )
-    val nextInvoiceStartDate = NextInvoiceStartDate(subscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
 
     val update = HolidayCreditUpdate(
@@ -55,7 +55,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Quarter",
       chargedThroughDate = None
     )
-    val nextInvoiceStartDate = NextInvoiceStartDate(subscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
     nextInvoiceStartDate shouldBe Left(HolidayStopFailure(
       "Original rate plan charge has no charged through date. A bill run is needed to fix this."
     ))
@@ -69,7 +69,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Annual",
       chargedThroughDate = Some(LocalDate.of(2020, 8, 2))
     )
-    val nextInvoiceStartDate = NextInvoiceStartDate(subscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
     val update = HolidayCreditUpdate(
       config,
@@ -106,7 +106,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Annual",
       chargedThroughDate = Some(LocalDate.of(2020, 7, 23))
     )
-    val nextInvoiceStartDate = NextInvoiceStartDate(subscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
     val update = HolidayCreditUpdate(
       config,


### PR DESCRIPTION
https://docs.google.com/document/d/1O-jIw0SBUcSjcLArZfWQY8ad2aX3H-b3O6ONrOQnFLQ

Holiday credit is applied to the next invoice on the first day of the next billing period.

This PR makes the above requirement more explicit by modelling the concept of next invoice like so

```
/**
 * Holiday credit is applied to the next invoice on the first day of the next billing period.
 *
 * 'Invoiced period' or `billing period that has already been invoiced` is defined as
 * [processedThroughDate, chargedThroughDate) meaning
 *   - from processedThroughDate inclusive
 *   - to chargedThroughDate exclusive
 *
 * Hence chargedThroughDate represents the first day of the next billing period. For quarterly
 * billing period this would be the first day of the next quarter, whilst for annual this would be
 * the first day of the next year.
 *
 * Note chargedThroughDate is an API concept. The UI and the actual invoice use the term 'Service Period'
 * where from and to dates are both inclusive.
 *
 * Note nextBillingPeriodStartDate represents a specific date yyyy-mm-dd unlike billingPeriod (quarterly)
 * or billingPeriodStartDay (1st of month).
 */
object NextBillingPeriodStartDate {
``` 

and making it part of the main for-comprehension in `def processHolidayStop`.