### PR TITLE
Adding new fields to Payment in zuora-datalake-export

### DIFF
--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -190,7 +190,7 @@ object Query extends Enum[Query] {
   )
   case object Payment extends Query(
     "Payment",
-    "SELECT EffectiveDate, Amount, Currency, Gateway, GatewayResponse, GatewayResponseCode, GatewayState, Status, SubmittedOn, ID, Account.ID FROM Payment",
+    "SELECT EffectiveDate, Amount, Currency, Gateway, GatewayResponse, GatewayResponseCode, GatewayState, Status, SubmittedOn, ID, Account.ID, AccountingCode, AppliedAmount, AppliedCreditBalanceAmount, AuthTransactionId, BankIdentificationNumber, CancelledOn, Comment, CreatedByID, CreatedDate, GatewayOrderID, MarkedForSubmissionOn, PaymentNumber, ReferencedPaymentID, ReferenceID, RefundAmount, SecondPaymentReferenceID, SettledOn, SoftDescriptor, SoftDescriptorPhone, Source, SourceName, TransferredtoAccounting, Type, UnappliedAmount, UpdatedByID, UpdatedDate, BillToContact.Id, DefaultPaymentMethod.Id, ParentAccount.Id, PaymentMethod.Id, PaymentMethodSnapshot.Id, SoldToContact.Id FROM Payment",
     "ophan-raw-zuora-increment-payment",
     "Payment.csv"
   )


### PR DESCRIPTION
Adding additional fields. The query additionally brings in the following fields:
```
Payment.AmountHomeCurrency,Payment.AmountCurrencyRounding,Payment.ExchangeRate,Payment.ExchangeRateDate,Payment.ProviderExchangeRateDate,Payment.HomeCurrency,Payment.TransactionCurrency
```
I had no problems with extracting the full dataset in one request from Zuora via Postman. 