### PR TITLE
Holiday stop cancelation endpoint

### DIFF
--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -13,7 +13,7 @@ All endpoints require...
 | POST | `/{STAGE}/hsr` | creates a new all holiday stop, example body `{ "start": "2023-06-10", "end": "2024-06-14", "subscriptionName": "A-S00071783" }`|
 | PATCH | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | with the same body as create endpoint above, amends the holiday stop request (where holiday stop request `Id` matches `{SF_ID}`) to the newly specified dates and adds/removes the underlying detail records where appropriate |
 | DELETE | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | marks the holiday stop request as 'withdrawn' in SalesForce (specifically; placing timestamp in `Withdrawn_Time__c` field) (where holiday stop request `Id` matches `{SF_ID}`) |
-| POST | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/cancel?effectiveCancellationDate=yyyy-MM-dd` | handles processing of holiday stops when a subscription is cancelled, unprocessed holiday stops before the effectiveCancellationDate will be marked with a charge code "ManualRefund_Cancellation" for reporting purposes.  This should only be called if the customer was refunded for holiday stops that falls in the cancellation period, otherwise no changes should be made to existing holiday stops. |
+| POST | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/cancel?effectiveCancellationDate=yyyy-MM-dd` | handles processing of holiday stops when a subscription is cancelled, unprocessed holiday stops before the effectiveCancellationDate will be marked with a charge code "ManualRefund_Cancellation" for reporting purposes.  This should only be called if the customer was refunded for holiday stops that fall in the cancellation period, otherwise no changes should be made to existing holiday stops. |
 
 
 ### Handling Multiple Environments

--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -13,6 +13,7 @@ All endpoints require...
 | POST | `/{STAGE}/hsr` | creates a new all holiday stop, example body `{ "start": "2023-06-10", "end": "2024-06-14", "subscriptionName": "A-S00071783" }`|
 | PATCH | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | with the same body as create endpoint above, amends the holiday stop request (where holiday stop request `Id` matches `{SF_ID}`) to the newly specified dates and adds/removes the underlying detail records where appropriate |
 | DELETE | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | marks the holiday stop request as 'withdrawn' in SalesForce (specifically; placing timestamp in `Withdrawn_Time__c` field) (where holiday stop request `Id` matches `{SF_ID}`) |
