### PR TITLE
Replace Seq with List to unlock cats

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/BackfillResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/BackfillResult.scala
@@ -4,6 +4,6 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.NewHolidaySt
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.ActionedHolidayStopRequestsDetailToBackfill
 
 case class BackfillResult(
-  requests: Seq[NewHolidayStopRequest],
-  zuoraRefs: Seq[ActionedHolidayStopRequestsDetailToBackfill]
+  requests: List[NewHolidayStopRequest],
+  zuoraRefs: List[ActionedHolidayStopRequestsDetailToBackfill]
 )

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopbackfill/Salesforce.scala
@@ -11,7 +11,7 @@ import scalaz.{-\/, \/-}
 
 object Salesforce {
 
-  def holidayStopRequestsByProduct(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName): Either[SalesforceFetchFailure, Seq[HolidayStopRequest]] =
+  def holidayStopRequestsByProduct(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName): Either[SalesforceFetchFailure, List[HolidayStopRequest]] =
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>
       val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
       val fetchOp = SalesforceHolidayStopRequest.LookupByProductNamePrefix(sfGet)
@@ -21,7 +21,7 @@ object Salesforce {
       case \/-(requests) => Right(requests)
     }
 
-  def holidayStopDetailsCreateResponse(sfCredentials: SFAuthConfig)(details: Seq[ActionedHolidayStopRequestsDetailToBackfill]): Either[SalesforceUpdateFailure, Unit] =
+  def holidayStopDetailsCreateResponse(sfCredentials: SFAuthConfig)(details: List[ActionedHolidayStopRequestsDetailToBackfill]): Either[SalesforceUpdateFailure, Unit] =
     SalesforceClient(RawEffects.response, sfCredentials).value.map { sfAuth =>
       val sfPost = sfAuth.wrapWith(JsonHttp.post)
       val sendOp = SalesforceHolidayStopRequestsDetail.BackfillActionedSalesforceHolidayStopRequestsDetail(sfPost)
@@ -31,7 +31,7 @@ object Salesforce {
       case _ => Right(())
     }
 
-  def holidayStopCreateResponse(sfCredentials: SFAuthConfig)(requests: Seq[NewHolidayStopRequest]): Either[SalesforceUpdateFailure, Unit] =
+  def holidayStopCreateResponse(sfCredentials: SFAuthConfig)(requests: List[NewHolidayStopRequest]): Either[SalesforceUpdateFailure, Unit] =
     SalesforceClient(RawEffects.response, sfCredentials).value.map { sfAuth =>
       val sfGet = sfAuth.wrapWith(JsonHttp.post)
       val createOp = CreateHolidayStopRequest(sfGet)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
@@ -6,12 +6,12 @@ import io.circe.generic.auto._
 import io.github.mkotsur.aws.handler.Lambda
 import io.github.mkotsur.aws.handler.Lambda._
 
-object Handler extends Lambda[None.type, Seq[HolidayStopResponse]] {
+object Handler extends Lambda[None.type, List[HolidayStopResponse]] {
 
   override protected def handle(
     `_`: None.type,
     context: Context
-  ): Either[Throwable, Seq[HolidayStopResponse]] = {
+  ): Either[Throwable, List[HolidayStopResponse]] = {
     Config() match {
       case Left(msg) => Left(new RuntimeException(s"Config failure: $msg"))
       case Right(config) =>

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCreditUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCreditUpdate.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 case class HolidayCreditUpdate(
   currentTerm: Option[Int],
   currentTermPeriodType: Option[String],
-  add: Seq[Add]
+  add: List[Add]
 )
 
 /**
@@ -27,13 +27,13 @@ object HolidayCreditUpdate {
       HolidayCreditUpdate(
         currentTerm = maybeExtendedTerm.map(_.length),
         currentTermPeriodType = maybeExtendedTerm.map(_.unit),
-        Seq(
+        List(
           Add(
             productRatePlanId = holidayCreditProduct.productRatePlanId,
             contractEffectiveDate = nextInvoiceStartDate,
             customerAcceptanceDate = nextInvoiceStartDate,
             serviceActivationDate = nextInvoiceStartDate,
-            chargeOverrides = Seq(
+            chargeOverrides = List(
               ChargeOverride(
                 productRatePlanChargeId = holidayCreditProduct.productRatePlanChargeId,
                 HolidayStart__c = stoppedPublicationDate,
@@ -53,7 +53,7 @@ case class Add(
   contractEffectiveDate: LocalDate,
   customerAcceptanceDate: LocalDate,
   serviceActivationDate: LocalDate,
-  chargeOverrides: Seq[ChargeOverride]
+  chargeOverrides: List[ChargeOverride]
 )
 
 case class ChargeOverride(

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -23,10 +23,10 @@ object HolidayStopProcess {
 
   def processHolidayStops(
     holidayCreditProduct: HolidayCreditProduct,
-    getHolidayStopRequestsFromSalesforce: ProductName => Either[OverallFailure, Seq[HolidayStopRequestsDetail]],
+    getHolidayStopRequestsFromSalesforce: ProductName => Either[OverallFailure, List[HolidayStopRequestsDetail]],
     getSubscription: SubscriptionName => Either[HolidayStopFailure, Subscription],
     updateSubscription: (Subscription, HolidayCreditUpdate) => Either[HolidayStopFailure, Unit],
-    writeHolidayStopsToSalesforce: Seq[HolidayStopResponse] => Either[OverallFailure, Unit]
+    writeHolidayStopsToSalesforce: List[HolidayStopResponse] => Either[OverallFailure, Unit]
   ): ProcessResult = {
     getHolidayStopRequestsFromSalesforce(ProductName("Guardian Weekly")) match {
       case Left(overallFailure) =>

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
@@ -2,12 +2,7 @@ package com.gu.holidaystopprocessor
 
 import com.typesafe.scalalogging.LazyLogging
 
-case class ProcessResult(
-  holidayStopsToApply: Seq[HolidayStop],
-  holidayStopResults: Seq[Either[HolidayStopFailure, HolidayStopResponse]],
-  resultsToExport: Seq[HolidayStopResponse],
-  overallFailure: Option[OverallFailure]
-)
+case class ProcessResult(holidayStopsToApply: List[HolidayStop], holidayStopResults: List[Either[HolidayStopFailure, HolidayStopResponse]], resultsToExport: List[HolidayStopResponse], overallFailure: Option[OverallFailure])
 
 object ProcessResult extends LazyLogging {
   def apply(failure: OverallFailure): ProcessResult =

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -14,7 +14,7 @@ object Salesforce {
 
   private def thresholdDate: LocalDate = LocalDate.now.plusDays(Config.daysInAdvance)
 
-  def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName): Either[OverallFailure, Seq[HolidayStopRequestsDetail]] =
+  def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName): Either[OverallFailure, List[HolidayStopRequestsDetail]] =
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>
       val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
       val fetchOp = SalesforceHolidayStopRequestsDetail.LookupPendingByProductNamePrefixAndDate(sfGet)
@@ -24,7 +24,7 @@ object Salesforce {
       case \/-(details) => Right(details)
     }
 
-  def holidayStopUpdateResponse(sfCredentials: SFAuthConfig)(responses: Seq[HolidayStopResponse]): Either[OverallFailure, Unit] =
+  def holidayStopUpdateResponse(sfCredentials: SFAuthConfig)(responses: List[HolidayStopResponse]): Either[OverallFailure, Unit] =
     SalesforceClient(RawEffects.response, sfCredentials).value.map { sfAuth =>
       val patch = sfAuth.wrapWith(JsonHttp.patch)
       val sendOp = ActionSalesforceHolidayStopRequestsDetail(patch) _

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
@@ -9,7 +9,7 @@ case class Subscription(
   currentTerm: Int,
   currentTermPeriodType: String,
   autoRenew: Boolean,
-  ratePlans: Seq[RatePlan]
+  ratePlans: List[RatePlan]
 ) {
 
   val originalRatePlanCharge: Option[RatePlanCharge] = {
@@ -47,7 +47,7 @@ case class Subscription(
 
 case class RatePlan(
   productName: String,
-  ratePlanCharges: Seq[RatePlanCharge]
+  ratePlanCharges: List[RatePlanCharge]
 )
 
 case class RatePlanCharge(

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ZuoraStatusResponse.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ZuoraStatusResponse.scala
@@ -3,7 +3,7 @@ package com.gu.holidaystopprocessor
 case class ZuoraStatusResponse(
   success: Boolean,
   subscriptionId: Option[String],
-  reasons: Option[Seq[Reason]]
+  reasons: Option[List[Reason]]
 )
 
 case class Reason(code: Long, message: String)

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -38,11 +38,11 @@ object Fixtures {
       currentTerm = 12,
       currentTermPeriodType = "Month",
       autoRenew = true,
-      ratePlans = Seq(
+      ratePlans = List(
         RatePlan(
           productName = "Guardian Weekly",
           ratePlanCharges =
-            Seq(mkRatePlanCharge(
+            List(mkRatePlanCharge(
               price,
               billingPeriod,
               chargedThroughDate
@@ -58,10 +58,10 @@ object Fixtures {
     currentTerm = 12,
     currentTermPeriodType = "Month",
     autoRenew = true,
-    ratePlans = Seq(
+    ratePlans = List(
       RatePlan(
         productName = "Discounts",
-        ratePlanCharges = Seq(RatePlanCharge(
+        ratePlanCharges = List(RatePlanCharge(
           name = "Holiday Credit",
           number = "C2",
           price = -3.27,
@@ -74,7 +74,7 @@ object Fixtures {
       ),
       RatePlan(
         productName = "Not a discount",
-        ratePlanCharges = Seq(RatePlanCharge(
+        ratePlanCharges = List(RatePlanCharge(
           name = "Holiday Credit",
           number = "C29",
           price = -3.27,
@@ -87,7 +87,7 @@ object Fixtures {
       ),
       RatePlan(
         productName = "Discounts",
-        ratePlanCharges = Seq(RatePlanCharge(
+        ratePlanCharges = List(RatePlanCharge(
           name = "Some other discount",
           number = "C73",
           price = -5.81,
@@ -100,7 +100,7 @@ object Fixtures {
       ),
       RatePlan(
         productName = "Discounts",
-        ratePlanCharges = Seq(RatePlanCharge(
+        ratePlanCharges = List(RatePlanCharge(
           name = "Holiday Credit",
           number = "C3",
           price = -5.81,
@@ -113,7 +113,7 @@ object Fixtures {
       ),
       RatePlan(
         productName = "Discounts",
-        ratePlanCharges = Seq(RatePlanCharge(
+        ratePlanCharges = List(RatePlanCharge(
           name = "Holiday Credit",
           number = "C987",
           price = -4.92,
@@ -126,7 +126,7 @@ object Fixtures {
       ),
       RatePlan(
         productName = "Guardian Weekly",
-        ratePlanCharges = Seq(mkRatePlanCharge(
+        ratePlanCharges = List(mkRatePlanCharge(
           price = 42.7,
           billingPeriod = "Quarter",
           chargedThroughDate = Some(LocalDate.of(2019, 9, 7))

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditSpec.scala
@@ -10,7 +10,7 @@ object HolidayCreditSpec extends Properties("HolidayCreditAmount") with OptionVa
 
   private val ratePlanChargeGen = for {
     price <- Gen.choose(0.01, 10000)
-    billingPeriod <- Gen.oneOf(Seq("Month", "Quarter", "Annual"))
+    billingPeriod <- Gen.oneOf(List("Month", "Quarter", "Annual"))
   } yield RatePlanCharge(
     name = "GW",
     number = "C5",
@@ -25,12 +25,12 @@ object HolidayCreditSpec extends Properties("HolidayCreditAmount") with OptionVa
   val subscription = Fixtures.mkSubscription()
 
   property("should never be positive") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
-    val ratePlans = Seq(RatePlan("", Seq(charge)))
+    val ratePlans = List(RatePlan("", List(charge)))
     HolidayCredit(subscription.copy(ratePlans = ratePlans)) <= 0
   }
 
   property("should never be overwhelmingly negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
-    val ratePlans = Seq(RatePlan("", Seq(charge)))
+    val ratePlans = List(RatePlan("", List(charge)))
     HolidayCredit(subscription.copy(ratePlans = ratePlans)) > -charge.price
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditTest.scala
@@ -7,7 +7,7 @@ class HolidayCreditTest extends FlatSpec with Matchers {
   "HolidayCredit" should "be correct for a quarterly billing period" in {
     val charge = Fixtures.mkRatePlanCharge(price = 30, billingPeriod = "Quarter")
     val subscription = Fixtures.mkSubscription()
-    val ratePlans = Seq(RatePlan("", Seq(charge)))
+    val ratePlans = List(RatePlan("", List(charge)))
     val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans))
     credit shouldBe -2.31
   }
@@ -15,7 +15,7 @@ class HolidayCreditTest extends FlatSpec with Matchers {
   it should "be correct for another quarterly billing period" in {
     val charge = Fixtures.mkRatePlanCharge(price = 37.5, billingPeriod = "Quarter")
     val subscription = Fixtures.mkSubscription()
-    val ratePlans = Seq(RatePlan("", Seq(charge)))
+    val ratePlans = List(RatePlan("", List(charge)))
     val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans))
     credit shouldBe -2.89
   }
@@ -23,7 +23,7 @@ class HolidayCreditTest extends FlatSpec with Matchers {
   it should "be correct for an annual billing period" in {
     val charge = Fixtures.mkRatePlanCharge(price = 120, billingPeriod = "Annual")
     val subscription = Fixtures.mkSubscription()
-    val ratePlans = Seq(RatePlan("", Seq(charge)))
+    val ratePlans = List(RatePlan("", List(charge)))
     val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans))
     credit shouldBe -2.31
   }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -24,7 +24,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     None
   )
 
-  private def getRequests(requestsGet: Either[OverallFailure, Seq[HolidayStopRequestsDetail]]): ProductName => Either[OverallFailure, Seq[HolidayStopRequestsDetail]] =
+  private def getRequests(requestsGet: Either[OverallFailure, List[HolidayStopRequestsDetail]]): ProductName => Either[OverallFailure, List[HolidayStopRequestsDetail]] =
     _ => requestsGet
 
   private def getSubscription(subscriptionGet: Either[HolidayStopFailure, Subscription]): SubscriptionName => Either[HolidayStopFailure, Subscription] = {
@@ -37,7 +37,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     case (_, _) => subscriptionUpdate
   }
 
-  private def exportAmendments(amendmentExport: Either[OverallFailure, Unit]): Seq[HolidayStopResponse] => Either[OverallFailure, Unit] =
+  private def exportAmendments(amendmentExport: Either[OverallFailure, Unit]): List[HolidayStopResponse] => Either[OverallFailure, Unit] =
     _ => amendmentExport
 
   "HolidayStopProcess" should "give correct added charge" in {
@@ -114,7 +114,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   "processHolidayStops" should "give correct charges added" in {
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
-      getRequests(Right(Seq(
+      getRequests(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)), "C1"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)), "C3"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R3", LocalDate.of(2019, 8, 9)), "C4")
@@ -146,7 +146,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "only export results that haven't already been exported" in {
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
-      getRequests(Right(Seq(
+      getRequests(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)), "C2"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)), "C5"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R3", LocalDate.of(2019, 8, 9)), "C6")
@@ -155,7 +155,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       updateSubscription(Right(())),
       exportAmendments(Right(()))
     )
-    responses.resultsToExport shouldBe Seq(
+    responses.resultsToExport shouldBe List(
       HolidayStopResponse(
         HolidayStopRequestsDetailId("R1"),
         subscriptionName = SubscriptionName("S1"),
@@ -171,7 +171,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "give an exception message if exporting results fails" in {
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
-      getRequests(Right(Seq(
+      getRequests(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("r1"), ""),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("r2"), ""),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("r3"), "")

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -30,13 +30,13 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     update shouldBe Right(HolidayCreditUpdate(
       currentTerm = None,
       currentTermPeriodType = None,
-      Seq(
+      List(
         Add(
           productRatePlanId = "ratePlanId",
           contractEffectiveDate = LocalDate.of(2019, 9, 12),
           customerAcceptanceDate = LocalDate.of(2019, 9, 12),
           serviceActivationDate = LocalDate.of(2019, 9, 12),
-          chargeOverrides = Seq(
+          chargeOverrides = List(
             ChargeOverride(
               productRatePlanChargeId = "ratePlanChargeId",
               HolidayStart__c = LocalDate.of(2019, 5, 18),


### PR DESCRIPTION
No typeclasses for Seq #1222: https://github.com/typelevel/cats/issues/1222, which forces unnecessary `toList`, for example, `s.toList.sequence`, 