### PR TITLE
Remove config signature pollution from Holiday stops methods

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -63,8 +63,7 @@ object Handler extends Logging {
       validateRequestAndCreateSteps(
         request,
         CreditCalculator.calculateCredit(
-          config.guardianWeeklyConfig.productRatePlanIds,
-          config.guardianWeeklyConfig.nForNProductRatePlanIds,
+          config,
           config.sundayVoucherConfig.productRatePlanChargeId
         ),
         getSubscriptionFromZuora(config, backend)

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -62,10 +62,7 @@ object Handler extends Logging {
     } yield Operation.noHealthcheck(request => // checking connectivity to SF is sufficient healthcheck so no special steps required
       validateRequestAndCreateSteps(
         request,
-        CreditCalculator.calculateCredit(
-          config,
-          config.sundayVoucherConfig.productRatePlanChargeId
-        ),
+        CreditCalculator.calculateCredit(config),
         getSubscriptionFromZuora(config, backend)
       )(request, sfClient))
   }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -23,7 +23,7 @@ object HolidayStopProcess {
             processDateOverride
           ),
           SundayVoucherHolidayStopProcessor.processHolidayStops(
-            config = config.sundayVoucherConfig,
+            config,
             getHolidayStopRequestsFromSalesforce = Salesforce.sundayVoucherHolidayStopRequests(config.sfConfig),
             getSubscription = Zuora.subscriptionGetResponse(config, zuoraAccessToken, backend),
             updateSubscription = Zuora.subscriptionUpdateResponse(config, zuoraAccessToken, backend),

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopProcess.scala
@@ -15,7 +15,7 @@ object HolidayStopProcess {
       case Right(zuoraAccessToken) =>
         List(
           GuardianWeeklyHolidayStopProcess.processHolidayStops(
-            config = config.guardianWeeklyConfig,
+            config,
             getHolidayStopRequestsFromSalesforce = Salesforce.holidayStopRequests(config.sfConfig),
             getSubscription = Zuora.subscriptionGetResponse(config, zuoraAccessToken, backend),
             updateSubscription = Zuora.subscriptionUpdateResponse(config, zuoraAccessToken, backend),

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyErrorHandlingSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyErrorHandlingSpec.scala
@@ -41,7 +41,7 @@ class GuardianWeeklyErrorHandlingSpec extends FlatSpec with Matchers with Option
     }
 
     val result = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       getHolidayStopRequestsFromSalesforce,
       getSubscription,
       updateSubscription,
@@ -68,7 +68,7 @@ class GuardianWeeklyErrorHandlingSpec extends FlatSpec with Matchers with Option
     }
 
     val result = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       getHolidayStopRequestsFromSalesforce,
       getSubscription,
       updateSubscription,
@@ -96,7 +96,7 @@ class GuardianWeeklyErrorHandlingSpec extends FlatSpec with Matchers with Option
     }
 
     val result = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       getHolidayStopRequestsFromSalesforce,
       getSubscription,
       updateSubscription,
@@ -123,7 +123,7 @@ class GuardianWeeklyErrorHandlingSpec extends FlatSpec with Matchers with Option
     }
 
     val result = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       getHolidayStopRequestsFromSalesforce,
       getSubscription,
       updateSubscription,

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
@@ -45,9 +45,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   "HolidayStopProcess" should "give correct added charge" in {
     val response = GuardianWeeklyHolidayStopProcess.writeHolidayStopToZuora(
-      guardianWeeklyConfig.holidayCreditProduct,
-      guardianWeeklyConfig.productRatePlanIds,
-      Nil,
+      Fixtures.config,
       getSubscription(Right(Fixtures.mkSubscriptionWithHolidayStops())),
       updateSubscription(Right(()))
     )(holidayStop)
@@ -64,9 +62,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   it should "give an exception message if update fails" in {
     val response = GuardianWeeklyHolidayStopProcess.writeHolidayStopToZuora(
-      guardianWeeklyConfig.holidayCreditProduct,
-      guardianWeeklyConfig.productRatePlanIds,
-      Nil,
+      Fixtures.config,
       getSubscription(Right(subscription)),
       updateSubscription(Left(ZuoraHolidayWriteError("update went wrong")))
     )(holidayStop)
@@ -75,9 +71,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   it should "give an exception message if getting subscription details fails" in {
     val response = GuardianWeeklyHolidayStopProcess.writeHolidayStopToZuora(
-      guardianWeeklyConfig.holidayCreditProduct,
-      guardianWeeklyConfig.productRatePlanIds,
-      Nil,
+      Fixtures.config,
       getSubscription(Left(ZuoraHolidayWriteError("get went wrong"))),
       updateSubscription(Right(()))
     )(holidayStop)
@@ -86,9 +80,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   it should "give an exception message if subscription isn't auto-renewing" in {
     val response = GuardianWeeklyHolidayStopProcess.writeHolidayStopToZuora(
-      guardianWeeklyConfig.holidayCreditProduct,
-      guardianWeeklyConfig.productRatePlanIds,
-      Nil,
+      Fixtures.config,
       getSubscription(Right(subscription.copy(autoRenew = false))),
       updateSubscription(Right(()))
     )(holidayStop)
@@ -98,9 +90,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   it should "just give charge added without applying an update if holiday stop has already been applied" in {
     val response = GuardianWeeklyHolidayStopProcess.writeHolidayStopToZuora(
-      guardianWeeklyConfig.holidayCreditProduct,
-      guardianWeeklyConfig.productRatePlanIds,
-      Nil,
+      Fixtures.config,
       getSubscription(Right(Fixtures.mkSubscriptionWithHolidayStops())),
       updateSubscription(Left(ZuoraHolidayWriteError("shouldn't need to apply an update")))
     )(holidayStop)
@@ -117,9 +107,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   it should "give a failure if subscription has no added charge" in {
     val response = GuardianWeeklyHolidayStopProcess.writeHolidayStopToZuora(
-      guardianWeeklyConfig.holidayCreditProduct,
-      guardianWeeklyConfig.productRatePlanIds,
-      Nil,
+      Fixtures.config,
       getSubscription(Right(subscription)),
       updateSubscription(Left(ZuoraHolidayWriteError("shouldn't need to apply an update")))
     )(holidayStop)
@@ -128,7 +116,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   "processHolidayStops" should "give correct charges added" in {
     val responses = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       getHolidayStopRequestsFromSalesforce(Right(List(
         Fixtures.mkHolidayStopRequestDetailsFromHolidayStopRequest(Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)), "C1"),
         Fixtures.mkHolidayStopRequestDetailsFromHolidayStopRequest(Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)), "C3"),
@@ -161,7 +149,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   it should "only export results that haven't already been exported" in {
     val responses = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       getHolidayStopRequestsFromSalesforce(Right(List(
         Fixtures.mkHolidayStopRequestDetailsFromHolidayStopRequest(Fixtures.mkHolidayStopRequest("R1", LocalDate.of(2019, 8, 2)), "C2"),
         Fixtures.mkHolidayStopRequestDetailsFromHolidayStopRequest(Fixtures.mkHolidayStopRequest("R2", LocalDate.of(2019, 9, 1)), "C5"),
@@ -187,7 +175,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
 
   it should "give an exception message if exporting results fails" in {
     val responses = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       getHolidayStopRequestsFromSalesforce(Right(List(
         Fixtures.mkHolidayStopRequestDetailsFromHolidayStopRequest(Fixtures.mkHolidayStopRequest("r1"), ""),
         Fixtures.mkHolidayStopRequestDetailsFromHolidayStopRequest(Fixtures.mkHolidayStopRequest("r2"), ""),
@@ -207,7 +195,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
     }
 
     val responses = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       verifyProcessDate,
       getSubscription(Right(subscription)),
       updateSubscription(Right(())),
@@ -224,7 +212,7 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
     }
 
     val responses = GuardianWeeklyHolidayStopProcess.processHolidayStops(
-      guardianWeeklyConfig,
+      Fixtures.config,
       verifyProcessDate,
       getSubscription(Right(subscription)),
       updateSubscription(Right(())),

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditUpdateTest.scala
@@ -19,7 +19,7 @@ class HolidayCreditUpdateTest extends FlatSpec with Matchers with EitherValues {
       billingPeriod = "Quarter",
       chargedThroughDate = Some(LocalDate.of(2019, 9, 12))
     )
-    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds, Nil)
+    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config)
     val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription.right.value, LocalDate.now)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
     val holidayCredit = GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now)
@@ -62,7 +62,7 @@ class HolidayCreditUpdateTest extends FlatSpec with Matchers with EitherValues {
       billingPeriod = "Quarter",
       chargedThroughDate = None
     )
-    CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds, Nil).left.value shouldBe a[ZuoraHolidayWriteError]
+    CurrentGuardianWeeklySubscription(subscription, Fixtures.config).left.value shouldBe a[ZuoraHolidayWriteError]
   }
 
   it should "generate an update with an extended term when charged-through date of subscription is after its term-end date" in {
@@ -73,7 +73,7 @@ class HolidayCreditUpdateTest extends FlatSpec with Matchers with EitherValues {
       billingPeriod = "Annual",
       chargedThroughDate = Some(LocalDate.of(2020, 8, 2))
     )
-    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds, Nil)
+    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config)
     val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription.right.value, LocalDate.now)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
     val holidayCredit = GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now)
@@ -113,7 +113,7 @@ class HolidayCreditUpdateTest extends FlatSpec with Matchers with EitherValues {
       billingPeriod = "Annual",
       chargedThroughDate = Some(LocalDate.of(2020, 7, 23))
     )
-    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds, Nil)
+    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config)
     val nextInvoiceStartDate = NextBillingPeriodStartDate(currentGuardianWeeklySubscription.right.value, LocalDate.now)
     val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
     val holidayCredit = GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now)

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/PredictedInvoicedPeriodSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/PredictedInvoicedPeriodSpec.scala
@@ -2,7 +2,6 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops._
 import com.gu.holiday_stops.subscription.{CurrentInvoicedPeriod, PredictedInvoicedPeriod, RatePlan, RatePlanCharge}
 import org.scalatest._
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
@@ -197,7 +197,7 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
     val SubscriptionMock = subscription
 
     SundayVoucherHolidayStopProcessor.processHolidayStops(
-      Fixtures.config.sundayVoucherConfig,
+      Fixtures.config,
       (_, _) => Right(holidayStopRequestsFromSalesforce),
       getSubscription = _ => Right(getSubscriptionMock()),
       updateSubscription = { case (SubscriptionMock, ExpectedHolidayCreditUpdate) => Right(()) }, // here is main logic of test

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
@@ -197,7 +197,7 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
     val SubscriptionMock = subscription
 
     SundayVoucherHolidayStopProcessor.processHolidayStops(
-      Fixtures.sundayVoucherHolidayStopConfig,
+      Fixtures.config.sundayVoucherConfig,
       (_, _) => Right(holidayStopRequestsFromSalesforce),
       getSubscription = _ => Right(getSubscriptionMock()),
       updateSubscription = { case (SubscriptionMock, ExpectedHolidayCreditUpdate) => Right(()) }, // here is main logic of test

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherNextBillingPeriodStartDateSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherNextBillingPeriodStartDateSpec.scala
@@ -3,7 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.holiday_stops.subscription.{CurrentSundayVoucherSubscription, Subscription}
-import com.gu.holiday_stops.SundayVoucherHolidayStopConfig
+import com.gu.holiday_stops.{Fixtures, SundayVoucherHolidayStopConfig}
 import org.scalatest._
 
 import scala.io.Source
@@ -14,7 +14,7 @@ class SundayVoucherNextBillingPeriodStartDateSpec extends FlatSpec with Matchers
   "CurrentSundayVoucherSubscription" should "satisfy all the predicates" in {
     val subscriptionRaw = Source.fromResource("SundayVoucherSubscription.json").mkString
     val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode CurrentSundayVoucherSubscription"))
-    val currentSundayVoucherSubscription = CurrentSundayVoucherSubscription(subscription, SundayVoucherHolidayStopConfig.Dev.productRatePlanChargeId).right.value
+    val currentSundayVoucherSubscription = CurrentSundayVoucherSubscription(subscription, Fixtures.config).right.value
     SundayVoucherNextBillingPeriodStartDate(currentSundayVoucherSubscription) should be(LocalDate.of(2019, 11, 6))
   }
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CreditCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CreditCalculator.scala
@@ -13,14 +13,13 @@ object CreditCalculator extends LazyLogging {
 
   def calculateCredit(
     config: Config,
-    sundayVoucherRatePlanId: String
   )(stoppedPublicationDate: LocalDate, subscription: Subscription): Either[ZuoraHolidayWriteError, Double] = {
     guardianWeeklyCredit(
       config,
       stoppedPublicationDate
     )(subscription) orElse {
       sundayVoucherCredit(
-        sundayVoucherRatePlanId,
+        config,
         stoppedPublicationDate
       )(subscription)
     } orElse {
@@ -31,8 +30,8 @@ object CreditCalculator extends LazyLogging {
   def guardianWeeklyCredit(config: Config, stoppedPublicationDate: LocalDate)(subscription: Subscription): Either[ZuoraHolidayWriteError, Double] =
     CurrentGuardianWeeklySubscription(subscription, config).map(GuardianWeeklyHolidayCredit(_, stoppedPublicationDate))
 
-  def sundayVoucherCredit(sundayVoucherRatePlanId: String, stoppedPublicationDate: LocalDate)(subscription: Subscription) = {
-    CurrentSundayVoucherSubscription(subscription, sundayVoucherRatePlanId)
+  def sundayVoucherCredit(config: Config, stoppedPublicationDate: LocalDate)(subscription: Subscription) = {
+    CurrentSundayVoucherSubscription(subscription, config)
       .map(SundayVoucherHolidayCredit(_, stoppedPublicationDate))
   }
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CreditCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CreditCalculator.scala
@@ -12,13 +12,11 @@ object CreditCalculator extends LazyLogging {
   type PartiallyWiredCreditCalculator = (LocalDate, Subscription) => Either[HolidayError, Double]
 
   def calculateCredit(
-    guardianWeeklyProductRatePlanIds: List[String],
-    gwNforNProductRatePlanIds: List[String],
+    config: Config,
     sundayVoucherRatePlanId: String
   )(stoppedPublicationDate: LocalDate, subscription: Subscription): Either[ZuoraHolidayWriteError, Double] = {
     guardianWeeklyCredit(
-      guardianWeeklyProductRatePlanIds,
-      gwNforNProductRatePlanIds,
+      config,
       stoppedPublicationDate
     )(subscription) orElse {
       sundayVoucherCredit(
@@ -30,9 +28,8 @@ object CreditCalculator extends LazyLogging {
     }
   } <| (logger.error("Failed to calculate holiday stop credits", _))
 
-  def guardianWeeklyCredit(guardianWeeklyProductRatePlanIds: List[String], gwNforNProductRatePlanIds: List[String], stoppedPublicationDate: LocalDate)(subscription: Subscription): Either[ZuoraHolidayWriteError, Double] =
-    CurrentGuardianWeeklySubscription(subscription, guardianWeeklyProductRatePlanIds, gwNforNProductRatePlanIds)
-      .map(GuardianWeeklyHolidayCredit(_, stoppedPublicationDate))
+  def guardianWeeklyCredit(config: Config, stoppedPublicationDate: LocalDate)(subscription: Subscription): Either[ZuoraHolidayWriteError, Double] =
+    CurrentGuardianWeeklySubscription(subscription, config).map(GuardianWeeklyHolidayCredit(_, stoppedPublicationDate))
 
   def sundayVoucherCredit(sundayVoucherRatePlanId: String, stoppedPublicationDate: LocalDate)(subscription: Subscription) = {
     CurrentSundayVoucherSubscription(subscription, sundayVoucherRatePlanId)

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentGuardianWeeklySubscription.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentGuardianWeeklySubscription.scala
@@ -2,7 +2,7 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.ZuoraHolidayWriteError
+import com.gu.holiday_stops.{Config, ZuoraHolidayWriteError}
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try
@@ -211,11 +211,9 @@ object CurrentGuardianWeeklySubscription {
       .ratePlans
       .find(ratePlan => guardianWeeklyNForNProductRatePlanIds.contains(ratePlan.productRatePlanId))
 
-  def apply(
-    subscription: Subscription,
-    guardianWeeklyProductRatePlanIds: List[String],
-    gwNforNProductRatePlanIds: List[String]
-  ): Either[ZuoraHolidayWriteError, CurrentGuardianWeeklySubscription] = {
+  def apply(subscription: Subscription, config: Config): Either[ZuoraHolidayWriteError, CurrentGuardianWeeklySubscription] = {
+    val guardianWeeklyProductRatePlanIds = config.guardianWeeklyConfig.productRatePlanIds
+    val gwNforNProductRatePlanIds = config.guardianWeeklyConfig.nForNProductRatePlanIds
 
     val maybeRegularGw =
       findGuardianWeeklyRatePlan(subscription, guardianWeeklyProductRatePlanIds)

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscription.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscription.scala
@@ -3,7 +3,7 @@ package com.gu.holiday_stops.subscription
 import java.time.temporal.ChronoUnit
 
 import cats.implicits._
-import com.gu.holiday_stops.ZuoraHolidayWriteError
+import com.gu.holiday_stops.{Config, ZuoraHolidayWriteError}
 
 object CurrentSundayVoucherSubscriptionPredicate {
   def ratePlanIsSundayVoucher(ratePlan: RatePlan, sundayVoucherProductRatePlanChargeId: String): Boolean =
@@ -57,10 +57,10 @@ object CurrentSundayVoucherSubscription {
 
   def apply(
     subscription: Subscription,
-    sundayVoucherProductRatePlanChargeId: String
+    config: Config
   ): Either[ZuoraHolidayWriteError, CurrentSundayVoucherSubscription] = {
 
-    findSundayVoucherRatePlan(subscription, sundayVoucherProductRatePlanChargeId).flatMap { currentSundayVoucherRatePlan =>
+    findSundayVoucherRatePlan(subscription, config.sundayVoucherConfig.productRatePlanChargeId).flatMap { currentSundayVoucherRatePlan =>
       for {
         currentSundayVoucherRatePlanRatePlanCharge <- currentSundayVoucherRatePlan.ratePlanCharges.headOption
         billingPeriod <- currentSundayVoucherRatePlanRatePlanCharge.billingPeriod

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -239,13 +239,7 @@ object Fixtures {
     estimatedCharge = None
   )
 
-//  val config = Config(
-//    zuoraConfig = null,
-//    sfConfig = null,
-//    GuardianWeeklyHolidayStopConfig.Dev,
-//    SundayVoucherHolidayStopConfig.Dev
-//  )
-
+  // FIXME remove this in favour of Fixture.config
   val guardianWeeklyConfig = GuardianWeeklyHolidayStopConfig(
     HolidayCreditProduct(
       productRatePlanId = "ratePlanId",
@@ -255,13 +249,10 @@ object Fixtures {
     GuardianWeeklyHolidayStopConfig.Dev.nForNProductRatePlanIds
   )
 
-//  val sundayVoucherHolidayStopConfig = SundayVoucherHolidayStopConfig(HolidayCreditProduct("", ""), "")
-  val sundayVoucherHolidayStopConfig = SundayVoucherHolidayStopConfig.Dev
-
   val config = Config(
     zuoraConfig = ZuoraConfig(baseUrl = "", holidayStopProcessor = HolidayStopProcessor(Oauth(clientId = "", clientSecret = ""))),
     sfConfig = SFAuthConfig("", "", "", "", "", ""),
-    guardianWeeklyConfig = guardianWeeklyConfig,
-    sundayVoucherConfig = sundayVoucherHolidayStopConfig
+    guardianWeeklyConfig = GuardianWeeklyHolidayStopConfig.Dev,
+    sundayVoucherConfig = SundayVoucherHolidayStopConfig.Dev
   )
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -251,8 +251,8 @@ object Fixtures {
       productRatePlanId = "ratePlanId",
       productRatePlanChargeId = "ratePlanChargeId"
     ),
-    GuardianWeeklyHolidayStopConfig.Prod.productRatePlanIds, // FIXME
-    GuardianWeeklyHolidayStopConfig.Prod.nForNProductRatePlanIds
+    GuardianWeeklyHolidayStopConfig.Dev.productRatePlanIds,
+    GuardianWeeklyHolidayStopConfig.Dev.nForNProductRatePlanIds
   )
 
 //  val sundayVoucherHolidayStopConfig = SundayVoucherHolidayStopConfig(HolidayCreditProduct("", ""), "")

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -239,6 +239,13 @@ object Fixtures {
     estimatedCharge = None
   )
 
+//  val config = Config(
+//    zuoraConfig = null,
+//    sfConfig = null,
+//    GuardianWeeklyHolidayStopConfig.Dev,
+//    SundayVoucherHolidayStopConfig.Dev
+//  )
+
   val guardianWeeklyConfig = GuardianWeeklyHolidayStopConfig(
     HolidayCreditProduct(
       productRatePlanId = "ratePlanId",

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/HolidayCreditTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/HolidayCreditTest.scala
@@ -11,7 +11,7 @@ class HolidayCreditTest extends FlatSpec with Matchers with EitherValues {
     val charge = Fixtures.mkRatePlanCharge(price = 30, billingPeriod = "Quarter")
     val ratePlans = List(RatePlan("", List(charge), Fixtures.guardianWeeklyConfig.productRatePlanIds.head, ""))
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
-    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.guardianWeeklyConfig.productRatePlanIds, Nil)
+    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config)
     val credit = GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now)
     credit shouldBe -2.31
   }
@@ -20,7 +20,7 @@ class HolidayCreditTest extends FlatSpec with Matchers with EitherValues {
     val charge = Fixtures.mkRatePlanCharge(price = 37.5, billingPeriod = "Quarter")
     val ratePlans = List(RatePlan("", List(charge), Fixtures.guardianWeeklyConfig.productRatePlanIds.head, ""))
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
-    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.guardianWeeklyConfig.productRatePlanIds, Nil)
+    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config)
     val credit = GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now)
     credit shouldBe -2.89
   }
@@ -29,7 +29,7 @@ class HolidayCreditTest extends FlatSpec with Matchers with EitherValues {
     val charge = Fixtures.mkRatePlanCharge(price = 120, billingPeriod = "Annual")
     val ratePlans = List(RatePlan("", List(charge), Fixtures.guardianWeeklyConfig.productRatePlanIds.head, ""))
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
-    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.guardianWeeklyConfig.productRatePlanIds, Nil)
+    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription, Fixtures.config)
     val credit = GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now)
     credit shouldBe -2.31
   }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
@@ -36,9 +36,6 @@ class CreditCalculatorSpec extends FlatSpec with Matchers with EitherValues {
     val subscriptionRaw = Source.fromResource(zuoraSubscriptionData).mkString
     val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail(s"Could not decode $zuoraSubscriptionData"))
 
-    CreditCalculator.calculateCredit(
-      Fixtures.config,
-      SundayVoucherHolidayStopConfig.Dev.productRatePlanChargeId
-    )(stopDate, subscription) should equal(Right(expectedCredit))
+    CreditCalculator.calculateCredit(Fixtures.config)(stopDate, subscription) should equal(Right(expectedCredit))
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
@@ -2,7 +2,7 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.{GuardianWeeklyHolidayStopConfig, SundayVoucherHolidayStopConfig}
+import com.gu.holiday_stops.{Fixtures, GuardianWeeklyHolidayStopConfig, SundayVoucherHolidayStopConfig}
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.scalatest._
@@ -37,8 +37,7 @@ class CreditCalculatorSpec extends FlatSpec with Matchers with EitherValues {
     val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail(s"Could not decode $zuoraSubscriptionData"))
 
     CreditCalculator.calculateCredit(
-      GuardianWeeklyHolidayStopConfig.Dev.productRatePlanIds,
-      GuardianWeeklyHolidayStopConfig.Dev.nForNProductRatePlanIds,
+      Fixtures.config,
       SundayVoucherHolidayStopConfig.Dev.productRatePlanChargeId
     )(stopDate, subscription) should equal(Right(expectedCredit))
   }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscriptionSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscriptionSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.holiday_stops.subscription
 
-import com.gu.holiday_stops.SundayVoucherHolidayStopConfig
+import com.gu.holiday_stops.{Fixtures, SundayVoucherHolidayStopConfig}
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.scalatest._
@@ -11,14 +11,14 @@ class CurrentSundayVoucherSubscriptionSpec extends FlatSpec with Matchers with E
   "CurrentSundayVoucherSubscription" should "satisfy all the predicates" in {
     val subscriptionRaw = Source.fromResource("SundayVoucherSubscription.json").mkString
     val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode CurrentSundayVoucherSubscription"))
-    val currentSundayVoucherSubscription = CurrentSundayVoucherSubscription(subscription, SundayVoucherHolidayStopConfig.Dev.productRatePlanChargeId)
+    val currentSundayVoucherSubscription = CurrentSundayVoucherSubscription(subscription, Fixtures.config)
     currentSundayVoucherSubscription.right.value.productRatePlanChargeId should be("2c92c0f95aff3b56015b1045fba832d4")
   }
 
   it should "fail on missing invoice" in {
     val subscriptionRaw = Source.fromResource("SundayVoucherSubscriptionMissingInvoice.json").mkString
     val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode CurrentSundayVoucherSubscription"))
-    val currentSundayVoucherSubscription = CurrentSundayVoucherSubscription(subscription, SundayVoucherHolidayStopConfig.Dev.productRatePlanChargeId)
+    val currentSundayVoucherSubscription = CurrentSundayVoucherSubscription(subscription, Fixtures.config)
     currentSundayVoucherSubscription.isLeft should be(true)
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCreditSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCreditSpec.scala
@@ -29,13 +29,13 @@ object GuardianWeeklyHolidayCreditSpec extends Properties("HolidayCreditAmount")
   val subscription = Fixtures.mkSubscription()
 
   property("should be negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
-    val ratePlans = List(RatePlan("", List(charge), GuardianWeeklyHolidayStopConfig.Prod.productRatePlanIds.head, ""))
+    val ratePlans = List(RatePlan("", List(charge), GuardianWeeklyHolidayStopConfig.Dev.productRatePlanIds.head, ""))
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), Fixtures.config)
     GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now) < 0
   }
 
   property("should never be overwhelmingly negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
-    val ratePlans = List(RatePlan("", List(charge), GuardianWeeklyHolidayStopConfig.Prod.productRatePlanIds.head, ""))
+    val ratePlans = List(RatePlan("", List(charge), GuardianWeeklyHolidayStopConfig.Dev.productRatePlanIds.head, ""))
     val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), Fixtures.config)
     GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now) > -charge.price
   }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCreditSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCreditSpec.scala
@@ -30,13 +30,13 @@ object GuardianWeeklyHolidayCreditSpec extends Properties("HolidayCreditAmount")
 
   property("should be negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
     val ratePlans = List(RatePlan("", List(charge), GuardianWeeklyHolidayStopConfig.Prod.productRatePlanIds.head, ""))
-    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), Fixtures.guardianWeeklyConfig.productRatePlanIds, Nil)
+    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), Fixtures.config)
     GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now) < 0
   }
 
   property("should never be overwhelmingly negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
     val ratePlans = List(RatePlan("", List(charge), GuardianWeeklyHolidayStopConfig.Prod.productRatePlanIds.head, ""))
-    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), Fixtures.guardianWeeklyConfig.productRatePlanIds, Nil)
+    val currentGuardianWeeklySubscription = CurrentGuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), Fixtures.config)
     GuardianWeeklyHolidayCredit(currentGuardianWeeklySubscription.right.value, LocalDate.now) > -charge.price
   }
 }


### PR DESCRIPTION
Pass the whole config object around instead of bits and pieces of it. For example,

 ```
def writeHolidayStopToZuora(
    holidayCreditProduct: HolidayCreditProduct,
    guardianWeeklyProductRatePlanIds: List[String],	
    gwNforNProductRatePlanIds: List[String],
    ...
```

becomes

```
def writeHolidayStopToZuora(
    config: Config,
    ...
```