### PR TITLE
Give holiday-stop processor an optional stop date

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
@@ -1,19 +1,28 @@
 package com.gu.holidaystopprocessor
 
+import java.time.LocalDate
+
 import cats.implicits._
 import com.amazonaws.services.lambda.runtime.Context
 import io.circe.generic.auto._
 import io.github.mkotsur.aws.handler.Lambda
 import io.github.mkotsur.aws.handler.Lambda._
 
-object Handler extends Lambda[None.type, List[HolidayStopResponse]] {
-  override def handle(`_`: None.type, context: Context): Either[Throwable, List[HolidayStopResponse]] = {
+object Handler extends Lambda[Option[LocalDate], List[HolidayStopResponse]] {
+
+  /**
+   * @param stopDate
+   *             The date for which relevant holiday stop requests will be processed.
+   *             This is to facilitate testing.
+   *             In normal use it will be missing and a default value will apply instead.
+   */
+  override def handle(stopDate: Option[LocalDate], context: Context): Either[Throwable, List[HolidayStopResponse]] = {
     Config() match {
       case Left(msg) =>
         Left(new RuntimeException(s"Config failure: $msg"))
 
       case Right(config) =>
-        val result = HolidayStopProcess(config)
+        val result = HolidayStopProcess(config, stopDate)
         ProcessResult.log(result)
         result.overallFailure match {
           case Some(failure) =>

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
@@ -11,18 +11,18 @@ import io.github.mkotsur.aws.handler.Lambda._
 object Handler extends Lambda[Option[LocalDate], List[HolidayStopResponse]] {
 
   /**
-   * @param stopDate
+   * @param processDateOverride
    *             The date for which relevant holiday stop requests will be processed.
    *             This is to facilitate testing.
    *             In normal use it will be missing and a default value will apply instead.
    */
-  override def handle(stopDate: Option[LocalDate], context: Context): Either[Throwable, List[HolidayStopResponse]] = {
+  override def handle(processDateOverride: Option[LocalDate], context: Context): Either[Throwable, List[HolidayStopResponse]] = {
     Config() match {
       case Left(msg) =>
         Left(new RuntimeException(s"Config failure: $msg"))
 
       case Right(config) =>
-        val result = HolidayStopProcess(config, stopDate)
+        val result = HolidayStopProcess(config, processDateOverride)
         ProcessResult.log(result)
         result.overallFailure match {
           case Some(failure) =>

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -6,7 +6,7 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
 
 object HolidayStopProcess {
 
-  def apply(config: Config): ProcessResult =
+  def apply(config: Config, stopDate: Option[LocalDate]): ProcessResult =
     Zuora.accessTokenGetResponse(config.zuoraConfig) match {
       case Left(overallFailure) =>
         ProcessResult(overallFailure)
@@ -14,7 +14,7 @@ object HolidayStopProcess {
       case Right(zuoraAccessToken) =>
         processHolidayStops(
           config.holidayCreditProduct,
-          getHolidayStopRequestsFromSalesforce = Salesforce.holidayStopRequests(config.sfConfig),
+          getHolidayStopRequestsFromSalesforce = Salesforce.holidayStopRequests(config.sfConfig, stopDate),
           getSubscription = Zuora.subscriptionGetResponse(config, zuoraAccessToken),
           updateSubscription = Zuora.subscriptionUpdateResponse(config, zuoraAccessToken),
           writeHolidayStopsToSalesforce = Salesforce.holidayStopUpdateResponse(config.sfConfig)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -14,11 +14,11 @@ object Salesforce {
 
   private def thresholdDate: LocalDate = LocalDate.now.plusDays(Config.daysInAdvance)
 
-  def holidayStopRequests(sfCredentials: SFAuthConfig)(productNamePrefix: ProductName): Either[OverallFailure, List[HolidayStopRequestsDetail]] =
+  def holidayStopRequests(sfCredentials: SFAuthConfig, stopDate: Option[LocalDate])(productNamePrefix: ProductName): Either[OverallFailure, List[HolidayStopRequestsDetail]] =
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>
       val sfGet = sfAuth.wrapWith(JsonHttp.getWithParams)
       val fetchOp = SalesforceHolidayStopRequestsDetail.LookupPendingByProductNamePrefixAndDate(sfGet)
-      fetchOp(productNamePrefix, thresholdDate)
+      fetchOp(productNamePrefix, stopDate.getOrElse(thresholdDate))
     }.toDisjunction match {
       case -\/(failure) => Left(OverallFailure(failure.toString))
       case \/-(details) => Right(details)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/StandaloneApp.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/StandaloneApp.scala
@@ -1,12 +1,16 @@
 package com.gu.holidaystopprocessor
 
+import java.time.LocalDate
+
 // This is just for functional testing locally.
 object StandaloneApp extends App {
+
+  val stopDate = args.headOption.map(LocalDate.parse)
 
   Config() match {
     case Left(msg) => println(s"Config failure: $msg")
     case Right(config) =>
-      val processResult = HolidayStopProcess(config)
+      val processResult = HolidayStopProcess(config, stopDate)
 
       println(processResult.holidayStopsToApply.size)
 


### PR DESCRIPTION
This will help to test the processing lambda by giving it an optional date to process.
Otherwise we'd have to come up with test cases that were on a fixed date, which would be painful.
