### PR TITLE
Make config available to calculation of holiday-stop credit

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/CreditCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/CreditCalculator.scala
@@ -4,8 +4,13 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.Subsc
 
 object CreditCalculator {
 
-  def guardianWeeklyCredit(config: Config, subscriptionName: SubscriptionName): Either[HolidayError, Double] =
+  /*
+   * This is an effectful high-level function, so seems safe to fetch Config as part of it.
+   * Assuming client will cache results and not need to make more use of Zuora in the same session.
+   */
+  def guardianWeeklyEstimatedCredit(subscriptionName: SubscriptionName): Either[HolidayError, Double] =
     for {
+      config <- Config()
       accessToken <- Zuora.accessTokenGetResponse(config.zuoraConfig)
       subscription <- Zuora.subscriptionGetResponse(config, accessToken)(subscriptionName)
       credit <- guardianWeeklyCredit(config.guardianWeeklyProductRatePlanIds)(subscription)


### PR DESCRIPTION
Now generating config during the calculation process rather than passing it in, as the function already has other effects.  This should make it much easier to use.