### PR TITLE
adding weekend voucher support to get existing stops endpoint

### DIFF
--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -283,8 +283,8 @@ class HandlerTest extends FlatSpec with Matchers {
                 ),
                 List(
                   IssueSpecifics(
-                    SundayVoucherIssueSuspensionConstants.firstAvailableDate(LocalDate.now()),
-                    SundayVoucherIssueSuspensionConstants.issueDayOfWeek.getValue
+                    SundayVoucherSuspensionConstants.issueConstants(0).firstAvailableDate(LocalDate.now()),
+                    SundayVoucherSuspensionConstants.issueConstants(0).issueDayOfWeek.getValue
                   )
                 ),
                 Some(SundayVoucherSuspensionConstants.annualIssueLimit)

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessor.scala
@@ -2,6 +2,7 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
+import cats.implicits._
 import com.gu.holiday_stops.ActionCalculator.VoucherProcessorLeadTime
 import com.gu.holiday_stops._
 import com.gu.holiday_stops.subscription._

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessor.scala
@@ -2,7 +2,7 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.ActionCalculator.SundayVoucherIssueSuspensionConstants
+import com.gu.holiday_stops.ActionCalculator.VoucherProcessorLeadTime
 import com.gu.holiday_stops._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailChargePrice, ProductName, ProductRatePlanKey, ProductRatePlanName, ProductType, StoppedPublicationDate, SubscriptionName}
 import cats.implicits._
