### PR TITLE
save estimated credits during create AND factor out V1 of /potential endpoint

### DIFF
--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -8,7 +8,6 @@ All endpoints require...
 
 | Method | Endpoint | Description |
 | --- | --- | --- | 
-| GET | `/{STAGE}/potential?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}`  (with `x-product-name-prefix` header set)  | [DEPRECATED]returns an array of dates for each issue impacted between the dates for the given product |
 | GET | `/{STAGE}/potential/{SUBSCRIPTION_NAME}?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}&estimateCredit={true`&#124;`false}`  (with `x-product-name-prefix` header set)  | returns a response containing dates for each issue impacted between the dates for the given product. Optionally the estimated credit can be calculated for each issue. |
 | GET | `/{STAGE}/hsr` | returns all holiday stops (past & present) for the user |
 | GET | `/{STAGE}/hsr` (with `x-product-name-prefix` header set) | returns all holiday stops (past & present) but including a calculated 'first available date' based on the type of product |

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -133,23 +133,6 @@ Resources:
             PathPart: "potential"
         DependsOn: HolidayStopApi
 
-    HolidayStopApiPotentialMethod:
-        Type: AWS::ApiGateway::Method
-        Properties:
-            AuthorizationType: NONE
-            ApiKeyRequired: true
-            RestApiId: !Ref HolidayStopApi
-            ResourceId: !Ref HolidayStopApiPotentialProxyResource
-            HttpMethod: GET
-            Integration:
-              Type: AWS_PROXY
-              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
-              Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HolidayStopApiLambda.Arn}/invocations
-        DependsOn:
-        - HolidayStopApi
-        - HolidayStopApiLambda
-        - HolidayStopApiPotentialProxyResource
-
     HolidayStopApiPotentialBySubscriptionNameProxyResource:
       Type: AWS::ApiGateway::Resource
       Properties:
@@ -290,6 +273,7 @@ Resources:
             DeploymentId: !Ref HolidayStopApiDeployment
             StageName: !Sub ${Stage}
         DependsOn:
+        - HolidayStopApiPotentialBySubscriptionNameGetMethod
         - HolidayStopApiGetAllMethod
         - HolidayStopApiGetBySubscriptionNameMethod
         - HolidayStopApiCreateMethod
@@ -301,7 +285,7 @@ Resources:
             Description: Deploys holiday-stop-api into an environment/stage
             RestApiId: !Ref HolidayStopApi
         DependsOn:
-        - HolidayStopApiPotentialMethod
+        - HolidayStopApiPotentialBySubscriptionNameGetMethod
         - HolidayStopApiGetAllMethod
         - HolidayStopApiGetBySubscriptionNameMethod
         - HolidayStopApiCreateMethod

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -5,6 +5,7 @@ import java.time.LocalDate
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
+import com.gu.holiday_stops.CreditCalculator.PartiallyWiredCreditCalculator
 import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestId, ProductName, SubscriptionName}
