### PR TITLE
Adding endpoint to get holiday stops affected by cancellation.

### DIFF
--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -16,6 +16,7 @@ All endpoints require...
 | PATCH | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | with the same body as create endpoint above, amends the holiday stop request (where holiday stop request `Id` matches `{SF_ID}`) to the newly specified dates and adds/removes the underlying detail records where appropriate |
 | DELETE | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | marks the holiday stop request as 'withdrawn' in SalesForce (specifically; placing timestamp in `Withdrawn_Time__c` field) (where holiday stop request `Id` matches `{SF_ID}`) |
 | POST | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/cancel?effectiveCancellationDate=yyyy-MM-dd` | handles processing of holiday stops when a subscription is cancelled, unprocessed holiday stops before the effectiveCancellationDate will be marked with a charge code "ManualRefund_Cancellation" for reporting purposes.  This should only be called if the customer was refunded for holiday stops that fall in the cancellation period, otherwise no changes should be made to existing holiday stops. |
+| GET | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/cancel?effectiveCancellationDate=yyyy-MM-dd` | returns details of existing holiday stops that should be manually refunded if a subscription is canceled. This includes unprocessed holiday stops for dates before the cancellation date defined by the effectiveCancellationDate query string parameter. |
 
 
 ### Handling Multiple Environments

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -282,7 +282,7 @@ Resources:
         ApiKeyRequired: true
         RestApiId: !Ref HolidayStopApi
         ResourceId: !Ref HolidayStopApiCancelResource
-        HttpMethod: Get
+        HttpMethod: GET
         RequestParameters:
           method.request.path.subscriptionName: true
         Integration:

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -275,6 +275,25 @@ Resources:
         - HolidayStopApiLambda
         - HolidayStopApiCancelResource
 
+    HolidayStopApiCancelGetMethod:
+      Type: AWS::ApiGateway::Method
+      Properties:
+        AuthorizationType: NONE
+        ApiKeyRequired: true
+        RestApiId: !Ref HolidayStopApi
+        ResourceId: !Ref HolidayStopApiCancelResource
+        HttpMethod: Get
+        RequestParameters:
+          method.request.path.subscriptionName: true
+        Integration:
+          Type: AWS_PROXY
+          IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
+          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HolidayStopApiLambda.Arn}/invocations
+      DependsOn:
+        - HolidayStopApi
+        - HolidayStopApiLambda
+        - HolidayStopApiCancelResource
+
     HolidayStopApiEditMethod:
       Type: AWS::ApiGateway::Method
       Properties:
@@ -309,6 +328,7 @@ Resources:
         - HolidayStopApiDeleteMethod
         - HolidayStopApiEditMethod
         - HolidayStopApiCancelPostMethod
+        - HolidayStopApiCancelGetMethod
 
     HolidayStopApiDeployment:
         Type: AWS::ApiGateway::Deployment

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -280,10 +280,10 @@ class HandlerTest extends FlatSpec with Matchers {
         operation
           .steps(
             cancelHolidayStops(
-              "POST",
-              subscriptionName,
-              contactId,
-              effectiveCancellationDate
+              isPreview = false,
+              subscriptionName = subscriptionName,
+              sfContactId = contactId,
+              effectiveCancellationDate = effectiveCancellationDate
             )
           )
       }
@@ -337,10 +337,10 @@ class HandlerTest extends FlatSpec with Matchers {
         operation
           .steps(
             cancelHolidayStops(
-              "GET",
-              subscriptionName,
-              contactId,
-              effectiveCancellationDate
+              isPreview = true,
+              subscriptionName = subscriptionName,
+              sfContactId = contactId,
+              effectiveCancellationDate = effectiveCancellationDate
             )
           )
       }
@@ -413,7 +413,8 @@ class HandlerTest extends FlatSpec with Matchers {
     )
   }
 
-  private def cancelHolidayStops(method: String, subscriptionName: String, sfContactId: String, effectiveCancellationDate: LocalDate) = {
+  private def cancelHolidayStops(isPreview: Boolean, subscriptionName: String, sfContactId: String, effectiveCancellationDate: LocalDate) = {
+    val method = if(isPreview) "GET" else "POST"
     ApiGatewayRequest(
       Some(method),
       Some(Map(


### PR DESCRIPTION
This PR adds support to the /hsr/<sub>/cancel for GET requests.

This will generate a 'preview' of the holiday stops that will get updated during a POST to the same endpoint. For more details see:

https://github.com/guardian/support-service-lambdas/pull/471

This endpoint is intended to be used by the salesforce UI to display information to the CSR about how much to manually refund to the customer in compensation for holiday stops that have been created but will not be honoured because the holiday stop processor will not process cancelled subscriptions.