### PR TITLE
Increase holiday-stop processor timeout

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -69,7 +69,7 @@ Resources:
         !GetAtt HolidayStopProcessorRole.Arn
       MemorySize: 512
       Runtime: java8
-      Timeout: 180
+      Timeout: 900
     DependsOn:
       - HolidayStopProcessorRole
 


### PR DESCRIPTION
An alarm went off and this looks like the most obvious cause.