### PR TITLE
Include extra fields for Braze holiday-stop confirmation template

### DIFF
--- a/handlers/batch-email-sender/README.md
+++ b/handlers/batch-email-sender/README.md
@@ -11,7 +11,7 @@ This lambda is responsible for handling the following _service_ emails (non-mark
 | Direct Debit Mandate failure 4 | `DD_Mandate_Failure__c`      | `MF4`                     | Direct Debit - Email 4        |
 | Direct Debit Mandate failure 5 | `DD_Mandate_Failure__c`      | `MF5`                     | Direct Debit - Email 5        |
 | Direct Debit Mandate failure 6 | `DD_Mandate_Failure__c`      | `MF6`                     | Direct Debit - Email 6        |
-| Holiday-stop confirmation      | `Holiday_Stop_Request__c`    | `create`                 | SV_HolidayStopConfirmation    |
+| Holiday-stop confirmation      | `Holiday_Stop_Request__c`    | `create`                  | SV_HolidayStopConfirmation    |
 
 ## How it works?
 

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
@@ -22,13 +22,17 @@ object EmailBatch {
       identity_id: Option[String],
       first_name: String,
       email_stage: String,
-      holiday_start_date: Option[String],
-      holiday_end_date: Option[String],
-      stopped_credit_sum: Option[String],
-      currency_symbol: Option[String],
-      stopped_issue_count: Option[String]
+      holiday_stop_request: Option[WireHolidayStopRequest]
+    )
+    case class WireHolidayStopRequest(
+      holiday_start_date: String,
+      holiday_end_date: String,
+      stopped_credit_sum: String,
+      currency_symbol: String,
+      stopped_issue_count: String
     )
 
+    implicit val holidayStopRequestReads = Json.reads[WireHolidayStopRequest]
     implicit val emailBatchItemPayloadReads = Json.reads[WireEmailBatchItemPayload]
     implicit val emailBatchItemReads = Json.reads[WireEmailBatchItem]
     implicit val emailBatch = Json.reads[WireEmailBatch]
@@ -67,13 +71,16 @@ object EmailBatch {
           identity_id = emailBatchPayload.identity_id.map(IdentityUserId),
           first_name = emailBatchPayload.first_name,
           email_stage = emailBatchPayload.email_stage,
-          holiday_start_date = emailBatchPayload.holiday_start_date.map(d =>
-            HolidayStartDate(fromSfDateToDisplayDate(d))),
-          holiday_end_date = emailBatchPayload.holiday_end_date.map(d =>
-            HolidayEndDate(fromSfDateToDisplayDate(d))),
-          stopped_credit_sum = emailBatchPayload.stopped_credit_sum.map(StoppedCreditSum(_)),
-          currency_symbol = emailBatchPayload.currency_symbol.map(CurrencySymbol(_)),
-          stopped_issue_count = emailBatchPayload.stopped_issue_count.map(StoppedIssueCount(_))
+          holiday_start_date = emailBatchPayload.holiday_stop_request.map(stop =>
+            HolidayStartDate(fromSfDateToDisplayDate(stop.holiday_start_date))),
+          holiday_end_date = emailBatchPayload.holiday_stop_request.map(stop =>
+            HolidayEndDate(fromSfDateToDisplayDate(stop.holiday_end_date))),
+          stopped_credit_sum = emailBatchPayload.holiday_stop_request.map(stop =>
+            StoppedCreditSum(stop.stopped_credit_sum)),
+          currency_symbol = emailBatchPayload.holiday_stop_request.map(stop =>
+            CurrencySymbol(stop.currency_symbol)),
+          stopped_issue_count = emailBatchPayload.holiday_stop_request.map(stop =>
+            StoppedIssueCount(stop.stopped_issue_count))
         ),
         object_name = wireEmailBatchItem.object_name
       )

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
@@ -21,7 +21,12 @@ object EmailBatch {
       last_name: String,
       identity_id: Option[String],
       first_name: String,
-      email_stage: String
+      email_stage: String,
+      holiday_start_date: Option[String],
+      holiday_end_date: Option[String],
+      stopped_credit_sum: Option[String],
+      currency_symbol: Option[String],
+      stopped_issue_count: Option[String]
     )
 
     implicit val emailBatchItemPayloadReads = Json.reads[WireEmailBatchItemPayload]
