### PR TITLE
Remove header logging from HTTP client

### DIFF
--- a/lib/effects/src/main/scala/com/gu/effects/Http.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/Http.scala
@@ -25,7 +25,7 @@ object Http extends Logging {
 
     { request: Request =>
       val maybeBodySummary = Option(request.body).map(bodySummary)
-      logger.info(s"HTTP request: ${request.method} ${request.url} headers ${request.headers}" + maybeBodySummary.map(summary => s", body:  $summary").getOrElse(""))
+      logger.info(s"HTTP request: ${request.method} ${request.url} " + maybeBodySummary.map(summary => s", body:  $summary").getOrElse(""))
       val response = restClient.newCall(request).execute
       logger.info(s"HTTP response: ${response.code}")
       response
@@ -38,7 +38,7 @@ object Http extends Logging {
       .build()
 
     { request: Request =>
-      logger.info(s"HTTP request: ${request.method} ${request.url} ${request.headers.toMultimap.size} headers")
+      logger.info(s"HTTP request: ${request.method} ${request.url} ${request.headers.toMultimap.size}")
       val response = restClient.newCall(request).execute
       logger.info(s"HTTP response: ${response.code}")
       response


### PR DESCRIPTION
In this PR I'm removing a log line that prints out the headers of a http request - Logging out the plain text headers is not always the best idea :) 