### PR TITLE
holiday-stop-api: introduce withdrawn timestamp to replace actual deletion

### DIFF
--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -11,7 +11,7 @@ All endpoints require...
 | GET | `/{STAGE}/potential/{SUBSCRIPTION_NAME}?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}&estimateCredit={true`&#124;`false}` | returns a response containing dates for each issue impacted between the start and end parameters inclusively, for the subscription. Optionally the estimated credit can be calculated for each issue (which comes with the invoice date it will be appear on) |
 | GET | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}` | returns all holiday stops (past & present) for the specified subscription (user is verified as the 'bill to' contact of the subscription). Response includes an 'annualIssueLimit' and an 'issueSpecifics' array containing a series of objects each with calculated 'firstAvailableDate' and 'issueDayOfWeek'.|
 | POST | `/{STAGE}/hsr` | creates a new all holiday stop, example body `{ "start": "2023-06-10", "end": "2024-06-14", "subscriptionName": "A-S00071783" }`|
-| DELETE | `/{STAGE}/hsr/{SUBSCRIPTION_NAME} /{SF_ID}` | deletes the holiday stop request from SalesForce (with Id matching `{SF_ID}`) |
+| DELETE | `/{STAGE}/hsr/{SUBSCRIPTION_NAME} /{SF_ID}` | marks the holiday stop request as 'withdrawn' in SalesForce (specifically; placing timestamp in `Withdrawn_Time__c` field) (where holiday stop request `Id` matches `{SF_ID}`) |
 
 
 ### Handling Multiple Environments

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -1,6 +1,6 @@
 package com.gu.holiday_stops
 
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime}
 
 import cats.implicits._
 import com.gu.holiday_stops.subscription.Subscription
@@ -20,7 +20,8 @@ object WireHolidayStopRequest {
       estimatedPrice = detail.Estimated_Price__c.map(_.value),
       actualPrice = detail.Actual_Price__c.map(_.value),
       invoiceDate = detail.Expected_Invoice_Date__c.map(_.value)
-    ))).getOrElse(List())
+    ))).getOrElse(List()),
+    withdrawnTime = sfHolidayStopRequest.Withdrawn_Time__c.map(_.value)
   )
 
   def calculateMutabilityFlags(firstAvailableDate: LocalDate, actionedCount: Int, endDate: LocalDate): MutabilityFlags = {
@@ -71,7 +72,8 @@ case class HolidayStopRequestFull(
   start: LocalDate,
   end: LocalDate,
   subscriptionName: SubscriptionName,
-  publicationsImpacted: List[HolidayStopRequestsDetail]
+  publicationsImpacted: List[HolidayStopRequestsDetail],
+  withdrawnTime: Option[LocalDateTime]
 )
 
 object HolidayStopRequestFull {

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -1,6 +1,6 @@
 package com.gu.holiday_stops
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.{LocalDate, ZonedDateTime}
 
 import cats.implicits._
 import com.gu.holiday_stops.subscription.Subscription
@@ -10,7 +10,7 @@ import play.api.libs.json.{Json, OFormat}
 
 object WireHolidayStopRequest {
 
-  def apply(sfHolidayStopRequest: HolidayStopRequest): HolidayStopRequestFull = HolidayStopRequestFull(
+  def apply(issueSpecifics: List[IssueSpecifics])(sfHolidayStopRequest: HolidayStopRequest): HolidayStopRequestFull = HolidayStopRequestFull(
     id = sfHolidayStopRequest.Id.value,
     start = sfHolidayStopRequest.Start_Date__c.value,
     end = sfHolidayStopRequest.End_Date__c.value,
@@ -21,25 +21,39 @@ object WireHolidayStopRequest {
       actualPrice = detail.Actual_Price__c.map(_.value),
       invoiceDate = detail.Expected_Invoice_Date__c.map(_.value)
     ))).getOrElse(List()),
-    withdrawnTime = sfHolidayStopRequest.Withdrawn_Time__c.map(_.value)
+    withdrawnTime = sfHolidayStopRequest.Withdrawn_Time__c.map(_.value),
+    mutabilityFlags = calculateMutabilityFlags(
+      isWithdrawn = sfHolidayStopRequest.Is_Withdrawn__c.value,
+      firstAvailableDate = issueSpecifics.map(_.firstAvailableDate).min[LocalDate](_ compareTo _),
+      actionedCount = sfHolidayStopRequest.Actioned_Count__c.value,
+      firstPublicationDate = sfHolidayStopRequest.Holiday_Stop_Request_Detail__r.map(_.records.map(_.Stopped_Publication_Date__c.value).min[LocalDate](_ compareTo _)).get,
+      lastPublicationDate = sfHolidayStopRequest.Holiday_Stop_Request_Detail__r.map(_.records.map(_.Stopped_Publication_Date__c.value).max[LocalDate](_ compareTo _)).get
+    )
   )
 
-  def calculateMutabilityFlags(firstAvailableDate: LocalDate, actionedCount: Int, endDate: LocalDate): MutabilityFlags = {
-    if (actionedCount == 0 && firstAvailableDate.isAfter(LocalDate.now())) {
+  def calculateMutabilityFlags(
+    isWithdrawn: Boolean,
+    firstAvailableDate: LocalDate,
+    actionedCount: Int,
+    firstPublicationDate: LocalDate,
+    lastPublicationDate: LocalDate
+  ): MutabilityFlags = {
+    if (actionedCount == 0 && firstAvailableDate.isAfter(firstPublicationDate.plusDays(2))) {
       // TODO log warning (with CloudWatch alert) as indicates processing of holiday stop is well overdue
     }
-    // TODO perhaps also check that actioned count is expected value and alert if not
+    val firstPublicationDateIsGreaterOrEqualToFirstAvailableDate =
+      firstPublicationDate.isEqual(firstAvailableDate) || firstPublicationDate.isAfter(firstAvailableDate)
     MutabilityFlags(
-      isDeletable = actionedCount == 0,
-      isEditable = firstAvailableDate.isBefore(endDate)
+      isFullyMutable = !isWithdrawn && actionedCount == 0 && firstPublicationDateIsGreaterOrEqualToFirstAvailableDate,
+      isEndDateEditable = !isWithdrawn && firstAvailableDate.isBefore(lastPublicationDate)
     )
   }
 
 }
 
 case class MutabilityFlags(
-  isDeletable: Boolean,
-  isEditable: Boolean
+  isFullyMutable: Boolean,
+  isEndDateEditable: Boolean
 )
 
 object MutabilityFlags {
@@ -73,7 +87,8 @@ case class HolidayStopRequestFull(
   end: LocalDate,
   subscriptionName: SubscriptionName,
   publicationsImpacted: List[HolidayStopRequestsDetail],
-  withdrawnTime: Option[LocalDateTime]
+  withdrawnTime: Option[ZonedDateTime],
+  mutabilityFlags: MutabilityFlags
 )
 
 object HolidayStopRequestFull {
@@ -97,9 +112,9 @@ object GetHolidayStopRequests {
       .leftMap(error => GetHolidayStopRequestsError(s"Failed to get product specifics for $subscription: $error"))
       .map(productSpecifics =>
         GetHolidayStopRequests(
-          holidayStopRequests.map(WireHolidayStopRequest.apply),
-          productSpecifics.issueSpecifics,
-          productSpecifics.annualIssueLimit
+          existing = holidayStopRequests.map(WireHolidayStopRequest.apply(productSpecifics.issueSpecifics)),
+          issueSpecifics = productSpecifics.issueSpecifics,
+          annualIssueLimit = productSpecifics.annualIssueLimit
         ))
 
   implicit val formatIssueSpecifics: OFormat[IssueSpecifics] = Json.format[IssueSpecifics]

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -211,7 +211,8 @@ class HandlerTest extends FlatSpec with Matchers {
                     holidayStopRequest.Start_Date__c.value,
                     holidayStopRequest.End_Date__c.value,
                     holidayStopRequest.Subscription_Name__c,
-                    List(toHolidayStopRequestDetail(holidayStopRequestsDetail))
+                    List(toHolidayStopRequestDetail(holidayStopRequestsDetail)),
+                    withdrawnTime = None
                   )
                 ),
                 List(

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -212,7 +212,8 @@ class HandlerTest extends FlatSpec with Matchers {
                     holidayStopRequest.End_Date__c.value,
                     holidayStopRequest.Subscription_Name__c,
                     List(toHolidayStopRequestDetail(holidayStopRequestsDetail)),
-                    withdrawnTime = None
+                    withdrawnTime = None,
+                    MutabilityFlags(isFullyMutable = false, isEndDateEditable = false)
                   )
                 ),
                 List(

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -50,9 +50,16 @@ object SalesforceHolidayStopRequest extends Logging {
   case class HolidayStopRequestActionedCount(value: Int) extends AnyVal
   implicit val formatHolidayStopRequestActionedCount = Jsonx.formatInline[HolidayStopRequestActionedCount]
 
+  case class HolidayStopRequestWithdrawnTime(value: ZonedDateTime) extends AnyVal
+  implicit val formatHolidayStopRequestWithdrawnTime = Jsonx.formatInline[HolidayStopRequestWithdrawnTime]
+
+  case class HolidayStopRequestIsWithdrawn(value: Boolean) extends AnyVal
+  implicit val formatHolidayStopRequestIsWithdrawn = Jsonx.formatInline[HolidayStopRequestIsWithdrawn]
+
   def getHolidayStopRequestPrefixSOQL(productNamePrefixOption: Option[ProductName] = None) = s"""
       | SELECT Id, Start_Date__c, End_Date__c, Subscription_Name__c, Product_Name__c,
-      | Actioned_Count__c, Pending_Count__c, Total_Issues_Publications_Impacted_Count__c, (
+      | Actioned_Count__c, Pending_Count__c, Total_Issues_Publications_Impacted_Count__c,
+      | Withdrawn_Time__c, Is_Withdrawn__c, (
       |   ${SalesforceHolidayStopRequestsDetail.SOQL_SELECT_CLAUSE}
       |   FROM Holiday_Stop_Request_Detail__r
       |   ${SalesforceHolidayStopRequestsDetail.SOQL_ORDER_BY_CLAUSE}
@@ -70,7 +77,9 @@ object SalesforceHolidayStopRequest extends Logging {
     Total_Issues_Publications_Impacted_Count__c: Int,
     Subscription_Name__c: SubscriptionName,
     Product_Name__c: ProductName,
-    Holiday_Stop_Request_Detail__r: Option[RecordsWrapperCaseClass[HolidayStopRequestsDetail]]
+    Holiday_Stop_Request_Detail__r: Option[RecordsWrapperCaseClass[HolidayStopRequestsDetail]],
+    Withdrawn_Time__c: Option[HolidayStopRequestWithdrawnTime],
+    Is_Withdrawn__c: HolidayStopRequestIsWithdrawn
   )
   implicit val format = Json.format[HolidayStopRequest]
 

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import com.gu.holiday_stops.subscription.{RatePlan, RatePlanCharge, Subscription}
 import com.gu.salesforce.RecordsWrapperCaseClass
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
-import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestActionedCount, HolidayStopRequestEndDate, HolidayStopRequestStartDate}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, HolidayStopRequestActionedCount, HolidayStopRequestEndDate, HolidayStopRequestIsWithdrawn, HolidayStopRequestStartDate, HolidayStopRequestWithdrawnTime}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
 import io.circe.generic.auto._
 import io.circe.parser.decode
@@ -221,7 +221,9 @@ object Fixtures extends Assertions {
     Total_Issues_Publications_Impacted_Count__c = 7,
     Subscription_Name__c = subscriptionName,
     Product_Name__c = ProductName("Gu Weekly"),
-    Holiday_Stop_Request_Detail__r = Some(RecordsWrapperCaseClass(requestDetail))
+    Holiday_Stop_Request_Detail__r = Some(RecordsWrapperCaseClass(requestDetail)),
+    Withdrawn_Time__c = None,
+    Is_Withdrawn__c = HolidayStopRequestIsWithdrawn(false)
   )
 
   def mkHolidayStopRequestDetailsFromHolidayStopRequest(request: HolidayStopRequest, chargeCode: String) = HolidayStopRequestsDetail(

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesForceHolidayStopsEffects.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesForceHolidayStopsEffects.scala
@@ -16,7 +16,8 @@ object SalesForceHolidayStopsEffects {
 
   def listHolidayQuery(contactId: String, subscriptionName: String) =
     "\n SELECT Id, Start_Date__c, End_Date__c, Subscription_Name__c, Product_Name__c," +
-      "\n Actioned_Count__c, Pending_Count__c, Total_Issues_Publications_Impacted_Count__c, (\n" +
+      "\n Actioned_Count__c, Pending_Count__c, Total_Issues_Publications_Impacted_Count__c," +
+      "\n Withdrawn_Time__c, Is_Withdrawn__c, (\n" +
       "   \n" +
       " SELECT Id, Subscription_Name__c, " +
       "Product_Name__c, Stopped_Publication_Date__c,\n" +

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -21,8 +21,7 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
   case class EndToEndResults(
     createResult: HolidayStopRequestId,
     preProcessingFetchResult: List[SalesforceHolidayStopRequest.HolidayStopRequest],
-    postProcessingFetchResult: List[SalesforceHolidayStopRequest.HolidayStopRequest],
-    deleteResult: String
+    postProcessingFetchResult: List[SalesforceHolidayStopRequest.HolidayStopRequest]
   )
 
   it should "Salesforce Holiday Stop Requests should work end to end" taggedAs EffectsTest in {
@@ -81,16 +80,16 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends FlatSpec with Matc
         HolidayStopRequestsDetailChargePrice(0)
       )).toDisjunction
 
-      deleteOp = SalesforceHolidayStopRequest.DeleteHolidayStopRequest(sfAuth.wrapWith(JsonHttp.deleteWithStringResponse))
-      deleteResult <- deleteOp(createResult).toDisjunction
+      deleteOp = SalesforceHolidayStopRequest.WithdrawHolidayStopRequest(sfAuth.wrapWith(JsonHttp.patch))
+      _ <- deleteOp(createResult).toDisjunction
 
-    } yield EndToEndResults(createResult, preProcessingFetchResult, postProcessingFetchResult, deleteResult)
+    } yield EndToEndResults(createResult, preProcessingFetchResult, postProcessingFetchResult)
 
     actual match {
 
       case -\/(failure) => fail(failure.toString)
 
-      case \/-(EndToEndResults(createResult, preProcessingFetchResult, postProcessingFetchResult, _)) =>
+      case \/-(EndToEndResults(createResult, preProcessingFetchResult, postProcessingFetchResult)) =>
 
         withClue("should be able to find the freshly created Holiday Stop Request and its Actioned Count should be ZERO") {
           preProcessingFetchResult


### PR DESCRIPTION
## MUST be released AFTER  https://github.com/guardian/salesforce/pull/93

- re-purpose DELETE endpoint to write a timestamp to `Withdrawn_Time__c`
- retrieve `Withdrawn_Time__c` and `Is_Withdrawn__c` from SF and expose `withdrawnTime` on the 'list existing' endpoint
- re-introduced `mutabilityFlags` so its easy to know on the client whether the holiday stop 
  - `isFullyEditable` (can be withdrawn or start/end dates moved) or 
  - `isEndDateEditable` (where only the end date of the holiday stop can be changed)