### PR TITLE
Move all Subscription interrogation code into its own package

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -5,7 +5,8 @@ import java.time.LocalDate
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.holiday_stops.CreditCalculator.PartiallyWiredCreditCalculator
+import com.gu.holiday_stops.subscription.CreditCalculator.PartiallyWiredCreditCalculator
+import com.gu.holiday_stops.subscription.{ActionCalculator, CreditCalculator, Subscription}
 import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestId, ProductName, ProductRatePlanKey, ProductRatePlanName, ProductType, SubscriptionName}

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -6,7 +6,7 @@ import java.time.LocalDate
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.holiday_stops.subscription.CreditCalculator.PartiallyWiredCreditCalculator
-import com.gu.holiday_stops.subscription.{ActionCalculator, CreditCalculator, Subscription}
+import com.gu.holiday_stops.subscription.{CreditCalculator, Subscription}
 import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestId, ProductName, ProductRatePlanKey, ProductRatePlanName, ProductType, SubscriptionName}

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -3,7 +3,6 @@ package com.gu.holiday_stops
 import java.time.LocalDate
 
 import cats.implicits._
-import com.gu.holiday_stops.subscription.{ActionCalculator, IssueSpecifics, LegacyProductSpecifics, ProductSpecifics}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{ProductName, ProductRatePlanKey, SubscriptionName}
 import play.api.libs.json.{Json, OFormat}

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -3,6 +3,7 @@ package com.gu.holiday_stops
 import java.time.LocalDate
 
 import cats.implicits._
+import com.gu.holiday_stops.subscription.{ActionCalculator, IssueSpecifics, LegacyProductSpecifics, ProductSpecifics}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{ProductName, ProductRatePlanKey, SubscriptionName}
 import play.api.libs.json.{Json, OFormat}

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -4,10 +4,10 @@ import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 import com.gu.effects.{FakeFetchString, SFTestEffects, TestingRawEffects}
-import com.gu.holiday_stops.subscription.ActionCalculator._
+import com.gu.holiday_stops.ActionCalculator._
 import com.gu.holiday_stops.Handler._
 import com.gu.holiday_stops.ZuoraSttpEffects.ZuoraSttpEffectsOps
-import com.gu.holiday_stops.subscription.{IssueSpecifics, LegacyProductSpecifics, RatePlan, RatePlanCharge, Subscription}
+import com.gu.holiday_stops.subscription.{RatePlan, RatePlanCharge, Subscription}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.SubscriptionName
 import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact._
 import com.gu.salesforce.holiday_stops.{SalesForceHolidayStopsEffects, SalesforceHolidayStopRequestsDetail}

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -4,9 +4,10 @@ import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 import com.gu.effects.{FakeFetchString, SFTestEffects, TestingRawEffects}
-import com.gu.holiday_stops.ActionCalculator._
+import com.gu.holiday_stops.subscription.ActionCalculator._
 import com.gu.holiday_stops.Handler._
 import com.gu.holiday_stops.ZuoraSttpEffects.ZuoraSttpEffectsOps
+import com.gu.holiday_stops.subscription.{IssueSpecifics, LegacyProductSpecifics, RatePlan, RatePlanCharge, Subscription}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.SubscriptionName
 import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact._
 import com.gu.salesforce.holiday_stops.{SalesForceHolidayStopsEffects, SalesforceHolidayStopRequestsDetail}

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcess.scala
@@ -2,10 +2,11 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.{CreditCalculator, CurrentGuardianWeeklySubscription, ExtendedTerm, GuardianWeeklyHolidayStopConfig, HolidayCreditProduct, HolidayCreditUpdate, HolidayStop, OverallFailure, SalesforceHolidayWriteError, Subscription, ZuoraHolidayWriteError}
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailChargePrice, ProductName, StoppedPublicationDate, SubscriptionName}
 import cats.implicits._
