### PR TITLE
Process holiday stops on non-auto-renewable subscriptions

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Processor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Processor.scala
@@ -77,7 +77,6 @@ object Processor {
     for {
       subscription <- getSubscription(stop.subscriptionName)
       stoppedProduct <- StoppedProduct(subscription, StoppedPublicationDate(stop.stoppedPublicationDate))
-      _ <- if (subscription.autoRenew) Right(()) else Left(ZuoraHolidayError(s"Cannot currently process non-auto-renewing subscription '${subscription.subscriptionNumber}'"))
       _ <- if (subscription.status == "Cancelled") Left(ZuoraHolidayError(s"Cannot process cancelled subscription because Zuora does not allow amending cancelled subs (Code: 58730020). Apply manual refund ASAP! $stop; ${subscription.subscriptionNumber};")) else Right(())
       holidayCredit = stoppedProduct.credit
       maybeExtendedTerm = ExtendedTerm(holidayCredit.invoiceDate, subscription)

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/GuardianWeeklyHolidayStopProcessTest.scala
@@ -73,14 +73,18 @@ class GuardianWeeklyHolidayStopProcessTest extends FlatSpec with Matchers with E
     response.left.value shouldBe ZuoraHolidayError("get went wrong")
   }
 
-  it should "give an exception message if subscription isn't auto-renewing" in {
+  /*
+   * Non-auto-renewing holiday stops are blocked at the point of creation,
+   * but there is no harm in processing them nonetheless
+   * if they were created before the block was put in place.
+   */
+  it should "not give an exception message if subscription isn't auto-renewing" in {
     val response = Processor.writeHolidayStopToZuora(
       Fixtures.config,
-      _ => Right(subscription.copy(autoRenew = false)),
+      _ => Right(Fixtures.mkSubscriptionWithHolidayStops().copy(autoRenew = false)),
       updateSubscription(Right(()))
     )(holidayStop)
-    response.left.value shouldBe
-      ZuoraHolidayError("Cannot currently process non-auto-renewing subscription 'S1'")
+    response.isRight shouldBe true
   }
 
   it should "fail if subscription is cancelled" in {


### PR DESCRIPTION
The holiday-stop API generates estimated credits and invoice dates correctly for stops on non-auto-renewing subs using code shared with the holiday-stop processor.  So we can be confident that the processor is able to process these accurately as it uses the same logic.

The ability to create holiday stops on non-auto-renewing subs has already been disabled in Salesforce, and it will soon be disabled in self-serve as well.  So this change will only affect the ~ 20 stops on non-auto-renewing subs that have already been created through self-serve.