### PR TITLE
Revert "Revert "Include invoice date with holiday-stop credit amounts""

### DIFF
--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -177,8 +177,8 @@ class HandlerTest extends FlatSpec with Matchers {
             response should equal(
               PotentialHolidayStopsResponse(
                 List(
-                  PotentialHolidayStop(LocalDate.of(2019, 1, 4), Some(HolidayStopCredit(-2.89))),
-                  PotentialHolidayStop(LocalDate.of(2019, 1, 11), Some(HolidayStopCredit(-2.89))),
+                  PotentialHolidayStop(LocalDate.of(2019, 1, 4), Some(HolidayStopCredit(-2.89, LocalDate.parse("2019-04-01")))),
+                  PotentialHolidayStop(LocalDate.of(2019, 1, 11), Some(HolidayStopCredit(-2.89, LocalDate.parse("2019-04-01")))),
                 )
               )
             )

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Processor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Processor.scala
@@ -78,10 +78,9 @@ object Processor {
       subscription <- getSubscription(stop.subscriptionName)
       stoppedProduct <- StoppedProduct(subscription, StoppedPublicationDate(stop.stoppedPublicationDate))
       _ <- if (subscription.autoRenew) Right(()) else Left(ZuoraHolidayError("Cannot currently process non-auto-renewing subscription"))
-      nextInvoiceStartDate = stoppedProduct.nextBillingPeriodStartDate
-      maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
       holidayCredit = stoppedProduct.credit
-      holidayCreditUpdate <- HolidayCreditUpdate(config.holidayCreditProduct, subscription, stop.stoppedPublicationDate, nextInvoiceStartDate, maybeExtendedTerm, holidayCredit)
+      maybeExtendedTerm = ExtendedTerm(holidayCredit.invoiceDate, subscription)
+      holidayCreditUpdate <- HolidayCreditUpdate(config.holidayCreditProduct, subscription, stop.stoppedPublicationDate, maybeExtendedTerm, holidayCredit)
       _ <- if (subscription.hasHolidayStop(stop)) Right(()) else updateSubscription(subscription, holidayCreditUpdate)
       updatedSubscription <- getSubscription(stop.subscriptionName)
       addedCharge <- updatedSubscription.ratePlanCharge(stop).toRight(ZuoraHolidayError(s"Failed to write holiday stop to Zuora: $stop"))

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditUpdateTest.scala
@@ -2,7 +2,6 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops
 import com.gu.holiday_stops._
 import com.gu.holiday_stops.subscription._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
@@ -22,15 +21,13 @@ class HolidayCreditUpdateTest extends FlatSpec with Matchers with EitherValues {
       chargedThroughDate = Some(chargedThroughDate)
     )
     val currentGuardianWeeklySubscription = GuardianWeeklySubscription(subscription, stoppedPublicationDate).right.value
-    val nextInvoiceStartDate = currentGuardianWeeklySubscription.nextBillingPeriodStartDate
-    val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
     val holidayCredit = currentGuardianWeeklySubscription.credit
+    val maybeExtendedTerm = ExtendedTerm(holidayCredit.invoiceDate, subscription)
 
     val update = HolidayCreditUpdate(
       Fixtures.config.holidayCreditProduct,
       subscription = subscription,
       stoppedPublicationDate = LocalDate.of(2019, 5, 18),
-      nextInvoiceStartDate = nextInvoiceStartDate,
       maybeExtendedTerm = maybeExtendedTerm,
       holidayCredit
     )
@@ -76,14 +73,12 @@ class HolidayCreditUpdateTest extends FlatSpec with Matchers with EitherValues {
       chargedThroughDate = Some(LocalDate.of(2020, 8, 2))
     )
     val currentGuardianWeeklySubscription = GuardianWeeklySubscription(subscription, stoppedPublicationDate).right.value
-    val nextInvoiceStartDate = currentGuardianWeeklySubscription.nextBillingPeriodStartDate
-    val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
     val holidayCredit = currentGuardianWeeklySubscription.credit
+    val maybeExtendedTerm = ExtendedTerm(holidayCredit.invoiceDate, subscription)
     val update = HolidayCreditUpdate(
       Fixtures.config.holidayCreditProduct,
       subscription = subscription,
       stoppedPublicationDate = LocalDate.of(2019, 8, 6),
-      nextInvoiceStartDate = nextInvoiceStartDate,
       maybeExtendedTerm = maybeExtendedTerm,
       holidayCredit
     )
@@ -116,14 +111,12 @@ class HolidayCreditUpdateTest extends FlatSpec with Matchers with EitherValues {
       chargedThroughDate = Some(LocalDate.of(2020, 7, 23))
     )
     val currentGuardianWeeklySubscription = GuardianWeeklySubscription(subscription, stoppedPublicationDate).right.value
-    val nextInvoiceStartDate = currentGuardianWeeklySubscription.nextBillingPeriodStartDate
-    val maybeExtendedTerm = ExtendedTerm(nextInvoiceStartDate, subscription)
     val holidayCredit = currentGuardianWeeklySubscription.credit
+    val maybeExtendedTerm = ExtendedTerm(holidayCredit.invoiceDate, subscription)
     val update = HolidayCreditUpdate(
       Fixtures.config.holidayCreditProduct,
       subscription = subscription,
       stoppedPublicationDate = LocalDate.of(2019, 8, 6),
-      nextInvoiceStartDate = nextInvoiceStartDate,
       maybeExtendedTerm = maybeExtendedTerm,
       holidayCredit
     )

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherNextBillingPeriodStartDateSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherNextBillingPeriodStartDateSpec.scala
@@ -17,6 +17,6 @@ class SundayVoucherNextBillingPeriodStartDateSpec extends FlatSpec with Matchers
     val stoppedProduct = StoppedProduct(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-27"))).right.value
     stoppedProduct shouldBe a[VoucherSubscription]
     stoppedProduct should matchPattern { case VoucherSubscription(_, _, _, _, _, VoucherDayOfWeek.Sunday) => }
-    stoppedProduct.nextBillingPeriodStartDate should be(LocalDate.of(2019, 11, 6))
+    stoppedProduct.credit.invoiceDate should be(LocalDate.of(2019, 11, 6))
   }
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayCreditUpdate.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayCreditUpdate.scala
@@ -21,9 +21,8 @@ object HolidayCreditUpdate {
     holidayCreditProduct: HolidayCreditProduct,
     subscription: Subscription,
     stoppedPublicationDate: LocalDate,
-    nextInvoiceStartDate: LocalDate,
     maybeExtendedTerm: Option[ExtendedTerm],
-    holidayCredit: Double
+    holidayCredit: HolidayStopCredit
   ): Either[ZuoraHolidayError, HolidayCreditUpdate] = {
     Right(
       HolidayCreditUpdate(
@@ -32,15 +31,15 @@ object HolidayCreditUpdate {
         List(
           Add(
             productRatePlanId = holidayCreditProduct.productRatePlanId,
-            contractEffectiveDate = nextInvoiceStartDate,
-            customerAcceptanceDate = nextInvoiceStartDate,
-            serviceActivationDate = nextInvoiceStartDate,
+            contractEffectiveDate = holidayCredit.invoiceDate,
+            customerAcceptanceDate = holidayCredit.invoiceDate,
+            serviceActivationDate = holidayCredit.invoiceDate,
             chargeOverrides = List(
               ChargeOverride(
                 productRatePlanChargeId = holidayCreditProduct.productRatePlanChargeId,
                 HolidayStart__c = stoppedPublicationDate,
                 HolidayEnd__c = stoppedPublicationDate,
-                price = holidayCredit
+                price = holidayCredit.amount
               )
             )
           )

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayStopCredit.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/HolidayStopCredit.scala
@@ -3,10 +3,3 @@ package com.gu.holiday_stops.subscription
 import java.time.LocalDate
 
 case class HolidayStopCredit(amount: Double, invoiceDate: LocalDate)
-
-object HolidayStopCredit {
-
-  // TODO: use genuine invoice date
-  def apply(amount: Double): HolidayStopCredit =
-    HolidayStopCredit(amount, invoiceDate = LocalDate.of(1970, 1, 1))
-}

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/HolidayCreditTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/HolidayCreditTest.scala
@@ -2,7 +2,7 @@ package com.gu.holiday_stops
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.subscription.{GuardianWeeklySubscription, RatePlan}
+import com.gu.holiday_stops.subscription.{GuardianWeeklySubscription, HolidayStopCredit, RatePlan}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
@@ -16,7 +16,7 @@ class HolidayCreditTest extends FlatSpec with Matchers with EitherValues {
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
     val currentGuardianWeeklySubscription = GuardianWeeklySubscription(subscription, stoppedPublicationDate)
     val credit = currentGuardianWeeklySubscription.right.value.credit
-    credit shouldBe -2.31
+    credit shouldBe HolidayStopCredit(-2.31, LocalDate.parse("2019-09-02"))
   }
 
   it should "be correct for another quarterly billing period" in {
@@ -25,7 +25,7 @@ class HolidayCreditTest extends FlatSpec with Matchers with EitherValues {
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
     val currentGuardianWeeklySubscription = GuardianWeeklySubscription(subscription, stoppedPublicationDate)
     val credit = currentGuardianWeeklySubscription.right.value.credit
-    credit shouldBe -2.89
+    credit shouldBe HolidayStopCredit(-2.89, LocalDate.parse("2019-09-02"))
   }
 
   it should "be correct for an annual billing period" in {
@@ -34,6 +34,6 @@ class HolidayCreditTest extends FlatSpec with Matchers with EitherValues {
     val subscription = Fixtures.mkSubscription().copy(ratePlans = ratePlans)
     val currentGuardianWeeklySubscription = GuardianWeeklySubscription(subscription, stoppedPublicationDate)
     val credit = currentGuardianWeeklySubscription.right.value.credit
-    credit shouldBe -2.31
+    credit shouldBe HolidayStopCredit(-2.31, LocalDate.parse("2019-09-02"))
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
@@ -2,7 +2,6 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
-import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
 import io.circe.generic.auto._
 import io.circe.parser.decode
@@ -15,21 +14,21 @@ class CreditCalculatorSpec extends FlatSpec with Matchers with EitherValues {
     checkCreditCalculation(
       zuoraSubscriptionData = "SundayVoucherSubscription.json",
       stopDate = LocalDate.of(2019, 11, 3),
-      expectedCredit = -2.70
+      expectedCredit = HolidayStopCredit(-2.70, LocalDate.parse("2019-11-06"))
     )
   }
   it should "calculate credit for guardian weekly in 6 for 6 period" in {
     checkCreditCalculation(
       zuoraSubscriptionData = "GuardianWeeklyWith6For6.json",
       stopDate = LocalDate.of(2019, 11, 8),
-      expectedCredit = -1
+      expectedCredit = HolidayStopCredit(-1.00, LocalDate.parse("2019-11-15"))
     )
   }
   it should "calculate credit for guardian weekly in 'normal' period" in {
     checkCreditCalculation(
       zuoraSubscriptionData = "GuardianWeeklyWith6For6.json",
       stopDate = LocalDate.of(2019, 11, 15),
-      expectedCredit = -2.89
+      expectedCredit = HolidayStopCredit(-2.89, LocalDate.parse("2020-02-15"))
     )
   }
 
@@ -37,7 +36,7 @@ class CreditCalculatorSpec extends FlatSpec with Matchers with EitherValues {
     checkCreditCalculation(
       zuoraSubscriptionData = "WeekendVoucherSubscription.json",
       stopDate = LocalDate.of(2019, 11, 16),
-      expectedCredit = -2.64
+      expectedCredit = HolidayStopCredit(-2.64, LocalDate.parse("2019-11-26"))
     )
   }
 
@@ -45,11 +44,11 @@ class CreditCalculatorSpec extends FlatSpec with Matchers with EitherValues {
     checkCreditCalculation(
       zuoraSubscriptionData = "WeekendVoucherSubscription.json",
       stopDate = LocalDate.of(2019, 11, 17),
-      expectedCredit = -2.55
+      expectedCredit = HolidayStopCredit(-2.55, LocalDate.parse("2019-11-26"))
     )
   }
 
-  private def checkCreditCalculation(zuoraSubscriptionData: String, stopDate: LocalDate, expectedCredit: Double) = {
+  private def checkCreditCalculation(zuoraSubscriptionData: String, stopDate: LocalDate, expectedCredit: HolidayStopCredit) = {
     val subscriptionRaw = Source.fromResource(zuoraSubscriptionData).mkString
     val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail(s"Could not decode $zuoraSubscriptionData"))
     val stoppedProduct = StoppedProduct(subscription, StoppedPublicationDate(stopDate)).right.value

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCreditSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyHolidayCreditSpec.scala
@@ -32,12 +32,12 @@ object GuardianWeeklyHolidayCreditSpec extends Properties("HolidayCreditAmount")
   property("should be negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
     val ratePlans = List(RatePlan("Guardian Weekly - Domestic", List(charge), "", ""))
     val currentGuardianWeeklySubscription = GuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), StoppedPublicationDate(chargedThroughDate.minusDays(1)))
-    currentGuardianWeeklySubscription.right.value.credit < 0
+    currentGuardianWeeklySubscription.right.value.credit.amount < 0
   }
 
   property("should never be overwhelmingly negative") = forAll(ratePlanChargeGen) { charge: RatePlanCharge =>
     val ratePlans = List(RatePlan("Guardian Weekly - Domestic", List(charge), "", ""))
     val currentGuardianWeeklySubscription = GuardianWeeklySubscription(subscription.copy(ratePlans = ratePlans), StoppedPublicationDate(chargedThroughDate.minusDays(1)))
-    currentGuardianWeeklySubscription.right.value.credit > -charge.price
+    currentGuardianWeeklySubscription.right.value.credit.amount > -charge.price
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedPublicationDateOutsideInvoiceSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedPublicationDateOutsideInvoiceSpec.scala
@@ -16,8 +16,7 @@ class StoppedPublicationDateOutsideInvoiceSpec extends FlatSpec with Matchers wi
     val subscriptionRaw = Source.fromResource("StoppedPublicationDateOutsideInvoice.json").mkString
     val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode GuardianWeeklySubscription"))
     val guardianWeeklySub = GuardianWeeklySubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-11")))
-    guardianWeeklySub.right.value.nextBillingPeriodStartDate should be(chargedThroughDate)
-    guardianWeeklySub.right.value.credit should be(-6.16)
+    guardianWeeklySub.right.value.credit should be(HolidayStopCredit(amount = -6.16, invoiceDate = chargedThroughDate))
   }
 
   it should "fail if stoppedPublicationDate is before current invoiced period start date" in {


### PR DESCRIPTION
This is a reinstatement of #440 which went awry because of a broken test.

See also #442 

Reverts guardian/support-service-lambdas#444
