### PR TITLE
Find invoice dates for holiday stops beyond the current billing period

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
@@ -1,5 +1,6 @@
 package com.gu.holiday_stops.subscription
 
+import java.time.LocalDate.now
 import java.time.{LocalDate, Period}
 
 import acyclic.skipped
@@ -71,7 +72,8 @@ abstract class StoppedProduct(
    */
   private def nextBillingPeriodStartDate: LocalDate = {
 
-    logger.info(s"Calculating nextBillingPeriodStartDate for $this")
+    if (stoppedPublicationDate.isAfter(now.plusYears(5)))
+      logger.info(s"Calculating nextBillingPeriodStartDate for curious case $this")
 
     if (billingPeriod == "Specific_Weeks") invoicedPeriod.endDateExcluding
     else {

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
@@ -6,6 +6,7 @@ import acyclic.skipped
 import cats.syntax.either._
 import com.gu.holiday_stops.{ZuoraHolidayError, ZuoraHolidayResponse}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
+import com.gu.util.Logging
 
 import scala.annotation.tailrec
 import scala.math.BigDecimal.RoundingMode
@@ -33,7 +34,7 @@ abstract class StoppedProduct(
   val price: Double,
   val billingPeriod: String,
   val invoicedPeriod: CurrentInvoicedPeriod,
-) {
+) extends Logging {
   private def creditAmount: Double = {
     def roundUp(d: Double): Double = BigDecimal(d).setScale(2, RoundingMode.UP).toDouble
     val recurringPrice = price
@@ -69,6 +70,8 @@ abstract class StoppedProduct(
    *         shows examples of the expected outcome.
    */
   private def nextBillingPeriodStartDate: LocalDate = {
+
+    logger.info(s"Calculating nextBillingPeriodStartDate for $this")
 
     if (billingPeriod == "Specific_Weeks") invoicedPeriod.endDateExcluding
     else {

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
@@ -73,7 +73,7 @@ abstract class StoppedProduct(
   private def nextBillingPeriodStartDate: LocalDate = {
 
     if (stoppedPublicationDate.isAfter(now.plusYears(5)))
-      logger.info(s"Calculating nextBillingPeriodStartDate for curious case $this")
+      logger.warn(s"Calculating nextBillingPeriodStartDate for curious case $this")
 
     if (billingPeriod == "Specific_Weeks") invoicedPeriod.endDateExcluding
     else {

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
@@ -78,24 +78,15 @@ abstract class StoppedProduct(
         )
       }
 
-      val latestPossibleInvoiceDate = LocalDate.now.plusYears(3)
-
       @tailrec
-      def go(invoicePeriod: CurrentInvoicedPeriod): LocalDate = {
+      def go(invoicePeriod: CurrentInvoicedPeriod): LocalDate =
         if (invoicePeriod.containsDate(stoppedPublicationDate))
           invoicePeriod.endDateExcluding
-        else {
-          if (invoicePeriod.endDateExcluding.isBefore(latestPossibleInvoiceDate))
-            go(CurrentInvoicedPeriod(
-              startDateIncluding = invoicePeriod.endDateExcluding,
-              endDateExcluding = invoicePeriod.endDateExcluding.plus(billingPeriodDuration)
-            ))
-          else
-            throw new RuntimeException(
-              s"Failed to determine invoice date before ${invoicePeriod.endDateExcluding}"
-            )
-        }
-      }
+        else
+          go(CurrentInvoicedPeriod(
+            startDateIncluding = invoicePeriod.endDateExcluding,
+            endDateExcluding = invoicePeriod.endDateExcluding.plus(billingPeriodDuration)
+          ))
 
       go(invoicedPeriod)
     }
@@ -149,4 +140,3 @@ object StoppedProduct {
     }
   }
 }
-

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/StoppedProduct.scala
@@ -51,17 +51,22 @@ abstract class StoppedProduct(
    *
    * Hence chargedThroughDate represents the first day of the next billing period. For quarterly
    * billing period this would be the first day of the next quarter, whilst for annual this would be
-   * the first day of the next year.
+   * the first day of the next year of the subscription.
    *
    * Note chargedThroughDate is an API concept. The UI and the actual invoice use the term 'Service Period'
    * where from and to dates are both inclusive.
    *
-   * Note nextBillingPeriodStartDate represents a specific date yyyy-mm-dd unlike billingPeriod (quarterly)
-   * or billingPeriodStartDay (1st of month).
+   * Note nextBillingPeriodStartDate represents a specific date yyyy-mm-dd unlike billingPeriod (eg. "quarterly")
+   * or billingPeriodStartDay (eg. 1st of month).
    *
    * There is a complication when reader has N-for-N intro plan (for example, GW Oct 18 - Six for Six - Domestic).
    * If the holiday falls within N-for-N then credit should be applied on the first regular invoice, not the next billing
    * period of GW regular plan.
+   *
+   * @return Date of the first day of the billing period
+   *         following this <code>stoppedPublicationDate</code>.
+   *         [[com.gu.holiday_stops.subscription.StoppedProductTest]]
+   *         shows examples of the expected outcome.
    */
   private def nextBillingPeriodStartDate: LocalDate = {
 

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -7,8 +7,13 @@ import com.gu.salesforce.RecordsWrapperCaseClass
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestActionedCount, HolidayStopRequestEndDate, HolidayStopRequestStartDate}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
+import io.circe.generic.auto._
+import io.circe.parser.decode
+import org.scalatest.Assertions
 
-object Fixtures {
+import scala.io.Source
+
+object Fixtures extends Assertions {
 
   def billingPeriodToMonths(billingPeriod: String): Int = billingPeriod match {
     case "Quarter" => 3
@@ -183,6 +188,11 @@ object Fixtures {
       )
     )
   )
+
+  def subscriptionFromJson(resource: String): Subscription = {
+    val subscriptionRaw = Source.fromResource(resource).mkString
+    decode[Subscription](subscriptionRaw).getOrElse(fail(s"Could not decode $subscriptionRaw"))
+  }
 
   def mkHolidayStopRequest(
     id: String,

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CreditCalculatorSpec.scala
@@ -2,14 +2,12 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
-import io.circe.generic.auto._
-import io.circe.parser.decode
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
 
-import scala.io.Source
-
-class CreditCalculatorSpec extends FlatSpec with Matchers with EitherValues {
+class CreditCalculatorSpec extends FlatSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
   "CreditCalculator" should "calculate credit for sunday voucher subscription" in {
     checkCreditCalculation(
       zuoraSubscriptionData = "SundayVoucherSubscription.json",
@@ -49,10 +47,9 @@ class CreditCalculatorSpec extends FlatSpec with Matchers with EitherValues {
   }
 
   private def checkCreditCalculation(zuoraSubscriptionData: String, stopDate: LocalDate, expectedCredit: HolidayStopCredit) = {
-    val subscriptionRaw = Source.fromResource(zuoraSubscriptionData).mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail(s"Could not decode $zuoraSubscriptionData"))
+    val subscription = Fixtures.subscriptionFromJson(zuoraSubscriptionData)
     val stoppedProduct = StoppedProduct(subscription, StoppedPublicationDate(stopDate)).right.value
 
-    stoppedProduct.credit should equal(expectedCredit)
+    stoppedProduct.credit should ===(expectedCredit)
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscriptionSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentSundayVoucherSubscriptionSpec.scala
@@ -2,25 +2,21 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
-import io.circe.generic.auto._
-import io.circe.parser.decode
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
 
-import scala.io.Source
-
-class CurrentSundayVoucherSubscriptionSpec extends FlatSpec with Matchers with EitherValues {
+class CurrentSundayVoucherSubscriptionSpec extends FlatSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
   "CurrentSundayVoucherSubscription" should "satisfy all the predicates" in {
-    val subscriptionRaw = Source.fromResource("SundayVoucherSubscription.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode CurrentSundayVoucherSubscription"))
+    val subscription = Fixtures.subscriptionFromJson("SundayVoucherSubscription.json")
     val currentSundayVoucherSubscription = VoucherSubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-27")))
-    currentSundayVoucherSubscription.right.value.dayOfWeek should be(VoucherDayOfWeek.Sunday)
+    currentSundayVoucherSubscription.right.value.dayOfWeek should ===(VoucherDayOfWeek.Sunday)
   }
 
   it should "fail on missing invoice" in {
-    val subscriptionRaw = Source.fromResource("SundayVoucherSubscriptionMissingInvoice.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode CurrentSundayVoucherSubscription"))
+    val subscription = Fixtures.subscriptionFromJson("SundayVoucherSubscriptionMissingInvoice.json")
     val currentSundayVoucherSubscription = VoucherSubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-27")))
-    currentSundayVoucherSubscription.isLeft should be(true)
+    currentSundayVoucherSubscription.isLeft should ===(true)
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentWeekendVoucherSubscriptionSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/CurrentWeekendVoucherSubscriptionSpec.scala
@@ -2,33 +2,28 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
-import io.circe.generic.auto._
-import io.circe.parser.decode
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
 
-import scala.io.Source
-
-class CurrentWeekendVoucherSubscriptionSpec extends FlatSpec with Matchers with EitherValues {
+class CurrentWeekendVoucherSubscriptionSpec extends FlatSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
   "CurrentWeekendVoucherSubscription" should "satisfy all the predicates" in {
-    val subscriptionRaw = Source.fromResource("WeekendVoucherSubscription.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode CurrentWeekendVoucherSubscription"))
+    val subscription = Fixtures.subscriptionFromJson("WeekendVoucherSubscription.json")
     val model = VoucherSubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-26"))).right.value
-    model.dayOfWeek should be(VoucherDayOfWeek.Saturday)
-    model.price should be(10.56)
+    model.dayOfWeek should ===(VoucherDayOfWeek.Saturday)
+    model.price should ===(10.56)
   }
 
   it should "fail if stoppedPublicationDate falls outside invoiced period" in {
-    val subscriptionRaw = Source.fromResource("WeekendVoucherSubscription.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode CurrentWeekendVoucherSubscription"))
+    val subscription = Fixtures.subscriptionFromJson("WeekendVoucherSubscription.json")
     val model = VoucherSubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-09-01")))
-    model.isLeft should be(true)
+    model.isLeft should ===(true)
   }
 
   it should "fail if stoppedPublicationDate falls outside weekend" in {
-    val subscriptionRaw = Source.fromResource("WeekendVoucherSubscription.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode CurrentWeekendVoucherSubscription"))
+    val subscription = Fixtures.subscriptionFromJson("WeekendVoucherSubscription.json")
     val model = VoucherSubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-28")))
-    model.isLeft should be(true)
+    model.isLeft should ===(true)
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyNforNSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/GuardianWeeklyNforNSpec.scala
@@ -2,32 +2,28 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
-import io.circe.generic.auto._
-import io.circe.parser.decode
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
-import scala.io.Source
 
-class GuardianWeeklyNforNSpec extends FlatSpec with Matchers with EitherValues {
+class GuardianWeeklyNforNSpec extends FlatSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
   private val nForNChargedThroughDate = LocalDate.parse("2019-11-15")
   "GuardianWeeklySubscription" should "represent N-for-N when stopped publication date falls within N-for-N" in {
-    val subscriptionRaw = Source.fromResource("GuardianWeeklyWith6For6.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode GuardianWeeklySubscription"))
+    val subscription = Fixtures.subscriptionFromJson("GuardianWeeklyWith6For6.json")
     val currentSundayVoucherSubscription = GuardianWeeklySubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-04")))
-    currentSundayVoucherSubscription.right.value.price should be(6)
+    currentSundayVoucherSubscription.right.value.price should ===(6.00)
   }
 
   it should "represent regular GW when stopped publication date falls after N-for-N" in {
-    val subscriptionRaw = Source.fromResource("GuardianWeeklyWith6For6.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode GuardianWeeklySubscription"))
+    val subscription = Fixtures.subscriptionFromJson("GuardianWeeklyWith6For6.json")
     val currentSundayVoucherSubscription = GuardianWeeklySubscription(subscription, StoppedPublicationDate(nForNChargedThroughDate))
-    currentSundayVoucherSubscription.right.value.price should be(37.5)
+    currentSundayVoucherSubscription.right.value.price should ===(37.50)
   }
 
   it should "should fail if stopped publication date is before current invoiced period start date " in {
-    val subscriptionRaw = Source.fromResource("GuardianWeeklyWith6For6.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode GuardianWeeklySubscription"))
+    val subscription = Fixtures.subscriptionFromJson("GuardianWeeklyWith6For6.json")
     val currentSundayVoucherSubscription = GuardianWeeklySubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-05-04").minusDays(1)))
-    currentSundayVoucherSubscription.isLeft should be(true)
+    currentSundayVoucherSubscription.isLeft should ===(true)
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedProductTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedProductTest.scala
@@ -43,7 +43,7 @@ class StoppedProductTest extends FlatSpec with Matchers with TypeCheckedTripleEq
     )
   }
 
-  it should "be first day of current billing period when stopped publication date is first day of a billing period" in {
+  it should "be first day of next billing period when stopped publication date is first day of a billing period" in {
     testInvoiceDate(
       resource = "GuardianWeeklyWith6For6.json",
       stoppedPublicationDate = "2020-05-15",

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedProductTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedProductTest.scala
@@ -42,13 +42,4 @@ class StoppedProductTest extends FlatSpec with Matchers with TypeCheckedTripleEq
       expectedInvoiceDate = "2020-06-26"
     )
   }
-
-  it should "throw a runtime exception when stopped publication date is too far in future" in {
-    val subscription = Fixtures.subscriptionFromJson("GuardianWeeklyWith6For6.json")
-    val date = StoppedPublicationDate(LocalDate.of(2025, 1, 1))
-    val stoppedProduct = StoppedProduct(subscription, date).right.value
-    assertThrows[RuntimeException] {
-      stoppedProduct.credit.invoiceDate
-    }
-  }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedProductTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedProductTest.scala
@@ -42,4 +42,20 @@ class StoppedProductTest extends FlatSpec with Matchers with TypeCheckedTripleEq
       expectedInvoiceDate = "2020-06-26"
     )
   }
+
+  it should "be first day of current billing period when stopped publication date is first day of a billing period" in {
+    testInvoiceDate(
+      resource = "GuardianWeeklyWith6For6.json",
+      stoppedPublicationDate = "2020-05-15",
+      expectedInvoiceDate = "2020-08-15"
+    )
+  }
+
+  it should "be first day of next billing period when stopped publication date is last day of a billing period" in {
+    testInvoiceDate(
+      resource = "GuardianWeeklyWith6For6.json",
+      stoppedPublicationDate = "2020-08-14",
+      expectedInvoiceDate = "2020-08-15"
+    )
+  }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedPublicationDateOutsideInvoiceSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedPublicationDateOutsideInvoiceSpec.scala
@@ -14,7 +14,7 @@ class StoppedPublicationDateOutsideInvoiceSpec extends FlatSpec with Matchers wi
   "StoppedPublication construction" should "succeed if stoppedPublicationDate is equal to or after current invoiced period start date" in {
     val subscription = Fixtures.subscriptionFromJson("StoppedPublicationDateOutsideInvoice.json")
     val guardianWeeklySub = GuardianWeeklySubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-11")))
-    guardianWeeklySub.right.value.credit should ===(HolidayStopCredit(amount = -6.16, invoiceDate = chargedThroughDate))
+    guardianWeeklySub.right.value.credit should ===(HolidayStopCredit(amount = -6.16, invoiceDate = chargedThroughDate.plusMonths(3)))
   }
 
   it should "fail if stoppedPublicationDate is before current invoiced period start date" in {

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedPublicationDateOutsideInvoiceSpec.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/StoppedPublicationDateOutsideInvoiceSpec.scala
@@ -2,27 +2,24 @@ package com.gu.holiday_stops.subscription
 
 import java.time.LocalDate
 
+import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.StoppedPublicationDate
-import io.circe.generic.auto._
-import io.circe.parser.decode
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
-import scala.io.Source
 
-class StoppedPublicationDateOutsideInvoiceSpec extends FlatSpec with Matchers with EitherValues {
+class StoppedPublicationDateOutsideInvoiceSpec extends FlatSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
   private val processedThroughDate = LocalDate.parse("2019-07-05")
   private val chargedThroughDate = LocalDate.parse("2019-10-05")
 
   "StoppedPublication construction" should "succeed if stoppedPublicationDate is equal to or after current invoiced period start date" in {
-    val subscriptionRaw = Source.fromResource("StoppedPublicationDateOutsideInvoice.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode GuardianWeeklySubscription"))
+    val subscription = Fixtures.subscriptionFromJson("StoppedPublicationDateOutsideInvoice.json")
     val guardianWeeklySub = GuardianWeeklySubscription(subscription, StoppedPublicationDate(LocalDate.parse("2019-10-11")))
-    guardianWeeklySub.right.value.credit should be(HolidayStopCredit(amount = -6.16, invoiceDate = chargedThroughDate))
+    guardianWeeklySub.right.value.credit should ===(HolidayStopCredit(amount = -6.16, invoiceDate = chargedThroughDate))
   }
 
   it should "fail if stoppedPublicationDate is before current invoiced period start date" in {
-    val subscriptionRaw = Source.fromResource("StoppedPublicationDateOutsideInvoice.json").mkString
-    val subscription = decode[Subscription](subscriptionRaw).getOrElse(fail("Could not decode GuardianWeeklySubscription"))
+    val subscription = Fixtures.subscriptionFromJson("StoppedPublicationDateOutsideInvoice.json")
     val guardianWeeklySub = GuardianWeeklySubscription(subscription, StoppedPublicationDate(processedThroughDate.minusDays(1)))
-    guardianWeeklySub.isLeft should be(true)
+    guardianWeeklySub.isLeft should ===(true)
   }
 }

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/SubscriptionTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/subscription/SubscriptionTest.scala
@@ -3,14 +3,15 @@ package com.gu.holiday_stops.subscription
 import java.time.LocalDate
 
 import com.gu.holiday_stops.Fixtures
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
-class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
+class SubscriptionTest extends FlatSpec with Matchers with OptionValues with TypeCheckedTripleEquals {
 
   "ratePlanCharge" should "give ratePlanCharge corresponding to holiday stop" in {
     val subscription = Fixtures.mkSubscriptionWithHolidayStops()
     val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 9))
-    subscription.ratePlanCharge(stop).value shouldBe RatePlanCharge(
+    subscription.ratePlanCharge(stop).value should ===(RatePlanCharge(
       name = "Holiday Credit",
       number = "C2",
       price = -3.27,
@@ -21,13 +22,13 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
       HolidayEnd__c = Some(LocalDate.of(2019, 8, 9)),
       processedThroughDate = None,
       productRatePlanChargeId = ""
-    )
+    ))
   }
 
   it should "give another ratePlanCharge corresponding to another holiday stop" in {
     val subscription = Fixtures.mkSubscriptionWithHolidayStops()
     val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 2))
-    subscription.ratePlanCharge(stop).value shouldBe RatePlanCharge(
+    subscription.ratePlanCharge(stop).value should ===(RatePlanCharge(
       name = "Holiday Credit",
       number = "C3",
       price = -5.81,
@@ -38,13 +39,13 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
       HolidayEnd__c = Some(LocalDate.of(2019, 8, 2)),
       processedThroughDate = None,
       productRatePlanChargeId = ""
-    )
+    ))
   }
 
   it should "give no ratePlanCharge when none correspond to holiday stop" in {
     val subscription = Fixtures.mkSubscriptionWithHolidayStops()
     val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 23))
-    subscription.ratePlanCharge(stop) shouldBe None
+    subscription.ratePlanCharge(stop) should ===(None)
   }
 
   it should "give no ratePlanCharge when subscription has no holiday stops applied" in {
@@ -56,25 +57,25 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
       chargedThroughDate = None
     )
     val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 23))
-    subscription.ratePlanCharge(stop) shouldBe None
+    subscription.ratePlanCharge(stop) should ===(None)
   }
 
   it should "give no RatePlanCharge when dates correspond but it's not for a holiday credit" in {
     val subscription = Fixtures.mkSubscriptionWithHolidayStops()
     val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 19))
