### PR TITLE
replace identity-cookie with identity-auth-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import Dependencies._
 
+updateOptions := updateOptions.value.withCachedResolution(true)
+
 val scalaSettings = Seq(
   scalaVersion := "2.12.6",
   version      := "0.0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies._
 
-updateOptions := updateOptions.value.withCachedResolution(true)
-
 val scalaSettings = Seq(
   scalaVersion := "2.12.6",
   version      := "0.0.1",

--- a/handlers/cancellation-sf-cases/build.sbt
+++ b/handlers/cancellation-sf-cases/build.sbt
@@ -15,7 +15,7 @@ riffRaffManifestProjectName := "MemSub::Subscriptions::Lambdas::Cancellation SF 
 riffRaffArtifactResources += (file("handlers/cancellation-sf-cases/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.gu.identity" %% "identity-cookie" % "3.160",
+  "com.gu.identity" %% "identity-auth-core" % "3.184-M6",
   "com.gu" %% "identity-test-users" % "0.7",
   playJsonExtensions
 )

--- a/handlers/cancellation-sf-cases/cfn.yaml
+++ b/handlers/cancellation-sf-cases/cfn.yaml
@@ -10,6 +10,7 @@ Parameters:
             - CODE
             - DEV
         Default: CODE
+    IdentityApiServerAccessToken:
 
 Conditions:
   CreateProdMonitoring: !Equals [ !Ref Stage, PROD ]
@@ -87,6 +88,7 @@ Resources:
             Environment:
                 Variables:
                   Stage: !Ref Stage
+                  IdentityApiServerAccessToken: !Ref IdentityApiServerAccessToken
             Role:
                 Fn::GetAtt:
                 - "CancellationSFCasesRole"

--- a/handlers/cancellation-sf-cases/cfn.yaml
+++ b/handlers/cancellation-sf-cases/cfn.yaml
@@ -11,6 +11,8 @@ Parameters:
             - DEV
         Default: CODE
     IdentityApiServerAccessToken:
+        Description: server access token for identity API
+        Type: String
 
 Conditions:
   CreateProdMonitoring: !Equals [ !Ref Stage, PROD ]

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -72,9 +72,8 @@ class EndToEndHandlerEffectsTest extends FlatSpec with Matchers {
 
 object Runner extends Matchers {
 
-  def fakeCookiesToIdentityUser(scGuU: String, guU: String) = {
+  def fakeCookiesToIdentityUser(scGuU: String) = {
     scGuU shouldEqual EndToEndData.scGuU
-    guU shouldEqual EndToEndData.guU
     Some(IdentityUser(IdentityId("100000932"), None))
   }
 
@@ -114,7 +113,6 @@ object Runner extends Matchers {
 object EndToEndData {
 
   val scGuU: String = "scGuU"
-  val guU: String = "guU"
 
   private def ApiGatewayRequestPayloadBuilder(
     httpMethod: String,
@@ -128,7 +126,7 @@ object EndToEndData {
        |    "path": "/case${pathSuffix}",
        |    "httpMethod": "${httpMethod}",
        |    "headers": {
-       |        "Cookie":"SC_GU_U=${scGuU};GU_U=${guU}"
+       |        "Cookie":"SC_GU_U=${scGuU}"
        |    },
        |    "queryStringParameters": null,
        |    "pathParameters": ${pathParameters},


### PR DESCRIPTION
When authenticating a user, we want to check that their session hasn't been invalidated. To do this, we need to callback to the identity API. This PR introduces the library identity-auth-core to do this.

Raised as a draft PR since there are some questions (inlined as PR comments) which I'd appreciate answers to.