### PR TITLE
Add invoice date to response to potential holiday-stop request

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -6,7 +6,7 @@ import java.time.LocalDate
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.holiday_stops.subscription.CreditCalculator.PartiallyWiredCreditCalculator
-import com.gu.holiday_stops.subscription.{CreditCalculator, Subscription}
+import com.gu.holiday_stops.subscription.{CreditCalculator, HolidayStopCredit, Subscription}
 import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestId, ProductName, ProductRatePlanKey, ProductRatePlanName, ProductType, SubscriptionName}
@@ -173,8 +173,13 @@ object Handler extends Logging {
       queryParams <- req.queryParamsAsCaseClass[PotentialHolidayStopsQueryParams]()
       potentialHolidayStopDates <- getPublicationDatesToBeStopped(productNamePrefix, queryParams)
       optionalSubscription <- getSubscriptionIfRequired(getSubscription, pathParams, queryParams)
-      potentialHolidayStops = potentialHolidayStopDates.map { stoppedPublicationDate => // unfortunately necessary due to GW N-for-N requiring stoppedPublicationDate to calculate correct credit estimation
-        PotentialHolidayStop(stoppedPublicationDate, optionalSubscription.flatMap(creditCalculator(stoppedPublicationDate, _).toOption))
+      potentialHolidayStops = potentialHolidayStopDates.map { stoppedPublicationDate =>
+        // unfortunately necessary due to GW N-for-N requiring stoppedPublicationDate to calculate correct credit estimation
+        PotentialHolidayStop(
+          stoppedPublicationDate,
+          optionalSubscription.flatMap(sub =>
+            creditCalculator(stoppedPublicationDate, sub).toOption.map(HolidayStopCredit(_)))
+        )
       }
     } yield ApiGatewayResponse("200", PotentialHolidayStopsResponse(potentialHolidayStops))).apiResponse
   }

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/PotentialHolidayStops.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/PotentialHolidayStops.scala
@@ -2,16 +2,45 @@ package com.gu.holiday_stops
 
 import java.time.LocalDate
 
-import play.api.libs.json.{Format, Json}
+import com.gu.holiday_stops.subscription.HolidayStopCredit
+import play.api.libs.json.Reads._
+import play.api.libs.json._
 
-case class PotentialHolidayStop(publicationDate: LocalDate, credit: Option[Double])
+case class PotentialHolidayStop(
+  publicationDate: LocalDate,
+  expectedCredit: Option[HolidayStopCredit]
+)
 
 object PotentialHolidayStop {
-  implicit val reads: Format[PotentialHolidayStop] = Json.format[PotentialHolidayStop]
+
+  // Hand-crafting the json representation to avoid needing a new endpoint when model changes
+  implicit val format: Format[PotentialHolidayStop] = new Format[PotentialHolidayStop] {
+
+    override def reads(json: JsValue): JsResult[PotentialHolidayStop] = for {
+      publicationDate <- (json \ "publicationDate").validate[LocalDate]
+      optAmount <- (json \ "credit").validateOpt[Double]
+      optInvoiceDate <- (json \ "invoiceDate").validateOpt[LocalDate]
+    } yield {
+      val expectedCredit = for {
+        amount <- optAmount
+        invoiceDate <- optInvoiceDate
+      } yield HolidayStopCredit(amount, invoiceDate)
+      PotentialHolidayStop(publicationDate, expectedCredit)
+    }
+
+    override def writes(stop: PotentialHolidayStop): JsValue =
+      Json.obj(
+        "publicationDate" -> stop.publicationDate,
+        "credit" -> stop.expectedCredit.map(_.amount),
+        "invoiceDate" -> stop.expectedCredit.map(_.invoiceDate)
+      )
+  }
 }
 
 case class PotentialHolidayStopsResponse(potentials: List[PotentialHolidayStop])
 
 object PotentialHolidayStopsResponse {
-  implicit val reads: Format[PotentialHolidayStopsResponse] = Json.format[PotentialHolidayStopsResponse]
+
+  implicit val format: Format[PotentialHolidayStopsResponse] =
+    Json.format[PotentialHolidayStopsResponse]
 }

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -7,7 +7,7 @@ import com.gu.effects.{FakeFetchString, SFTestEffects, TestingRawEffects}
 import com.gu.holiday_stops.ActionCalculator._
 import com.gu.holiday_stops.Handler._
 import com.gu.holiday_stops.ZuoraSttpEffects.ZuoraSttpEffectsOps