@@ -52,16 +57,23 @@ object EmailBatch {
 
       EmailBatchItem(
         payload = EmailBatchItemPayload(
-          EmailBatchItemId(emailBatchPayload.record_id),
-          emailBatchPayload.to_address,
-          SubscriberId(emailBatchPayload.subscriber_id),
-          SfContactId(emailBatchPayload.sf_contact_id),
-          emailBatchPayload.product,
-          fromSfDateToDisplayDate(emailBatchPayload.next_charge_date),
-          emailBatchPayload.last_name,
-          emailBatchPayload.identity_id.map(IdentityUserId),
-          emailBatchPayload.first_name,
-          emailBatchPayload.email_stage
+          record_id = EmailBatchItemId(emailBatchPayload.record_id),
+          to_address = emailBatchPayload.to_address,
+          subscriber_id = SubscriberId(emailBatchPayload.subscriber_id),
+          sf_contact_id = SfContactId(emailBatchPayload.sf_contact_id),
+          product = emailBatchPayload.product,
+          next_charge_date = fromSfDateToDisplayDate(emailBatchPayload.next_charge_date),
+          last_name = emailBatchPayload.last_name,
+          identity_id = emailBatchPayload.identity_id.map(IdentityUserId),
+          first_name = emailBatchPayload.first_name,
+          email_stage = emailBatchPayload.email_stage,
+          holiday_start_date = emailBatchPayload.holiday_start_date.map(d =>
+            HolidayStartDate(fromSfDateToDisplayDate(d))),
+          holiday_end_date = emailBatchPayload.holiday_end_date.map(d =>
+            HolidayEndDate(fromSfDateToDisplayDate(d))),
+          stopped_credit_sum = emailBatchPayload.stopped_credit_sum.map(StoppedCreditSum(_)),
+          currency_symbol = emailBatchPayload.currency_symbol.map(CurrencySymbol(_)),
+          stopped_issue_count = emailBatchPayload.stopped_issue_count.map(StoppedIssueCount(_))
         ),
         object_name = wireEmailBatchItem.object_name
       )
@@ -75,6 +87,11 @@ case class SubscriberId(value: String) extends AnyVal
 case class SfContactId(value: String) extends AnyVal
 case class IdentityUserId(value: String) extends AnyVal
 case class EmailBatchItemId(value: String) extends AnyVal
+case class HolidayStartDate(value: String) extends AnyVal
+case class HolidayEndDate(value: String) extends AnyVal
+case class StoppedCreditSum(value: String) extends AnyVal
+case class CurrencySymbol(value: String) extends AnyVal
+case class StoppedIssueCount(value: String) extends AnyVal
 
 case class EmailBatchItemPayload(
   record_id: EmailBatchItemId,
@@ -86,9 +103,13 @@ case class EmailBatchItemPayload(
   last_name: String,
   identity_id: Option[IdentityUserId],
   first_name: String,
-  email_stage: String
+  email_stage: String,
+  holiday_start_date: Option[HolidayStartDate],
+  holiday_end_date: Option[HolidayEndDate],
+  stopped_credit_sum: Option[StoppedCreditSum],
+  currency_symbol: Option[CurrencySymbol],
+  stopped_issue_count: Option[StoppedIssueCount]
 )
 
 case class EmailBatchItem(payload: EmailBatchItemPayload, object_name: String)
 case class EmailBatch(emailBatchItems: List[EmailBatchItem])
-

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
@@ -14,13 +14,21 @@ object EmailToSend {
 
   def fromEmailBatchItem(emailBatchItem: EmailBatchItem): EmailToSend = {
 
+    def optional(fldName: String, fldValue: Option[String]): Seq[(String, String)] =
+      fldValue.map(v => Seq(fldName -> v)).getOrElse(Nil)
+
     val customFields: Map[String, String] = Map(
       "first_name" -> emailBatchItem.payload.first_name,
       "last_name" -> emailBatchItem.payload.last_name,
       "subscriber_id" -> emailBatchItem.payload.subscriber_id.value,
       "next_charge_date" -> emailBatchItem.payload.next_charge_date,
       "product" -> emailBatchItem.payload.product
-    )
+    ) ++
+      optional("holiday_start_date", emailBatchItem.payload.holiday_start_date.map(_.value)) ++
+      optional("holiday_end_date", emailBatchItem.payload.holiday_end_date.map(_.value)) ++
+      optional("stopped_credit_sum", emailBatchItem.payload.stopped_credit_sum.map(_.value)) ++
+      optional("currency_symbol", emailBatchItem.payload.currency_symbol.map(_.value)) ++
+      optional("stopped_issue_count", emailBatchItem.payload.stopped_issue_count.map(_.value))
 
     val emailPayloadTo = EmailPayloadTo(
       Address = emailBatchItem.payload.to_address,

--- a/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
@@ -163,11 +163,14 @@ class EmailBatchTest extends FlatSpec {
         |             "last_name":"bla",
         |             "first_name":"something",
         |             "email_stage":"create",
-        |             "holiday_start_date": "2019-09-27",
-        |             "holiday_end_date": "2019-10-12",
-        |             "stopped_credit_sum": "97.42",
-        |             "currency_symbol": "&pound;",
-        |             "stopped_issue_count": "3"
+        |             "holiday_stop_request":
+        |             {
+        |               "holiday_start_date": "2019-09-27",
+        |               "holiday_end_date": "2019-10-12",
+        |               "stopped_credit_sum": "97.42",
+        |               "currency_symbol": "&pound;",
+        |               "stopped_issue_count": "3"
+        |             }
         |         },
         |         "object_name":"Holiday_Stop_Request__c"
         |       }

--- a/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
@@ -45,7 +45,12 @@ class EmailBatchTest extends FlatSpec {
             last_name = "bla",
             identity_id = Some(IdentityUserId("30002177")),
             first_name = "something",
-            email_stage = "MBv1 - 1"
+            email_stage = "MBv1 - 1",
+            holiday_start_date = None,
+            holiday_end_date = None,
+            stopped_credit_sum = None,
+            currency_symbol = None,
+            stopped_issue_count = None
           ),
           object_name = "Card_Expiry__c"
         )
@@ -124,9 +129,73 @@ class EmailBatchTest extends FlatSpec {
             last_name = "bla",
             identity_id = None,
             first_name = "something",
-            email_stage = "MBv1 - 1"
+            email_stage = "MBv1 - 1",
+            holiday_start_date = None,
+            holiday_end_date = None,
+            stopped_credit_sum = None,
+            currency_symbol = None,
+            stopped_issue_count = None
           ),
           object_name = "Card_Expiry__c"
+        )
+      )
+    )
+
+    val wireBatch = Json.parse(sampleBatch).as[WireEmailBatch]
+    assert(EmailBatch.WireModel.fromWire(wireBatch) == expected)
+
+  }
+
+  "EmailBatch.fromWire" should "transform a holiday-stop create confirmation correctly" in {
+    val sampleBatch =
+      """
+        |{
+        |     "batch_items":
+        |   [
+        |       {
+        |         "payload":{
+        |             "record_id":"a2E6E000000aBxr",
+        |             "to_address":"dlasdj@dasd.com",
+        |             "subscriber_id":"A-S00044748",
+        |             "sf_contact_id":"0036E00000KtDaHQAV",
+        |             "product":"Membership",
+        |             "next_charge_date":"2018-09-03",
+        |             "last_name":"bla",
+        |             "first_name":"something",
+        |             "email_stage":"create",
+        |             "holiday_start_date": "2019-09-27",
+        |             "holiday_end_date": "2019-10-12",
+        |             "stopped_credit_sum": "97.42",
+        |             "currency_symbol": "&pound;",
+        |             "stopped_issue_count": "3"
+        |         },
+        |         "object_name":"Holiday_Stop_Request__c"
+        |       }
+        |   ]
+        |}
+      """.stripMargin
+
+    val expected = EmailBatch(
+      List(
+        EmailBatchItem(
+          payload = EmailBatchItemPayload(
+            record_id = EmailBatchItemId("a2E6E000000aBxr"),
+            to_address = "dlasdj@dasd.com",
+            subscriber_id = SubscriberId("A-S00044748"),
+            sf_contact_id = SfContactId("0036E00000KtDaHQAV"),
+            product = "Membership",
+            next_charge_date = "3 September 2018",
+            last_name = "bla",
+            identity_id = None,
+            first_name = "something",
+            email_stage = "create",
+            holiday_start_date = Some(HolidayStartDate("27 September 2019")),
+            holiday_end_date = Some(HolidayEndDate("12 October 2019")),
+            stopped_credit_sum = Some(StoppedCreditSum("97.42")),
+            currency_symbol = Some(CurrencySymbol("&pound;")),
+            stopped_issue_count = Some(StoppedIssueCount("3"))
+          ),
+          object_name = "Holiday_Stop_Request__c"
         )
       )
     )

--- a/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/SqsSendBatchTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/SqsSendBatchTest.scala
@@ -43,7 +43,12 @@ object SqsSendBatchTestData {
       last_name = "bla",
       identity_id = Some(IdentityUserId("30002177")),
       first_name = "something",
-      email_stage = "MBv1 - 1"
+      email_stage = "MBv1 - 1",
+      holiday_start_date = None,
+      holiday_end_date = None,
+      stopped_credit_sum = None,
+      currency_symbol = None,
+      stopped_issue_count = None
     ),
     object_name = "Card_Expiry__c"
   )
