### PR TITLE
holiday-stop-api now accepts alternate Salesforce access token

### DIFF
--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -6,6 +6,8 @@ All endpoints require...
   - `x-identity-id` header which specifies the identityID of the user to request data for _(sent in the `manage-frontend` use-case)_
   - `x-salesforce-contact-id` header which specifies the Salesforce contact ID of the user to request data for _(sent in the CSR UI (in Salesforce) use-case)_
 
+**If being used in the CSR UI (in Salesforce) use-case**, then one should also pass the CSR's Session ID via the `X-Ephemeral-Salesforce-Access-Token` header (can be obtained in Apex with `UserInfo.getSessionId()`) so that the actions can be attributed correctly to the CSR (rather than the confiugured API user for this repo).
+
 | Method | Endpoint | Description |
 | --- | --- | --- | 
 | GET | `/{STAGE}/potential/{SUBSCRIPTION_NAME}?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}&estimateCredit={true`&#124;`false}` | returns a response containing dates for each issue impacted between the start and end parameters inclusively, for the subscription. Optionally the estimated credit can be calculated for each issue (which comes with the invoice date it will be appear on) |

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.holiday_stops.subscription.{StoppedProduct, Subscription}
 import com.gu.salesforce.SalesforceClient
+import com.gu.salesforce.SalesforceClient.withAlternateAccessTokenIfPresentInHeaderList
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestId, StoppedPublicationDate, SubscriptionName}
 import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact._
@@ -65,7 +66,11 @@ object Handler extends Logging {
       validateRequestAndCreateSteps(
         request,
         getSubscriptionFromZuora(config, backend)
-      )(request, sfClient))
+      )(
+        request,
+        sfClient.setupRequest(withAlternateAccessTokenIfPresentInHeaderList(request.headers))
+      )
+    )
   }
 
   private def validateRequestAndCreateSteps(


### PR DESCRIPTION
Following on from https://github.com/guardian/support-service-lambdas/pull/469, this PR makes use of `withAlternateAccessTokenIfPresentInHeaderList` for the SalesforceClient used across the `holiday-stop-api`. 

This means that when the CSR Holiday Stop UI in Salesforce makes use of the `holiday-stop-api` (e.g. withdrawal, creation, amendment) the changes get attributed correctly to the CSR performing the action - by passing their Session ID in the `X-Ephemeral-Salesforce-Access-Token` header.