### PR TITLE
holiday-stop-api: new PATCH endpoint for amending existing holiday stops

### DIFF
--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -13,7 +13,8 @@ All endpoints require...
 | GET | `/{STAGE}/potential/{SUBSCRIPTION_NAME}?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}&estimateCredit={true`&#124;`false}` | returns a response containing dates for each issue impacted between the start and end parameters inclusively, for the subscription. Optionally the estimated credit can be calculated for each issue (which comes with the invoice date it will be appear on) |
 | GET | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}` | returns all holiday stops (past & present) for the specified subscription (user is verified as the 'bill to' contact of the subscription). Response includes an 'annualIssueLimit' and an 'issueSpecifics' array containing a series of objects each with calculated 'firstAvailableDate' and 'issueDayOfWeek'.|
 | POST | `/{STAGE}/hsr` | creates a new all holiday stop, example body `{ "start": "2023-06-10", "end": "2024-06-14", "subscriptionName": "A-S00071783" }`|
-| DELETE | `/{STAGE}/hsr/{SUBSCRIPTION_NAME} /{SF_ID}` | marks the holiday stop request as 'withdrawn' in SalesForce (specifically; placing timestamp in `Withdrawn_Time__c` field) (where holiday stop request `Id` matches `{SF_ID}`) |
+| PATCH | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | with the same body as create endpoint above, amends the holiday stop request (where holiday stop request `Id` matches `{SF_ID}`) to the newly specified dates and adds/removes the underlying detail records where appropriate |
+| DELETE | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | marks the holiday stop request as 'withdrawn' in SalesForce (specifically; placing timestamp in `Withdrawn_Time__c` field) (where holiday stop request `Id` matches `{SF_ID}`) |
 
 
 ### Handling Multiple Environments

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -246,8 +246,26 @@ Resources:
         - HolidayStopApiLambda
         - HolidayStopApiDeleteAndEditResource
 
-    # TODO HolidayStopApiEditMethod
-    
+    HolidayStopApiEditMethod:
+      Type: AWS::ApiGateway::Method
+      Properties:
+        AuthorizationType: NONE
+        ApiKeyRequired: true
+        RestApiId: !Ref HolidayStopApi
+        ResourceId: !Ref HolidayStopApiDeleteAndEditResource
+        HttpMethod: PATCH
+        RequestParameters:
+          method.request.path.subscriptionName: true
+          method.request.path.holidayStopRequestId: true
+        Integration:
+          Type: AWS_PROXY
+          IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
+          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HolidayStopApiLambda.Arn}/invocations
+      DependsOn:
+        - HolidayStopApi
+        - HolidayStopApiLambda
+        - HolidayStopApiDeleteAndEditResource
+
     HolidayStopApiStage:
         Type: AWS::ApiGateway::Stage
         Properties:
@@ -260,6 +278,7 @@ Resources:
         - HolidayStopApiGetBySubscriptionNameMethod
         - HolidayStopApiCreateMethod
         - HolidayStopApiDeleteMethod
+        - HolidayStopApiEditMethod
 
     HolidayStopApiDeployment:
         Type: AWS::ApiGateway::Deployment
@@ -271,6 +290,7 @@ Resources:
         - HolidayStopApiGetBySubscriptionNameMethod
         - HolidayStopApiCreateMethod
         - HolidayStopApiDeleteMethod
+        - HolidayStopApiEditMethod
 
     5xxApiAlarm:
       Type: AWS::CloudWatch::Alarm

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -125,6 +125,7 @@ object Handler extends Logging {
         }
       case "hsr" :: _ :: _ :: Nil =>
         httpMethod match {
+          case "PATCH" => stepsToAmend(getSubscription) _
           case "DELETE" => stepsToWithdraw _
           case _ => unsupported _
         }
@@ -233,6 +234,34 @@ object Handler extends Logging {
     } yield ApiGatewayResponse.successfulExecution).apiResponse
   }
 
+  case class SpecificHolidayStopRequestPathParams(subscriptionName: SubscriptionName, holidayStopRequestId: HolidayStopRequestId)
+  implicit val readsSpecificHolidayStopRequestPathParams = Json.reads[SpecificHolidayStopRequestPathParams]
+
+  def stepsToAmend(
+    getSubscription: SubscriptionName => Either[HolidayError, Subscription]
+  )(req: ApiGatewayRequest, sfClient: SfClient): ApiResponse = {
+
+    val lookupOp = SalesforceHolidayStopRequest.LookupByContactAndOptionalSubscriptionName(sfClient.wrapWith(JsonHttp.getWithParams))
+    val amendOp = SalesforceHolidayStopRequest.AmendHolidayStopRequest(sfClient.wrapWith(JsonHttp.post))
+
+    (for {
+      requestBody <- req.bodyAsCaseClass[HolidayStopRequestPartial]()
+      contact <- extractContactFromHeaders(req.headers)
+      pathParams <- req.pathParamsAsCaseClass[SpecificHolidayStopRequestPathParams]()
+      zuoraSubscription <- getSubscription(pathParams.subscriptionName).toApiGatewayOp("get subscription from zuora")
+      allExisting <- lookupOp(contact, Some(pathParams.subscriptionName)).toDisjunction.toApiGatewayOp(s"lookup Holiday Stop Requests for contact $contact")
+      existingPublicationsThatWereToBeStopped <- allExisting.find(_.Id == pathParams.holidayStopRequestId).flatMap(_.Holiday_Stop_Request_Detail__r.map(_.records)).toApiGatewayOp(s"contact $contact does not own ${requestBody.subscriptionName.value}")
+      newPublicationDatesToBeStopped <- ActionCalculator
+        .publicationDatesToBeStopped(requestBody.start, requestBody.end, ProductVariant(zuoraSubscription.ratePlans))
+        .toApiGatewayOp(s"calculating publication dates")
+      amendBody = AmendHolidayStopRequest.buildBody(pathParams.holidayStopRequestId, requestBody.start, requestBody.end, newPublicationDatesToBeStopped, existingPublicationsThatWereToBeStopped, zuoraSubscription)
+      _ <- amendOp(amendBody).toDisjunction.toApiGatewayOp(
+        exposeSfErrorMessageIn500ApiResponse(s"amend Holiday Stop Request for subscription ${requestBody.subscriptionName} (contact $contact)")
+      )
+    } yield ApiGatewayResponse.successfulExecution).apiResponse
+
+  }
+
   def getSubscriptionFromZuora(
     config: Config,
     backend: SttpBackend[Id, Nothing]
@@ -244,8 +273,6 @@ object Handler extends Logging {
       subscription <- Zuora.subscriptionGetResponse(config, accessToken, backend)(subscriptionName)
     } yield subscription
 
-  case class WithdrawPathParams(subscriptionName: SubscriptionName, holidayStopRequestId: HolidayStopRequestId)
-
   def stepsToWithdraw(req: ApiGatewayRequest, sfClient: SfClient): ApiResponse = {
 
     val lookupOp = SalesforceHolidayStopRequest.LookupByContactAndOptionalSubscriptionName(sfClient.wrapWith(JsonHttp.getWithParams))
@@ -253,7 +280,7 @@ object Handler extends Logging {
 
     (for {
       contact <- extractContactFromHeaders(req.headers)
-      pathParams <- req.pathParamsAsCaseClass[WithdrawPathParams]()(Json.reads[WithdrawPathParams])
+      pathParams <- req.pathParamsAsCaseClass[SpecificHolidayStopRequestPathParams]()
       existingForUser <- lookupOp(contact, None).toDisjunction.toApiGatewayOp(s"lookup Holiday Stop Requests for contact $contact")
       _ = existingForUser.exists(_.Id == pathParams.holidayStopRequestId).toApiGatewayContinueProcessing(ApiGatewayResponse.forbidden("not your holiday stop"))
       _ <- withdrawOp(pathParams.holidayStopRequestId).toDisjunction.toApiGatewayOp(

--- a/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceConstants.scala
+++ b/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceConstants.scala
@@ -8,6 +8,8 @@ object SalesforceConstants {
 
   val sfObjectsBaseUrl: String = sfApiBaseUrl + "/sobjects/"
 
-  val compositeTreeBaseUrl: String = "/services/data/v38.0/composite/tree/"
+  val compositeBaseUrl: String = "/services/data/v38.0/composite/"
+
+  val compositeTreeBaseUrl: String = compositeBaseUrl + "tree/"
 
 }


### PR DESCRIPTION
Introduced new `PATCH` endpoint `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` which takes the  same body as the create endpoint (e.g. `{ "start": "2023-06-10", "end": "2024-06-14", "subscriptionName": "A-S00071783" }`) and amends the holiday stop request (where holiday stop request `Id` matches `{SF_ID}`) to the newly specified dates and adds/removes the underlying detail records where appropriate.

To do this it uses a **Salesforce _composite_ REST request** (see [official documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_composite.htm) and [this neat article about it](https://www.mstsolutions.com/technical/use-composite-api-instead-of-apex-rest-class/)) to make a combination of...

- [One] `PATCH` on the top level `Holiday_Stop_Request__c` (master) to change the `Start_Date__c` and `End_Date__c`
- [Zero of More] `POST`s to the `Holiday_Stop_Requests_Detail__c` (detail) to create any additional detail records representing the additional publications not present in the existing holiday stop being amended.
- [Zero or More] `DELETE`s of the `Holiday_Stop_Requests_Detail__c` (detail) to remove any detail records which were present for the existing holiday stop being amended, which are no longer part of the new dates of the holiday stop.

... all in the same call and **importantly in one transaction (as per `allOrNone`:`true` field in the request)**, meaning that if any individual part fails then everything is rolled-back (like a DB transaction).