### PR TITLE
holiday-stops: log credit calculation errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,8 @@ lazy val `holiday-stops` = all(project in file("lib/holiday-stops"))
       circe,
       circeParser,
       sttp,
-      sttpCirce
+      sttpCirce,
+      mouse
     ) ++ logging
   )
 

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/CreditCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/CreditCalculator.scala
@@ -3,11 +3,21 @@ package com.gu.holiday_stops
 import java.time.LocalDate
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.SubscriptionName
+import com.gu.util.Logging
 import com.softwaremill.sttp.{Id, SttpBackend}
 
 object CreditCalculator {
 
   type PartiallyWiredCreditCalculator = (SubscriptionName, LocalDate) => Either[HolidayError, Double]
+
+  implicit class HolidayErrorImplicits[T](theEither: Either[HolidayError, T]) extends Logging {
+
+    def logError: Either[HolidayError, T] = {
+      theEither.left.map(err => logger.error(s"Failed to calculate holiday stop credits because : " + err.reason))
+      theEither
+    }
+
+  }
 
   def apply(
     config: Config,
@@ -17,14 +27,14 @@ object CreditCalculator {
     stoppedPublicationDate: LocalDate
   ): Either[HolidayError, Double] =
     for {
-      accessToken <- Zuora.accessTokenGetResponse(config.zuoraConfig, backend)
-      subscription <- Zuora.subscriptionGetResponse(config, accessToken, backend)(subscriptionName)
+      accessToken <- Zuora.accessTokenGetResponse(config.zuoraConfig, backend).logError
+      subscription <- Zuora.subscriptionGetResponse(config, accessToken, backend)(subscriptionName).logError
       credit <- guardianWeeklyCredit(
         config.guardianWeeklyConfig.productRatePlanIds,
         config.guardianWeeklyConfig.nForNProductRatePlanIds,
         stoppedPublicationDate
-      )(subscription)
-    } yield credit //TODO log failures
+      )(subscription).logError
+    } yield credit
 
   def guardianWeeklyCredit(guardianWeeklyProductRatePlanIds: List[String], gwNforNProductRatePlanIds: List[String], stoppedPublicationDate: LocalDate)(subscription: Subscription): Either[ZuoraHolidayWriteError, Double] =
     CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds, gwNforNProductRatePlanIds)

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/CreditCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/CreditCalculator.scala
@@ -3,21 +3,13 @@ package com.gu.holiday_stops
 import java.time.LocalDate
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.SubscriptionName
-import com.gu.util.Logging
 import com.softwaremill.sttp.{Id, SttpBackend}
+import com.typesafe.scalalogging.LazyLogging
+import mouse.all._
 
-object CreditCalculator {
+object CreditCalculator extends LazyLogging {
 
   type PartiallyWiredCreditCalculator = (SubscriptionName, LocalDate) => Either[HolidayError, Double]
-
-  implicit class HolidayErrorImplicits[T](theEither: Either[HolidayError, T]) extends Logging {
-
-    def logError: Either[HolidayError, T] = {
-      theEither.left.map(err => logger.error(s"Failed to calculate holiday stop credits because : " + err.reason))
-      theEither
-    }
-
-  }
 
   def apply(
     config: Config,
@@ -26,15 +18,15 @@ object CreditCalculator {
     subscriptionName: SubscriptionName,
     stoppedPublicationDate: LocalDate
   ): Either[HolidayError, Double] =
-    for {
-      accessToken <- Zuora.accessTokenGetResponse(config.zuoraConfig, backend).logError
-      subscription <- Zuora.subscriptionGetResponse(config, accessToken, backend)(subscriptionName).logError
+    (for {
+      accessToken <- Zuora.accessTokenGetResponse(config.zuoraConfig, backend)
+      subscription <- Zuora.subscriptionGetResponse(config, accessToken, backend)(subscriptionName)
       credit <- guardianWeeklyCredit(
         config.guardianWeeklyConfig.productRatePlanIds,
         config.guardianWeeklyConfig.nForNProductRatePlanIds,
         stoppedPublicationDate
-      )(subscription).logError
-    } yield credit
+      )(subscription)
+    } yield credit) <| (logger.error("Failed to calculate holiday stop credits", _))
 
   def guardianWeeklyCredit(guardianWeeklyProductRatePlanIds: List[String], gwNforNProductRatePlanIds: List[String], stoppedPublicationDate: LocalDate)(subscription: Subscription): Either[ZuoraHolidayWriteError, Double] =
     CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds, gwNforNProductRatePlanIds)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,4 +27,5 @@ object Dependencies {
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion
+  val mouse = "org.typelevel" % "mouse_2.12" % "0.23" // can be removed once we move to Scala 2.13 (native 'tap')
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,5 +27,5 @@ object Dependencies {
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion
-  val mouse = "org.typelevel" % "mouse_2.12" % "0.23" // can be removed once we move to Scala 2.13 (native 'tap')
+  val mouse = "org.typelevel" %% "mouse" % "0.23" // can be removed once we move to Scala 2.13 (native 'tap')
 }


### PR DESCRIPTION
In https://github.com/guardian/support-service-lambdas/pull/413 I left behind a TODO.

Anytime the system cannot determine the 'credit' we should log accordingly - this PR does exactly that.

Uses `<|` from [mouse](https://github.com/typelevel/mouse) - which can be replaced for native implementation of 'tap' once we upgrade to Scala 2.13 (as per [comment](https://github.com/guardian/support-service-lambdas/pull/414#pullrequestreview-289481017) from @mario-galic).