@@ -57,18 +58,17 @@ object Handler extends Logging {
       config <- Config(fetchString).toApiGatewayOp("Failed to load config")
       sfClient <- SalesforceClient(response, config.sfConfig).value.toDisjunction.toApiGatewayOp("authenticate with SalesForce")
     } yield Operation.noHealthcheck(request => // checking connectivity to SF is sufficient healthcheck so no special steps required
-      validateRequestAndCreateSteps(request, config, backend)(request, sfClient))
+      validateRequestAndCreateSteps(request, CreditCalculator(config, backend))(request, sfClient))
   }
 
   private def validateRequestAndCreateSteps(
     request: ApiGatewayRequest,
-    config: Config,
-    backend: SttpBackend[Id, Nothing]
+    creditCalculator: PartiallyWiredCreditCalculator
   ) = {
     (for {
       httpMethod <- validateMethod(request.httpMethod)
       path <- validatePath(request.path)
-    } yield createSteps(httpMethod, splitPath(path), config, backend)).fold(
+    } yield createSteps(httpMethod, splitPath(path), creditCalculator)).fold(
       { errorMessage: String =>
         badrequest(errorMessage) _
       },
@@ -93,24 +93,18 @@ object Handler extends Logging {
   private def createSteps(
     httpMethod: String,
     path: List[String],
-    config: Config,
-    backend: SttpBackend[Id, Nothing]
+    creditCalculator: PartiallyWiredCreditCalculator
   ) = {
     path match {
-      case "potential" :: Nil =>
-        httpMethod match {
-          case "GET" => stepsForPotentialHolidayStopV1 _
-          case _ => unsupported _
-        }
       case "potential" :: _ :: Nil =>
         httpMethod match {
-          case "GET" => stepsForPotentialHolidayStopV2(config, backend) _
+          case "GET" => stepsForPotentialHolidayStop(creditCalculator) _
           case _ => unsupported _
         }
       case "hsr" :: Nil =>
         httpMethod match {
           case "GET" => stepsToListExisting _
-          case "POST" => stepsToCreate _
+          case "POST" => stepsToCreate(creditCalculator) _
           case _ => unsupported _
         }
       case "hsr" :: _ :: Nil =>
@@ -144,36 +138,22 @@ object Handler extends Logging {
     case (HEADER_IDENTITY_ID, identityId) => Left(IdentityId(identityId))
   }).toApiGatewayOp(s"either '$HEADER_IDENTITY_ID' header OR '$HEADER_SALESFORCE_CONTACT_ID' (one is required)")
 
-  case class PotentialHolidayStopsV1PathParams(startDate: LocalDate, endDate: LocalDate)
+  case class PotentialHolidayStopsPathParams(subscriptionName: SubscriptionName)
+  case class PotentialHolidayStopsQueryParams(startDate: LocalDate, endDate: LocalDate, estimateCredit: Option[String])
 
-  def stepsForPotentialHolidayStopV1(req: ApiGatewayRequest, unused: SfClient): ApiResponse = {
-    implicit val formatLocalDateAsSalesforceDate = SalesforceHolidayStopRequest.formatLocalDateAsSalesforceDate
-    implicit val readsPotentialHolidayStopParams = Json.reads[PotentialHolidayStopsV1PathParams]
+  def stepsForPotentialHolidayStop(creditCalculator: PartiallyWiredCreditCalculator)(req: ApiGatewayRequest, unused: SfClient): ApiResponse = {
+    implicit val reads: Reads[PotentialHolidayStopsQueryParams] = Json.reads[PotentialHolidayStopsQueryParams]
     (for {
+      pathParams <- req.pathParamsAsCaseClass[PotentialHolidayStopsPathParams]()(Json.reads[PotentialHolidayStopsPathParams])
       productNamePrefix <- req.headers.flatMap(_.get(HEADER_PRODUCT_NAME_PREFIX)).toApiGatewayOp(s"missing '$HEADER_PRODUCT_NAME_PREFIX' header")
-      params <- req.queryParamsAsCaseClass[PotentialHolidayStopsV1PathParams]()
-    } yield ApiGatewayResponse(
-      "200",
-      ActionCalculator.publicationDatesToBeStopped(params.startDate, params.endDate, ProductName(productNamePrefix))
-    )).apiResponse
-  }
-
-  case class PotentialHolidayStopsV2PathParams(subscriptionName: SubscriptionName)
-  case class PotentialHolidayStopsV2QueryParams(startDate: LocalDate, endDate: LocalDate, estimateCredit: Option[String])
-
-  def stepsForPotentialHolidayStopV2(config: Config, backend: SttpBackend[Id, Nothing])(req: ApiGatewayRequest, unused: SfClient): ApiResponse = {
-    implicit val reads: Reads[PotentialHolidayStopsV2QueryParams] = Json.reads[PotentialHolidayStopsV2QueryParams]
-    (for {
-      pathParams <- req.pathParamsAsCaseClass[PotentialHolidayStopsV2PathParams]()(Json.reads[PotentialHolidayStopsV2PathParams])
-      productNamePrefix <- req.headers.flatMap(_.get(HEADER_PRODUCT_NAME_PREFIX)).toApiGatewayOp(s"missing '$HEADER_PRODUCT_NAME_PREFIX' header")
-      queryParams <- req.queryParamsAsCaseClass[PotentialHolidayStopsV2QueryParams]()
+      queryParams <- req.queryParamsAsCaseClass[PotentialHolidayStopsQueryParams]()
     } yield {
       val potentialHolidayStops =
         ActionCalculator
           .publicationDatesToBeStopped(queryParams.startDate, queryParams.endDate, ProductName(productNamePrefix))
           .map { stoppedPublicationDate => // unfortunately necessary due to GW N-for-N requiring stoppedPublicationDate to calculate correct credit estimation
             if (queryParams.estimateCredit.contains("true"))
-              PotentialHolidayStop(stoppedPublicationDate, CreditCalculator(config, pathParams.subscriptionName, backend, stoppedPublicationDate).toOption)
+              PotentialHolidayStop(stoppedPublicationDate, creditCalculator(pathParams.subscriptionName, stoppedPublicationDate).toOption)
             else
               PotentialHolidayStop(stoppedPublicationDate, None)
           }
@@ -204,7 +184,7 @@ object Handler extends Logging {
     )).apiResponse
   }
 
-  def stepsToCreate(req: ApiGatewayRequest, sfClient: SfClient): ApiResponse = {
+  def stepsToCreate(creditCalculator: PartiallyWiredCreditCalculator)(req: ApiGatewayRequest, sfClient: SfClient): ApiResponse = {
 
     val verifyContactOwnsSubOp = SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact(sfClient.wrapWith(JsonHttp.getWithParams))
     val createOp = SalesforceHolidayStopRequest.CreateHolidayStopRequestWithDetail(sfClient.wrapWith(JsonHttp.post))
@@ -214,7 +194,8 @@ object Handler extends Logging {
       contact <- extractContactFromHeaders(req.headers)
       maybeMatchingSub <- verifyContactOwnsSubOp(requestBody.subscriptionName, contact).toDisjunction.toApiGatewayOp(s"fetching subscriptions for contact $contact")
       matchingSub <- maybeMatchingSub.toApiGatewayOp(s"contact $contact does not own ${requestBody.subscriptionName.value}")
-      _ <- createOp(CreateHolidayStopRequestWithDetail.buildBody(requestBody.start, requestBody.end, matchingSub)).toDisjunction.toApiGatewayOp(s"create new Holiday Stop Request for subscription ${requestBody.subscriptionName} (contact $contact)")
+      createBody = CreateHolidayStopRequestWithDetail.buildBody(creditCalculator)(requestBody.start, requestBody.end, matchingSub)
+      _ <- createOp(createBody).toDisjunction.toApiGatewayOp(s"create new Holiday Stop Request for subscription ${requestBody.subscriptionName} (contact $contact)")
       // TODO nice to have - handle 'FIELD_CUSTOM_VALIDATION_EXCEPTION' etc back from SF and place in response
     } yield ApiGatewayResponse.successfulExecution).apiResponse
   }

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -19,7 +19,9 @@ object WireHolidayStopRequest {
       sfHolidayStopRequest.End_Date__c.value
     ),
     publicationsImpacted = sfHolidayStopRequest.Holiday_Stop_Request_Detail__r.map(_.records.map(detail => HolidayStopRequestsDetail(
-      publicationDate = detail.Stopped_Publication_Date__c.value
+      publicationDate = detail.Stopped_Publication_Date__c.value,
+      estimatedPrice = detail.Estimated_Price__c.map(_.value),
+      actualPrice = detail.Actual_Price__c.map(_.value)
     ))).getOrElse(List())
   )
 
@@ -47,7 +49,8 @@ object MutabilityFlags {
 
 case class HolidayStopRequestsDetail(
   publicationDate: LocalDate,
-  // TODO add other fields
+  estimatedPrice: Option[Double],
+  actualPrice: Option[Double]
 )
 object HolidayStopRequestsDetail{
   implicit val writes: OWrites[HolidayStopRequestsDetail] = Json.writes[HolidayStopRequestsDetail]

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -46,13 +46,12 @@ object MutabilityFlags {
   implicit val writes: OWrites[MutabilityFlags] = Json.writes[MutabilityFlags]
 }
 
-
 case class HolidayStopRequestsDetail(
   publicationDate: LocalDate,
   estimatedPrice: Option[Double],
   actualPrice: Option[Double]
 )
-object HolidayStopRequestsDetail{
+object HolidayStopRequestsDetail {
   implicit val writes: OWrites[HolidayStopRequestsDetail] = Json.writes[HolidayStopRequestsDetail]
 }
 
@@ -61,7 +60,7 @@ case class HolidayStopRequestPartial(
   end: LocalDate,
   subscriptionName: SubscriptionName
 )
-object HolidayStopRequestPartial{
+object HolidayStopRequestPartial {
   implicit val reads: Reads[HolidayStopRequestPartial] = Json.reads[HolidayStopRequestPartial]
 }
 
@@ -73,7 +72,7 @@ case class HolidayStopRequestFull(
   mutabilityFlags: MutabilityFlags,
   publicationsImpacted: List[HolidayStopRequestsDetail]
 )
-object HolidayStopRequestFull{
+object HolidayStopRequestFull {
   implicit val writes: OWrites[HolidayStopRequestFull] = Json.writes[HolidayStopRequestFull]
 }
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
@@ -216,7 +216,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
     responses.overallFailure.value shouldBe OverallFailure("Export failed")
   }
   it should "use process date override" in {
-    val processOverrideDate  = LocalDate.now().plusDays(123)
+    val processOverrideDate = LocalDate.now().plusDays(123)
     def verifyProcessDate(productName: ProductName, processDate: LocalDate): Either[OverallFailure, List[HolidayStopRequestsDetail]] = {
       processDate should equal(processOverrideDate)
       Right(Nil)

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/CreditCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/CreditCalculator.scala
@@ -6,10 +6,14 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.Subsc
 import com.softwaremill.sttp.{Id, SttpBackend}
 
 object CreditCalculator {
+
+  type PartiallyWiredCreditCalculator = (SubscriptionName, LocalDate) => Either[HolidayError, Double]
+
   def apply(
     config: Config,
+    backend: SttpBackend[Id, Nothing]
+  )(
     subscriptionName: SubscriptionName,
-    backend: SttpBackend[Id, Nothing],
     stoppedPublicationDate: LocalDate
   ): Either[HolidayError, Double] =
     for {
@@ -20,7 +24,7 @@ object CreditCalculator {
         config.guardianWeeklyConfig.nForNProductRatePlanIds,
         stoppedPublicationDate
       )(subscription)
-    } yield credit
+    } yield credit //TODO log failures
 
   def guardianWeeklyCredit(guardianWeeklyProductRatePlanIds: List[String], gwNforNProductRatePlanIds: List[String], stoppedPublicationDate: LocalDate)(subscription: Subscription): Either[ZuoraHolidayWriteError, Double] =
     CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds, gwNforNProductRatePlanIds)

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import com.gu.holiday_stops.ActionCalculator
+import com.gu.holiday_stops.CreditCalculator.PartiallyWiredCreditCalculator
 import com.gu.salesforce.RecordsWrapperCaseClass
 import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact._
 import play.api.libs.json._
@@ -133,6 +134,7 @@ object SalesforceHolidayStopRequest extends Logging {
 
   case class CompositeTreeHolidayStopRequestsDetail(
     Stopped_Publication_Date__c: LocalDate,
+    Estimated_Price__c: Option[HolidayStopRequestsDetailChargePrice],
     attributes: CompositeAttributes = CompositeAttributes(
       SalesforceHolidayStopRequestsDetail.holidayStopRequestsDetailSfObjectRef,
       UUID.randomUUID().toString
@@ -169,20 +171,26 @@ object SalesforceHolidayStopRequest extends Logging {
         .map(_.results.find(_.referenceId == holidayStopRequestSfObjectRef).map(_.id).get) //FIXME refactor this to map None to ClientFailure rather than nasty .get
         .runRequest
 
-    def buildBody(start: LocalDate, end: LocalDate, subscription: MatchingSubscription) = RecordsWrapperCaseClass(List(
-      CompositeTreeHolidayStopRequest(
-        Start_Date__c = HolidayStopRequestStartDate(start),
-        End_Date__c = HolidayStopRequestEndDate(end),
-        SF_Subscription__c = subscription.Id,
-        Holiday_Stop_Request_Detail__r = RecordsWrapperCaseClass(
-          ActionCalculator.publicationDatesToBeStopped(
-            start,
-            end,
-            subscription.Product_Name__c
-          ).map(CompositeTreeHolidayStopRequestsDetail(_))
+    def buildBody(creditCalculator: PartiallyWiredCreditCalculator)(start: LocalDate, end: LocalDate, subscription: MatchingSubscription) =
+      RecordsWrapperCaseClass(List(
+        CompositeTreeHolidayStopRequest(
+          Start_Date__c = HolidayStopRequestStartDate(start),
+          End_Date__c = HolidayStopRequestEndDate(end),
+          SF_Subscription__c = subscription.Id,
+          Holiday_Stop_Request_Detail__r = RecordsWrapperCaseClass(
+            ActionCalculator.publicationDatesToBeStopped(
+              start,
+              end,
+              subscription.Product_Name__c
+            ).map { stoppedPublicationDate =>
+                CompositeTreeHolidayStopRequestsDetail(
+                  stoppedPublicationDate,
+                  creditCalculator(subscription.Name, stoppedPublicationDate).toOption.map(HolidayStopRequestsDetailChargePrice)
+                )
+              }
+          )
         )
-      )
-    ))
+      ))
 
   }
 

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -43,10 +43,12 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
 
       createOp = SalesforceHolidayStopRequest.CreateHolidayStopRequestWithDetail(sfAuth.wrapWith(JsonHttp.post))
       createResult <- createOp(CreateHolidayStopRequestWithDetail.buildBody(
-        startDate,
-        endDate,
-        maybeMatchingSubscription.get
-      )).toDisjunction
+        (_, _) => Right(0.0) // fake PartiallyWiredCreditCalculator
+      )(
+          startDate,
+          endDate,
+          maybeMatchingSubscription.get
+        )).toDisjunction
 
       fetchOp = SalesforceHolidayStopRequest.LookupByDateAndProductNamePrefix(sfAuth.wrapWith(JsonHttp.getWithParams))
       preProcessingFetchResult <- fetchOp(lookupDate, productName).toDisjunction


### PR DESCRIPTION
### MUST be released after https://github.com/guardian/manage-frontend/pull/274

- Eliminated V1 of /potential endpoint (and cleaned up naming and README accordingly) - following https://github.com/guardian/manage-frontend/pull/274
- Now calculates credit on actual creation call (rather than just on /potential) and then posts to SalesForce in the 'composite tree' call. Did some refactors along the way such as...
  - introduction of type alias `PartiallyWiredCreditCalculator` and created this up-front in the `operationForEffects` function within `Handler` rather than passing the `config` and `backend` instances around everywhere