@@ -42,7 +42,7 @@ object SundayVoucherHolidayStopProcessor {
     }
   }
   private def calculateProcessDate(processDateOverride: Option[LocalDate]) = {
-    processDateOverride.getOrElse(LocalDate.now.plusDays(SundayVoucherIssueSuspensionConstants.processorRunLeadTimeDays))
+    processDateOverride.getOrElse(LocalDate.now.plusDays(VoucherProcessorLeadTime))
   }
 
   private def writeHolidayStopToZuora(

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
@@ -110,17 +110,26 @@ object ActionCalculator {
 
   val SundayVoucherSuspensionConstants = SuspensionConstants(
     annualIssueLimit = 6,
-    issueConstants = List(SundayVoucherIssueSuspensionConstants)
+    issueConstants = List(voucherIssueSuspensionConstants(DayOfWeek.SUNDAY))
   )
 
-  case object SundayVoucherIssueSuspensionConstants extends IssueSuspensionConstants(
-    issueDayOfWeek = DayOfWeek.SUNDAY,
-    processorRunLeadTimeDays = 1,
-  ) {
-    def firstAvailableDate(today: LocalDate): LocalDate = {
-      today.plus(processorRunLeadTimeDays.toLong, ChronoUnit.DAYS)
+  val WeekendVoucherSuspensionConstants = SuspensionConstants(
+    annualIssueLimit = 6,
+    issueConstants = List(
+      voucherIssueSuspensionConstants(DayOfWeek.SATURDAY),
+      voucherIssueSuspensionConstants(DayOfWeek.SUNDAY)
+    )
+  )
+
+  def voucherIssueSuspensionConstants(dayOfWeek: DayOfWeek): IssueSuspensionConstants =
+    new IssueSuspensionConstants(
+      issueDayOfWeek = dayOfWeek,
+      processorRunLeadTimeDays = 1,
+    ) {
+      def firstAvailableDate(today: LocalDate): LocalDate = {
+        today.plus(processorRunLeadTimeDays.toLong, ChronoUnit.DAYS)
+      }
     }
-  }
 
   // TODO this will likely need to change to return an array of days of week (when we support more than just GW)
   def suspensionConstantsByProduct(productNamePrefix: ProductName): SuspensionConstants =
@@ -134,6 +143,8 @@ object ActionCalculator {
   def suspensionConstantsByProductRatePlanKey(
     productKey: ProductRatePlanKey
   ): Either[ActionCalculatorError, SuspensionConstants] = productKey match {
+    case ProductRatePlanKey(ProductType("Newspaper - Voucher Book"), ProductRatePlanName("Weekend")) =>
+      Right(WeekendVoucherSuspensionConstants)
     case ProductRatePlanKey(ProductType("Newspaper - Voucher Book"), ProductRatePlanName("Sunday")) =>
       Right(SundayVoucherSuspensionConstants)
     case ProductRatePlanKey(ProductType("Guardian Weekly"), _) =>

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
@@ -58,7 +58,7 @@ object ActionCalculator {
    */
   sealed abstract class IssueSuspensionConstants(
     val issueDayOfWeek: DayOfWeek,
-    val processorRunLeadTimeDays: Int,
+    val processorRunLeadTimeDays: Int
   ) {
     /**
      * The first date a holiday can started on for this issue when creating a stop on the supplied date
@@ -108,23 +108,26 @@ object ActionCalculator {
     }
   }
 
-  val SundayVoucherSuspensionConstants = SuspensionConstants(
-    annualIssueLimit = 6,
-    issueConstants = List(voucherIssueSuspensionConstants(DayOfWeek.SUNDAY))
+  val SundayVoucherSuspensionConstants = voucherSuspensionConstans(
+    List(voucherIssueSuspensionConstants(DayOfWeek.SUNDAY))
   )
 
-  val WeekendVoucherSuspensionConstants = SuspensionConstants(
-    annualIssueLimit = 6,
-    issueConstants = List(
+  val WeekendVoucherSuspensionConstants = voucherSuspensionConstans(
+    List(
       voucherIssueSuspensionConstants(DayOfWeek.SATURDAY),
       voucherIssueSuspensionConstants(DayOfWeek.SUNDAY)
     )
   )
 
+  def voucherSuspensionConstans(issueSuspensionConstants: List[IssueSuspensionConstants]) =
+    SuspensionConstants(issueSuspensionConstants.size * 6, issueSuspensionConstants)
+
+  lazy val VoucherProcessorLeadTime: Int = 1
+
   def voucherIssueSuspensionConstants(dayOfWeek: DayOfWeek): IssueSuspensionConstants =
     new IssueSuspensionConstants(
       issueDayOfWeek = dayOfWeek,
-      processorRunLeadTimeDays = 1,
+      processorRunLeadTimeDays = VoucherProcessorLeadTime
     ) {
       def firstAvailableDate(today: LocalDate): LocalDate = {
         today.plus(processorRunLeadTimeDays.toLong, ChronoUnit.DAYS)

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
@@ -151,6 +151,42 @@ class ActionCalculatorTest extends FlatSpec with Matchers with EitherValues {
         LocalDate.of(2019, 6, 23)
       ))
   }
+  it should "correctly list the action dates for Weekend Voucher" in {
+    val weekendVoucherProductRatePlanKey =
+      ProductRatePlanKey(ProductType("Newspaper - Voucher Book"), ProductRatePlanName("Weekend"))
+
+    ActionCalculator.publicationDatesToBeStopped(
+      fromInclusive = LocalDate.of(2019, 5, 20),
+      toInclusive = LocalDate.of(2019, 6, 21),
+      productRatePlanKey = weekendVoucherProductRatePlanKey
+    ) shouldEqual Right(List(
+        LocalDate.of(2019, 5, 25),
+        LocalDate.of(2019, 5, 26),
+        LocalDate.of(2019, 6, 1),
+        LocalDate.of(2019, 6, 2),
+        LocalDate.of(2019, 6, 8),
+        LocalDate.of(2019, 6, 9),
+        LocalDate.of(2019, 6, 15),
+        LocalDate.of(2019, 6, 16)
+      ))
+
+    ActionCalculator.publicationDatesToBeStopped(
+      fromInclusive = LocalDate.of(2019, 5, 20),
+      toInclusive = LocalDate.of(2019, 6, 23),
+      productRatePlanKey = weekendVoucherProductRatePlanKey
+    ) shouldEqual Right(List(
+        LocalDate.of(2019, 5, 25),
+        LocalDate.of(2019, 5, 26),
+        LocalDate.of(2019, 6, 1),
+        LocalDate.of(2019, 6, 2),
+        LocalDate.of(2019, 6, 8),
+        LocalDate.of(2019, 6, 9),
+        LocalDate.of(2019, 6, 15),
+        LocalDate.of(2019, 6, 16),
+        LocalDate.of(2019, 6, 22),
+        LocalDate.of(2019, 6, 23)
+      ))
+  }
   it should "return an error for an unsupported product rate plan" in {
     val unsupportedProductRatePlanKey =
       ProductRatePlanKey(ProductType("not supported"), ProductRatePlanName("not supported"))


### PR DESCRIPTION
This PR enables calling the Get `/hsr/<sub>` endpoint with productType="Newspaper - Voucher Book" and productRatePlanName="Weekend"