### PR TITLE
Factor out overall failure decision

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Failures.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Failures.scala
@@ -1,7 +1,29 @@
 package com.gu.holidaystopprocessor
 
-// A failure to process an individual holiday stop
-case class HolidayStopFailure(reason: String)
+sealed trait HolidayError {
+  val reason: String
+}
+case class ZuoraHolidayWriteError(reason: String) extends HolidayError
+case class SalesforceHolidayWriteError(reason: String) extends HolidayError
+case class OverallFailure(reason: String) extends HolidayError
 
-// A general failure during the processing of holiday stops, but not caused by any particular holiday stop
-case class OverallFailure(reason: String)
+/**
+ * FIXME: Current implementation is not atomic, so how should we handle inconsistent state cleanup?
+ * FIXME: Improve error logging so we know which of the scenarios below is the case.
+ *
+ * The error scenarios we need to consider are
+ *   - Some writes to Zuora fail (but others succeed), and Salesforce write succeed
+ *   - Some writes to Zuora fail (but others succeed), and Salesforce write fails
+ *   - All writes to Zuora fail
+ */
+object OverallFailure {
+  def apply(
+    zuoraFailures: List[ZuoraHolidayWriteError],
+    salesforceResult: Either[SalesforceHolidayWriteError, Unit]
+  ): Option[OverallFailure] = {
+
+    val zuoraError = zuoraFailures.headOption.map(e => OverallFailure(e.reason))
+    val salesforceError = salesforceResult.left.toOption.map(e => OverallFailure(e.reason))
+    salesforceError orElse zuoraError
+  }
+}

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
@@ -7,23 +7,22 @@ import io.github.mkotsur.aws.handler.Lambda
 import io.github.mkotsur.aws.handler.Lambda._
 
 object Handler extends Lambda[None.type, List[HolidayStopResponse]] {
-
-  override protected def handle(
-    `_`: None.type,
-    context: Context
-  ): Either[Throwable, List[HolidayStopResponse]] = {
+  override def handle(`_`: None.type, context: Context): Either[Throwable, List[HolidayStopResponse]] = {
     Config() match {
-      case Left(msg) => Left(new RuntimeException(s"Config failure: $msg"))
+      case Left(msg) =>
+        Left(new RuntimeException(s"Config failure: $msg"))
+
       case Right(config) =>
         val result = HolidayStopProcess(config)
         ProcessResult.log(result)
-        result
-          .overallFailure
-          .map(failure => Left(new RuntimeException(failure.reason)))
-          .getOrElse {
-            result.holidayStopResults.sequence
-              .leftMap { failure => new RuntimeException(failure.reason) }
-          }
+        result.overallFailure match {
+          case Some(failure) =>
+            Left(new RuntimeException(failure.reason))
+
+          case None =>
+            val (_, successfulZuoraResponses) = result.holidayStopResults.separate
+            Right(successfulZuoraResponses)
+        }
     }
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCreditUpdate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCreditUpdate.scala
@@ -22,7 +22,7 @@ object HolidayCreditUpdate {
     nextInvoiceStartDate: LocalDate,
     maybeExtendedTerm: Option[ExtendedTerm],
     holidayCredit: Double
-  ): Either[HolidayStopFailure, HolidayCreditUpdate] = {
+  ): Either[ZuoraHolidayWriteError, HolidayCreditUpdate] = {
     Right(
       HolidayCreditUpdate(
         currentTerm = maybeExtendedTerm.map(_.length),

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
@@ -21,10 +21,10 @@ import java.time.LocalDate
  * or billingPeriodStartDay (1st of month).
  */
 object NextBillingPeriodStartDate {
-  def apply(subscription: Subscription): Either[HolidayStopFailure, LocalDate] = {
+  def apply(subscription: Subscription): Either[ZuoraHolidayWriteError, LocalDate] = {
     subscription
       .originalRatePlanCharge
       .flatMap(_.chargedThroughDate)
-      .toRight(HolidayStopFailure("Original rate plan charge has no charged through date. A bill run is needed to fix this."))
+      .toRight(ZuoraHolidayWriteError("Original rate plan charge has no charged through date. A bill run is needed to fix this."))
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
@@ -2,7 +2,7 @@ package com.gu.holidaystopprocessor
 
 import com.typesafe.scalalogging.LazyLogging
 
-case class ProcessResult(holidayStopsToApply: List[HolidayStop], holidayStopResults: List[Either[HolidayStopFailure, HolidayStopResponse]], resultsToExport: List[HolidayStopResponse], overallFailure: Option[OverallFailure])
+case class ProcessResult(holidayStopsToApply: List[HolidayStop], holidayStopResults: List[Either[ZuoraHolidayWriteError, HolidayStopResponse]], resultsToExport: List[HolidayStopResponse], overallFailure: Option[OverallFailure])
 
 object ProcessResult extends LazyLogging {
   def apply(failure: OverallFailure): ProcessResult =

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -24,7 +24,7 @@ object Salesforce {
       case \/-(details) => Right(details)
     }
 
-  def holidayStopUpdateResponse(sfCredentials: SFAuthConfig)(responses: List[HolidayStopResponse]): Either[OverallFailure, Unit] =
+  def holidayStopUpdateResponse(sfCredentials: SFAuthConfig)(responses: List[HolidayStopResponse]): Either[SalesforceHolidayWriteError, Unit] =
     SalesforceClient(RawEffects.response, sfCredentials).value.map { sfAuth =>
       val patch = sfAuth.wrapWith(JsonHttp.patch)
       val sendOp = ActionSalesforceHolidayStopRequestsDetail(patch) _
@@ -33,7 +33,7 @@ object Salesforce {
         sendOp(response.requestId)(actioned)
       }
     }.toDisjunction match {
-      case -\/(failure) => Left(OverallFailure(failure.toString))
+      case -\/(failure) => Left(SalesforceHolidayWriteError(failure.toString))
       case _ => Right(())
     }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -58,7 +58,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       chargedThroughDate = None
     )
     val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
-    nextInvoiceStartDate shouldBe Left(HolidayStopFailure(
+    nextInvoiceStartDate shouldBe Left(ZuoraHolidayWriteError(
       "Original rate plan charge has no charged through date. A bill run is needed to fix this."
     ))
   }


### PR DESCRIPTION
This PR tries to clean up error handling in the main lambda handler and should not contain semantic changes. However note the following FIXMEs we should address in followups:

```
/**
 * FIXME: Current implementation is not atomic, so how should we handle inconsistent state cleanup?
 * FIXME: Improve error logging so we know which of the scenarios below is the case.
 *
 * The error scenarios we need to consider are
 *   - Some writes to Zuora fail (but others succeed), and Salesforce write succeed
 *   - Some writes to Zuora fail (but others succeed), and Salesforce write fails
 *   - All writes to Zuora fail
 */
```