### PR TITLE
Calculate credit amount as a function of current guardian weekly subscription

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Config.scala
@@ -13,7 +13,8 @@ import scala.io.Source
 case class Config(
   zuoraConfig: ZuoraConfig,
   sfConfig: SFAuthConfig,
-  holidayCreditProduct: HolidayCreditProduct
+  holidayCreditProduct: HolidayCreditProduct,
+  guardianWeeklyProductRatePlanIds: List[String]
 )
 
 /**
@@ -35,6 +36,81 @@ case class HolidayStopProcessor(oauth: Oauth)
 case class Oauth(clientId: String, clientSecret: String)
 
 object Config {
+
+  /**
+   * How to find productrateplan IDs?
+   *
+   * https://{{zuoraUrlPrefix}}/query/jobs
+   *
+   * {
+   *   "query": "select id, name from productrateplan limit 201",
+   *   "outputFormat": "JSON",
+   *   "compression": "NONE",
+   *   "retries": 1,
+   *   "output": {
+   *     "target": "API_RESPONSE"
+   *   }
+   * }
+   */
+  val guardianWeeklyProductRatePlanIdsPROD = List(
+    // Product: {"id":"2c92a0ff-6619-bf89-0166-1aa3247c4b1d", "name":"Guardian Weekly - Domestic"}
+    "2c92a0fe6619b4b901661aa8e66c1692", // "name": "GW Oct 18 - Annual - Domestic"
+    "2c92a0fe6619b4b301661aa494392ee2", // "name": "GW Oct 18 - Quarterly - Domestic"
+
+    // Product: {"2c92a0fe-6619-b4b9-0166-1aaf826435de", "name":"Guardian Weekly - ROW"}
+    "2c92a0fe6619b4b601661ab300222651", // "name":"GW Oct 18 - Annual - ROW"
+    "2c92a0086619bf8901661ab02752722f", // "name":"GW Oct 18 - Quarterly - ROW"
+
+    // Product: {"id":"2c92a0fd-57d0-a987-0157-d73fa27c3de1","name":"Guardian Weekly Zone A"}
+    "2c92a0fd57d0a9870157d7412f19424f", // "name":"Guardian Weekly Quarterly"
+    "2c92a0ff57d0a0b60157d741e722439a", // "name":"Guardian Weekly Annual"
+
+    // Product: {"id":"2c92a0fe-57d0-a0c4-0157-d74240d35541","name":"Guardian Weekly Zone B"}
+    "2c92a0fe57d0a0c40157d74241005544", // "name":"Guardian Weekly Quarterly"
+    "2c92a0fe57d0a0c40157d74240de5543", // "name":"Guardian Weekly Annual"
+
+    // Product: {"id":"2c92a0ff-58bd-f4eb-0158-f307ecc102ad","name":"Guardian Weekly Zone C"}
+    "2c92a0ff58bdf4eb0158f307ed0e02be", // "name":"Guardian Weekly Quarterly"
+    "2c92a0ff58bdf4eb0158f307eccf02af" // "name":"Guardian Weekly Annual"
+  )
+
+  val guardianWeeklyProductRatePlanIdsUAT = List(
+    // Product: {"id":"2c92a0ff-6619-bf89-0166-1aa3247c4b1d", "name":"Guardian Weekly - Domestic"}
+    "2c92c0f9660fc4d70166107fa5412641", // "name": "GW Oct 18 - Annual - Domestic"
+    "2c92c0f8660fb5d601661081ea010391", // "name": "GW Oct 18 - Quarterly - Domestic"
+
+    // Product: {"2c92a0fe-6619-b4b9-0166-1aaf826435de", "name":"Guardian Weekly - ROW"}
+    "2c92c0f9660fc4d70166109a2eb0607c", // "name":"GW Oct 18 - Annual - ROW"
+    "2c92c0f9660fc4d70166109c01465f10", // "name":"GW Oct 18 - Quarterly - ROW"
+
+    "2c92c0f8574ebcdf015751506daf54c4", // "name":"Guardian Weekly Quarterly"
+    "2c92c0f8574654af015747f934cc4a04", // "name":"Guardian Weekly Annual"
+
+    "2c92c0f9574ee3d80157514ee1c36a8e", // "name":"Guardian Weekly Quarterly"
+    "2c92c0f8574ebcdf015751506d7154ae", // "name":"Guardian Weekly Annual"
+
+    "2c92c0f958aa45650158da23e5eb29d8", // "name":"Guardian Weekly Quarterly"
+    "2c92c0f958aa45650158da23e5ab29c9" // "name":"Guardian Weekly Annual"
+  )
+
+  val guardianWeeklyProductRatePlanIdsDEV = List(
+    // Product: {"id":"2c92c0f8-65d2-72ef-0165-f14cc19d238a", "name":"Guardian Weekly - Domestic"}
+    "2c92c0f965d280590165f16b1b9946c2", // "name": "GW Oct 18 - Annual - Domestic"
+    "2c92c0f965dc30640165f150c0956859", // "name": "GW Oct 18 - Quarterly - Domestic"
+
+    // Product: {"2c92c0f9-65f2-121e-0166-0fb1f1057b1a", "name":"Guardian Weekly - ROW"}
+    "2c92c0f965f2122101660fb33ed24a45", // "name":"GW Oct 18 - Annual - ROW"
+    "2c92c0f965f2122101660fb81b745a06", // "name":"GW Oct 18 - Quarterly - ROW"
+
+    "2c92c0f8574b2b8101574c4a9480068d", // "name":"Guardian Weekly Annual"
+    "2c92c0f8574b2b8101574c4a957706be", // "name":"Guardian Weekly Quarterly"
+
+    "2c92c0f8574b2be601574c323ca15c7e", // "name":"Guardian Weekly Quarterly"
+    "2c92c0f8574b2be601574c39888d6850", // "name":"Guardian Weekly Annual"
+
+    "2c92c0f858aa38af0158da325cec0b2e", // "name":"Guardian Weekly Quarterly"
+    "2c92c0f858aa38af0158da325d2f0b3d", // "name":"Guardian Weekly Annual"
+  )
 
   /**
    * Min number of days ahead that a holiday stop can be applied
@@ -83,7 +159,8 @@ object Config {
             HolidayCreditProduct(
               productRatePlanId = "2c92a0076ae9189c016b080c930a6186",
               productRatePlanChargeId = "2c92a0086ae928d7016b080f638477a6"
-            )
+            ),
+            guardianWeeklyProductRatePlanIdsPROD
           )
         case "CODE" =>
           Config(
@@ -92,7 +169,8 @@ object Config {
             HolidayCreditProduct(
               productRatePlanId = "2c92c0f86b0378b0016b08112e870d0a",
               productRatePlanChargeId = "2c92c0f86b0378b0016b08112ec70d14"
-            )
+            ),
+            guardianWeeklyProductRatePlanIdsUAT
           )
         case "DEV" =>
           Config(
@@ -101,7 +179,8 @@ object Config {
             HolidayCreditProduct(
               productRatePlanId = "2c92c0f96b03800b016b081fc04f1ba2",
               productRatePlanChargeId = "2c92c0f96b03800b016b081fc0f41bb4"
-            )
+            ),
+            guardianWeeklyProductRatePlanIdsDEV
           )
       }
     }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -10,8 +10,7 @@ sealed trait CurrentGuardianWeeklyRatePlanCondition
 case object RatePlanIsGuardianWeekly extends CurrentGuardianWeeklyRatePlanCondition
 // case object TodayHasBeenInvoiced extends CurrentGuardianWeeklyRatePlanCondition // FIXME: This is a stronger check than RatePlanHasBeenInvoiced but requires significant refactoring of tests
 case object RatePlanHasBeenInvoiced extends CurrentGuardianWeeklyRatePlanCondition
-case object RatePlanHasACharge extends CurrentGuardianWeeklyRatePlanCondition
-case object RatePlanHasOnlyOneCharge extends CurrentGuardianWeeklyRatePlanCondition
+case object RatePlanHasExactlyOneCharge extends CurrentGuardianWeeklyRatePlanCondition
 case object ChargeIsQuarterlyOrAnnual extends CurrentGuardianWeeklyRatePlanCondition
 
 /**
@@ -75,8 +74,8 @@ object CurrentGuardianWeeklySubscription {
       .find { ratePlan =>
         List[(CurrentGuardianWeeklyRatePlanCondition, Boolean)](
           RatePlanIsGuardianWeekly -> guardianWeeklyProductRatePlanIds.contains(ratePlan.productRatePlanId),
-          RatePlanHasACharge -> ratePlan.ratePlanCharges.nonEmpty,
-          RatePlanHasOnlyOneCharge -> (ratePlan.ratePlanCharges.size == 1),
+          //          RatePlanHasACharge -> ratePlan.ratePlanCharges.nonEmpty,
+          RatePlanHasExactlyOneCharge -> (ratePlan.ratePlanCharges.size == 1),
           // FIXME: Enable this after test refactoring - the problem is LocalDate.now() call
           //          TodayHasBeenInvoiced ->
           //            Try {

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -1,0 +1,102 @@
+package com.gu.holidaystopprocessor
+
+import java.time.LocalDate
+import scala.util.Try
+
+/**
+ * Conditions defining what Guardian Weekly subscription the customer has today.
+ */
+sealed trait CurrentGuardianWeeklyRatePlanCondition
+case object RatePlanIsGuardianWeekly extends CurrentGuardianWeeklyRatePlanCondition
+case object TodayHasBeenInvoiced extends CurrentGuardianWeeklyRatePlanCondition
+case object RatePlanHasACharge extends CurrentGuardianWeeklyRatePlanCondition
+case object RatePlanHasOnlyOneCharge extends CurrentGuardianWeeklyRatePlanCondition
+case object ChargeIsQuarterlyOrAnnual extends CurrentGuardianWeeklyRatePlanCondition
+
+/**
+ * Model representing 'What Guardian Weekly does the customer have today?'
+ *
+ * The idea is to have a single unified object as an answer to this question because Zuora's answer is
+ * scattered across multiple objects such as Subscription, RatePlan, RatePlanCharge.
+ */
+case class CurrentGuardianWeeklySubscription(
+  subscriptionNumber: String,
+  billingPeriod: String,
+  price: Double,
+  invoicedPeriod: CurrentInvoicedPeriod,
+  ratePlanId: String,
+  productRatePlanId: String
+)
+
+/**
+ * Is date between two dates where including the start while excluding the end?
+ */
+object PeriodContainsDate extends ((LocalDate, LocalDate, LocalDate) => Boolean) {
+  def apply(
+    startPeriodInclusive: LocalDate,
+    endPeriodExcluding: LocalDate,
+    date: LocalDate
+  ): Boolean =
+    (date.isEqual(startPeriodInclusive) || date.isAfter(startPeriodInclusive)) && date.isBefore(endPeriodExcluding)
+}
+
+/**
+ * Invoiced period defined by [startDateIncluding, endDateExcluding) specifies the current period for which
+ * the customer has been billed. Today must be within this period.
+ *
+ * @param startDateIncluding service active on startDateIncluding; corresponds to processedThroughDate
+ * @param endDateExcluding service stops one endDateExcluding; corresponds to chargedThroughDate
+ */
+case class CurrentInvoicedPeriod(
+  startDateIncluding: LocalDate,
+  endDateExcluding: LocalDate
+) {
+  private val todayIsWithinCurrentInvoicedPeriod: Boolean = PeriodContainsDate(
+    startPeriodInclusive = startDateIncluding,
+    endPeriodExcluding = endDateExcluding,
+    date = LocalDate.now()
+  )
+  //  require(todayIsWithinCurrentInvoicedPeriod, "Today should be within [startDateIncluding, endDateExcluding)")
+}
+
+/**
+ * What Guardian Weekly does the customer have today?
+ *
+ * Zuora subscription can have multiple rate plans so this function selects just the one representing
+ * current Guardian Weekly subscription. Given a Zuora subscription return a single current rate plan
+ * attached to Guardian Weekly product that satisfies all of the CurrentGuardianWeeklyRatePlanPredicates.
+ */
+object CurrentGuardianWeeklySubscription {
+  def apply(subscription: Subscription, guardianWeeklyProductRatePlanIds: List[String]): CurrentGuardianWeeklySubscription =
+    subscription
+      .ratePlans
+      .find { ratePlan =>
+        List[(CurrentGuardianWeeklyRatePlanCondition, Boolean)](
+          RatePlanIsGuardianWeekly -> guardianWeeklyProductRatePlanIds.contains(ratePlan.productRatePlanId),
+          RatePlanHasACharge -> ratePlan.ratePlanCharges.nonEmpty,
+          RatePlanHasOnlyOneCharge -> (ratePlan.ratePlanCharges.size == 1),
+          //          TodayHasBeenInvoiced ->
+          //            Try {
+          //              PeriodContainsDate(
+          //                startPeriodInclusive = ratePlan.ratePlanCharges.head.processedThroughDate.get,
+          //                endPeriodExcluding = ratePlan.ratePlanCharges.head.chargedThroughDate.get,
+          //                date = LocalDate.now()
+          //              )
+          //            }.getOrElse(false),
+          ChargeIsQuarterlyOrAnnual -> Try(List("Annual", "Quarter").contains(ratePlan.ratePlanCharges.head.billingPeriod.get)).getOrElse(false)
+        ).forall(_._2)
+      }
+      .map { currentGuardianWeeklyRatePlan =>
+        new CurrentGuardianWeeklySubscription(
+          subscriptionNumber = subscription.subscriptionNumber,
+          billingPeriod = currentGuardianWeeklyRatePlan.ratePlanCharges.head.billingPeriod.get,
+          price = currentGuardianWeeklyRatePlan.ratePlanCharges.head.price,
+          invoicedPeriod = CurrentInvoicedPeriod(
+            startDateIncluding = currentGuardianWeeklyRatePlan.ratePlanCharges.head.processedThroughDate.get,
+            endDateExcluding = currentGuardianWeeklyRatePlan.ratePlanCharges.head.chargedThroughDate.get
+          ),
+          ratePlanId = currentGuardianWeeklyRatePlan.id,
+          productRatePlanId = currentGuardianWeeklyRatePlan.productRatePlanId
+        )
+      }.getOrElse(throw new RuntimeException(s"Subscription does not have a current Guardian Weekly rate plan: ${subscription}"))
+}

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -90,7 +90,7 @@ object CurrentGuardianWeeklySubscription {
           ChargeIsQuarterlyOrAnnual -> Try(List("Annual", "Quarter").contains(ratePlan.ratePlanCharges.head.billingPeriod.get)).getOrElse(false)
         ).forall(_._2)
       }
