### PR TITLE
holiday-stop-api: surface salesforce error messages

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -3,7 +3,6 @@ package com.gu.holiday_stops
 import java.io.{InputStream, OutputStream}
 import java.time.LocalDate
 
-import cats.syntax.either._
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.holiday_stops.subscription.{StoppedProduct, Subscription}
@@ -57,7 +56,11 @@ object Handler extends Logging {
   ): ApiGatewayOp[Operation] = {
     for {
       config <- Config(fetchString).toApiGatewayOp("Failed to load config")
-      sfClient <- SalesforceClient(response, config.sfConfig).value.toDisjunction.toApiGatewayOp("authenticate with SalesForce")
+      sfClient <- SalesforceClient(
+        response,
+        config.sfConfig,
+        shouldExposeSalesforceErrorMessageInClientFailure = true
+      ).value.toDisjunction.toApiGatewayOp("authenticate with SalesForce")
     } yield Operation.noHealthcheck(request => // checking connectivity to SF is sufficient healthcheck so no special steps required
       validateRequestAndCreateSteps(
         request,

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -137,7 +137,11 @@ object Handler extends Logging {
   def extractContactFromHeaders(headers: Option[Map[String, String]]): ApiGatewayOp[Contact] = headers.flatMap(_.toList.collectFirst {
     case (HEADER_SALESFORCE_CONTACT_ID, sfContactId) => Right(SalesforceContactId(sfContactId))
     case (HEADER_IDENTITY_ID, identityId) => Left(IdentityId(identityId))
-  }).toApiGatewayOp(s"either '$HEADER_IDENTITY_ID' header OR '$HEADER_SALESFORCE_CONTACT_ID' (one is required)")
+  }).toApiGatewayContinueProcessing(
+    ApiGatewayResponse.badRequest(
+    s"either '$HEADER_IDENTITY_ID' header OR '$HEADER_SALESFORCE_CONTACT_ID' (one is required)"
+    )
+  )
 
   case class PotentialHolidayStopsPathParams(subscriptionName: SubscriptionName)
 

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/Types.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/Types.scala
@@ -16,6 +16,8 @@ object Types {
 
   case class GenericError(message: String) extends ClientFailure
 
+  case class CustomError(message: String) extends ClientFailure
+
   case class PaymentError(message: String) extends ClientFailure
 
   case class ClientSuccess[A](value: A) extends ClientFailableOp[A] {
@@ -48,6 +50,11 @@ object Types {
         case scalaz.-\/(failure) => failure
       }
 
+  }
+
+  implicit class BoolToOption(val self: Boolean) extends AnyVal {
+    def toOption[A](value: => A): Option[A] =
+      if (self) Some(value) else None
   }
 
   implicit val clientFailableOpM: Monad[ClientFailableOp] = {


### PR DESCRIPTION
After introducing 'withdrawal' of holiday stops (see https://github.com/guardian/support-service-lambdas/pull/463) which has custom validation (see https://github.com/guardian/salesforce/pull/96) the custom message back from Salesforce needed exposing. This PR does that for 'withdrawal' but also addresses a similar TODO for the 'create' endpoint (the validation there relates to overlapping holiday stops).

This PR also includes re-categorising missing identity/sf_contact header as `400 Bad Request` rather than generic 500 error.

**In order to surface those messages from Salesforce all the way to the surface required some changes deep into the wiring of how REST requests are abstracted in this repo - see https://github.com/guardian/support-service-lambdas/pull/466/commits/98afb0c3ce189a6b5711092c8cd9c56e16b4d611 for only these changes.**