### PR TITLE
expose `invoiceDate` for each publication on the 'list existing' endpoint

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -18,7 +18,8 @@ object WireHolidayStopRequest {
     publicationsImpacted = sfHolidayStopRequest.Holiday_Stop_Request_Detail__r.map(_.records.map(detail => HolidayStopRequestsDetail(
       publicationDate = detail.Stopped_Publication_Date__c.value,
       estimatedPrice = detail.Estimated_Price__c.map(_.value),
-      actualPrice = detail.Actual_Price__c.map(_.value)
+      actualPrice = detail.Actual_Price__c.map(_.value),
+      invoiceDate = detail.Expected_Invoice_Date__c.map(_.value)
     ))).getOrElse(List())
   )
 
@@ -47,7 +48,8 @@ object MutabilityFlags {
 case class HolidayStopRequestsDetail(
   publicationDate: LocalDate,
   estimatedPrice: Option[Double],
-  actualPrice: Option[Double]
+  actualPrice: Option[Double],
+  invoiceDate: Option[LocalDate]
 )
 
 object HolidayStopRequestsDetail {

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -233,6 +233,7 @@ class HandlerTest extends FlatSpec with Matchers {
       holidayStop.Stopped_Publication_Date__c.value,
       holidayStop.Estimated_Price__c.map(_.value),
       holidayStop.Actual_Price__c.map(_.value),
+      holidayStop.Expected_Invoice_Date__c.map(_.value)
     )
   }
 

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ProcessResult.scala
@@ -28,7 +28,7 @@ object ProcessResult extends LazyLogging {
     (zuoraHolidayWriteResult.estimatedPrice, Some(zuoraHolidayWriteResult.actualPrice)).mapN { (estimated, actual) =>
       if (estimated.value != actual.value)
         logger.warn(s"Difference between actual and estimated credit. Investigate ASAP! estimated.value=${estimated.value}; actual.value=${actual.value}")
-        // throw new RuntimeException(s"Difference between actual and estimated credit. Investigate ASAP! estimated.value=${estimated.value}; actual.value=${actual.value}")
+      // throw new RuntimeException(s"Difference between actual and estimated credit. Investigate ASAP! estimated.value=${estimated.value}; actual.value=${actual.value}")
     }
   }
 }

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SundayVoucherHolidayStopProcessTest.scala
@@ -19,9 +19,9 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
       Some(HolidayStopRequestsDetailChargePrice(-2.7)), // Estimated_Price__c: Option[HolidayStopRequestsDetailChargePrice],
       Some(HolidayStopRequestsDetailChargeCode("C-00057516")), // Charge_Code__c: Option[HolidayStopRequestsDetailChargeCode],
       None, // Actual_Price__c: Option[HolidayStopRequestsDetailChargePrice]
+      None // Expected_Invoice_Date__c: Option[HolidayStopRequestsDetailExpectedInvoiceDate]
     )
   )
-
 
   val holidayStops = List(
     HolidayStop(
@@ -58,10 +58,11 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
           None,
           None,
           Some(LocalDate.parse("2019-10-20")),
-          "2c92c0f95aff3b56015b1045fba832d4")),
+          "2c92c0f95aff3b56015b1045fba832d4"
+        )),
         "2c92c0f95aff3b56015b1045fb9332d2",
-        "2c92c0f86d6263c0016d6271c6750a35")
-      ),
+        "2c92c0f86d6263c0016d6271c6750a35"
+      )),
       "Active"
     )
 
@@ -174,8 +175,6 @@ class SundayVoucherHolidayStopProcessTest extends FlatSpec with Matchers {
     notAlreadyActionedHolidays,
     OverallFailure(failedZuoraResponses, salesforceExportResult)
   )
