### PR TITLE
expose httpMethod on the ApiGatewayRequest

### DIFF
--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -94,7 +94,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, None, Some(request), None))
 
     actual.shouldBe(successfulResponseFromZuora)
   }
@@ -107,7 +107,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, None, Some(request), None))
 
     verifyResponse(
       actualResponse = actual,
@@ -125,7 +125,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, None, Some(request), None))
 
     val expectedResponseBody =
       """{
@@ -155,7 +155,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, None, Some(request), None))
 
     verifyResponse(
       actualResponse = actual,
@@ -168,7 +168,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
     val request = "{}"
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, None, Some(request), None))
 
     verifyResponse(
       actualResponse = actual,
@@ -186,7 +186,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, None, Some(request), None))
 
     val expectedResponseBody =
       """{

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -103,7 +103,7 @@ class ContributionStepsTest extends FlatSpec with Matchers {
       addContribution = fakeAddContributionSteps,
       addPaperSub = dummySteps,
       addDigipackSub = dummySteps
-    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
+    )(ApiGatewayRequest(None, None, Some(Json.stringify(requestInput)), None, None))
 
     val actual = Await.result(futureActual, 30 seconds)
     actual.statusCode should be("200")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
@@ -94,7 +94,7 @@ class PaperStepsTest extends FlatSpec with Matchers {
       addContribution = dummySteps,
       addPaperSub = fakeAddVoucherSteps,
       addDigipackSub = dummySteps
-    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
+    )(ApiGatewayRequest(None, None, Some(Json.stringify(requestInput)), None, None))
 
     val actual = Await.result(futureActual, 30 seconds)
     actual.statusCode should be("200")

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -33,7 +33,7 @@ class EndToEndTest extends FlatSpec with Matchers {
         |   "accountId":"sfacc"
         |}
       """.stripMargin
-    val input = ApiGatewayRequest(None, Some(body), None, None)
+    val input = ApiGatewayRequest(None, None, Some(body), None, None)
 
     val (responseString, requests) = getResultAndRequests(input)
 

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
@@ -12,6 +12,7 @@ import scala.util.{Failure, Success, Try}
   header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
   */
 case class ApiGatewayRequest(
+  httpMethod: Option[String],
   queryStringParameters: Option[Map[String, String]],
   body: Option[String],
   headers: Option[Map[String, String]],

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
@@ -72,6 +72,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
 
     val expected: JsResult[ApiGatewayRequest] = JsSuccess(
       ApiGatewayRequest(
+        httpMethod = Some("POST"),
         queryStringParameters = Some(queryStringParameters),
         body = Some(eventBodySimple),
         headers = Some(eventHeaders)
@@ -90,7 +91,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
 
   it should "deserialise empty query string to case class" in {
 
-    val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = None, body = None, headers = None)
+    val noQueryParamsRequest = ApiGatewayRequest(httpMethod = None, queryStringParameters = None, body = None, headers = None)
 
     noQueryParamsRequest.queryParamsAsCaseClass[TestParams]() shouldBe ContinueProcessing(TestParams(None))
   }
@@ -100,7 +101,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
       "ignoredParam" -> "ignoredValue",
       "testQueryParam" -> "testValue"
     ))
-    val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = queryParams, body = None, headers = None)
+    val noQueryParamsRequest = ApiGatewayRequest(httpMethod = None, queryStringParameters = queryParams, body = None, headers = None)
     noQueryParamsRequest.queryParamsAsCaseClass[TestParams]() shouldBe ContinueProcessing(TestParams(Some("testValue")))
   }
 
@@ -113,7 +114,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
     val queryParams = Some(Map(
       "wrongParamName" -> "someValue"
     ))
-    val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = queryParams, body = None, headers = None)
+    val noQueryParamsRequest = ApiGatewayRequest(httpMethod = None, queryStringParameters = queryParams, body = None, headers = None)
     val actual = noQueryParamsRequest.queryParamsAsCaseClass[NonOptionalParams]()
     val expected = -\/("400")
     actual.toDisjunction.leftMap(_.statusCode) shouldBe expected
@@ -123,7 +124,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
     val queryParams = Some(Map(
       "testQueryParam" -> "someValue"
     ))
-    val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = queryParams, body = None, headers = None)
+    val noQueryParamsRequest = ApiGatewayRequest(httpMethod = None, queryStringParameters = queryParams, body = None, headers = None)
     val actual = noQueryParamsRequest.queryParamsAsCaseClass[NonOptionalParams]()
     val expected = ContinueProcessing(NonOptionalParams("someValue"))
     actual shouldBe expected
@@ -134,7 +135,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
       "testQueryParam" -> "someValue",
       "another" -> "someOtherValue"
     ))
-    val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = queryParams, body = None, headers = None)
+    val noQueryParamsRequest = ApiGatewayRequest(httpMethod = None, queryStringParameters = queryParams, body = None, headers = None)
     val actual = noQueryParamsRequest.queryParamsAsCaseClass[NonOptionalParams]()
     val expected = ContinueProcessing(NonOptionalParams("someValue"))
     actual shouldBe expected

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/OperationTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/OperationTest.scala
@@ -10,7 +10,7 @@ class OperationTest extends FlatSpec with Matchers {
 
     val operation = Operation(_ => ApiGatewayResponse("200", "blah"), () => ApiGatewayResponse("0", "blah"))
     val newOperation = operation.prependRequestValidationToSteps(req => ContinueProcessing(()))
-    val actual = newOperation.steps(ApiGatewayRequest(None, None, None, None))
+    val actual = newOperation.steps(ApiGatewayRequest(None, None, None, None, None))
     actual.statusCode should be("200")
 
   }
@@ -19,7 +19,7 @@ class OperationTest extends FlatSpec with Matchers {
 
     val operation = Operation(_ => ApiGatewayResponse("200", "blah"), () => ApiGatewayResponse("0", "blah"))
     val newOperation = operation.prependRequestValidationToSteps(req => ReturnWithResponse(ApiGatewayResponse("401", "blah")))
-    val actual = newOperation.steps(ApiGatewayRequest(None, None, None, None))
+    val actual = newOperation.steps(ApiGatewayRequest(None, None, None, None, None))
     actual.statusCode should be("401")
 
   }

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -392,7 +392,7 @@ class SourceUpdatedStepsApplyTest extends FlatSpec with Matchers {
         |}
       """.stripMargin
 
-    val testGatewayRequest = ApiGatewayRequest(None, Some(body.toString), Some(badHeaders))
+    val testGatewayRequest = ApiGatewayRequest(None, None, Some(body.toString), Some(badHeaders))
 
     val actual = sourceUpdatedSteps.steps(testGatewayRequest)
 


### PR DESCRIPTION
Useful to have the underlying `httpMethod` available on the `ApiGatewayRequest`

_Pulling out some of the changes in https://github.com/guardian/support-service-lambdas/pull/302 to simplify it_