### PR TITLE
Simplify next available date calculation

### DIFF
--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
@@ -30,15 +30,15 @@ class ActionCalculatorTest extends FlatSpec with Matchers {
     type Today = LocalDate
     type FirstAvailableDate = LocalDate
     val gwTodayToFirstAvailableDate = ListMap[Today, FirstAvailableDate](
-      LocalDate.of(2019, 6,  1) -> LocalDate.of(2019, 6,  8), // first available on Sun
-      LocalDate.of(2019, 6,  2) -> LocalDate.of(2019, 6,  8), // first available on Sun
-      LocalDate.of(2019, 6,  3) -> LocalDate.of(2019, 6,  8), // first available on Sun
-      LocalDate.of(2019, 6,  4) -> LocalDate.of(2019, 6, 15), // jump on Tue, a day before processor run
-      LocalDate.of(2019, 6,  5) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6,  6) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6,  7) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6,  8) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6,  9) -> LocalDate.of(2019, 6, 15), // first available on Sun
+      LocalDate.of(2019, 6, 1) -> LocalDate.of(2019, 6, 8), // first available on Sun
+      LocalDate.of(2019, 6, 2) -> LocalDate.of(2019, 6, 8), // first available on Sun
+      LocalDate.of(2019, 6, 3) -> LocalDate.of(2019, 6, 8), // first available on Sun
+      LocalDate.of(2019, 6, 4) -> LocalDate.of(2019, 6, 15), // jump on Tue, a day before processor run
+      LocalDate.of(2019, 6, 5) -> LocalDate.of(2019, 6, 15), // first available on Sun
+      LocalDate.of(2019, 6, 6) -> LocalDate.of(2019, 6, 15), // first available on Sun
+      LocalDate.of(2019, 6, 7) -> LocalDate.of(2019, 6, 15), // first available on Sun
+      LocalDate.of(2019, 6, 8) -> LocalDate.of(2019, 6, 15), // first available on Sun
+      LocalDate.of(2019, 6, 9) -> LocalDate.of(2019, 6, 15), // first available on Sun
       LocalDate.of(2019, 6, 10) -> LocalDate.of(2019, 6, 15), // first available on Sun
       LocalDate.of(2019, 6, 11) -> LocalDate.of(2019, 6, 22), // jump on Tue, a day before processor run
       LocalDate.of(2019, 6, 12) -> LocalDate.of(2019, 6, 22), // first available on Sun
@@ -54,37 +54,22 @@ class ActionCalculatorTest extends FlatSpec with Matchers {
       LocalDate.of(2019, 6, 22) -> LocalDate.of(2019, 6, 29), // first available on Sun
       LocalDate.of(2019, 6, 23) -> LocalDate.of(2019, 6, 29), // first available on Sun
       LocalDate.of(2019, 6, 24) -> LocalDate.of(2019, 6, 29), // first available on Sun
-      LocalDate.of(2019, 6, 25) -> LocalDate.of(2019, 7,  6), // jump on Tue, a day before processor run
-      LocalDate.of(2019, 6, 26) -> LocalDate.of(2019, 7,  6), // first available on Sun
-      LocalDate.of(2019, 6, 27) -> LocalDate.of(2019, 7,  6), // first available on Sun
-      LocalDate.of(2019, 6, 28) -> LocalDate.of(2019, 7,  6), // first available on Sun
-      LocalDate.of(2019, 6, 29) -> LocalDate.of(2019, 7,  6), // first available on Sun
-      LocalDate.of(2019, 6, 30) -> LocalDate.of(2019, 7,  6), // first available on Sun
-      LocalDate.of(2019, 7,  1) -> LocalDate.of(2019, 7,  6), // first available on Sun
-      LocalDate.of(2019, 7,  2) -> LocalDate.of(2019, 7, 13) // jump on Tue, a day before processor run
+      LocalDate.of(2019, 6, 25) -> LocalDate.of(2019, 7, 6), // jump on Tue, a day before processor run
+      LocalDate.of(2019, 6, 26) -> LocalDate.of(2019, 7, 6), // first available on Sun
+      LocalDate.of(2019, 6, 27) -> LocalDate.of(2019, 7, 6), // first available on Sun
+      LocalDate.of(2019, 6, 28) -> LocalDate.of(2019, 7, 6), // first available on Sun
+      LocalDate.of(2019, 6, 29) -> LocalDate.of(2019, 7, 6), // first available on Sun
+      LocalDate.of(2019, 6, 30) -> LocalDate.of(2019, 7, 6), // first available on Sun
+      LocalDate.of(2019, 7, 1) -> LocalDate.of(2019, 7, 6), // first available on Sun
+      LocalDate.of(2019, 7, 2) -> LocalDate.of(2019, 7, 13) // jump on Tue, a day before processor run
 
     )
 
     gwTodayToFirstAvailableDate foreach {
       case (today, expected) =>
         ActionCalculator
-          .getProductSpecifics(gwProductName, today, debug = false)
+          .getProductSpecifics(gwProductName, today)
           .firstAvailableDate shouldEqual expected
-    }
-
-  }
-
-  it should "calculate the next target day of the week given a date" in {
-
-    val gwInputsAndExpected = Map(
-      DayOfWeek.THURSDAY -> LocalDate.of(2019, 6, 20),
-      DayOfWeek.FRIDAY -> LocalDate.of(2019, 6, 21),
-      DayOfWeek.SATURDAY -> LocalDate.of(2019, 6, 15),
-    )
-
-    gwInputsAndExpected foreach {
-      case (dayOfWeek, expected) =>
-        ActionCalculator.findNextTargetDayOfWeek(LocalDate.of(2019, 6, 14), dayOfWeek) shouldEqual expected
     }
 
   }


### PR DESCRIPTION
The algorithm simplifies to

```
/**
 * If there are less than 5 days between today and the day after next publication day,
 * then Saturday after next (i.e., next-next Saturday),
 * otherwise next Saturday
 */
```