-import com.gu.holiday_stops.subscription.{RatePlan, RatePlanCharge, Subscription}
+import com.gu.holiday_stops.subscription.{HolidayStopCredit, RatePlan, RatePlanCharge, Subscription}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.SubscriptionName
 import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact._
 import com.gu.salesforce.holiday_stops.{SalesForceHolidayStopsEffects, SalesforceHolidayStopRequestsDetail}
@@ -178,8 +178,8 @@ class HandlerTest extends FlatSpec with Matchers {
             response should equal(
               PotentialHolidayStopsResponse(
                 List(
-                  PotentialHolidayStop(LocalDate.of(2019, 1, 4), Some(-2.89)),
-                  PotentialHolidayStop(LocalDate.of(2019, 1, 11), Some(-2.89)),
+                  PotentialHolidayStop(LocalDate.of(2019, 1, 4), Some(HolidayStopCredit(-2.89))),
+                  PotentialHolidayStop(LocalDate.of(2019, 1, 11), Some(HolidayStopCredit(-2.89))),
                 )
               )
             )

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/PotentialHolidayStopsResponseTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/PotentialHolidayStopsResponseTest.scala
@@ -1,0 +1,35 @@
+package com.gu.holiday_stops
+
+import java.time.LocalDate
+
+import com.gu.holiday_stops.subscription.HolidayStopCredit
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.Json
+
+class PotentialHolidayStopsResponseTest extends FlatSpec with Matchers {
+
+  private val response = PotentialHolidayStopsResponse(
+    List(
+      PotentialHolidayStop(
+        publicationDate = LocalDate.of(2019, 9, 27),
+        expectedCredit = Some(
+          HolidayStopCredit(
+            amount = -2.89,
+            invoiceDate = LocalDate.of(2019, 10, 1)
+          )
+        )
+      )
+    )
+  )
+
+  private val jsonString =
+    """{"potentials":[{"publicationDate":"2019-09-27","credit":-2.89,"invoiceDate":"2019-10-01"}]}"""
+
+  "parse" should "read json correctly" in {
+    Json.parse(jsonString).as[PotentialHolidayStopsResponse] should equal(response)
+  }
+
+  "toJson" should "generate correct json" in {
+    Json.toJson(response).toString should equal(jsonString)
+  }
+}

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayStopCredit.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayStopCredit.scala
@@ -1,0 +1,16 @@
+package com.gu.holiday_stops.subscription
+
+import java.time.LocalDate
+
+import play.api.libs.json.{Format, Json}
+
+case class HolidayStopCredit(amount: Double, invoiceDate: LocalDate)
+
+object HolidayStopCredit {
+
+  implicit val format: Format[HolidayStopCredit] = Json.format[HolidayStopCredit]
+
+  // TODO: use genuine invoice date
+  def apply(amount: Double): HolidayStopCredit =
+    HolidayStopCredit(amount, invoiceDate = LocalDate.of(1970, 1, 1))
+}

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayStopCredit.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayStopCredit.scala
@@ -2,13 +2,9 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
-import play.api.libs.json.{Format, Json}
-
 case class HolidayStopCredit(amount: Double, invoiceDate: LocalDate)
 
 object HolidayStopCredit {
-
-  implicit val format: Format[HolidayStopCredit] = Json.format[HolidayStopCredit]
 
   // TODO: use genuine invoice date
   def apply(amount: Double): HolidayStopCredit =


### PR DESCRIPTION
This remodels the `PotentialHolidayStop` class slightly so that it includes the expected dates of the invoices on which the holiday credit will be deducted.

I've done this in such a way that the json response will still be usable without modifying calling code.  The new invoice date field will be unused initially so I've given it a dummy value of `1970-01-01` until I move the code that works out the actual invoice date.
