### PR TITLE
Change first available date for Guardian Weekly holiday stops

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ActionCalculator.scala
@@ -72,8 +72,8 @@ object ActionCalculator {
     issueDayOfWeek = DayOfWeek.FRIDAY,
     processorRunLeadTimeDays = 8 + (1 /* safety-day */ ), //one (safety) day before the Thursday of the week before the Friday issue day
   ) {
-    val minDaysBetweenTodayAndFirstAvailableDate = 5
-    val maxDaysBetweenTodayAndFirstAvailableDate = 11
+    val minDaysBetweenTodayAndFirstAvailableDate = 4
+    val maxDaysBetweenTodayAndFirstAvailableDate = 10
     val firstAvailableDateDayOfWeek = DayOfWeek.SATURDAY
 
     /**

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/ActionCalculatorTest.scala
@@ -7,8 +7,6 @@ import com.gu.holiday_stops.ProductVariant._
 import org.scalatest.Inside.inside
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
-import scala.collection.immutable.ListMap
-
 class ActionCalculatorTest extends FlatSpec with Matchers with EitherValues {
 
   type Today = LocalDate
@@ -26,51 +24,56 @@ class ActionCalculatorTest extends FlatSpec with Matchers with EitherValues {
   }
 
   it should "calculate first available date for Guardian Weekly" in {
-    val gwTodayToFirstAvailableDate = ListMap[Today, FirstAvailableDate](
-      LocalDate.of(2019, 6, 1) -> LocalDate.of(2019, 6, 8), // first available on Sun
-      LocalDate.of(2019, 6, 2) -> LocalDate.of(2019, 6, 8), // first available on Sun
-      LocalDate.of(2019, 6, 3) -> LocalDate.of(2019, 6, 8), // first available on Sun
-      LocalDate.of(2019, 6, 4) -> LocalDate.of(2019, 6, 15), // jump on Tue, a day before processor run
-      LocalDate.of(2019, 6, 5) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6, 6) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6, 7) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6, 8) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6, 9) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6, 10) -> LocalDate.of(2019, 6, 15), // first available on Sun
-      LocalDate.of(2019, 6, 11) -> LocalDate.of(2019, 6, 22), // jump on Tue, a day before processor run
-      LocalDate.of(2019, 6, 12) -> LocalDate.of(2019, 6, 22), // first available on Sun
-      LocalDate.of(2019, 6, 13) -> LocalDate.of(2019, 6, 22), // first available on Sun
-      LocalDate.of(2019, 6, 14) -> LocalDate.of(2019, 6, 22), // first available on Sun
-      LocalDate.of(2019, 6, 15) -> LocalDate.of(2019, 6, 22), // first available on Sun
-      LocalDate.of(2019, 6, 16) -> LocalDate.of(2019, 6, 22), // first available on Sun
-      LocalDate.of(2019, 6, 17) -> LocalDate.of(2019, 6, 22), // first available on Sun
-      LocalDate.of(2019, 6, 18) -> LocalDate.of(2019, 6, 29), // jump on Tue, a day before processor run
-      LocalDate.of(2019, 6, 19) -> LocalDate.of(2019, 6, 29), // first available on Sun
-      LocalDate.of(2019, 6, 20) -> LocalDate.of(2019, 6, 29), // first available on Sun
-      LocalDate.of(2019, 6, 21) -> LocalDate.of(2019, 6, 29), // first available on Sun
-      LocalDate.of(2019, 6, 22) -> LocalDate.of(2019, 6, 29), // first available on Sun
-      LocalDate.of(2019, 6, 23) -> LocalDate.of(2019, 6, 29), // first available on Sun
-      LocalDate.of(2019, 6, 24) -> LocalDate.of(2019, 6, 29), // first available on Sun
-      LocalDate.of(2019, 6, 25) -> LocalDate.of(2019, 7, 6), // jump on Tue, a day before processor run
-      LocalDate.of(2019, 6, 26) -> LocalDate.of(2019, 7, 6), // first available on Sun
-      LocalDate.of(2019, 6, 27) -> LocalDate.of(2019, 7, 6), // first available on Sun
-      LocalDate.of(2019, 6, 28) -> LocalDate.of(2019, 7, 6), // first available on Sun
-      LocalDate.of(2019, 6, 29) -> LocalDate.of(2019, 7, 6), // first available on Sun
-      LocalDate.of(2019, 6, 30) -> LocalDate.of(2019, 7, 6), // first available on Sun
-      LocalDate.of(2019, 7, 1) -> LocalDate.of(2019, 7, 6), // first available on Sun
-      LocalDate.of(2019, 7, 2) -> LocalDate.of(2019, 7, 13) // jump on Tue, a day before processor run
+
+    case class TestDateRange(today: Today, expectedFirstAvailableDate: FirstAvailableDate, comment: String)
+
+    val gwTodayToFirstAvailableDate = List(
+      TestDateRange(LocalDate.of(2019, 6,  1), LocalDate.of(2019, 6,  8), "On a Saturday first available on next Sat"),
+      TestDateRange(LocalDate.of(2019, 6,  2), LocalDate.of(2019, 6,  8), "On a Sunday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6,  3), LocalDate.of(2019, 6,  8), "On a Monday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6,  4), LocalDate.of(2019, 6,  8), "On a Tuesday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6,  5), LocalDate.of(2019, 6, 15), "On a Wednesday, first available jumps to following Sat"),
+      TestDateRange(LocalDate.of(2019, 6,  6), LocalDate.of(2019, 6, 15), "On a Thursday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6,  7), LocalDate.of(2019, 6, 15), "On a Friday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6,  8), LocalDate.of(2019, 6, 15), "On a Saturday, first available on next Sat"),
+      TestDateRange(LocalDate.of(2019, 6,  9), LocalDate.of(2019, 6, 15), "On a Sunday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 10), LocalDate.of(2019, 6, 15), "On a Monday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 11), LocalDate.of(2019, 6, 15), "On a Tuesday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 12), LocalDate.of(2019, 6, 22), "On a Wednesday, first available jumps to following Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 13), LocalDate.of(2019, 6, 22), "On a Thursday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 14), LocalDate.of(2019, 6, 22), "On a Friday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 15), LocalDate.of(2019, 6, 22), "On a Saturday first available on next Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 16), LocalDate.of(2019, 6, 22), "On a Sunday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 17), LocalDate.of(2019, 6, 22), "On a Monday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 18), LocalDate.of(2019, 6, 22), "On a Tuesday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 19), LocalDate.of(2019, 6, 29), "On a Wednesday, first available jumps to following Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 20), LocalDate.of(2019, 6, 29), "On a Thursday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 21), LocalDate.of(2019, 6, 29), "On a Friday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 22), LocalDate.of(2019, 6, 29), "On a Saturday first available on next Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 23), LocalDate.of(2019, 6, 29), "On a Sunday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 24), LocalDate.of(2019, 6, 29), "On a Monday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 25), LocalDate.of(2019, 6, 29), "On a Tuesday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 26), LocalDate.of(2019, 7,  6), "On a Wednesday, first available jumps to following Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 27), LocalDate.of(2019, 7,  6), "On a Thursday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 28), LocalDate.of(2019, 7,  6), "On a Friday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 29), LocalDate.of(2019, 7,  6), "On a Saturday first available on next Sat"),
+      TestDateRange(LocalDate.of(2019, 6, 30), LocalDate.of(2019, 7,  6), "On a Sunday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 7,  1), LocalDate.of(2019, 7,  6), "On a Monday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 7,  2), LocalDate.of(2019, 7,  6), "On a Tuesday, first available on Sat"),
+      TestDateRange(LocalDate.of(2019, 7,  3), LocalDate.of(2019, 7,  13), "On a Wednesday, first available jumps to following Sat")
     )
     val subscription = Fixtures.mkGuardianWeeklySubscription(customerAcceptanceDate = LocalDate.of(2018, 6, 1))
 
     gwTodayToFirstAvailableDate foreach {
-      case (today, expected) =>
+      case TestDateRange(today, expected, comment) =>
         inside(ActionCalculator
           .getProductSpecificsByProductVariant(
             GuardianWeekly,
             subscription,
             today
           )) {
-          case Right(ProductSpecifics(_, List(issueSpecifics))) => issueSpecifics.firstAvailableDate shouldEqual expected
+          case Right(ProductSpecifics(_, List(issueSpecifics))) =>
+            withClue(s"Expected: $comment.  Problem was ") { issueSpecifics.firstAvailableDate shouldEqual expected }
         }
     }
   }


### PR DESCRIPTION
We have reduced the lead time before a Guardian Weekly subscription can be suspended, so it's now possible to suspend the following week's issue at any time up to the end of the preceding Tuesday (GMT).

We had previously set the lead time so that you would have to wait at least 11 days from a Tuesday before being able to suspend a subscription to ensure that fulfilment was possible.  However, with hindsight that seems like an overly cautious decision.