-      .map { currentGuardianWeeklyRatePlan =>
+      .map { currentGuardianWeeklyRatePlan => // these ugly gets are safe due to above conditions
         new CurrentGuardianWeeklySubscription(
           subscriptionNumber = subscription.subscriptionNumber,
           billingPeriod = currentGuardianWeeklyRatePlan.ratePlanCharges.head.billingPeriod.get,

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -46,7 +46,7 @@ object PeriodContainsDate extends ((LocalDate, LocalDate, LocalDate) => Boolean)
  * the customer has been billed. Today must be within this period.
  *
  * @param startDateIncluding service active on startDateIncluding; corresponds to processedThroughDate
- * @param endDateExcluding service stops one endDateExcluding; corresponds to chargedThroughDate
+ * @param endDateExcluding service ends on endDateExcluding; corresponds to chargedThroughDate
  */
 case class CurrentInvoicedPeriod(
   startDateIncluding: LocalDate,

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -86,7 +86,11 @@ object CurrentGuardianWeeklySubscription {
           //                date = LocalDate.now()
           //              )
           //            }.getOrElse(false),
-          RatePlanHasBeenInvoiced -> (ratePlan.ratePlanCharges.head.processedThroughDate.isDefined && ratePlan.ratePlanCharges.head.chargedThroughDate.isDefined),
+          RatePlanHasBeenInvoiced -> Try {
+            val fromInclusive = ratePlan.ratePlanCharges.head.processedThroughDate.get
+            val toExclusive = ratePlan.ratePlanCharges.head.chargedThroughDate.get
+            toExclusive.isAfter(fromInclusive)
+          }.getOrElse(false),
           ChargeIsQuarterlyOrAnnual -> Try(List("Annual", "Quarter").contains(ratePlan.ratePlanCharges.head.billingPeriod.get)).getOrElse(false)
         ).forall(_._2)
       }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -8,7 +8,8 @@ import scala.util.Try
  */
 sealed trait CurrentGuardianWeeklyRatePlanCondition
 case object RatePlanIsGuardianWeekly extends CurrentGuardianWeeklyRatePlanCondition
-case object TodayHasBeenInvoiced extends CurrentGuardianWeeklyRatePlanCondition
+// case object TodayHasBeenInvoiced extends CurrentGuardianWeeklyRatePlanCondition // FIXME: This is a stronger check than RatePlanHasBeenInvoiced but requires significant refactoring of tests
+case object RatePlanHasBeenInvoiced extends CurrentGuardianWeeklyRatePlanCondition
 case object RatePlanHasACharge extends CurrentGuardianWeeklyRatePlanCondition
 case object RatePlanHasOnlyOneCharge extends CurrentGuardianWeeklyRatePlanCondition
 case object ChargeIsQuarterlyOrAnnual extends CurrentGuardianWeeklyRatePlanCondition
@@ -56,6 +57,7 @@ case class CurrentInvoicedPeriod(
     endPeriodExcluding = endDateExcluding,
     date = LocalDate.now()
   )
+  // FIXME: Enable this after test refactoring
   //  require(todayIsWithinCurrentInvoicedPeriod, "Today should be within [startDateIncluding, endDateExcluding)")
 }
 
@@ -75,6 +77,7 @@ object CurrentGuardianWeeklySubscription {
           RatePlanIsGuardianWeekly -> guardianWeeklyProductRatePlanIds.contains(ratePlan.productRatePlanId),
           RatePlanHasACharge -> ratePlan.ratePlanCharges.nonEmpty,
           RatePlanHasOnlyOneCharge -> (ratePlan.ratePlanCharges.size == 1),
+          // FIXME: Enable this after test refactoring - the problem is LocalDate.now() call
           //          TodayHasBeenInvoiced ->
           //            Try {
           //              PeriodContainsDate(
@@ -83,6 +86,7 @@ object CurrentGuardianWeeklySubscription {
           //                date = LocalDate.now()
           //              )
           //            }.getOrElse(false),
+          RatePlanHasBeenInvoiced -> (ratePlan.ratePlanCharges.head.processedThroughDate.isDefined && ratePlan.ratePlanCharges.head.chargedThroughDate.isDefined),
           ChargeIsQuarterlyOrAnnual -> Try(List("Annual", "Quarter").contains(ratePlan.ratePlanCharges.head.billingPeriod.get)).getOrElse(false)
         ).forall(_._2)
       }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -94,13 +94,14 @@ object CurrentGuardianWeeklySubscription {
         ).forall(_._2)
       }
       .map { currentGuardianWeeklyRatePlan => // these ugly gets are safe due to above conditions
+        val currentGuardianWeeklyRatePlanCharge = currentGuardianWeeklyRatePlan.ratePlanCharges.head
         new CurrentGuardianWeeklySubscription(
           subscriptionNumber = subscription.subscriptionNumber,
-          billingPeriod = currentGuardianWeeklyRatePlan.ratePlanCharges.head.billingPeriod.get,
-          price = currentGuardianWeeklyRatePlan.ratePlanCharges.head.price,
+          billingPeriod = currentGuardianWeeklyRatePlanCharge.billingPeriod.get,
+          price = currentGuardianWeeklyRatePlanCharge.price,
           invoicedPeriod = CurrentInvoicedPeriod(
-            startDateIncluding = currentGuardianWeeklyRatePlan.ratePlanCharges.head.processedThroughDate.get,
-            endDateExcluding = currentGuardianWeeklyRatePlan.ratePlanCharges.head.chargedThroughDate.get
+            startDateIncluding = currentGuardianWeeklyRatePlanCharge.processedThroughDate.get,
+            endDateExcluding = currentGuardianWeeklyRatePlanCharge.chargedThroughDate.get
           ),
           ratePlanId = currentGuardianWeeklyRatePlan.id,
           productRatePlanId = currentGuardianWeeklyRatePlan.productRatePlanId

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCredit.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCredit.scala
@@ -12,7 +12,7 @@ object HolidayCredit {
   def apply(subscription: Subscription, guardianWeeklyProductRatePlanIds: List[String]): Double = {
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds)
     val recurringPrice = currentGuardianWeeklySubscription.price
-    val numPublicationsInPeriod = BillingPeriodToApproxWeekCount(currentGuardianWeeklySubscription.billingPeriod)
+    val numPublicationsInPeriod = BillingPeriodToApproxWeekCount(currentGuardianWeeklySubscription)
     def roundUp(d: Double): Double = BigDecimal(d).setScale(2, RoundingMode.UP).toDouble
     -roundUp(recurringPrice / numPublicationsInPeriod)
   }
@@ -20,10 +20,10 @@ object HolidayCredit {
 
 // FIXME: Is this assumption safe?
 object BillingPeriodToApproxWeekCount {
-  def apply(billingPeriod: String): Int =
-    billingPeriod match {
+  def apply(currentGuardianWeeklySubscription: CurrentGuardianWeeklySubscription): Int =
+    currentGuardianWeeklySubscription.billingPeriod match {
       case "Quarter" => 13
       case "Annual" => 52
-      case _ => 52
+      case _ => throw new RuntimeException(s"Failed to convert billing period to weeks because unexpected billing period: $currentGuardianWeeklySubscription")
     }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -14,6 +14,7 @@ object HolidayStopProcess {
       case Right(zuoraAccessToken) =>
         processHolidayStops(
           config.holidayCreditProduct,
+          guardianWeeklyProductRatePlanIds = config.guardianWeeklyProductRatePlanIds,
           getHolidayStopRequestsFromSalesforce = Salesforce.holidayStopRequests(config.sfConfig),
           getSubscription = Zuora.subscriptionGetResponse(config, zuoraAccessToken),
           updateSubscription = Zuora.subscriptionUpdateResponse(config, zuoraAccessToken),
@@ -23,6 +24,7 @@ object HolidayStopProcess {
 
   def processHolidayStops(
     holidayCreditProduct: HolidayCreditProduct,
+    guardianWeeklyProductRatePlanIds: List[String],
     getHolidayStopRequestsFromSalesforce: ProductName => Either[OverallFailure, List[HolidayStopRequestsDetail]],
     getSubscription: SubscriptionName => Either[ZuoraHolidayWriteError, Subscription],
     updateSubscription: (Subscription, HolidayCreditUpdate) => Either[ZuoraHolidayWriteError, Unit],
@@ -35,7 +37,7 @@ object HolidayStopProcess {
       case Right(holidayStopRequestsFromSalesforce) =>
         val holidayStops = holidayStopRequestsFromSalesforce.distinct.map(HolidayStop(_))
         val alreadyActionedHolidayStops = holidayStopRequestsFromSalesforce.flatMap(_.Charge_Code__c).distinct
-        val allZuoraHolidayStopResponses = holidayStops.map(writeHolidayStopToZuora(holidayCreditProduct, getSubscription, updateSubscription))
+        val allZuoraHolidayStopResponses = holidayStops.map(writeHolidayStopToZuora(holidayCreditProduct, guardianWeeklyProductRatePlanIds, getSubscription, updateSubscription))
         val (failedZuoraResponses, successfulZuoraResponses) = allZuoraHolidayStopResponses.separate
         val notAlreadyActionedHolidays = successfulZuoraResponses.filterNot(v => alreadyActionedHolidayStops.contains(v.chargeCode))
         val salesforceExportResult = writeHolidayStopsToSalesforce(notAlreadyActionedHolidays)
@@ -53,6 +55,7 @@ object HolidayStopProcess {
    */
   def writeHolidayStopToZuora(
     holidayCreditProduct: HolidayCreditProduct,
+    guardianWeeklyProductRatePlanIds: List[String],
     getSubscription: SubscriptionName => Either[ZuoraHolidayWriteError, Subscription],
     updateSubscription: (Subscription, HolidayCreditUpdate) => Either[ZuoraHolidayWriteError, Unit]
   )(stop: HolidayStop): Either[ZuoraHolidayWriteError, HolidayStopResponse] =
@@ -61,7 +64,7 @@ object HolidayStopProcess {
       _ <- if (subscription.autoRenew) Right(()) else Left(ZuoraHolidayWriteError("Cannot currently process non-auto-renewing subscription"))
       nextInvoiceStartDate <- NextBillingPeriodStartDate(subscription)
       maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
-      holidayCredit = HolidayCredit(subscription)
+      holidayCredit = HolidayCredit(subscription, guardianWeeklyProductRatePlanIds)
       holidayCreditUpdate <- HolidayCreditUpdate(holidayCreditProduct, subscription, stop.stoppedPublicationDate, nextInvoiceStartDate, maybeExtendedTerm, holidayCredit)
       _ <- if (subscription.hasHolidayStop(stop)) Right(()) else updateSubscription(subscription, holidayCreditUpdate)
       updatedSubscription <- getSubscription(stop.subscriptionName)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
@@ -20,6 +20,8 @@ import java.time.LocalDate
  * Note nextBillingPeriodStartDate represents a specific date yyyy-mm-dd unlike billingPeriod (quarterly)
  * or billingPeriodStartDay (1st of month).
  */
+
+// FIXME: This should be function of CurrentGuardianWeeklySubscription
 object NextBillingPeriodStartDate {
   def apply(subscription: Subscription): Either[ZuoraHolidayWriteError, LocalDate] = {
     subscription

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Subscription.scala
@@ -47,7 +47,9 @@ case class Subscription(
 
 case class RatePlan(
   productName: String,
-  ratePlanCharges: List[RatePlanCharge]
+  ratePlanCharges: List[RatePlanCharge],
+  productRatePlanId: String,
+  id: String
 )
 
 case class RatePlanCharge(
@@ -58,16 +60,8 @@ case class RatePlanCharge(
   effectiveStartDate: LocalDate,
   chargedThroughDate: Option[LocalDate],
   HolidayStart__c: Option[LocalDate],
-  HolidayEnd__c: Option[LocalDate]
-) {
+  HolidayEnd__c: Option[LocalDate],
+  processedThroughDate: Option[LocalDate],
+)
 
-  val weekCountApprox: Int = {
-    val default = 52
-    billingPeriod map {
-      case "Month" => 4
-      case "Quarter" => 13
-      case "Annual" => 52
-      case _ => default
-    } getOrElse default
-  }
-}
+

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -9,6 +9,11 @@ import com.gu.util.Time
 
 object Fixtures {
 
+  def billingPeriodToMonths(billingPeriod: String): Int = billingPeriod match {
+    case "Quarter" => 3
+    case "Annual" => 12
+  }
+
   def mkRatePlanCharge(
     price: Double,
     billingPeriod: String,
@@ -21,14 +26,15 @@ object Fixtures {
     effectiveStartDate = LocalDate.of(2018, 6, 10),
     chargedThroughDate,
     HolidayStart__c = None,
-    HolidayEnd__c = None
+    HolidayEnd__c = None,
+    processedThroughDate = chargedThroughDate.map(_.minusMonths(billingPeriodToMonths(billingPeriod)))
   )
 
   def mkSubscription(
     termStartDate: LocalDate = LocalDate.now(),
     termEndDate: LocalDate = LocalDate.now(),
     price: Double = -1.0,
-    billingPeriod: String = "Quarterly",
+    billingPeriod: String = "Quarter",
     chargedThroughDate: Option[LocalDate] = None
   ) =
     Subscription(
@@ -46,7 +52,9 @@ object Fixtures {
               price,
               billingPeriod,
               chargedThroughDate
-            ))
+            )),
+          Fixtures.config.guardianWeeklyProductRatePlanIds.head,
+          ""
         )
       )
     )
@@ -69,8 +77,11 @@ object Fixtures {
           effectiveStartDate = LocalDate.of(2019, 9, 7),
           chargedThroughDate = None,
           HolidayStart__c = Some(LocalDate.of(2019, 8, 9)),
-          HolidayEnd__c = Some(LocalDate.of(2019, 8, 9))
-        ))
+          HolidayEnd__c = Some(LocalDate.of(2019, 8, 9)),
+          processedThroughDate = None
+        )),
+        Fixtures.config.guardianWeeklyProductRatePlanIds.head,
+        ""
       ),
       RatePlan(
         productName = "Not a discount",
@@ -82,8 +93,11 @@ object Fixtures {
           effectiveStartDate = LocalDate.of(2019, 9, 7),
           chargedThroughDate = None,
           HolidayStart__c = Some(LocalDate.of(2019, 8, 11)),
-          HolidayEnd__c = Some(LocalDate.of(2019, 8, 11))
-        ))
+          HolidayEnd__c = Some(LocalDate.of(2019, 8, 11)),
+          processedThroughDate = None
+        )),
+        Fixtures.config.guardianWeeklyProductRatePlanIds.head,
+        ""
       ),
       RatePlan(
         productName = "Discounts",
@@ -95,8 +109,11 @@ object Fixtures {
           effectiveStartDate = LocalDate.of(2019, 9, 7),
           chargedThroughDate = None,
           HolidayStart__c = Some(LocalDate.of(2019, 8, 19)),
-          HolidayEnd__c = Some(LocalDate.of(2019, 8, 19))
-        ))
+          HolidayEnd__c = Some(LocalDate.of(2019, 8, 19)),
+          processedThroughDate = None
+        )),
+        "",
+        ""
       ),
       RatePlan(
         productName = "Discounts",
@@ -108,8 +125,11 @@ object Fixtures {
           effectiveStartDate = LocalDate.of(2019, 9, 7),
           chargedThroughDate = None,
           HolidayStart__c = Some(LocalDate.of(2019, 8, 2)),
-          HolidayEnd__c = Some(LocalDate.of(2019, 8, 2))
-        ))
+          HolidayEnd__c = Some(LocalDate.of(2019, 8, 2)),
+          processedThroughDate = None
+        )),
+        Fixtures.config.guardianWeeklyProductRatePlanIds.head,
+        ""
       ),
       RatePlan(
         productName = "Discounts",
@@ -121,8 +141,11 @@ object Fixtures {
           effectiveStartDate = LocalDate.of(2018, 11, 16),
           chargedThroughDate = None,
           HolidayStart__c = Some(LocalDate.of(2018, 11, 16)),
-          HolidayEnd__c = Some(LocalDate.of(2019, 1, 4))
-        ))
+          HolidayEnd__c = Some(LocalDate.of(2019, 1, 4)),
+          processedThroughDate = None
+        )),
+        Fixtures.config.guardianWeeklyProductRatePlanIds.head,
+        ""
       ),
       RatePlan(
         productName = "Guardian Weekly",
@@ -130,7 +153,9 @@ object Fixtures {
           price = 42.7,
           billingPeriod = "Quarter",
           chargedThroughDate = Some(LocalDate.of(2019, 9, 7))
-        ))
+        )),
+        Fixtures.config.guardianWeeklyProductRatePlanIds.head,
+        ""
       )
     )
   )
