### PR TITLE
Filter out cancelled holiday stops

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
@@ -87,7 +87,10 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
           | FROM $holidayStopRequestsDetailSfObjectRef
           | WHERE Product_Name__c LIKE '${productNamePrefix.value}%'
           | AND Stopped_Publication_Date__c = ${date.toString}
-          | AND Subscription_Status__c != 'Cancelled'
+          | AND (
+          |   Subscription_Cancellation_Effective_Date__c = null
+          |   OR Subscription_Cancellation_Effective_Date__c > ${date.toString}
+          | )
           | AND Is_Actioned__c = false
           | $SOQL_ORDER_BY_CLAUSE
           |""".stripMargin

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
@@ -87,6 +87,7 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
           | FROM $holidayStopRequestsDetailSfObjectRef
           | WHERE Product_Name__c LIKE '${productNamePrefix.value}%'
           | AND Stopped_Publication_Date__c = ${date.toString}
+          | AND Subscription_Status__c != 'Cancelled'
           | AND Is_Actioned__c = false
           | $SOQL_ORDER_BY_CLAUSE
           |""".stripMargin


### PR DESCRIPTION
This is to ensure the holiday-stop processor ignores cancelled subscriptions.

It depends on guardian/salesforce#40.