-
-
 
   "SundayVoucherHolidayStopProcess" should "pass in correct HolidayCreditUpdate request to zuora updateSubscription call" in {
     val exptedStoppedPublicationDate = LocalDate.parse("2019-10-20")

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
@@ -39,6 +39,9 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
   case class HolidayStopRequestsDetailChargePrice(value: Double) extends AnyVal
   implicit val formatHolidayStopRequestsDetailChargePrice = Jsonx.formatInline[HolidayStopRequestsDetailChargePrice]
 
+  case class HolidayStopRequestsDetailExpectedInvoiceDate(value: LocalDate) extends AnyVal
+  implicit val formatHolidayStopRequestsDetailExpectedInvoiceDate = Jsonx.formatInline[HolidayStopRequestsDetailExpectedInvoiceDate]
+
   case class StoppedPublicationDate(value: LocalDate) extends AnyVal {
     def getDayOfWeek: String = value.getDayOfWeek.toString.toLowerCase.capitalize
   }
@@ -66,7 +69,8 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
     Stopped_Publication_Date__c: StoppedPublicationDate,
     Estimated_Price__c: Option[HolidayStopRequestsDetailChargePrice],
     Charge_Code__c: Option[HolidayStopRequestsDetailChargeCode],
-    Actual_Price__c: Option[HolidayStopRequestsDetailChargePrice]
+    Actual_Price__c: Option[HolidayStopRequestsDetailChargePrice],
+    Expected_Invoice_Date__c: Option[HolidayStopRequestsDetailExpectedInvoiceDate]
   )
   implicit val formatHolidayStopRequestsDetail = Json.format[HolidayStopRequestsDetail]
 
@@ -74,7 +78,7 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
 
   val SOQL_SELECT_CLAUSE = """
       | SELECT Id, Subscription_Name__c, Product_Name__c, Stopped_Publication_Date__c,
-      | Estimated_Price__c, Charge_Code__c, Actual_Price__c
+      | Estimated_Price__c, Charge_Code__c, Actual_Price__c, Expected_Invoice_Date__c
       |""".stripMargin
 
   val SOQL_ORDER_BY_CLAUSE = "ORDER BY Stopped_Publication_Date__c ASC"

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -231,7 +231,8 @@ object Fixtures extends Assertions {
     Stopped_Publication_Date__c = StoppedPublicationDate(request.Start_Date__c.value),
     Estimated_Price__c = None,
     Charge_Code__c = Some(HolidayStopRequestsDetailChargeCode(chargeCode)),
-    Actual_Price__c = None
+    Actual_Price__c = None,
+    Expected_Invoice_Date__c = None
   )
 
   def mkHolidayStopRequestDetails(
@@ -240,8 +241,9 @@ object Fixtures extends Assertions {
     productName: String = "Product 1",
     stopDate: LocalDate = LocalDate.of(2019, 1, 1),
     chargeCode: String = "Charge code 1",
-    estimatedPrice:  Option[Double] = None,
-    actualPrice:  Option[Double] = None,
+    estimatedPrice: Option[Double] = None,
+    actualPrice: Option[Double] = None,
+    expectedInvoiceDate: Option[LocalDate] = None
   ) = {
     HolidayStopRequestsDetail(
       Id = HolidayStopRequestsDetailId(id),
@@ -250,7 +252,8 @@ object Fixtures extends Assertions {
       Stopped_Publication_Date__c = StoppedPublicationDate(stopDate),
       Estimated_Price__c = estimatedPrice.map(HolidayStopRequestsDetailChargePrice.apply),
       Charge_Code__c = Some(HolidayStopRequestsDetailChargeCode(chargeCode)),
-      Actual_Price__c = actualPrice.map(HolidayStopRequestsDetailChargePrice.apply)
+      Actual_Price__c = actualPrice.map(HolidayStopRequestsDetailChargePrice.apply),
+      Expected_Invoice_Date__c = expectedInvoiceDate.map(HolidayStopRequestsDetailExpectedInvoiceDate.apply)
     )
   }
 

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesForceHolidayStopsEffects.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesForceHolidayStopsEffects.scala
@@ -20,7 +20,7 @@ object SalesForceHolidayStopsEffects {
       "   \n" +
       " SELECT Id, Subscription_Name__c, " +
       "Product_Name__c, Stopped_Publication_Date__c,\n" +
-      " Estimated_Price__c, Charge_Code__c, Actual_Price__c\n" +
+      " Estimated_Price__c, Charge_Code__c, Actual_Price__c, Expected_Invoice_Date__c\n" +
       "\n   " +
       "FROM Holiday_Stop_Request_Detail__r\n   " +
       "ORDER BY Stopped_Publication_Date__c ASC\n" +


### PR DESCRIPTION
- [x] **MUST check `Expected_Invoice_Date__c` field has correct visibility in UAT & PROD Salesforce (was manually changed in DEV)**