### PR TITLE
Use different credentials for holiday-stop backfill

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Config.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Config.scala
@@ -14,11 +14,7 @@ object Config {
   private def salesforceCredentials(stage: String): Either[ConfigFailure, SFAuthConfig] = {
     val profileName = "membership"
     val bucketName = "gu-reader-revenue-private"
-    val key =
-      if (stage == "DEV")
-        s"membership/support-service-lambdas/$stage/sfAuth-$stage.json"
-      else
-        s"membership/support-service-lambdas/$stage/sfAuth-$stage.v1.json"
+    val key = s"membership/support-service-lambdas/$stage/sfHolidayStopBackfillAuth-$stage.json"
     val builder =
       AmazonS3Client.builder
         .withCredentials(new ProfileCredentialsProvider(profileName))


### PR DESCRIPTION
This will enable us to distinguish requests generated by the backfiller from other requests generated by CSR or self-serve.

The credentials (and backfill code) can be removed once we're sure we're not going to need to run any more backfills. See https://trello.com/c/dZQiLjXh.
