### PR TITLE
fixing holiday stop cancellation endpoints handling of processed stops

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellation.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellation.scala
@@ -24,7 +24,7 @@ object HolidayStopSubscriptionCancellation {
 
     allHolidayStopRequestDetails
       .collect {
-        case requestDetail if holidayStopShouldBeRefunded(
+        case requestDetail if holidayStopShouldBeManuallyRefunded(
           requestDetail,
           cancellationDate
         ) =>
@@ -38,7 +38,7 @@ object HolidayStopSubscriptionCancellation {
       }
   }
 
-  private def holidayStopShouldBeRefunded(
+  private def holidayStopShouldBeManuallyRefunded(
     holidayStop: SalesforceHolidayStopRequestsDetail.HolidayStopRequestsDetail,
     cancellationDate: LocalDate
   ) = {

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellationTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellationTest.scala
@@ -3,51 +3,100 @@ package com.gu.holiday_stops
 import java.time.LocalDate
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetailChargeCode, HolidayStopRequestsDetailChargePrice}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Inside, Matchers}
 
 class HolidayStopSubscriptionCancellationTest extends FlatSpec with Matchers {
-  "HolidayStopSubscriptionCancellationTest" should "return unprocessed holiday stops before cancellation" in {
-    val estimatedPrice = 1.23
+  val estimatedPrice = 1.23
 
-    val cancellationDate = LocalDate.now().plusMonths(1)
-    val cancelableDetail1 = testDetail(cancellationDate.minusDays(1), None, estimatedPrice)
-    val cancelableDetail2 = testDetail(cancellationDate, None, estimatedPrice)
-    val afterCancellationDateDetail = testDetail(cancellationDate.plusDays(1), None, estimatedPrice)
-    val allReadyProcessedDetail = testDetail(cancellationDate.minusDays(10), Some("ChargeCode-1111"), estimatedPrice)
+  val cancellationDate = LocalDate.now()
+  val dateBeforeCancellation = cancellationDate.minusDays(1)
+  val dateAfterCancellation = cancellationDate.plusDays(1)
+
+  "HolidayStopSubscriptionCancellationTest" should "return only unprocessed holiday stops before cancellation date" in {
+
+    val unprocessedStopForDateBeforeCancellation =
+      testDetail(dateBeforeCancellation, None, estimatedPrice, Some(cancellationDate))
+    val unprocessedStopForDateOnCancellation =
+      testDetail(cancellationDate, None, estimatedPrice, Some(cancellationDate))
+    val unprocessedStopForDateAfterCancellation =
+      testDetail(dateAfterCancellation, None, estimatedPrice, Some(cancellationDate))
 
     val holidayStopRequests = List(
       Fixtures.mkHolidayStopRequest(
         "id",
         requestDetail = List(
-          cancelableDetail1,
-          cancelableDetail2,
-          afterCancellationDateDetail,
-          allReadyProcessedDetail
+          unprocessedStopForDateBeforeCancellation,
+          unprocessedStopForDateOnCancellation,
+          unprocessedStopForDateAfterCancellation
         )
       )
     )
 
-    val requestsDetails = HolidayStopSubscriptionCancellation(cancellationDate, holidayStopRequests)
-
-    requestsDetails should contain allOf (
-      cancelableDetail1.copy(
+    HolidayStopSubscriptionCancellation(cancellationDate, holidayStopRequests) should contain only(
+      unprocessedStopForDateBeforeCancellation.copy(
         Actual_Price__c = Some(HolidayStopRequestsDetailChargePrice(estimatedPrice)),
         Charge_Code__c = Some(HolidayStopRequestsDetailChargeCode("ManualRefund_Cancellation"))
-      ),
-        cancelableDetail2.copy(
-          Actual_Price__c = Some(HolidayStopRequestsDetailChargePrice(estimatedPrice)),
-          Charge_Code__c = Some(HolidayStopRequestsDetailChargeCode("ManualRefund_Cancellation"))
+      )
+    )
+  }
+  it should "return holiday processed stops with refund date after cancellation date" in {
+
+    val processedExpectedRefundedBeforeCancellationDate = testDetail(
+      dateBeforeCancellation,
+      Some("ChargeCode-1111"),
+      estimatedPrice,
+      estimatedInvoiceDate = Some(dateBeforeCancellation)
+    )
+    val processedExpectedRefundedOnCancellationDate = testDetail(
+      dateBeforeCancellation,
+      Some("ChargeCode-1111"),
+      estimatedPrice,
+      estimatedInvoiceDate = Some(cancellationDate)
+    )
+    val processedExpectedRefundedAfterCancellationDate = testDetail(
+      dateBeforeCancellation,
+      Some("ChargeCode-1111"),
+      estimatedPrice,
+      estimatedInvoiceDate = Some(dateAfterCancellation)
+    )
+    val processedMissingExpectedRefundedDate = testDetail(
+      dateBeforeCancellation,
+      Some("ChargeCode-1111"),
+      estimatedPrice,
+      estimatedInvoiceDate = None
+    )
+    val holidayStopRequests = List(
+      Fixtures.mkHolidayStopRequest(
+        "id",
+        requestDetail = List(
+          processedMissingExpectedRefundedDate,
+          processedExpectedRefundedBeforeCancellationDate,
+          processedExpectedRefundedOnCancellationDate,
+          processedExpectedRefundedAfterCancellationDate
         )
+      )
+    )
+
+    HolidayStopSubscriptionCancellation(cancellationDate, holidayStopRequests) should contain only(
+      processedExpectedRefundedOnCancellationDate.copy(
+        Actual_Price__c = Some(HolidayStopRequestsDetailChargePrice(estimatedPrice)),
+      ),
+      processedExpectedRefundedAfterCancellationDate.copy(
+        Actual_Price__c = Some(HolidayStopRequestsDetailChargePrice(estimatedPrice)),
+      )
     )
   }
 
-  private def testDetail(date: LocalDate, chargeCode: Option[String], estimatedPrice: Double) = {
-    val cancelableDetail1 = Fixtures.mkHolidayStopRequestDetails(
+  private def testDetail(stopDate: LocalDate,
+                         chargeCode: Option[String],
+                         estimatedPrice: Double,
+                         estimatedInvoiceDate: Option[LocalDate]) = {
+    Fixtures.mkHolidayStopRequestDetails(
       estimatedPrice = Some(estimatedPrice),
       actualPrice = None,
       chargeCode = chargeCode,
-      stopDate = date
+      stopDate = stopDate,
+      expectedInvoiceDate = estimatedInvoiceDate
     )
-    cancelableDetail1
   }
 }

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellationTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HolidayStopSubscriptionCancellationTest.scala
@@ -12,7 +12,7 @@ class HolidayStopSubscriptionCancellationTest extends FlatSpec with Matchers {
   val dateBeforeCancellation = cancellationDate.minusDays(1)
   val dateAfterCancellation = cancellationDate.plusDays(1)
 
-  "HolidayStopSubscriptionCancellationTest" should "return only unprocessed holiday stops before cancellation date" in {
+  "HolidayStopSubscriptionCancellationTest" should "return unprocessed holiday stops before cancellation date" in {
 
     val unprocessedStopForDateBeforeCancellation =
       testDetail(dateBeforeCancellation, None, estimatedPrice, Some(cancellationDate))
@@ -39,7 +39,7 @@ class HolidayStopSubscriptionCancellationTest extends FlatSpec with Matchers {
       )
     )
   }
-  it should "return holiday processed stops with refund date after cancellation date" in {
+  it should "return processed holiday stops with refund date after cancellation date" in {
 
     val processedExpectedRefundedBeforeCancellationDate = testDetail(
       dateBeforeCancellation,


### PR DESCRIPTION
This fixes the logic for selecting holiday stops that should be manually refunded when a subscription is canceled.

The existing logic excluded any stops that have already been processed by the holiday stop processor. 

This change takes account for the fact that a processed stop may not be automatically refunded to the customer if the bill that the refund is applied to is on or after the cancelation date.

For some examples of what happens to the billing schedules in Zuora when a subscription is canceled see the following screen shots:

[Sub A-S00052388 before cancelation](https://github.com/guardian/support-service-lambdas/files/3846348/A-S00052388-before-cancelation.pdf)

[Sub A-S00052388 cancelled on the first day of a billing cycle 22-02-2020 (holiday stops from previous cycle are NOT refunded)](https://github.com/guardian/support-service-lambdas/files/3846347/A-S00052388-after-canel-22-02-2020.pdf)

[Sub A-S00052389 before cancelation](https://github.com/guardian/support-service-lambdas/files/3846350/A-S00052389-before-cancelation.pdf)

[Sub A-S00052389 cancelled on the second day of billing cycle 23-02-2020 (holiday stops from previous cycle ARE refunded)](https://github.com/guardian/support-service-lambdas/files/3846447/A-S00052389-after-cancelation-23-02-2020.pdf)
