### PR TITLE
Add schedule permission to holiday-stop processor

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -107,5 +107,18 @@ Resources:
       Targets:
         - Arn: !GetAtt HolidayStopProcessor.Arn
           Id: !Ref HolidayStopProcessor
+          Input: "null"
     DependsOn:
       - HolidayStopProcessor
+
+  HolidayStopProcessorLambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsProd
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName: !Ref HolidayStopProcessor
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt HolidayStopProcessorScheduleRule.Arn
+    DependsOn:
+      - HolidayStopProcessor
+      - HolidayStopProcessorScheduleRule


### PR DESCRIPTION
This is a step that I didn't realise was necessary!  I've already applied the updated template in Prod and the lambda has been successfully running on schedule since yesterday afternoon.

This change also includes a null input to the lambda to stop it complaining.  It expects an optional date.