@@ -174,6 +199,7 @@ object Fixtures {
     HolidayCreditProduct(
       productRatePlanId = "ratePlanId",
       productRatePlanChargeId = "ratePlanChargeId"
-    )
+    ),
+    Config.guardianWeeklyProductRatePlanIdsPROD // FIXME
   )
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditTest.scala
@@ -7,24 +7,24 @@ class HolidayCreditTest extends FlatSpec with Matchers {
   "HolidayCredit" should "be correct for a quarterly billing period" in {
     val charge = Fixtures.mkRatePlanCharge(price = 30, billingPeriod = "Quarter")
     val subscription = Fixtures.mkSubscription()
-    val ratePlans = List(RatePlan("", List(charge)))
-    val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans))
+    val ratePlans = List(RatePlan("", List(charge), Fixtures.config.guardianWeeklyProductRatePlanIds.head, ""))
+    val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans), Fixtures.config.guardianWeeklyProductRatePlanIds)
     credit shouldBe -2.31
   }
 
   it should "be correct for another quarterly billing period" in {
     val charge = Fixtures.mkRatePlanCharge(price = 37.5, billingPeriod = "Quarter")
     val subscription = Fixtures.mkSubscription()
-    val ratePlans = List(RatePlan("", List(charge)))
-    val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans))
+    val ratePlans = List(RatePlan("", List(charge), Fixtures.config.guardianWeeklyProductRatePlanIds.head, ""))
+    val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans), Fixtures.config.guardianWeeklyProductRatePlanIds)
     credit shouldBe -2.89
   }
 
   it should "be correct for an annual billing period" in {
     val charge = Fixtures.mkRatePlanCharge(price = 120, billingPeriod = "Annual")
     val subscription = Fixtures.mkSubscription()
-    val ratePlans = List(RatePlan("", List(charge)))
-    val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans))
+    val ratePlans = List(RatePlan("", List(charge), Fixtures.config.guardianWeeklyProductRatePlanIds.head, ""))
+    val credit = HolidayCredit(subscription.copy(ratePlans = ratePlans), Fixtures.config.guardianWeeklyProductRatePlanIds)
     credit shouldBe -2.31
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -43,6 +43,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   "HolidayStopProcess" should "give correct added charge" in {
     val response = HolidayStopProcess.writeHolidayStopToZuora(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getSubscription(Right(Fixtures.mkSubscriptionWithHolidayStops())),
       updateSubscription(Right(()))
     )(holidayStop)
@@ -60,6 +61,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "give an exception message if update fails" in {
     val response = HolidayStopProcess.writeHolidayStopToZuora(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getSubscription(Right(subscription)),
       updateSubscription(Left(ZuoraHolidayWriteError("update went wrong")))
     )(holidayStop)
@@ -69,6 +71,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "give an exception message if getting subscription details fails" in {
     val response = HolidayStopProcess.writeHolidayStopToZuora(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getSubscription(Left(ZuoraHolidayWriteError("get went wrong"))),
       updateSubscription(Right(()))
     )(holidayStop)
@@ -78,6 +81,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "give an exception message if subscription isn't auto-renewing" in {
     val response = HolidayStopProcess.writeHolidayStopToZuora(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getSubscription(Right(subscription.copy(autoRenew = false))),
       updateSubscription(Right(()))
     )(holidayStop)
@@ -88,6 +92,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "just give charge added without applying an update if holiday stop has already been applied" in {
     val response = HolidayStopProcess.writeHolidayStopToZuora(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getSubscription(Right(Fixtures.mkSubscriptionWithHolidayStops())),
       updateSubscription(Left(ZuoraHolidayWriteError("shouldn't need to apply an update")))
     )(holidayStop)
@@ -105,6 +110,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "give a failure if subscription has no added charge" in {
     val response = HolidayStopProcess.writeHolidayStopToZuora(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getSubscription(Right(subscription)),
       updateSubscription(Left(ZuoraHolidayWriteError("shouldn't need to apply an update")))
     )(holidayStop)
@@ -114,6 +120,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   "processHolidayStops" should "give correct charges added" in {
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getRequests(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)), "C1"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)), "C3"),
@@ -146,6 +153,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "only export results that haven't already been exported" in {
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getRequests(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)), "C2"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)), "C5"),
@@ -171,6 +179,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
   it should "give an exception message if exporting results fails" in {
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
       getRequests(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("r1"), ""),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("r2"), ""),

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionTest.scala
@@ -17,7 +17,8 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
       effectiveStartDate = LocalDate.of(2019, 9, 7),
       chargedThroughDate = None,
       HolidayStart__c = Some(LocalDate.of(2019, 8, 9)),
