### PR TITLE
Zuora does not allow amending cancelled subscriptions with holiday stop

### DIFF
--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -144,7 +144,8 @@ class HandlerTest extends FlatSpec with Matchers {
           "",
           ""
         )
-      )
+      ),
+      "Active"
     )
 
     val testBackend = SttpBackendStub

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Processor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Processor.scala
@@ -78,6 +78,7 @@ object Processor {
       subscription <- getSubscription(stop.subscriptionName)
       stoppedProduct <- StoppedProduct(subscription, StoppedPublicationDate(stop.stoppedPublicationDate))
       _ <- if (subscription.autoRenew) Right(()) else Left(ZuoraHolidayError("Cannot currently process non-auto-renewing subscription"))
+      _ <- if (subscription.status == "Cancelled") Left(ZuoraHolidayError(s"Cannot process cancelled subscription because Zuora does not allow amending cancelled subs (Code: 58730020). Apply manual refund ASAP! $stop; ${subscription.subscriptionNumber};")) else Right(())
       holidayCredit = stoppedProduct.credit
       maybeExtendedTerm = ExtendedTerm(holidayCredit.invoiceDate, subscription)
       holidayCreditUpdate <- HolidayCreditUpdate(config.holidayCreditProduct, subscription, stop.stoppedPublicationDate, maybeExtendedTerm, holidayCredit)

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
@@ -81,6 +81,15 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
       ZuoraHolidayError("Cannot currently process non-auto-renewing subscription")
   }
 
+  it should "fail if subscription is cancelled" in {
+    val response = Processor.writeHolidayStopToZuora(
+      Fixtures.config,
+      _ => Right(subscription.copy(status = "Cancelled")),
+      updateSubscription(Left(ZuoraHolidayError("shouldn't need to apply an update")))
+    )(holidayStop)
+    response.left.value.reason should include("Apply manual refund")
+  }
+
   it should "just give charge added without applying an update if holiday stop has already been applied" in {
     val response = Processor.writeHolidayStopToZuora(
       Fixtures.config,

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
@@ -59,7 +59,8 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
           "2c92c0f95aff3b56015b1045fba832d4")),
         "2c92c0f95aff3b56015b1045fb9332d2",
         "2c92c0f86d6263c0016d6271c6750a35")
-      )
+      ),
+      "Active"
     )
 
   val updatedSubscription =
@@ -107,7 +108,8 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
           "2c92c0f95aff3b56015b1045fb9332d2",
           "2c92c0fb6d627309016d628f3fda31d7"
         )
-      )
+      ),
+      "Active"
     )
 
   val zuoraGetSubscriptionResponsesStack = mutable.Stack[Subscription](

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/Subscription.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/Subscription.scala
@@ -11,7 +11,8 @@ case class Subscription(
   currentTerm: Int,
   currentTermPeriodType: String,
   autoRenew: Boolean,
-  ratePlans: List[RatePlan]
+  ratePlans: List[RatePlan],
+  status: String
 ) {
 
   def ratePlanCharge(stop: HolidayStop): Option[RatePlanCharge] = {

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -58,10 +58,12 @@ object Fixtures {
           "",
           ""
         )
-      )
+      ),
+      status = "Active"
     )
 
   def mkSubscriptionWithHolidayStops() = Subscription(
+    status = "Active",
     subscriptionNumber = "S1",
     termStartDate = LocalDate.of(2019, 3, 1),
     termEndDate = LocalDate.of(2020, 3, 1),


### PR DESCRIPTION
Consider [`A-S00836178`](https://www.zuora.com/apps/Subscription.do?method=view&id=2c92a0086d4dcd5a016d67fed9ad7d0a). Guardian Weekly subscriber scheduled a holiday stop for `2019-10-11` however subscriptions will be cancelled on `2019-12-07`. Two issues arise

- Zuora prevents amendments on cancelled subscriptions, so issue will still be delivered.
- We cannot apply holiday credit to the next invoice as there is no next invoice. (We can handle this with manual refund).