### PR TITLE
Adding RevenueEventItemInvoiceItem Query to zuora-datalake-export

### DIFF
--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -214,6 +214,13 @@ object Query extends Enum[Query] {
     "ophan-raw-zuora-increment-invoiceitem",
     "InvoiceItem.csv"
   )
+
+  case object RevenueEventItemInvoiceItem extends Query(
+    "RevenueEventItemInvoiceItem",
+    """SELECT Amount, CreatedById, CreatedDate, Currency, Id, UpdatedById, UpdatedDate, Account.Id, AccountingPeriod.Id, Amendment.Id, BillToContact.Id, DefaultPaymentMethod.Id, Invoice.Id, InvoiceItem.Id, JournalEntry.Id, JournalRun.Id, ParentAccount.Id, Product.Id, ProductRatePlan.Id, ProductRatePlanCharge.Id, RatePlan.Id, RatePlanCharge.Id, RevenueChargeSummary.Id, RevenueEventInvoiceItem.Id, RevenueEventType.Id, RevenueScheduleInvoiceItem.Id, SoldToContact.Id, Subscription.Id FROM RevenueEventItemInvoiceItem""",
+    "ophan-raw-zuora-increment-revenueeventiteminvoiceitem",
+    "RevenueEventItemInvoiceItem.csv"
+  )
 }
 
 object ZuoraApiHost {

--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -217,7 +217,7 @@ object Query extends Enum[Query] {
 
   case object RevenueEventItemInvoiceItem extends Query(
     "RevenueEventItemInvoiceItem",
-    """SELECT Amount, CreatedById, CreatedDate, Currency, Id, UpdatedById, UpdatedDate, Account.Id, AccountingPeriod.Id, Amendment.Id, BillToContact.Id, DefaultPaymentMethod.Id, Invoice.Id, InvoiceItem.Id, JournalEntry.Id, JournalRun.Id, ParentAccount.Id, Product.Id, ProductRatePlan.Id, ProductRatePlanCharge.Id, RatePlan.Id, RatePlanCharge.Id, RevenueChargeSummary.Id, RevenueEventInvoiceItem.Id, RevenueEventType.Id, RevenueScheduleInvoiceItem.Id, SoldToContact.Id, Subscription.Id FROM RevenueEventItemInvoiceItem""",
+    """SELECT Amount, CreatedById, CreatedDate, Currency, Id, UpdatedById, UpdatedDate, Account.Id, AccountingPeriod.Id, Amendment.Id, BillToContact.Id, DefaultPaymentMethod.Id, Invoice.Id, InvoiceItem.Id, JournalEntry.Id, JournalRun.Id, ParentAccount.Id, Product.Id, ProductRatePlan.Id, ProductRatePlanCharge.Id, RatePlan.Id, RatePlanCharge.Id, RevenueChargeSummary.Id, RevenueEventInvoiceItem.Id, RevenueEventType.Id, RevenueScheduleInvoiceItem.Id, SoldToContact.Id, Subscription.Id FROM RevenueEventItemInvoiceItem WHERE (CreatedDate >= '2019-10-22T00:00:00') AND (CreatedDate <= '2099-01-01T00:00:00')""",
     "ophan-raw-zuora-increment-revenueeventiteminvoiceitem",
     "RevenueEventItemInvoiceItem.csv"
   )


### PR DESCRIPTION
## Why
Data Delivery wants to test exporting largest possible dataset using the current methods to determine if we should extend the current process / evaluate some PaaS solution or back the possible direct S3 export.

## Does it work
We've checked the query in Zuora web UI (with limit) and it worked as expected. 

## Related PR:
https://github.com/guardian/ophan-data-lake/pull/4607