-      HolidayEnd__c = Some(LocalDate.of(2019, 8, 9))
+      HolidayEnd__c = Some(LocalDate.of(2019, 8, 9)),
+      processedThroughDate = None
     )
   }
 
@@ -32,7 +33,8 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
       effectiveStartDate = LocalDate.of(2019, 9, 7),
       chargedThroughDate = None,
       HolidayStart__c = Some(LocalDate.of(2019, 8, 2)),
-      HolidayEnd__c = Some(LocalDate.of(2019, 8, 2))
+      HolidayEnd__c = Some(LocalDate.of(2019, 8, 2)),
+      processedThroughDate = None
     )
   }
 
@@ -77,7 +79,8 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
       effectiveStartDate = LocalDate.of(2018, 11, 16),
       chargedThroughDate = None,
       HolidayStart__c = Some(LocalDate.of(2018, 11, 16)),
-      HolidayEnd__c = Some(LocalDate.of(2019, 1, 4))
+      HolidayEnd__c = Some(LocalDate.of(2019, 1, 4)),
+      processedThroughDate = None
     )
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -17,7 +17,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     )
     val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
-    val holidayCredit = HolidayCredit(subscription)
+    val holidayCredit = HolidayCredit(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
 
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
@@ -73,7 +73,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     )
     val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