-    subscription.ratePlanCharge(stop) shouldBe None
+    subscription.ratePlanCharge(stop) should ===(None)
   }
 
   it should "give no RatePlanCharge when dates correspond but it's not for a discount plan" in {
     val subscription = Fixtures.mkSubscriptionWithHolidayStops()
     val stop = Fixtures.mkHolidayStop(LocalDate.of(2019, 8, 11))
-    subscription.ratePlanCharge(stop) shouldBe None
+    subscription.ratePlanCharge(stop) should ===(None)
   }
 
   it should "give RatePlanCharge when dates overlap but don't match precisely" in {
     val subscription = Fixtures.mkSubscriptionWithHolidayStops()
     val stop = Fixtures.mkHolidayStop(LocalDate.of(2018, 12, 22))
-    subscription.ratePlanCharge(stop).value shouldBe RatePlanCharge(
+    subscription.ratePlanCharge(stop).value should ===(RatePlanCharge(
       name = "Holiday Credit",
       number = "C987",
       price = -4.92,
@@ -85,6 +86,6 @@ class SubscriptionTest extends FlatSpec with Matchers with OptionValues {
       HolidayEnd__c = Some(LocalDate.of(2019, 1, 4)),
       processedThroughDate = None,
       productRatePlanChargeId = ""
-    )
+    ))
   }
 }


### PR DESCRIPTION
This determines the first day of each billing period from the current period onwards.  It uses the date of the first day of the billing period following the period in which the holiday stop falls as the effective date of the holiday credit amendment.

It will be interesting to see what happens when a subscription becomes effective on 29 February of a leap year.  If I can find a subscription like that I'll use it as a test case.

There's also some refactoring of unit tests, following discussion [here](https://stackoverflow.com/questions/56900131/why-does-scalatest-by-default-not-enforce-types-when-matching).
