### PR TITLE
add success marker file to salesforce export state machine

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -256,6 +256,14 @@ Resources:
           - Effect: Allow
             Action: s3:GetObject
             Resource: !Sub "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/sfExportAuth-${Stage}*.json"
+      - PolicyName: DestBuckets
+        PolicyDocument:
+          Statement:
+            - Effect: Allow
+              Action:
+                - s3:PutObject
+                - s3:PutObjectAcl
+              Resource: !FindInMap [StageMap, !Ref Stage, destBuckets]
   CleanBucket:
     Type: AWS::Lambda::Function
     Properties:

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/EndJobHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/EndJobHandler.scala
@@ -3,11 +3,17 @@ package com.gu.sf_datalake_export.handlers
 import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.effects.{GetFromS3, RawEffects}
+import com.amazonaws.services.s3.model.{PutObjectRequest, PutObjectResult}
+import com.gu.effects.{GetFromS3, RawEffects, S3Path}
 import com.gu.salesforce.SalesforceAuthenticate.{SFAuthConfig, SFExportAuthConfig}
 import com.gu.salesforce.SalesforceClient
-import com.gu.sf_datalake_export.salesforce_bulk_api.CloseJob
+import com.gu.sf_datalake_export.handlers.StartJobHandler.ShouldUploadToDataLake
+import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.ObjectName
+import com.gu.sf_datalake_export.salesforce_bulk_api.{CloseJob, S3UploadFile}
 import com.gu.sf_datalake_export.salesforce_bulk_api.CreateJob.JobId
+import com.gu.sf_datalake_export.salesforce_bulk_api.GetBatchResult.JobName
+import com.gu.sf_datalake_export.salesforce_bulk_api.S3UploadFile.{File, FileContent, FileName}
+import com.gu.sf_datalake_export.util.ExportS3Path
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.{LoadConfigModule, Stage}
@@ -16,11 +22,15 @@ import com.gu.util.resthttp.JsonHttp
 import okhttp3.{Request, Response}
 import play.api.libs.json.{Json, Reads}
 import com.gu.sf_datalake_export.util.TryOps._
+
 import scala.util.Try
 
 object EndJobHandler {
 
   case class WireRequest(
+    jobName: String,
+    uploadToDataLake: Boolean,
+    objectName: String,
     jobId: String
   )
 
@@ -35,22 +45,35 @@ object EndJobHandler {
   }
 
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
+    val uploadFile = S3UploadFile(RawEffects.s3Write) _
     JsonHandler(
       lambdaIO = LambdaIO(inputStream, outputStream, context),
-      operation = operation(RawEffects.stage, GetFromS3.fetchString, RawEffects.response)
+      operation = operation(RawEffects.stage, GetFromS3.fetchString, uploadFile, RawEffects.response)
     )
   }
 
   def operation(
     stage: Stage,
     fetchString: StringFromS3,
+    uploadFile: (S3Path, File) => Try[_],
     getResponse: Request => Response
   )(request: WireRequest): Try[WireResponse] = {
 
     val loadConfig = LoadConfigModule(stage, fetchString)
     val jobId = JobId(request.jobId)
+    val shouldUploadToDataLake = ShouldUploadToDataLake(request.uploadToDataLake)
+    val jobName = JobName(request.jobName)
+    val objectName = ObjectName(request.objectName)
+
+    val uploadPath: S3Path = ExportS3Path(stage)(objectName, shouldUploadToDataLake)
+
+    val successFile = {
+      val fileName = FileName(s"_SUCCESS_${jobName.value}")
+      File(fileName, FileContent(""))
+    }
 
     for {
+      _ <- uploadFile(uploadPath, successFile)
       sfConfig <- loadConfig[SFAuthConfig](SFExportAuthConfig.location, SFAuthConfig.reads).leftMap(_.error).toTry
       sfClient <- SalesforceClient(getResponse, sfConfig).value.toTry
       wiredCloseJob = sfClient.wrapWith(JsonHttp.post).wrapWith(CloseJob.wrapper)

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndJobManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndJobManualTest.scala
@@ -8,7 +8,10 @@ import com.gu.sf_datalake_export.handlers.EndJobHandler
 object EndJobManualTest extends App {
   val request =
     """{
-      | "jobId" : "7506E000004FloxQAC"
+      | "jobName" : "Contact_2019-08-05",
+      | "objectName" : "Contact",
+      | "uploadToDataLake" : false,
+      | "jobId" : "7503E000006JRNsQAO"
       |}
     """.stripMargin
 


### PR DESCRIPTION
Currently the salesforce data lake ETL jobs are triggered by time. We would like to trigger the jobs on the presence of the raw files instead. 

The current job generates returns raw data for a table in multiple files. The amount and name of the files is not known beforehand.

This PR adds a dummy file we can upload to S3 once we are sure all the raw CSV files have been uploaded.
The ETL job can be configured to trigger on the presence this dummy file in the raw bucket.

Tested in `CODE`, of course this doesn't test uploading to the actual raw directory in the Ophan account. I copied the S3 write permissions from the downloader lambda so hopefully it works in PROD as well