### PR TITLE
add new rate plan charge fields

### DIFF
--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -141,7 +141,7 @@ object Query extends Enum[Query] {
   )
   case object RatePlanCharge extends Query(
     "RatePlanCharge",
-    "SELECT Account.ID, EffectiveStartDate, EffectiveEndDate, HolidayStart__c, HolidayEnd__c, ID, MRR,Name, TCV, Version, BillingPeriod, ProcessedThroughDate, ChargedThroughDate, Product.Name, RatePlan.ID, RatePlan.Name, Subscription.ID, ProductRatePlanCharge.BillingPeriod FROM RatePlanCharge",
+    "SELECT Account.ID, EffectiveStartDate, EffectiveEndDate, HolidayStart__c, HolidayEnd__c, ID, MRR,Name, TCV, Version, BillingPeriod, ProcessedThroughDate, ChargedThroughDate, Product.Name, RatePlan.ID, RatePlan.Name, Subscription.ID, ProductRatePlanCharge.BillingPeriod, AccountingCode, ApplyDiscountTo, BillCycleDay, BillCycleType, BillingPeriodAlignment, BillingTiming, ChargeModel, ChargeNumber, ChargeType, CreatedById, CreatedDate, Description, DiscountLevel, DTCV, ForceSync__c, IsLastSegment, ListPriceBase, NumberofPeriods, OriginalID, OverageCalculationOption, OverageUnusedUnitsCreditOption, PriceChangeOption, PriceIncreasePercentage, Quantity, RatingGroup, RevenueRecognitionRuleName, RevRecCode, RevRecTriggerCondition, Segment, SpecificBillingPeriod, SpecificEndDate, TriggerDate, TriggerEvent, UOM, UpdatedByID, UpdatedDate, UpToPeriods, UpToPeriodsType, WeeklyBillCycleDay, Amendment.ID, BillToContact.ID, DefaultPaymentMethod.ID, ParentAccount.ID, Product.ID, ProductRatePlan.ID, ProductRatePlanCharge.ID, SoldToContact.ID FROM RatePlanCharge",
     "ophan-raw-zuora-increment-rateplancharge",
     "RatePlanCharge.csv"
   )


### PR DESCRIPTION
Recreates this this reverted PR to add extra needed fields to RatePlanCharge: https://github.com/guardian/support-service-lambdas/pull/480

This was reverted because of a ophan-datalake bug which is fixed here: https://github.com/guardian/ophan-data-lake/pull/4709