### PR TITLE
holiday-stops-api : now supports new "x-salesforce-contact-id" header…

### DIFF
--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -1,0 +1,27 @@
+package com.gu.holiday_stops
+
+import org.scalatest.{FlatSpec, Matchers}
+import com.gu.holiday_stops.Handler._
+import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact._
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+
+class HandlerTest extends FlatSpec with Matchers {
+
+  it should s"convert either the '$HEADER_IDENTITY_ID' header OR '$HEADER_SALESFORCE_CONTACT_ID' header to Contact or fail" in {
+
+    Handler.extractContactFromHeaders(None) shouldBe a[ReturnWithResponse]
+    Handler.extractContactFromHeaders(Some(Map())) shouldBe a[ReturnWithResponse]
+
+    val expectedIdentityIdCoreValue = "identity_id"
+    Handler.extractContactFromHeaders(Some(Map(
+      HEADER_IDENTITY_ID -> expectedIdentityIdCoreValue
+    ))) shouldBe ContinueProcessing(Left(IdentityId(expectedIdentityIdCoreValue)))
+
+    val expectedSfContactIdCoreValue = "sf_contact_id"
+    Handler.extractContactFromHeaders(Some(Map(
+      HEADER_SALESFORCE_CONTACT_ID -> expectedSfContactIdCoreValue
+    ))) shouldBe ContinueProcessing(Right(SalesforceContactId(expectedSfContactIdCoreValue)))
+
+  }
+
+}

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -14,7 +14,7 @@ import java.util.UUID
 
 import com.gu.holiday_stops.ActionCalculator
 import com.gu.salesforce.RecordsWrapperCaseClass
-import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndIdentityID.{MatchingSubscription, SFSubscriptionId}
+import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact._
 import play.api.libs.json._
 
 object SalesforceHolidayStopRequest extends Logging {
@@ -107,14 +107,14 @@ object SalesforceHolidayStopRequest extends Logging {
     }
   }
 
-  object LookupByIdentityIdAndOptionalSubscriptionName {
+  object LookupByContactAndOptionalSubscriptionName {
 
-    def apply(sfGet: HttpOp[RestRequestMaker.GetRequestWithParams, JsValue]): (String, Option[SubscriptionName]) => ClientFailableOp[List[HolidayStopRequest]] =
+    def apply(sfGet: HttpOp[RestRequestMaker.GetRequestWithParams, JsValue]): (Contact, Option[SubscriptionName]) => ClientFailableOp[List[HolidayStopRequest]] =
       sfGet.setupRequestMultiArg(toRequest _).parse[RecordsWrapperCaseClass[HolidayStopRequest]].map(_.records).runRequestMultiArg
 
-    def toRequest(identityId: String, optionalSubscriptionName: Option[SubscriptionName]) = {
+    def toRequest(contact: Contact, optionalSubscriptionName: Option[SubscriptionName]) = {
       val soqlQuery = getHolidayStopRequestPrefixSOQL() +
-        s"WHERE IdentityID__c = '$identityId'" +
+        s"WHERE SF_Subscription__r.${contactToWhereClausePart(contact)}" +
         optionalSubscriptionName.map(subName => s" AND Subscription_Name__c = '${subName.value}'").getOrElse("")
       logger.info(s"using SF query : $soqlQuery")
       RestRequestMaker.GetRequestWithParams(RelativePath(soqlQueryBaseUrl), UrlParams(Map("q" -> soqlQuery)))

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -7,6 +7,7 @@ import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
+import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact.IdentityId
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.resthttp.JsonHttp
@@ -34,10 +35,10 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
 
-      verifySubOwnerOp = SalesforceSFSubscription.SubscriptionForSubscriptionNameAndIdentityID(sfAuth.wrapWith(JsonHttp.getWithParams))
+      verifySubOwnerOp = SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact(sfAuth.wrapWith(JsonHttp.getWithParams))
       maybeMatchingSubscription <- verifySubOwnerOp(
         SubscriptionName("A-S00050817"), // must exist in DEV Scalculate the first available date basedalesForce
-        "100004814"
+        Left(IdentityId("100004814"))
       ).toDisjunction
 
       createOp = SalesforceHolidayStopRequest.CreateHolidayStopRequestWithDetail(sfAuth.wrapWith(JsonHttp.post))


### PR DESCRIPTION
… as an alternative to the `x-identity-id` header 

In that the `holiday-stop-api` is now being used/consumed in Salesforce - CSRs should be able to add holiday stops for customers without IdentityID - this new header `x-salesforce-contact-id` is now sent from Salesforce (see https://github.com/guardian/salesforce/pull/24).

This refactor means `holiday-stop-api` now supports one or the other for fetching/creating/deleting holiday stop requests in Salesforce, but fails the request if neither are provided.