### PR TITLE
write Expected_Invoice_Date__c to Salesforce in the create call

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/package.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/package.scala
@@ -1,13 +1,6 @@
 package com.gu
 
-import java.time.LocalDate
-
-import acyclic.skipped
-
-import com.gu.holiday_stops.subscription.Subscription
-
 package object holiday_stops {
   type ZuoraHolidayResponse[T] = Either[ZuoraHolidayError, T]
   type SalesforceHolidayResponse[T] = Either[SalesforceHolidayError, T]
-  type CreditCalculation = (LocalDate, Subscription) => Either[HolidayError, Double]
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import ai.x.play.json.Jsonx
-import com.gu.holiday_stops.{CreditCalculation, ZuoraHolidayError}
+import com.gu.holiday_stops.ZuoraHolidayError
 import com.gu.holiday_stops.subscription.{HolidayStopCredit, StoppedProduct, Subscription}
 import com.gu.salesforce.RecordsWrapperCaseClass
 import com.gu.salesforce.SalesforceConstants._
@@ -173,8 +173,6 @@ object SalesforceHolidayStopRequest extends Logging {
         .runRequest
 
     def buildBody(
-      creditCalculator: CreditCalculation
-    )(
       start: LocalDate,
       end: LocalDate,
       publicationDatesToBeStopped: List[LocalDate],

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -5,8 +5,8 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import ai.x.play.json.Jsonx
-import com.gu.holiday_stops.CreditCalculation
-import com.gu.holiday_stops.subscription.Subscription
+import com.gu.holiday_stops.{CreditCalculation, ZuoraHolidayError}
+import com.gu.holiday_stops.subscription.{HolidayStopCredit, StoppedProduct, Subscription}
 import com.gu.salesforce.RecordsWrapperCaseClass
 import com.gu.salesforce.SalesforceConstants._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
@@ -135,6 +135,7 @@ object SalesforceHolidayStopRequest extends Logging {
   case class CompositeTreeHolidayStopRequestsDetail(
     Stopped_Publication_Date__c: LocalDate,
     Estimated_Price__c: Option[HolidayStopRequestsDetailChargePrice],
+    Expected_Invoice_Date__c: Option[HolidayStopRequestsDetailExpectedInvoiceDate],
     attributes: CompositeAttributes = CompositeAttributes(
       SalesforceHolidayStopRequestsDetail.holidayStopRequestsDetailSfObjectRef,
       UUID.randomUUID().toString
@@ -187,9 +188,13 @@ object SalesforceHolidayStopRequest extends Logging {
           SF_Subscription__c = sfSubscription.Id,
           Holiday_Stop_Request_Detail__r = RecordsWrapperCaseClass(
             publicationDatesToBeStopped.map { stoppedPublicationDate =>
+              val expectedCredit: Either[ZuoraHolidayError, HolidayStopCredit] =
+                StoppedProduct(zuoraSubscription, StoppedPublicationDate(stoppedPublicationDate)).map(_.credit)
+              // TODO log any credit calculation failure (currently swallowed in the toOption below)
               CompositeTreeHolidayStopRequestsDetail(
                 stoppedPublicationDate,
-                creditCalculator(stoppedPublicationDate, zuoraSubscription).toOption.map(HolidayStopRequestsDetailChargePrice)
+                Estimated_Price__c = expectedCredit.toOption.map(_.amount).map(HolidayStopRequestsDetailChargePrice),
+                Expected_Invoice_Date__c = expectedCredit.toOption.map(_.invoiceDate).map(HolidayStopRequestsDetailExpectedInvoiceDate)
               )
             }
           )

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -3,7 +3,7 @@ package com.gu.salesforce.holiday_stops
 import java.time.LocalDate
 
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.holiday_stops.{ActionCalculator, CreditCalculation, Fixtures, ProductVariant}
+import com.gu.holiday_stops.{ActionCalculator, Fixtures, ProductVariant}
 import com.gu.holiday_stops.subscription.Subscription
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.SalesforceClient
@@ -15,7 +15,6 @@ import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.resthttp.JsonHttp
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.{-\/, \/-}
-import com.gu.util.resthttp.RestRequestMaker.toClientFailableOp
 
 class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matchers {
 
@@ -44,7 +43,6 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
         Left(IdentityId("100004814"))
       ).toDisjunction
 
-      fakePartiallyWiredCreditCalculator: CreditCalculation = (_: LocalDate, _: Subscription) => Right(0.0)
       fakeSubscription: Subscription = Fixtures.mkGuardianWeeklySubscription()
 
       publicationDatesToBeStopped = ActionCalculator
@@ -54,8 +52,6 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
 
       createOp = SalesforceHolidayStopRequest.CreateHolidayStopRequestWithDetail(sfAuth.wrapWith(JsonHttp.post))
       createResult <- createOp(CreateHolidayStopRequestWithDetail.buildBody(
-        fakePartiallyWiredCreditCalculator
-      )(
         startDate,
         endDate,
         publicationDatesToBeStopped,


### PR DESCRIPTION
### holiday-stop-api
Refactor to to make the credit calculation call more directly in the create call **(so the invoiceDate is accessible to send to Salesforce as `Expected_Invoice_Date__c`)** which meant that the `CreditCalculation` type alias could be eliminated and needn't be passed around various places in the `Handler`.