### PR TITLE
Increase holiday-stop processor timeout

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -69,7 +69,7 @@ Resources:
         !GetAtt HolidayStopProcessorRole.Arn
       MemorySize: 512
       Runtime: java8
-      Timeout: 60
+      Timeout: 180
     DependsOn:
       - HolidayStopProcessorRole
 


### PR DESCRIPTION
The lambda timed out earlier this morning:
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/1722550/64246744-4ae7c480-cf05-11e9-9f93-5f96913ec236.png">

If job takes more than 3 minutes it's probably gone wrong.