-import com.gu.holiday_stops.ActionCalculator.{GuardianWeeklyIssueSuspensionConstants, suspensionConstantsByProduct}
+import com.gu.holiday_stops.ActionCalculator.GuardianWeeklyIssueSuspensionConstants
+import com.gu.holiday_stops._
+import com.gu.holiday_stops.subscription._
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailChargePrice, ProductName, StoppedPublicationDate, SubscriptionName}
 
 object GuardianWeeklyHolidayStopProcess {
   def processHolidayStops(

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/NextBillingPeriodStartDate.scala
@@ -2,7 +2,7 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.{CurrentGuardianWeeklySubscription, CurrentSundayVoucherSubscription}
+import com.gu.holiday_stops.subscription.{CurrentGuardianWeeklySubscription, CurrentSundayVoucherSubscription}
 
 /**
  * Holiday credit is applied to the next invoice on the first day of the next billing period.

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessor.scala
@@ -2,10 +2,11 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
+import cats.implicits._
 import com.gu.holiday_stops.ActionCalculator.SundayVoucherIssueSuspensionConstants
 import com.gu.holiday_stops._
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailChargePrice, ProductName, ProductRatePlanKey, ProductRatePlanName, ProductType, StoppedPublicationDate, SubscriptionName}
-import cats.implicits._
+import com.gu.holiday_stops.subscription._
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailChargePrice, ProductRatePlanKey, ProductRatePlanName, ProductType, StoppedPublicationDate, SubscriptionName}
 
 object SundayVoucherHolidayStopProcessor {
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyErrorHandlingSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyErrorHandlingSpec.scala
@@ -5,6 +5,7 @@ import java.time.LocalDate
 import cats.implicits._
 import com.gu.holiday_stops.Fixtures._
 import com.gu.holiday_stops._
+import com.gu.holiday_stops.subscription.{HolidayCreditUpdate, Subscription}
 import com.gu.holidaystopprocessor.{GuardianWeeklyHolidayStopProcess, HolidayStopResponse}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, ProductName, SubscriptionName}
 import org.scalatest._

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
@@ -2,9 +2,10 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.ActionCalculator.GuardianWeeklyIssueSuspensionConstants
+import com.gu.holiday_stops.subscription.ActionCalculator.GuardianWeeklyIssueSuspensionConstants
 import com.gu.holiday_stops.Fixtures.{guardianWeeklyConfig, mkSubscription}
 import com.gu.holiday_stops._
+import com.gu.holiday_stops.subscription.{HolidayCreditUpdate, Subscription}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
 import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
@@ -2,7 +2,7 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.subscription.ActionCalculator.GuardianWeeklyIssueSuspensionConstants
+import com.gu.holiday_stops.ActionCalculator.GuardianWeeklyIssueSuspensionConstants
 import com.gu.holiday_stops.Fixtures.{guardianWeeklyConfig, mkSubscription}
 import com.gu.holiday_stops._
 import com.gu.holiday_stops.subscription.{HolidayCreditUpdate, Subscription}

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditUpdateTest.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.gu.holiday_stops.Fixtures.guardianWeeklyConfig
 import com.gu.holiday_stops._
+import com.gu.holiday_stops.subscription._
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 class HolidayCreditUpdateTest extends FlatSpec with Matchers with EitherValues {

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/PredictedInvoicedPeriodSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/PredictedInvoicedPeriodSpec.scala
@@ -3,6 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.holiday_stops._
+import com.gu.holiday_stops.subscription.{CurrentInvoicedPeriod, PredictedInvoicedPeriod, RatePlan, RatePlanCharge}
 import org.scalatest._
 
 class PredictedInvoicedPeriodSpec extends FlatSpec with Matchers with OptionValues {

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
@@ -3,6 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.holiday_stops._
+import com.gu.holiday_stops.subscription.{Add, ChargeOverride, HolidayCreditUpdate, RatePlan, RatePlanCharge, Subscription}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherNextBillingPeriodStartDateSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherNextBillingPeriodStartDateSpec.scala
@@ -2,7 +2,8 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.{CurrentSundayVoucherSubscription, Subscription, SundayVoucherHolidayStopConfig}
+import com.gu.holiday_stops.subscription.{CurrentSundayVoucherSubscription, Subscription}
+import com.gu.holiday_stops.SundayVoucherHolidayStopConfig
 import org.scalatest._
 
 import scala.io.Source

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/Zuora.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/Zuora.scala
@@ -1,5 +1,6 @@
 package com.gu.holiday_stops
 
+import com.gu.holiday_stops.subscription.{HolidayCreditUpdate, Subscription}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.SubscriptionName
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CreditCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CreditCalculator.scala
@@ -1,8 +1,9 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
 import cats.syntax.either._
+import com.gu.holiday_stops._
 import com.typesafe.scalalogging.LazyLogging
 import mouse.all._
 

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentGuardianWeeklySubscription.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentGuardianWeeklySubscription.scala
@@ -1,7 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.ZuoraHolidayWriteError
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscription.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscription.scala
@@ -1,7 +1,9 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.temporal.ChronoUnit
+
 import cats.implicits._
+import com.gu.holiday_stops.ZuoraHolidayWriteError
 
 object CurrentSundayVoucherSubscriptionPredicate {
   def ratePlanIsSundayVoucher(ratePlan: RatePlan, sundayVoucherProductRatePlanChargeId: String): Boolean =

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentWeekendVoucherSubscription.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentWeekendVoucherSubscription.scala
@@ -1,7 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
-import enumeratum._
+import com.gu.holiday_stops.ZuoraHolidayWriteError
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
+import enumeratum._
 
 object CurrentWeekendVoucherSubscriptionPredicates {
   def ratePlanIsWeekendVoucher(ratePlan: RatePlan, weekendVoucherProductRatePlanId: String): Boolean =

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/ExtendedTerm.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/ExtendedTerm.scala
@@ -1,4 +1,4 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit.DAYS

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCredit.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCredit.scala
@@ -1,6 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
+
+import com.gu.holiday_stops.BillingPeriodToApproxWeekCount
 
 import scala.math.BigDecimal.RoundingMode
 

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayCreditUpdate.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayCreditUpdate.scala
@@ -1,6 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
+
+import com.gu.holiday_stops.{HolidayCreditProduct, ZuoraHolidayWriteError}
 
 case class HolidayCreditUpdate(
   currentTerm: Option[Int],

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/Subscription.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/Subscription.scala
@@ -1,6 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
+
+import com.gu.holiday_stops.HolidayStop
 
 case class Subscription(
   subscriptionNumber: String,

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/SundayVoucherHolidayCredit.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/SundayVoucherHolidayCredit.scala
@@ -1,6 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
+
+import com.gu.holiday_stops.BillingPeriodToApproxWeekCount
 
 import scala.math.BigDecimal.RoundingMode
 

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -5,8 +5,9 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import ai.x.play.json.Jsonx
-import com.gu.holiday_stops.{ActionCalculator, Subscription}
-import com.gu.holiday_stops.CreditCalculator.PartiallyWiredCreditCalculator
+import com.gu.holiday_stops.ActionCalculator
+import com.gu.holiday_stops.subscription.CreditCalculator.PartiallyWiredCreditCalculator
+import com.gu.holiday_stops.subscription.Subscription
 import com.gu.salesforce.RecordsWrapperCaseClass
 import com.gu.salesforce.SalesforceConstants._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -2,6 +2,7 @@ package com.gu.holiday_stops
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.subscription.{RatePlan, RatePlanCharge, Subscription}
 import com.gu.salesforce.RecordsWrapperCaseClass
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestActionedCount, HolidayStopRequestEndDate, HolidayStopRequestStartDate}

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/HolidayCreditTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/HolidayCreditTest.scala
@@ -2,6 +2,7 @@ package com.gu.holiday_stops
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.subscription.{CurrentGuardianWeeklySubscription, GuardianWeeklyHolidayCredit, RatePlan}
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 class HolidayCreditTest extends FlatSpec with Matchers with EitherValues {

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ZuoraSttpEffects.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ZuoraSttpEffects.scala
@@ -1,5 +1,6 @@
 package com.gu.holiday_stops
 
+import com.gu.holiday_stops.subscription.Subscription
 import com.softwaremill.sttp.testing.SttpBackendStub
 import com.softwaremill.sttp.{Id, Response}
 

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
@@ -1,7 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.{GuardianWeeklyHolidayStopConfig, SundayVoucherHolidayStopConfig}
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.scalatest._

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscriptionSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscriptionSpec.scala
@@ -1,9 +1,11 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
-import org.scalatest._
-import scala.io.Source
-import io.circe.parser.decode
+import com.gu.holiday_stops.SundayVoucherHolidayStopConfig
 import io.circe.generic.auto._
+import io.circe.parser.decode
+import org.scalatest._
+
+import scala.io.Source
 
 class CurrentSundayVoucherSubscriptionSpec extends FlatSpec with Matchers with EitherValues {
   "CurrentSundayVoucherSubscription" should "satisfy all the predicates" in {

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentWeekendVoucherSubscriptionSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentWeekendVoucherSubscriptionSpec.scala
@@ -1,7 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.WeekendVoucherHolidayStopConfig
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
 import io.circe.generic.auto._
 import io.circe.parser.decode

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCreditSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCreditSpec.scala
@@ -1,9 +1,10 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.{Fixtures, GuardianWeeklyHolidayStopConfig}
 import org.scalacheck.Prop.forAll
-import org.scalacheck._
+import org.scalacheck.{Gen, Properties}
 import org.scalatest.{EitherValues, OptionValues}
 
 object GuardianWeeklyHolidayCreditSpec extends Properties("HolidayCreditAmount") with OptionValues with EitherValues {

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/SubscriptionTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/SubscriptionTest.scala
@@ -1,7 +1,8 @@
-package com.gu.holiday_stops
+package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.Fixtures
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
 class SubscriptionTest extends FlatSpec with Matchers with OptionValues {

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -3,8 +3,9 @@ package com.gu.salesforce.holiday_stops
 import java.time.LocalDate
 
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.holiday_stops.CreditCalculator.PartiallyWiredCreditCalculator
-import com.gu.holiday_stops.{Fixtures, Subscription}
+import com.gu.holiday_stops.subscription.CreditCalculator.PartiallyWiredCreditCalculator
+import com.gu.holiday_stops.Fixtures
+import com.gu.holiday_stops.subscription.Subscription
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._


### PR DESCRIPTION
This moves all the code that just interrogates Subscriptions into its own package, `com.gu.holiday_stops.subscription`, as a first step to refactoring it.

It contains raw Zuora subscription which is transformed to Guardian models of subscription.