+| POST | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/cancel?effectiveCancellationDate=yyyy-MM-dd` | handles processing of holiday stops when a subscription is cancelled, unprocessed holiday stops before the effectiveCancellationDate will be marked with a charge code "ManualRefund_Cancellation" for reporting purposes.  This should only be called if the customer was refunded for holiday stops that falls in the cancellation period, otherwise no changes should be made to existing holiday stops. |
 
 
 ### Handling Multiple Environments

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -295,26 +295,6 @@ Resources:
         - HolidayStopApiLambda
         - HolidayStopApiDeleteAndEditResource
 
-    HolidayStopApiEditMethod:
-      Type: AWS::ApiGateway::Method
-      Properties:
-        AuthorizationType: NONE
-        ApiKeyRequired: true
-        RestApiId: !Ref HolidayStopApi
-        ResourceId: !Ref HolidayStopApiDeleteAndEditResource
-        HttpMethod: PATCH
-        RequestParameters:
-          method.request.path.subscriptionName: true
-          method.request.path.holidayStopRequestId: true
-        Integration:
-          Type: AWS_PROXY
-          IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
-          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HolidayStopApiLambda.Arn}/invocations
-      DependsOn:
-        - HolidayStopApi
-        - HolidayStopApiLambda
-        - HolidayStopApiDeleteAndEditResource
-
     HolidayStopApiStage:
         Type: AWS::ApiGateway::Stage
         Properties:

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -275,9 +275,6 @@ Resources:
         - HolidayStopApiLambda
         - HolidayStopApiCancelResource
 
-
-    # TODO HolidayStopApiEditMethod
-    
     HolidayStopApiEditMethod:
       Type: AWS::ApiGateway::Method
       Properties:

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -246,6 +246,36 @@ Resources:
         - HolidayStopApiLambda
         - HolidayStopApiDeleteAndEditResource
 
+    HolidayStopApiCancelResource:
+      Type: AWS::ApiGateway::Resource
+      Properties:
+        RestApiId: !Ref HolidayStopApi
+        ParentId: !Ref HolidayStopApiBySubscriptionNameProxyResource
+        PathPart: "cancel"
+      DependsOn:
+        - HolidayStopApi
+        - HolidayStopApiBySubscriptionNameProxyResource
+
+    HolidayStopApiCancelPostMethod:
+      Type: AWS::ApiGateway::Method
+      Properties:
+        AuthorizationType: NONE
+        ApiKeyRequired: true
+        RestApiId: !Ref HolidayStopApi
+        ResourceId: !Ref HolidayStopApiCancelResource
+        HttpMethod: POST
+        RequestParameters:
+          method.request.path.subscriptionName: true
+        Integration:
+          Type: AWS_PROXY
+          IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
+          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HolidayStopApiLambda.Arn}/invocations
+      DependsOn:
+        - HolidayStopApi
+        - HolidayStopApiLambda
+        - HolidayStopApiCancelResource
+
+
     # TODO HolidayStopApiEditMethod
     
     HolidayStopApiStage:

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -68,11 +68,11 @@ object Handler extends Logging {
     } yield Operation.noHealthcheck(request => // checking connectivity to SF is sufficient healthcheck so no special steps required
       validateRequestAndCreateSteps(
         request,
-        getSubscriptionFromZuora(config, backend)
+        getSubscriptionFromZuora(config, backend),
+        idGenerator
       )(
         request,
-        sfClient.setupRequest(withAlternateAccessTokenIfPresentInHeaderList(request.headers)),
-        idGenerator
+        sfClient.setupRequest(withAlternateAccessTokenIfPresentInHeaderList(request.headers))
       )
     )
   }
@@ -245,34 +245,6 @@ object Handler extends Logging {
     } yield ApiGatewayResponse.successfulExecution).apiResponse
   }
 
-  case class SpecificHolidayStopRequestPathParams(subscriptionName: SubscriptionName, holidayStopRequestId: HolidayStopRequestId)
-  implicit val readsSpecificHolidayStopRequestPathParams = Json.reads[SpecificHolidayStopRequestPathParams]
-
-  def stepsToAmend(
-    getSubscription: SubscriptionName => Either[HolidayError, Subscription]
-  )(req: ApiGatewayRequest, sfClient: SfClient): ApiResponse = {
-
-    val lookupOp = SalesforceHolidayStopRequest.LookupByContactAndOptionalSubscriptionName(sfClient.wrapWith(JsonHttp.getWithParams))
-    val amendOp = SalesforceHolidayStopRequest.AmendHolidayStopRequest(sfClient.wrapWith(JsonHttp.post))
-
-    (for {
-      requestBody <- req.bodyAsCaseClass[HolidayStopRequestPartial]()
-      contact <- extractContactFromHeaders(req.headers)
-      pathParams <- req.pathParamsAsCaseClass[SpecificHolidayStopRequestPathParams]()
-      zuoraSubscription <- getSubscription(pathParams.subscriptionName).toApiGatewayOp("get subscription from zuora")
-      allExisting <- lookupOp(contact, Some(pathParams.subscriptionName)).toDisjunction.toApiGatewayOp(s"lookup Holiday Stop Requests for contact $contact")
-      existingPublicationsThatWereToBeStopped <- allExisting.find(_.Id == pathParams.holidayStopRequestId).flatMap(_.Holiday_Stop_Request_Detail__r.map(_.records)).toApiGatewayOp(s"contact $contact does not own ${requestBody.subscriptionName.value}")
-      newPublicationDatesToBeStopped <- ActionCalculator
-        .publicationDatesToBeStopped(requestBody.start, requestBody.end, ProductVariant(zuoraSubscription.ratePlans))
-        .toApiGatewayOp(s"calculating publication dates")
-      amendBody = AmendHolidayStopRequest.buildBody(pathParams.holidayStopRequestId, requestBody.start, requestBody.end, newPublicationDatesToBeStopped, existingPublicationsThatWereToBeStopped, zuoraSubscription)
-      _ <- amendOp(amendBody).toDisjunction.toApiGatewayOp(
-        exposeSfErrorMessageIn500ApiResponse(s"amend Holiday Stop Request for subscription ${requestBody.subscriptionName} (contact $contact)")
-      )
-    } yield ApiGatewayResponse.successfulExecution).apiResponse
-
-  }
-
   case class CancelHolidayStopsPathParams(subscriptionName: SubscriptionName)
   case class CancelHolidayStopsQueryParams(effectiveCancellationDate: Option[LocalDate])
 
@@ -329,9 +301,11 @@ object Handler extends Logging {
         .publicationDatesToBeStopped(requestBody.start, requestBody.end, ProductVariant(zuoraSubscription.ratePlans))
         .toApiGatewayOp(s"calculating publication dates")
       amendBody = AmendHolidayStopRequest.buildBody(pathParams.holidayStopRequestId, requestBody.start, requestBody.end, newPublicationDatesToBeStopped, existingPublicationsThatWereToBeStopped, zuoraSubscription)
-      _ <- amendOp(amendBody).toDisjunction.toApiGatewayOp(s"amend Holiday Stop Request for subscription ${requestBody.subscriptionName} (contact $contact)")
-      // TODO nice to have - handle 'FIELD_CUSTOM_VALIDATION_EXCEPTION' etc back from SF and place in response
+      _ <- amendOp(amendBody).toDisjunction.toApiGatewayOp(
+        exposeSfErrorMessageIn500ApiResponse(s"amend Holiday Stop Request for subscription ${requestBody.subscriptionName} (contact $contact)")
+      )
     } yield ApiGatewayResponse.successfulExecution).apiResponse
+
   }
 
   def getSubscriptionFromZuora(

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellation.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellation.scala
@@ -1,0 +1,36 @@
+package com.gu.holiday_stops
+
+import java.time.LocalDate
+
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.HolidayStopRequest
+import com.gu.salesforce.holiday_stops.{SalesforceHolidayStopRequest, SalesforceHolidayStopRequestsDetail}
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailChargePrice, SubscriptionName}
+
+final case class HolidayStopSubscriptionCancellationError(reason: String)
+
+object HolidayStopSubscriptionCancellation {
+  def apply(
+    cancellationDate: LocalDate,
+    holidayStopRequests: List[HolidayStopRequest]
+  ): List[SalesforceHolidayStopRequestsDetail.HolidayStopRequestsDetail] = {
+    val allHolidayStopRequestDetails: List[SalesforceHolidayStopRequestsDetail.HolidayStopRequestsDetail] =
+      holidayStopRequests
+        .flatMap { holidayStopRequest =>
+          holidayStopRequest
+            .Holiday_Stop_Request_Detail__r
+            .map(_.records)
+            .getOrElse(Nil)
+        }
+
+    allHolidayStopRequestDetails
+      .collect {
+        case requestDetail: SalesforceHolidayStopRequestsDetail.HolidayStopRequestsDetail if requestDetail.Charge_Code__c == None
+          && (requestDetail.Stopped_Publication_Date__c.value.isBefore(cancellationDate)
+            || requestDetail.Stopped_Publication_Date__c.value.isEqual(cancellationDate)) =>
+          requestDetail.copy(
+            Charge_Code__c = Some(HolidayStopRequestsDetailChargeCode("ManualRefund_Cancellation")),
+            Actual_Price__c = requestDetail.Estimated_Price__c
+          )
+      }
+  }
+}

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -1,6 +1,7 @@
 package com.gu.holiday_stops
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 import com.gu.effects.{FakeFetchString, SFTestEffects, TestingRawEffects}
 import com.gu.holiday_stops.ActionCalculator._
@@ -19,6 +20,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsObject, JsString, JsSuccess, Json}
 
 class HandlerTest extends FlatSpec with Matchers {
+  val testId = "test-generated-id"
 
   it should s"convert either the '$HEADER_IDENTITY_ID' header OR '$HEADER_SALESFORCE_CONTACT_ID' header to Contact or fail" in {
 
@@ -90,7 +92,8 @@ class HandlerTest extends FlatSpec with Matchers {
         defaultTestEffects.response,
         Stage("DEV"),
         FakeFetchString.fetchString,
-        testBackend
+        testBackend,
+        "test-generated-id"
       ).map { operation =>
         operation
           .steps(legacyPotentialIssueDateRequest(
@@ -125,7 +128,8 @@ class HandlerTest extends FlatSpec with Matchers {
           defaultTestEffects.response,
           Stage("DEV"),
           FakeFetchString.fetchString,
-          SttpBackendStub.synchronous
+          SttpBackendStub.synchronous,
+          testId
         )
         .map(_.steps(ApiGatewayRequest(None, None, None, None, None, None)))
     ) {
@@ -145,7 +149,8 @@ class HandlerTest extends FlatSpec with Matchers {
           defaultTestEffects.response,
           Stage("DEV"),
           FakeFetchString.fetchString,
-          SttpBackendStub.synchronous
+          SttpBackendStub.synchronous,
+          testId
         )
         .map(_.steps(ApiGatewayRequest(Some("GET"), None, None, None, None, None)))
     ) {
@@ -189,7 +194,8 @@ class HandlerTest extends FlatSpec with Matchers {
         ).response,
         Stage("DEV"),
         FakeFetchString.fetchString,
-        testBackend
+        testBackend,
+        testId
       ).map { operation =>
         operation
           .steps(
@@ -231,6 +237,58 @@ class HandlerTest extends FlatSpec with Matchers {
             )
 
         }
+    }
+  }
+  "POST /hsr/<<sub name>>/cancel?effectiveCancelationDate=yy-MM-dd endpoint" should
+    "update holiday stops detail for cancellation" in {
+
+    val effectiveCancellationDate = LocalDate.of(2019,10,1)
+    val subscriptionName = "Sub12344"
+    val contactId = "Contact1234"
+    val price = 1.23
+    val holidayStopRequestsDetail = Fixtures.mkHolidayStopRequestDetails(
+      chargeCode = None,
+      stopDate = effectiveCancellationDate.minusDays(1),
+      estimatedPrice = Some(price)
+    )
+
+    val testBackend = SttpBackendStub
+      .synchronous
+
+    val holidayStopRequest = Fixtures.mkHolidayStopRequest(
+      id = "holidayStopId",
+      subscriptionName = SubscriptionName(subscriptionName),
+      requestDetail = List(holidayStopRequestsDetail)
+    )
+
+    inside(
+      Handler.operationForEffects(
+        new TestingRawEffects(
+          responses = Map(
+            SalesForceHolidayStopsEffects.listHolidayStops(contactId, subscriptionName, List(holidayStopRequest))
+          ),
+          postResponses = Map(
+            SFTestEffects.authSuccess,
+            SFTestEffects.cancelSuccess(testId, price)
+          )
+        ).response,
+        Stage("DEV"),
+        FakeFetchString.fetchString,
+        testBackend,
+        testId
+      ).map { operation =>
+        operation
+          .steps(
+            cancelHolidayStops(
+              subscriptionName,
+              contactId,
+              effectiveCancellationDate
+            )
+          )
+      }
+    ) {
+      case ContinueProcessing(response) =>
+        response.statusCode should equal("200")
     }
   }
 
@@ -287,6 +345,19 @@ class HandlerTest extends FlatSpec with Matchers {
       Some(Map("x-salesforce-contact-id" -> sfContactId)),
       Some(JsObject(Seq("subscriptionName" -> JsString(subscriptionName)))),
       Some(s"/hsr/$subscriptionName ")
+    )
+  }
+
+  private def cancelHolidayStops(subscriptionName: String, sfContactId: String, effectiveCancellationDate: LocalDate) = {
+    ApiGatewayRequest(
+      Some("POST"),
+      Some(Map(
+        "effectiveCancellationDate" -> effectiveCancellationDate.format(DateTimeFormatter.ISO_LOCAL_DATE)
+      )),
+      None,
+      Some(Map("x-salesforce-contact-id" -> sfContactId)),
+      Some(JsObject(Seq("subscriptionName" -> JsString(subscriptionName)))),
+      Some(s"/hsr/$subscriptionName/cancel")
     )
   }
 

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellationTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellationTest.scala
@@ -1,0 +1,53 @@
+package com.gu.holiday_stops
+
+import java.time.LocalDate
+
+import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailChargePrice}
+import org.scalatest.{FlatSpec, Matchers}
+
+class HolidayStopSubscriptionCancellationTest extends FlatSpec with Matchers {
+  "HolidayStopSubscriptionCancellationTest" should "return unprocessed holiday stops before cancellation" in {
+    val estimatedPrice = 1.23
+
+    val cancellationDate = LocalDate.now().plusMonths(1)
+    val cancelableDetail1 = testDetail(cancellationDate.minusDays(1), None, estimatedPrice)
+    val cancelableDetail2 = testDetail(cancellationDate, None, estimatedPrice)
+    val afterCancellationDateDetail = testDetail(cancellationDate.plusDays(1), None, estimatedPrice)
+    val allReadyProcessedDetail = testDetail(cancellationDate.minusDays(10), Some("ChargeCode-1111"), estimatedPrice)
+
+    val holidayStopRequests = List(
+      Fixtures.mkHolidayStopRequest(
+        "id",
+        requestDetail = List(
+          cancelableDetail1,
+          cancelableDetail2,
+          afterCancellationDateDetail,
+          allReadyProcessedDetail
+        )
+      )
+    )
+
+    val requestsDetails = HolidayStopSubscriptionCancellation(cancellationDate, holidayStopRequests)
+
+    requestsDetails should contain allOf (
+      cancelableDetail1.copy(
+        Actual_Price__c = Some(HolidayStopRequestsDetailChargePrice(estimatedPrice)),
+        Charge_Code__c = Some(HolidayStopRequestsDetailChargeCode("ManualRefund_Cancellation"))
+      ),
+        cancelableDetail2.copy(
+          Actual_Price__c = Some(HolidayStopRequestsDetailChargePrice(estimatedPrice)),
+          Charge_Code__c = Some(HolidayStopRequestsDetailChargeCode("ManualRefund_Cancellation"))
+        )
+    )
+  }
+
+  private def testDetail(date: LocalDate, chargeCode: Option[String], estimatedPrice: Double) = {
+    val cancelableDetail1 = Fixtures.mkHolidayStopRequestDetails(
+      estimatedPrice = Some(estimatedPrice),
+      actualPrice = None,
+      chargeCode = chargeCode,
+      stopDate = date
+    )
+    cancelableDetail1
+  }
+}

--- a/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
@@ -25,4 +25,12 @@ object SFTestEffects {
     ),
       HTTPResponse(200, authSuccessResponseBody)
   )
+
+  def cancelSuccess(referenceId: String, price: Double) = (
+    POSTRequest(
+      "/services/data/v38.0/composite/",
+      s"""{"allOrNone":true,"compositeRequest":[{"method":"PATCH","url":"/services/data/v29.0/sobjects/Holiday_Stop_Requests_Detail__c/HSD-1","referenceId":"CANCEL DETAIL : $referenceId","body":{"Actual_Price__c":$price,"Charge_Code__c":"ManualRefund_Cancellation"}}]}"""
+    ),
+      HTTPResponse(200, """{ "compositeResponse" : []}""".stripMargin)
+  )
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -326,13 +326,16 @@ object SalesforceHolidayStopRequest extends Logging {
       }.runRequest
 
 
-    def buildBody(holidayStopRequestsDetails: List[HolidayStopRequestsDetail]): CompositeRequest = {
+    def buildBody(
+      holidayStopRequestsDetails: List[HolidayStopRequestsDetail],
+      idGenerator: => String
+    ): CompositeRequest = {
       val requestDetailParts = holidayStopRequestsDetails
         .map { requestDetail =>
           CompositePart(
             "PATCH",
             s"$holidayStopRequestsDetailSfObjectsBaseUrl/${requestDetail.Id.value}",
-            "CANCEL DETAIL : " + UUID.randomUUID().toString,
+            "CANCEL DETAIL : " + idGenerator,
             Json.toJson(CancelHolidayStopRequestDetailBody(requestDetail.Actual_Price__c, requestDetail.Charge_Code__c))
           )
         }

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -313,6 +313,36 @@ object SalesforceHolidayStopRequest extends Logging {
 
   }
 
+  object CancelHolidayStopRequestDetail {
+    implicit val cancelHolidayStopRequestDetailBodyReads = Json.writes[CancelHolidayStopRequestDetailBody]
+    final case class CancelHolidayStopRequestDetailBody (
+      Actual_Price__c: Option[HolidayStopRequestsDetailChargePrice],
+      Charge_Code__c: Option[HolidayStopRequestsDetailChargeCode]
+    )
+
+    def apply(sfPost: HttpOp[RestRequestMaker.PostRequest, JsValue]): CompositeRequest => ClientFailableOp[JsValue] =
+      sfPost.setupRequest[CompositeRequest] { cancelHolidayStopRequestsWithDetail =>
+        PostRequest(cancelHolidayStopRequestsWithDetail, RelativePath(compositeBaseUrl))
+      }.runRequest
+
+
+    def buildBody(holidayStopRequestsDetails: List[HolidayStopRequestsDetail]): CompositeRequest = {
+      val requestDetailParts = holidayStopRequestsDetails
+        .map { requestDetail =>
+          CompositePart(
+            "PATCH",
+            s"$holidayStopRequestsDetailSfObjectsBaseUrl/${requestDetail.Id.value}",
+            "CANCEL DETAIL : " + UUID.randomUUID().toString,
+            Json.toJson(CancelHolidayStopRequestDetailBody(requestDetail.Actual_Price__c, requestDetail.Charge_Code__c))
+          )
+        }
+      CompositeRequest(
+        allOrNone = true,
+        requestDetailParts
+      )
+    }
+  }
+
   private def getStoppedProductAndLogFailure(zuoraSubscription: Subscription, stoppedPublicationDate: LocalDate) = {
     StoppedProduct(zuoraSubscription, StoppedPublicationDate(stoppedPublicationDate))
       .fold(

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
@@ -17,6 +17,7 @@ import acyclic.skipped
 object SalesforceHolidayStopRequestsDetail extends Logging {
 
   val holidayStopRequestsDetailSfObjectRef = "Holiday_Stop_Requests_Detail__c"
+  val holidayStopRequestsDetailSfObjectsBaseUrl = sfObjectsBaseUrl + holidayStopRequestsDetailSfObjectRef
 
   case class HolidayStopRequestsDetailId(value: String) extends AnyVal
   implicit val formatHolidayStopRequestsDetailId = Jsonx.formatInline[HolidayStopRequestsDetailId]

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -280,7 +280,7 @@ object Fixtures extends Assertions {
     subscriptionName: String = "Subscription 1",
     productName: String = "Product 1",
     stopDate: LocalDate = LocalDate.of(2019, 1, 1),
-    chargeCode: String = "Charge code 1",
+    chargeCode: Option[String] = Some("Charge code 1"),
     estimatedPrice: Option[Double] = None,
     actualPrice: Option[Double] = None,
     expectedInvoiceDate: Option[LocalDate] = None
@@ -291,7 +291,7 @@ object Fixtures extends Assertions {
       Product_Name__c = ProductName(productName),
       Stopped_Publication_Date__c = StoppedPublicationDate(stopDate),
       Estimated_Price__c = estimatedPrice.map(HolidayStopRequestsDetailChargePrice.apply),
-      Charge_Code__c = Some(HolidayStopRequestsDetailChargeCode(chargeCode)),
+      Charge_Code__c = chargeCode.map(HolidayStopRequestsDetailChargeCode.apply),
       Actual_Price__c = actualPrice.map(HolidayStopRequestsDetailChargePrice.apply),
       Expected_Invoice_Date__c = expectedInvoiceDate.map(HolidayStopRequestsDetailExpectedInvoiceDate.apply)
     )


### PR DESCRIPTION
This PR adds the holiday stops cancelation endpoint.

This endpoint applies the logic to update existing holiday stops in the event that the subscription is canceled.

The CSR will have the option to refund the user for holiday stops that have already been booked as the will not be credited during the normal operation of the holiday stops processor, because updates can no longer be made to zuora for that sub and the user may not have another bill for credits to be applied to.

In this case this endpoint will update unprocessed holiday stops details that are for stops before the cancelation date. 

Setting the charge code to 'ManualRefund_Cancellation' and the actual price to the estimated price. 

This supports reporting on the amount of money refunded in the case of holiday stops cancelation and in the event of the sub being uncanceled will prevent the processor issuing  double money back.

If the CSR does not issue a refund then this endpoint should not be called, in this case the processor will ignore the holiday stops due to the subscription being canceled and no credit will be applied.