### PR TITLE
Replace oraclejdk8 with openjdk8 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport &&
     sbt ++$TRAVIS_SCALA_VERSION coverageAggregate


### PR DESCRIPTION
Travis no longer supports Oracle Java 8.
Does Open Java cause us any problems?  Let's see.
