### PR TITLE
send new product api alarm to SX team

### DIFF
--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -308,7 +308,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
         AlarmName:
           !Sub
             - 5XX rate from ${ApiName}


### PR DESCRIPTION
We had an alarm yesterday which came to the subscriptions team.  This is because subscriptionsdev used to be the old post touchpoint team which morphed into the fulfilment team and then into SX.  Now that S&C has turned into the subscriptions team, we have taken over the list, but that means we have taken over the alarm!
Switching to fulfilment_dev which should get the correct team.

However, I am happy to say that the alarm should go to the whole RR team if that's the consensus?