-    val holidayCredit = HolidayCredit(subscription)
+    val holidayCredit = HolidayCredit(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
       subscription = subscription,
@@ -112,7 +112,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     )
     val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
-    val holidayCredit = HolidayCredit(subscription)
+    val holidayCredit = HolidayCredit(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
       subscription = subscription,


### PR DESCRIPTION
Main change is in `HolidayCredit.scala`.

Calculating holiday credit amount depends on picking the correct guardian weekly rate plan. Since subscription can have arbitrary number of arbitrary rate plans we cannot simply depend on sorting by date and picking the earliest.

This PR introduces the concept of `CurrentGuardianWeeklySubscription` which is entity that satisfies the following predicates

```
sealed trait CurrentGuardianWeeklyRatePlanCondition
case object RatePlanIsGuardianWeekly extends CurrentGuardianWeeklyRatePlanCondition
// case object TodayHasBeenInvoiced extends CurrentGuardianWeeklyRatePlanCondition // FIXME: This is a stronger check than RatePlanHasBeenInvoiced but requires significant refactoring of tests
case object RatePlanHasBeenInvoiced extends CurrentGuardianWeeklyRatePlanCondition
case object RatePlanHasACharge extends CurrentGuardianWeeklyRatePlanCondition
case object RatePlanHasOnlyOneCharge extends CurrentGuardianWeeklyRatePlanCondition
case object ChargeIsQuarterlyOrAnnual extends CurrentGuardianWeeklyRatePlanCondition
```

Most important is `RatePlanIsGuardianWeekly` which is checked against hardcoded list of `productRatePlanIds`.

This complication is a result of decision to model things like discounts as products which makes it much harder determining what actual product the users has.

Note there are few FIXMEs here. In particular the following **must** be addressed in separate PR:

```
// FIXME: This should be function of CurrentGuardianWeeklySubscription
object NextBillingPeriodStartDate
```

 