### PR TITLE
First available date contract acceptance date

### DIFF
--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -257,7 +257,6 @@ Resources:
             StageName: !Sub ${Stage}
         DependsOn:
         - HolidayStopApiPotentialBySubscriptionNameGetMethod
-        - HolidayStopApiGetAllMethod
         - HolidayStopApiGetBySubscriptionNameMethod
         - HolidayStopApiCreateMethod
         - HolidayStopApiDeleteMethod
@@ -269,7 +268,6 @@ Resources:
             RestApiId: !Ref HolidayStopApi
         DependsOn:
         - HolidayStopApiPotentialBySubscriptionNameGetMethod
-        - HolidayStopApiGetAllMethod
         - HolidayStopApiGetBySubscriptionNameMethod
         - HolidayStopApiCreateMethod
         - HolidayStopApiDeleteMethod

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -170,23 +170,6 @@ Resources:
             PathPart: "hsr"
         DependsOn: HolidayStopApi
 
-    HolidayStopApiGetAllMethod:
-        Type: AWS::ApiGateway::Method
-        Properties:
-            AuthorizationType: NONE
-            ApiKeyRequired: true
-            RestApiId: !Ref HolidayStopApi
-            ResourceId: !Ref HolidayStopApiGetAllAndCreateProxyResource
-            HttpMethod: GET
-            Integration:
-              Type: AWS_PROXY
-              IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
-              Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HolidayStopApiLambda.Arn}/invocations
-        DependsOn:
-        - HolidayStopApi
-        - HolidayStopApiLambda
-        - HolidayStopApiGetAllAndCreateProxyResource
-
     HolidayStopApiCreateMethod:
       Type: AWS::ApiGateway::Method
       Properties:

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -111,7 +111,6 @@ object Handler extends Logging {
         }
       case "hsr" :: Nil =>
         httpMethod match {
-          case "GET" => stepsToListExisting(getSubscription) _
           case "POST" => stepsToCreate(creditCalculator, getSubscription) _
           case _ => unsupported _
         }

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -224,7 +224,7 @@ object Handler extends Logging {
 
     val lookupOp = SalesforceHolidayStopRequest.LookupByContactAndOptionalSubscriptionName(sfClient.wrapWith(JsonHttp.getWithParams))
 
-    val extractOptionalSubNameOp: ApiGatewayOp[SubscriptionName] = req.pathParamsAsCaseClass[ListExistingPathParams]()(Json.reads[ListExistingPathParams]).map(_.subscriptionName)
+    val extractSubNameOp: ApiGatewayOp[SubscriptionName] = req.pathParamsAsCaseClass[ListExistingPathParams]()(Json.reads[ListExistingPathParams]).map(_.subscriptionName)
 
     val optionalProductNamePrefix = req.headers.flatMap(_.get(HEADER_PRODUCT_NAME_PREFIX).map(ProductName.apply))
 
@@ -232,12 +232,12 @@ object Handler extends Logging {
 
     (for {
       contact <- extractContactFromHeaders(req.headers)
-      optionalSubName <- extractOptionalSubNameOp
-      usersHolidayStopRequests <- lookupOp(contact, Some(optionalSubName))
+      subName <- extractSubNameOp
+      usersHolidayStopRequests <- lookupOp(contact, Some(subName))
         .toDisjunction
         .toApiGatewayOp(s"lookup Holiday Stop Requests for contact $contact")
-      subscription <- getSubscription(optionalSubName)
-        .toApiGatewayOp(s"get subscription $optionalSubName")
+      subscription <- getSubscription(subName)
+        .toApiGatewayOp(s"get subscription $subName")
       response <- GetHolidayStopRequests(
         usersHolidayStopRequests,
         optionalProductNamePrefix,

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -3,6 +3,7 @@ package com.gu.holiday_stops
 import java.time.LocalDate
 
 import cats.implicits._
+import com.gu.holiday_stops.subscription.Subscription
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{Product, ProductName, SubscriptionName}
 import play.api.libs.json.{Json, OFormat}
@@ -87,17 +88,18 @@ object GetHolidayStopRequests {
   def apply(
     holidayStopRequests: List[HolidayStopRequest],
     optionalProductNamePrefix: Option[ProductName],
-    optionalProduct: Option[Product]
+    optionalProduct: Option[Product],
+    subscription: Subscription
   ): Either[GetHolidayStopRequestsError, GetHolidayStopRequests] = {
     for {
       optionalProductSpecificForProductPrefix <- optionalProductNamePrefix.map(
-        productNamePrefix => ActionCalculator.getProductSpecifics(productNamePrefix)
+        productNamePrefix => ActionCalculator.getProductSpecifics(productNamePrefix, subscription)
       ).asRight[GetHolidayStopRequestsError]
 
       optionalProductSpecificForProductNameRatePlanName <- optionalProduct.traverse(
         productRatePlanKey =>
           ActionCalculator
-            .getProductSpecificsByProductRatePlanKey(productRatePlanKey)
+            .getProductSpecificsByProductRatePlanKey(productRatePlanKey, subscription)
             .leftMap(error => GetHolidayStopRequestsError(s"Failed to get product specifics for $productRatePlanKey: $error"))
       )
     } yield GetHolidayStopRequests(

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -117,11 +117,13 @@ class HandlerTest extends FlatSpec with Matchers {
 
     val startDate = LocalDate.of(2019, 1, 1)
     val endDate = startDate.plusMonths(3)
+    val customerAcceptanceDate = startDate.plusMonths(1)
 
     val subscription = Subscription(
       subscriptionNumber = subscriptionName,
       termStartDate = startDate,
       termEndDate = endDate,
+      customerAcceptanceDate = customerAcceptanceDate,
       currentTerm = 12,
       currentTermPeriodType = "Month",
       autoRenew = true,
@@ -231,6 +233,7 @@ class HandlerTest extends FlatSpec with Matchers {
     val testBackend = SttpBackendStub.synchronous
 
     val subscriptionName = "Sub12344"
+    val subscription = Fixtures.mkSubscription()
     val contactId = "Contact1234"
     val holidayStopRequestsDetail = Fixtures.mkHolidayStopRequestDetails()
 
@@ -284,7 +287,7 @@ class HandlerTest extends FlatSpec with Matchers {
                 ),
                 List(
                   IssueSpecifics(
-                    SundayVoucherSuspensionConstants.issueConstants(0).firstAvailableDate(LocalDate.now()),
+                    SundayVoucherSuspensionConstants.issueConstants(0).firstAvailableDate(LocalDate.now(), subscription),
                     SundayVoucherSuspensionConstants.issueConstants(0).issueDayOfWeek.getValue
                   )
                 ),
@@ -302,6 +305,7 @@ class HandlerTest extends FlatSpec with Matchers {
     val subscriptionName = "Sub12344"
     val contactId = "Contact1234"
     val holidayStopRequestsDetail = Fixtures.mkHolidayStopRequestDetails()
+    val subscription = Fixtures.mkSubscription()
 
     val holidayStopRequest = Fixtures.mkHolidayStopRequest(
       id = "holidayStopId",
@@ -342,7 +346,7 @@ class HandlerTest extends FlatSpec with Matchers {
               GetHolidayStopRequests(
                 Some(
                   LegacyProductSpecifics(
-                    GuardianWeeklyIssueSuspensionConstants.firstAvailableDate(LocalDate.now()),
+                    GuardianWeeklyIssueSuspensionConstants.firstAvailableDate(LocalDate.now(), subscription),
                     GuardianWeeklyIssueSuspensionConstants.issueDayOfWeek.getValue,
                     GuardianWeeklySuspensionConstants.annualIssueLimit
                   )

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -230,12 +230,16 @@ class HandlerTest extends FlatSpec with Matchers {
   }
   "GET /hsr/<<sub name>>?productType=...&ratePlanName=... endpoint" should
     "get subscription and calculate product specifics for product type and rate plan name query params" in {
-    val testBackend = SttpBackendStub.synchronous
 
     val subscriptionName = "Sub12344"
     val subscription = Fixtures.mkSubscription()
     val contactId = "Contact1234"
     val holidayStopRequestsDetail = Fixtures.mkHolidayStopRequestDetails()
+
+    val testBackend = SttpBackendStub
+      .synchronous
+      .stubZuoraAuthCall()
+      .stubZuoraSubscription(subscriptionName, subscription)
 
     val holidayStopRequest = Fixtures.mkHolidayStopRequest(
       id = "holidayStopId",
@@ -300,12 +304,15 @@ class HandlerTest extends FlatSpec with Matchers {
   }
   "GET /hsr/<<sub name>> endpoint" should
     "get subscription and calculate product specifics for product name prefix header" in {
-    val testBackend = SttpBackendStub.synchronous
-
     val subscriptionName = "Sub12344"
     val contactId = "Contact1234"
     val holidayStopRequestsDetail = Fixtures.mkHolidayStopRequestDetails()
     val subscription = Fixtures.mkSubscription()
+
+    val testBackend = SttpBackendStub
+      .synchronous
+      .stubZuoraAuthCall()
+      .stubZuoraSubscription(subscriptionName, subscription)
 
     val holidayStopRequest = Fixtures.mkHolidayStopRequest(
       id = "holidayStopId",

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
@@ -41,6 +41,7 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
       "A-S00051832",
       LocalDate.parse("2019-09-24"),
       LocalDate.parse("2020-09-24"),
+      LocalDate.parse("2020-09-24"),
       12,
       "Month",
       true,
@@ -67,6 +68,7 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
     Subscription(
       "A-S00051832",
       LocalDate.parse("2019-09-24"),
+      LocalDate.parse("2020-09-24"),
       LocalDate.parse("2020-09-24"),
       12,
       "Month",

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
@@ -99,7 +99,7 @@ object ActionCalculator {
           (today `with` dayAfterNextPublicationDay) // next Saturday
 
       verify(firstAvailableDate, today)
-      latestOf(firstAvailableDate, subscription.customerAcceptanceDate)
+      firstAvailableDate
     }
 
     private def verify(firstAvailableDate: LocalDate, today: LocalDate): Unit = {

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
@@ -3,6 +3,10 @@ package com.gu.holiday_stops
 import java.time.temporal.ChronoUnit.DAYS
 import java.time.temporal.{ChronoUnit, TemporalAdjusters}
 import java.time.{DayOfWeek, LocalDate}
+
+import cats.data.NonEmptyList
+import cats.kernel.Order
+import com.gu.holiday_stops.subscription.Subscription
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.Product._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{Product, ProductName}
 
@@ -63,8 +67,9 @@ object ActionCalculator {
     /**
      * The first date a holiday can started on for this issue when creating a stop on the supplied date
      * @param today          Date the holiday is being created on
+     * @param subscription   Subscription holiday is being created for
      */
-    def firstAvailableDate(today: LocalDate): LocalDate
+    def firstAvailableDate(today: LocalDate, subscription: Subscription): LocalDate
   }
 
   val GuardianWeeklySuspensionConstants = SuspensionConstants(
@@ -85,16 +90,16 @@ object ActionCalculator {
      * then Saturday after next (i.e., next-next Saturday),
      * otherwise next Saturday
      */
-    def firstAvailableDate(today: LocalDate): LocalDate = {
+    def firstAvailableDate(today: LocalDate, subscription: Subscription): LocalDate = {
       val dayAfterNextPublicationDay = TemporalAdjusters.next(issueDayOfWeek.plus(1)) // Saturday because GW is published on Friday, https://stackoverflow.com/a/29010338/5205022
-      val firstAvailableDate =
+      val firstAvailableDate: LocalDate =
         if (DAYS.between(today, today `with` dayAfterNextPublicationDay) < minDaysBetweenTodayAndFirstAvailableDate)
           (today `with` dayAfterNextPublicationDay `with` dayAfterNextPublicationDay) // Saturday after next
         else
           (today `with` dayAfterNextPublicationDay) // next Saturday
 
       verify(firstAvailableDate, today)
-      firstAvailableDate
+      latestOf(firstAvailableDate, subscription.customerAcceptanceDate)
     }
 
     private def verify(firstAvailableDate: LocalDate, today: LocalDate): Unit = {
@@ -162,8 +167,8 @@ object ActionCalculator {
       issueDayOfWeek = dayOfWeek,
       processorRunLeadTimeDays = VoucherProcessorLeadTime
     ) {
-      def firstAvailableDate(today: LocalDate): LocalDate = {
-        today.plusDays(processorRunLeadTimeDays.toLong)
+      def firstAvailableDate(today: LocalDate, subscription: Subscription): LocalDate = {
+        latestOf(subscription.customerAcceptanceDate, today.plusDays(processorRunLeadTimeDays.toLong))
       }
     }
 
@@ -192,11 +197,15 @@ object ActionCalculator {
       case _ => Left(ActionCalculatorError(s"ProductRatePlan $product is not supported"))
     }
 
-  def getProductSpecifics(productNamePrefix: ProductName, today: LocalDate = LocalDate.now()): LegacyProductSpecifics = {
+  def getProductSpecifics(
+    productNamePrefix: ProductName,
+    subscription: Subscription,
+    today: LocalDate = LocalDate.now()
+  ): LegacyProductSpecifics = {
     val productSuspensionConstants = suspensionConstantsByProduct(productNamePrefix)
     val firstIssueConstants = productSuspensionConstants.issueConstants(0)
     LegacyProductSpecifics(
-      firstIssueConstants.firstAvailableDate(today),
+      firstIssueConstants.firstAvailableDate(today, subscription),
       firstIssueConstants.issueDayOfWeek.getValue,
       productSuspensionConstants.annualIssueLimit
     )
@@ -204,6 +213,7 @@ object ActionCalculator {
 
   def getProductSpecificsByProductRatePlanKey(
     product: Product,
+    subscription: Subscription,
     today: LocalDate = LocalDate.now()
   ): Either[ActionCalculatorError, ProductSpecifics] = {
     suspensionConstantsByProductRatePlanKey(product)
@@ -212,7 +222,7 @@ object ActionCalculator {
           constants.annualIssueLimit,
           constants.issueConstants.map { issueConstants =>
             IssueSpecifics(
-              issueConstants.firstAvailableDate(today),
+              issueConstants.firstAvailableDate(today, subscription),
               issueConstants.issueDayOfWeek.getValue
             )
           }
@@ -254,6 +264,10 @@ object ActionCalculator {
     }
   }
 
+  def latestOf(head: LocalDate, tail: LocalDate*) = {
+    NonEmptyList(head, tail.toList)
+      .sorted(Order.fromLessThan[LocalDate](_.isAfter(_))).head
+  }
 }
 
 case class ActionCalculatorError(message: String)

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/Subscription.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/subscription/Subscription.scala
@@ -8,6 +8,7 @@ case class Subscription(
   subscriptionNumber: String,
   termStartDate: LocalDate,
   termEndDate: LocalDate,
+  customerAcceptanceDate: LocalDate,
   currentTerm: Int,
   currentTermPeriodType: String,
   autoRenew: Boolean,

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
@@ -36,9 +36,7 @@ class ActionCalculatorTest extends FlatSpec with Matchers with EitherValues {
   }
 
   it should "calculate first available date for Guardian Weekly" in {
-    val customerAcceptanceDate = LocalDate.of(2019, 6, 8)
     val gwTodayToFirstAvailableDate = ListMap[Today, FirstAvailableDate](
-      LocalDate.of(2019, 5, 1) -> LocalDate.of(2019, 6, 8), // jump to first sunday after customerAcceptanceDate
       LocalDate.of(2019, 6, 1) -> LocalDate.of(2019, 6, 8), // first available on Sun
       LocalDate.of(2019, 6, 2) -> LocalDate.of(2019, 6, 8), // first available on Sun
       LocalDate.of(2019, 6, 3) -> LocalDate.of(2019, 6, 8), // first available on Sun
@@ -72,7 +70,7 @@ class ActionCalculatorTest extends FlatSpec with Matchers with EitherValues {
       LocalDate.of(2019, 7, 1) -> LocalDate.of(2019, 7, 6), // first available on Sun
       LocalDate.of(2019, 7, 2) -> LocalDate.of(2019, 7, 13) // jump on Tue, a day before processor run
     )
-    val subscription = Fixtures.mkSubscription(customerAcceptanceDate = customerAcceptanceDate)
+    val subscription = Fixtures.mkSubscription()
 
     gwTodayToFirstAvailableDate foreach {
       case (today, expected) =>

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -35,6 +35,7 @@ object Fixtures {
   def mkSubscription(
     termStartDate: LocalDate = LocalDate.now(),
     termEndDate: LocalDate = LocalDate.now(),
+    customerAcceptanceDate: LocalDate = LocalDate.now(),
     price: Double = -1.0,
     billingPeriod: String = "Quarter",
     chargedThroughDate: Option[LocalDate] = None
@@ -43,6 +44,7 @@ object Fixtures {
       subscriptionNumber = "S1",
       termStartDate,
       termEndDate,
+      customerAcceptanceDate,
       currentTerm = 12,
       currentTermPeriodType = "Month",
       autoRenew = true,
@@ -67,6 +69,7 @@ object Fixtures {
     subscriptionNumber = "S1",
     termStartDate = LocalDate.of(2019, 3, 1),
     termEndDate = LocalDate.of(2020, 3, 1),
+    customerAcceptanceDate = LocalDate.of(2020, 4, 1),
     currentTerm = 12,
     currentTermPeriodType = "Month",
     autoRenew = true,


### PR DESCRIPTION
This PR add some logic to the calculation of the holiday stops first available date to prevent holiday stops from being created before fulfilment has been started for that subscription:
- Subscriptions are fetched from Zuora in calls to GET /hsr/<<sub>>
- The GET /hsr endpoint has been removed as first available date cannot be calculated without a subscription. this endpoint is not currently in being used.
- Subscription.customerAcceptanceDate defines when fulfilment starts.