### PR TITLE
Fix scalariform warning

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 
 resolvers += Resolver.typesafeRepo("releases")
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 


### PR DESCRIPTION
This stops Travis giving formatting warnings like this:
```
[warn] Scalariform parser error for /home/travis/build/guardian/support-service-lambdas/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala: expected start of definition, but was Token(VAL,val,876,val)
```
See:
* https://docs.scala-lang.org/sips/completed/trailing-commas.html
and
* https://github.com/sbt/sbt-scalariform/releases/tag/1.8.3
