### PR TITLE
Prevent errors short-circuiting holiday processing

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/CurrentGuardianWeeklySubscription.scala
@@ -95,7 +95,7 @@ case class CurrentInvoicedPeriod(
  * attached to Guardian Weekly product that satisfies all of the CurrentGuardianWeeklyRatePlanPredicates.
  */
 object CurrentGuardianWeeklySubscription {
-  def apply(subscription: Subscription, guardianWeeklyProductRatePlanIds: List[String]): CurrentGuardianWeeklySubscription =
+  def apply(subscription: Subscription, guardianWeeklyProductRatePlanIds: List[String]): Either[ZuoraHolidayWriteError, CurrentGuardianWeeklySubscription] =
     subscription
       .ratePlans
       .find { ratePlan =>
@@ -119,5 +119,5 @@ object CurrentGuardianWeeklySubscription {
           ratePlanId = currentGuardianWeeklyRatePlan.id,
           productRatePlanId = currentGuardianWeeklyRatePlan.productRatePlanId
         )
-      }.getOrElse(throw new RuntimeException(s"Subscription does not have a current Guardian Weekly rate plan: ${subscription}"))
+      }.toRight(ZuoraHolidayWriteError(s"Subscription does not have a current Guardian Weekly rate plan: ${subscription}"))
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Failures.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Failures.scala
@@ -10,11 +10,6 @@ case class OverallFailure(reason: String) extends HolidayError
 /**
  * FIXME: Current implementation is not atomic, so how should we handle inconsistent state cleanup?
  * FIXME: Improve error logging so we know which of the scenarios below is the case.
- *
- * The error scenarios we need to consider are
- *   - Some writes to Zuora fail (but others succeed), and Salesforce write succeed
- *   - Some writes to Zuora fail (but others succeed), and Salesforce write fails
- *   - All writes to Zuora fail
  */
 object OverallFailure {
   def apply(

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -62,7 +62,7 @@ object HolidayStopProcess {
     for {
       subscription <- getSubscription(stop.subscriptionName)
       _ <- if (subscription.autoRenew) Right(()) else Left(ZuoraHolidayWriteError("Cannot currently process non-auto-renewing subscription"))
-      currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds)
+      currentGuardianWeeklySubscription <- CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds)
       nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription)
       maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
       holidayCredit = HolidayCredit(currentGuardianWeeklySubscription)

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ErrorHandlingSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ErrorHandlingSpec.scala
@@ -1,0 +1,137 @@
+package com.gu.holidaystopprocessor
+
+import java.time.LocalDate
+import cats.implicits._
+import com.gu.holidaystopprocessor.Fixtures._
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, ProductName, SubscriptionName}
+import org.scalatest._
+
+/**
+ * Make sure short-circuiting does not happen.
+ */
+class ErrorHandlingSpec extends FlatSpec with Matchers with OptionValues {
+  val getHolidayStopRequestsFromSalesforce: ProductName => Either[OverallFailure, List[HolidayStopRequestsDetail]] = {
+    _ =>
+      Right(List(
+        mkHolidayStopRequestDetails(mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2), SubscriptionName("A-S1")), "C1"),
+        mkHolidayStopRequestDetails(mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1), SubscriptionName("A-S2")), "C3"),
+        mkHolidayStopRequestDetails(mkHolidayStopRequest("R3", LocalDate.of(2019, 8, 9), SubscriptionName("A-S3")), "C4")
+      ))
+  }
+
+  val subscription: Subscription = mkSubscriptionWithHolidayStops()
+
+  val updateSubscription: (Subscription, HolidayCreditUpdate) => Either[ZuoraHolidayWriteError, Unit] = {
+    case _ => Right(())
+  }
+
+  "Error handling" should "not short-circuit if some writes to Zuora fail (but others succeed), and Salesforce write succeeds" in {
+    val getSubscription: SubscriptionName => Either[ZuoraHolidayWriteError, Subscription] = {
+      case subName if subName.value == "A-S1" => Right(subscription)
+      case subName if subName.value == "A-S2" => Left(ZuoraHolidayWriteError("zuora boom")) // NOTE: this line is key to the test
+      case subName if subName.value == "A-S3" => Right(subscription)
+    }
+
+    val writeHolidayStopsToSalesforce: List[HolidayStopResponse] => Either[SalesforceHolidayWriteError, Unit] = {
+      case _ => Right(())
+    }
+
+    val result = HolidayStopProcess.processHolidayStops(
+      config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
+      getHolidayStopRequestsFromSalesforce,
+      getSubscription,
+      updateSubscription,
+      writeHolidayStopsToSalesforce
+    )
+
+    val (failedZuoraResponses, successfulZuoraResponses) = result.holidayStopResults.separate
+    failedZuoraResponses.size shouldBe 1
+    successfulZuoraResponses.size shouldBe 2
+    (failedZuoraResponses.size + successfulZuoraResponses.size) shouldBe 3
+    result.overallFailure.value shouldBe (OverallFailure("zuora boom"))
+  }
+
+  it should "not short-circuit if all Zuora writes succeeds, and Salesforce write fails" in {
+    val getSubscription: SubscriptionName => Either[ZuoraHolidayWriteError, Subscription] = {
+      case subName if subName.value == "A-S1" => Right(subscription)
+      case subName if subName.value == "A-S2" => Right(subscription)
+      case subName if subName.value == "A-S3" => Right(subscription)
+    }
+
+    val writeHolidayStopsToSalesforce: List[HolidayStopResponse] => Either[SalesforceHolidayWriteError, Unit] = {
+      case _ => Left(SalesforceHolidayWriteError("salesforce boom")) // NOTE: this line is key to the test
+    }
+
+    val result = HolidayStopProcess.processHolidayStops(
+      config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
+      getHolidayStopRequestsFromSalesforce,
+      getSubscription,
+      updateSubscription,
+      writeHolidayStopsToSalesforce
+    )
+
+    val (failedZuoraResponses, successfulZuoraResponses) = result.holidayStopResults.separate
+    failedZuoraResponses.size shouldBe 0
+    successfulZuoraResponses.size shouldBe 3
+    (failedZuoraResponses.size + successfulZuoraResponses.size) shouldBe 3
+    result.overallFailure.value shouldBe (OverallFailure("salesforce boom"))
+
+  }
+
+  it should "collect all Zuora failures" in {
+    val getSubscription: SubscriptionName => Either[ZuoraHolidayWriteError, Subscription] = {
+      case subName if subName.value == "A-S1" => Left(ZuoraHolidayWriteError("zuora boom 1"))
+      case subName if subName.value == "A-S2" => Left(ZuoraHolidayWriteError("zuora boom 2"))
+      case subName if subName.value == "A-S3" => Left(ZuoraHolidayWriteError("zuora boom 3"))
+    }
+
+    val writeHolidayStopsToSalesforce: List[HolidayStopResponse] => Either[SalesforceHolidayWriteError, Unit] = {
+      case _ => Right(())
+    }
+
+    val result = HolidayStopProcess.processHolidayStops(
+      config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
+      getHolidayStopRequestsFromSalesforce,
+      getSubscription,
+      updateSubscription,
+      writeHolidayStopsToSalesforce
+    )
+
+    val (failedZuoraResponses, successfulZuoraResponses) = result.holidayStopResults.separate
+    failedZuoraResponses.size shouldBe 3
+    successfulZuoraResponses.size shouldBe 0
+    (failedZuoraResponses.size + successfulZuoraResponses.size) shouldBe 3
+    result.overallFailure.value shouldBe (OverallFailure("zuora boom 1"))
+  }
+
+  it should "be None if all Zuora writes succeed and Salesforce write succeeds" in {
+    val getSubscription: SubscriptionName => Either[ZuoraHolidayWriteError, Subscription] = {
+      case subName if subName.value == "A-S1" => Right(subscription)
+      case subName if subName.value == "A-S2" => Right(subscription)
+      case subName if subName.value == "A-S3" => Right(subscription)
+    }
+
+    val writeHolidayStopsToSalesforce: List[HolidayStopResponse] => Either[SalesforceHolidayWriteError, Unit] = {
+      case _ => Right(())
+    }
+
+    val result = HolidayStopProcess.processHolidayStops(
+      config.holidayCreditProduct,
+      config.guardianWeeklyProductRatePlanIds,
+      getHolidayStopRequestsFromSalesforce,
+      getSubscription,
+      updateSubscription,
+      writeHolidayStopsToSalesforce
+    )
+
+    val (failedZuoraResponses, successfulZuoraResponses) = result.holidayStopResults.separate
+    failedZuoraResponses.size shouldBe 0
+    successfulZuoraResponses.size shouldBe 3
+    (failedZuoraResponses.size + successfulZuoraResponses.size) shouldBe 3
+    result.overallFailure should be(None)
+  }
+
+}

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/Fixtures.scala
@@ -83,6 +83,22 @@ object Fixtures {
         ""
       ),
       RatePlan(
+        productName = "Discounts",
+        ratePlanCharges = List(RatePlanCharge(
+          name = "Holiday Credit",
+          number = "C5",
+          price = -3.27,
+          billingPeriod = None,
+          effectiveStartDate = LocalDate.of(2019, 9, 7),
+          chargedThroughDate = None,
+          HolidayStart__c = Some(LocalDate.of(2019, 9, 1)),
+          HolidayEnd__c = Some(LocalDate.of(2019, 9, 1)),
+          processedThroughDate = None
+        )),
+        Fixtures.config.guardianWeeklyProductRatePlanIds.head,
+        ""
+      ),
+      RatePlan(
         productName = "Not a discount",
         ratePlanCharges = List(RatePlanCharge(
           name = "Holiday Credit",
@@ -161,7 +177,8 @@ object Fixtures {
 
   def mkHolidayStopRequest(
     id: String,
-    stopDate: LocalDate = LocalDate.of(2019, 1, 1)
+    stopDate: LocalDate = LocalDate.of(2019, 1, 1),
+    subscriptionName: SubscriptionName = SubscriptionName("S1")
   ) = HolidayStopRequest(
     Id = HolidayStopRequestId(id),
     Start_Date__c = HolidayStopRequestStartDate(stopDate),
@@ -169,7 +186,7 @@ object Fixtures {
     Actioned_Count__c = HolidayStopRequestActionedCount(3),
     Pending_Count__c = 4,
     Total_Issues_Publications_Impacted_Count__c = 7,
-    Subscription_Name__c = SubscriptionName("S1"),
+    Subscription_Name__c = subscriptionName,
     Product_Name__c = ProductName("Gu Weekly"),
     Holiday_Stop_Request_Detail__r = None
   )

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditSpec.scala
@@ -4,9 +4,9 @@ import java.time.LocalDate
 
 import org.scalacheck.Prop.forAll
 import org.scalacheck._
-import org.scalatest.OptionValues
+import org.scalatest.{EitherValues, OptionValues}
 
-object HolidayCreditSpec extends Properties("HolidayCreditAmount") with OptionValues {
+object HolidayCreditSpec extends Properties("HolidayCreditAmount") with OptionValues with EitherValues {
 
   private val ratePlanChargeGen = for {
     price <- Gen.choose(0.01, 10000)
@@ -30,12 +30,12 @@ object HolidayCreditSpec extends Properties("HolidayCreditAmount") with OptionVa
   property("should be negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
     val ratePlans = List(RatePlan("", List(charge), Config.guardianWeeklyProductRatePlanIdsPROD.head, ""))
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), Fixtures.config.guardianWeeklyProductRatePlanIds)
-    HolidayCredit(currentGuardianWeeklySubscription) < 0
+    HolidayCredit(currentGuardianWeeklySubscription.right.value) < 0
   }
 
   property("should never be overwhelmingly negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
     val ratePlans = List(RatePlan("", List(charge), Config.guardianWeeklyProductRatePlanIdsPROD.head, ""))
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), Fixtures.config.guardianWeeklyProductRatePlanIds)
-    HolidayCredit(currentGuardianWeeklySubscription) > -charge.price
+    HolidayCredit(currentGuardianWeeklySubscription.right.value) > -charge.price
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditTest.scala
@@ -1,15 +1,15 @@
 package com.gu.holidaystopprocessor
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
-class HolidayCreditTest extends FlatSpec with Matchers {
+class HolidayCreditTest extends FlatSpec with Matchers with EitherValues {
 
   "HolidayCredit" should "be correct for a quarterly billing period" in {
     val charge = Fixtures.mkRatePlanCharge(price = 30, billingPeriod = "Quarter")
     val ratePlans = List(RatePlan("", List(charge), Fixtures.config.guardianWeeklyProductRatePlanIds.head, ""))
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
-    val credit = HolidayCredit(currentGuardianWeeklySubscription)
+    val credit = HolidayCredit(currentGuardianWeeklySubscription.right.value)
     credit shouldBe -2.31
   }
 
@@ -18,7 +18,7 @@ class HolidayCreditTest extends FlatSpec with Matchers {
     val ratePlans = List(RatePlan("", List(charge), Fixtures.config.guardianWeeklyProductRatePlanIds.head, ""))
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
-    val credit = HolidayCredit(currentGuardianWeeklySubscription)
+    val credit = HolidayCredit(currentGuardianWeeklySubscription.right.value)
     credit shouldBe -2.89
   }
 
@@ -27,7 +27,7 @@ class HolidayCreditTest extends FlatSpec with Matchers {
     val ratePlans = List(RatePlan("", List(charge), Fixtures.config.guardianWeeklyProductRatePlanIds.head, ""))
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config.guardianWeeklyProductRatePlanIds)
-    val credit = HolidayCredit(currentGuardianWeeklySubscription)
+    val credit = HolidayCredit(currentGuardianWeeklySubscription.right.value)
     credit shouldBe -2.31
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -24,7 +24,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     None
   )
 
-  private def getRequests(requestsGet: Either[OverallFailure, List[HolidayStopRequestsDetail]]): ProductName => Either[OverallFailure, List[HolidayStopRequestsDetail]] =
+  private def getHolidayStopRequestsFromSalesforce(requestsGet: Either[OverallFailure, List[HolidayStopRequestsDetail]]): ProductName => Either[OverallFailure, List[HolidayStopRequestsDetail]] =
     _ => requestsGet
 
   private def getSubscription(subscriptionGet: Either[ZuoraHolidayWriteError, Subscription]): SubscriptionName => Either[ZuoraHolidayWriteError, Subscription] = {
@@ -121,7 +121,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
       config.guardianWeeklyProductRatePlanIds,
-      getRequests(Right(List(
+      getHolidayStopRequestsFromSalesforce(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)), "C1"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)), "C3"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R3", LocalDate.of(2019, 8, 9)), "C4")
@@ -154,7 +154,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
       config.guardianWeeklyProductRatePlanIds,
-      getRequests(Right(List(
+      getHolidayStopRequestsFromSalesforce(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)), "C2"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)), "C5"),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("R3", LocalDate.of(2019, 8, 9)), "C6")
@@ -180,7 +180,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
     val responses = HolidayStopProcess.processHolidayStops(
       config.holidayCreditProduct,
       config.guardianWeeklyProductRatePlanIds,
-      getRequests(Right(List(
+      getHolidayStopRequestsFromSalesforce(Right(List(
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("r1"), ""),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("r2"), ""),
         Fixtures.mkHolidayStopRequestDetails(Fixtures.mkHolidayStopRequest("r3"), "")

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -3,11 +3,9 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.holidaystopprocessor.Fixtures.config
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
-import scala.util.Try
-
-class SubscriptionUpdateTest extends FlatSpec with Matchers {
+class SubscriptionUpdateTest extends FlatSpec with Matchers with EitherValues {
 
   val guardianWeeklyProductRatePlanIds = Fixtures.config.guardianWeeklyProductRatePlanIds
 
@@ -20,9 +18,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       chargedThroughDate = Some(LocalDate.of(2019, 9, 12))
     )
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds)
-    val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription.right.value)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
-    val holidayCredit = HolidayCredit(currentGuardianWeeklySubscription)
+    val holidayCredit = HolidayCredit(currentGuardianWeeklySubscription.right.value)
 
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
@@ -54,7 +52,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
     ))
   }
 
-  it should "fail to generate an update when there's no charged-through date" in {
+  it should "fail to generate an update when there's no chargedThroughDate, i.e., no invoice has been generated" in {
     val subscription = Fixtures.mkSubscription(
       termStartDate = LocalDate.of(2019, 7, 12),
       termEndDate = LocalDate.of(2020, 7, 12),
@@ -62,7 +60,7 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       billingPeriod = "Quarter",
       chargedThroughDate = None
     )
-    Try(CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds)).isFailure shouldBe true
+    CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds).left.value shouldBe a[ZuoraHolidayWriteError]
   }
 
   it should "generate an update with an extended term when charged-through date of subscription is after its term-end date" in {
@@ -74,9 +72,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       chargedThroughDate = Some(LocalDate.of(2020, 8, 2))
     )
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds)
-    val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription.right.value)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
-    val holidayCredit = HolidayCredit(currentGuardianWeeklySubscription)
+    val holidayCredit = HolidayCredit(currentGuardianWeeklySubscription.right.value)
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
       subscription = subscription,
@@ -114,9 +112,9 @@ class SubscriptionUpdateTest extends FlatSpec with Matchers {
       chargedThroughDate = Some(LocalDate.of(2020, 7, 23))
     )
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds)
-    val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription)
+    val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription.right.value)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
-    val holidayCredit = HolidayCredit(currentGuardianWeeklySubscription)
+    val holidayCredit = HolidayCredit(currentGuardianWeeklySubscription.right.value)
     val update = HolidayCreditUpdate(
       config.holidayCreditProduct,
       subscription = subscription,


### PR DESCRIPTION
Lambda will fail at the end-of-the-world if there exists at least one zuora or salesforce write failure, however it will **NO LONGER** prevent other HolidayStopRequests in the batch from being attempted.