### PR TITLE
Document IntegrationHttpMethod needs to be POST

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -160,7 +160,7 @@ Resources:
               method.request.querystring.apiToken: true
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ZuoraAutoCancelLambda.Arn}/invocations
         DependsOn:
         - ZuoraAutoCancelAPI
@@ -179,7 +179,7 @@ Resources:
               method.request.querystring.apiToken: true
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PaymentFailureLambda.Arn}/invocations
         DependsOn:
         - ZuoraAutoCancelAPI
@@ -237,7 +237,7 @@ Resources:
               method.request.querystring.apiToken: true
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StripeCustomerSourceUpdatedLambda.Arn}/invocations
         DependsOn:
         - ZuoraAutoCancelAPI

--- a/handlers/HOWTO-create-lambda.md
+++ b/handlers/HOWTO-create-lambda.md
@@ -16,6 +16,10 @@ Hopefully we can make this process easier in future (code generation or ideally 
 1. follow the steps after "deploy to code" again in order to update the PROD domain name.
 1. set up a health check job in Runscope (optional)
 
+**IMPORTANT:** The `IntegrationHttpMethod` (between API Gateway with Lambda) needs to always be `POST` - see https://stackoverflow.com/a/55457240/5205022 for more information
+
+**NOTE:** If you make subsequent configuration changes to the API Gateway (even via CloudFormation) you may need to manually 'Deploy API' which can be done via the AWS Console (API Gateway > _{gateway in question}_ > Resources > Actions ▼ > Deploy API)
+
 ## Deploying a lambda with riffraff for the first time
 1. preview the deploy using riffraff and only tick the "copy file to s3" step before hitting deploy
 1. go back to the deploy screen and deploy as normal (all the steps)

--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -100,7 +100,7 @@ Resources:
       HttpMethod: POST
       Integration:
         Type: AWS_PROXY
-        IntegrationHttpMethod: POST
+        IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
         Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BatchEmailSenderLambda.Arn}/invocations
     DependsOn:
     - BatchEmailSenderApi

--- a/handlers/cancellation-sf-cases/cfn.yaml
+++ b/handlers/cancellation-sf-cases/cfn.yaml
@@ -115,7 +115,7 @@ Resources:
             HttpMethod: POST
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CancellationSFRaiseCaseLambda.Arn}/invocations
         DependsOn:
         - CancellationSFCasesAPI
@@ -173,7 +173,7 @@ Resources:
               method.request.path.caseId: true
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CancellationSFUpdateCaseLambda.Arn}/invocations
         DependsOn:
         - CancellationSFCasesAPI

--- a/handlers/identity-backfill/cfn.yaml
+++ b/handlers/identity-backfill/cfn.yaml
@@ -106,7 +106,7 @@ Resources:
               method.request.querystring.apiToken: true
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IdentityBackfillLambda.Arn}/invocations
         DependsOn:
         - IdentityBackfillAPI

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -110,7 +110,7 @@ Resources:
               method.request.querystring.identityId: true
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IdentityRetentionLambda.Arn}/invocations
         DependsOn:
         - IdentityRetentionAPI

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -151,7 +151,7 @@ Resources:
             HttpMethod: POST
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AddSubscriptionLambda.Arn}/invocations
         DependsOn:
         - NewProductApi
@@ -205,7 +205,7 @@ Resources:
         HttpMethod: GET
         Integration:
           Type: AWS_PROXY
-          IntegrationHttpMethod: POST
+          IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
           Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ProductCatalogLambda.Arn}/invocations
       DependsOn:
             - NewProductApi

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -106,7 +106,7 @@ Resources:
               method.request.querystring.identityId: true
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SfContactMergeLambda.Arn}/invocations
         DependsOn:
         - SfContactMergeAPI


### PR DESCRIPTION
The `IntegrationHttpMethod` (between API Gateway with Lambda) needs to always be `POST` so this change makes that explicit in all the places it's used. 


**Because https://stackoverflow.com/a/55457240/5205022**

_Pulling out some of the changes in https://github.com/guardian/support-service-lambdas/pull/302 to simplify it_
