### PR TITLE
Next billing period as function of CurrentGuardianWeeklySubscription

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -98,7 +98,8 @@ object CurrentGuardianWeeklySubscription {
   def apply(subscription: Subscription, guardianWeeklyProductRatePlanIds: List[String]): CurrentGuardianWeeklySubscription =
     subscription
       .ratePlans
-      .find { ratePlan => List(
+      .find { ratePlan =>
+        List(
           RatePlanIsGuardianWeekly(ratePlan, guardianWeeklyProductRatePlanIds),
           RatePlanHasExactlyOneCharge(ratePlan),
           RatePlanHasBeenInvoiced(ratePlan),

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -62,7 +62,7 @@ object HolidayStopProcess {
     for {
       subscription <- getSubscription(stop.subscriptionName)
       _ <- if (subscription.autoRenew) Right(()) else Left(ZuoraHolidayWriteError("Cannot currently process non-auto-renewing subscription"))
-      nextInvoiceStartDate <- NextBillingPeriodStartDate(subscription)
+      nextInvoiceStartDate <- NextBillingPeriodStartDate(subscription, guardianWeeklyProductRatePlanIds)
       maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
       holidayCredit = HolidayCredit(subscription, guardianWeeklyProductRatePlanIds)
       holidayCreditUpdate <- HolidayCreditUpdate(holidayCreditProduct, subscription, stop.stoppedPublicationDate, nextInvoiceStartDate, maybeExtendedTerm, holidayCredit)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
@@ -21,12 +21,10 @@ import java.time.LocalDate
  * or billingPeriodStartDay (1st of month).
  */
 
-// FIXME: This should be function of CurrentGuardianWeeklySubscription
 object NextBillingPeriodStartDate {
-  def apply(subscription: Subscription): Either[ZuoraHolidayWriteError, LocalDate] = {
-    subscription
-      .originalRatePlanCharge
-      .flatMap(_.chargedThroughDate)
-      .toRight(ZuoraHolidayWriteError("Original rate plan charge has no charged through date. A bill run is needed to fix this."))
+  def apply(subscription: Subscription, guardianWeeklyProductRatePlanIds: List[String]): Either[ZuoraHolidayWriteError, LocalDate] = {
+    Right(CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds)
+      .invoicedPeriod
+      .endDateExcluding)
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -5,7 +5,11 @@ import java.time.LocalDate
 import com.gu.holidaystopprocessor.Fixtures.config
 import org.scalatest.{FlatSpec, Matchers}
 
+import scala.util.Try
+
 class SubscriptionUpdateTest extends FlatSpec with Matchers {
+
+  val guardianWeeklyProductRatePlanIds = Fixtures.config.guardianWeeklyProductRatePlanIds
 
   "holidayCreditToAdd" should "generate update correctly" in {
     val subscription = Fixtures.mkSubscription(
@@ -15,9 +19,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Quarter",
       chargedThroughDate = Some(LocalDate.of(2019, 9, 12))
     )
-    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription, guardianWeeklyProductRatePlanIds)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
-    val holidayCredit = HolidayCredit(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
+    val holidayCredit = HolidayCredit(subscription, guardianWeeklyProductRatePlanIds)
 
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
@@ -57,10 +61,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Quarter",
       chargedThroughDate = None
     )
-    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
-    nextInvoiceStartDate shouldBe Left(ZuoraHolidayWriteError(
-      "Original rate plan charge has no charged through date. A bill run is needed to fix this."
-    ))
+    Try(NextBillingPeriodStartDate(subscription, guardianWeeklyProductRatePlanIds)).isFailure shouldBe true
   }
 
   it should "generate an update with an extended term when charged-through date of subscription is after its term-end date" in {
@@ -71,9 +72,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Annual",
       chargedThroughDate = Some(LocalDate.of(2020, 8, 2))
     )
-    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription, guardianWeeklyProductRatePlanIds)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
-    val holidayCredit = HolidayCredit(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
+    val holidayCredit = HolidayCredit(subscription, guardianWeeklyProductRatePlanIds)
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
       subscription = subscription,
@@ -110,9 +111,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Annual",
       chargedThroughDate = Some(LocalDate.of(2020, 7, 23))
     )
-    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(subscription, guardianWeeklyProductRatePlanIds)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate.right.get, subscription)
-    val holidayCredit = HolidayCredit(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
+    val holidayCredit = HolidayCredit(subscription, guardianWeeklyProductRatePlanIds)
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
       subscription = subscription,


### PR DESCRIPTION
Address FIXME introduced by https://github.com/guardian/support-service-lambdas/pull/371

```
// FIXME: This should be function of CurrentGuardianWeeklySubscription	
object NextBillingPeriodStartDate
```