@@ -59,7 +64,12 @@ object SqsSendBatchTestData {
       last_name = "bla",
       identity_id = Some(IdentityUserId("30002178")),
       first_name = "something",
-      email_stage = "MBv1 - 1"
+      email_stage = "MBv1 - 1",
+      holiday_start_date = None,
+      holiday_end_date = None,
+      stopped_credit_sum = None,
+      currency_symbol = None,
+      stopped_issue_count = None
     ),
     object_name = "Card_Expiry__c"
   )

--- a/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSendTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSendTest.scala
@@ -16,7 +16,12 @@ class EmailToSendTest extends FlatSpec {
       last_name = "bla",
       identity_id = Some(IdentityUserId("30002177")),
       first_name = "something",
-      email_stage = "MBv1 - 1"
+      email_stage = "MBv1 - 1",
+      holiday_start_date = None,
+      holiday_end_date = None,
+      stopped_credit_sum = None,
+      currency_symbol = None,
+      stopped_issue_count = None
     )
 
   val emailBatchItemStub = EmailBatchItem(
@@ -64,9 +69,29 @@ class EmailToSendTest extends FlatSpec {
   it should "create holiday-stop confirmation email to send" in {
     val emailBatchItem = emailBatchItemStub.copy(
       object_name = "Holiday_Stop_Request__c",
-      payload = emailBatchItemPayloadStub.copy(email_stage = "create")
+      payload = emailBatchItemPayloadStub.copy(
+        email_stage = "create",
+        holiday_start_date = Some(HolidayStartDate("2019-11-01")),
+        holiday_end_date = Some(HolidayEndDate("2019-11-17")),
+        stopped_credit_sum = Some(StoppedCreditSum("11.24")),
+        currency_symbol = Some(CurrencySymbol("&pound;")),
+        stopped_issue_count = Some(StoppedIssueCount("2"))
+      )
     )
-    val expected = expectedStub.copy(DataExtensionName = "SV_HolidayStopConfirmation")
+    val expected = expectedStub.copy(
+      To = expectedStub.To.copy(
+        ContactAttributes = expectedStub.To.ContactAttributes.copy(
+          expectedStub.To.ContactAttributes.SubscriberAttributes ++ Map(
+            "holiday_start_date" -> "2019-11-01",
+            "holiday_end_date" -> "2019-11-17",
+            "stopped_credit_sum" -> "11.24",
+            "currency_symbol" -> "&pound;",
+            "stopped_issue_count" -> "2"
+          )
+        )
+      ),
+      DataExtensionName = "SV_HolidayStopConfirmation"
+    )
     assert(EmailToSend.fromEmailBatchItem(emailBatchItem) == expected)
   }
 


### PR DESCRIPTION
There are some very specific fields used in the holiday-stop Braze template that haven't been included for any other template so far.  It should be quite obvious what the new fields mean, I hope.

This follows on from #410 