### PR TITLE
holiday-stop-api : safely handle Salesforce 'composite' requests

### DIFF
--- a/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
@@ -31,6 +31,6 @@ object SFTestEffects {
       "/services/data/v38.0/composite/",
       s"""{"allOrNone":true,"compositeRequest":[{"method":"PATCH","url":"/services/data/v29.0/sobjects/Holiday_Stop_Requests_Detail__c/HSD-1","referenceId":"CANCEL DETAIL : $referenceId","body":{"Actual_Price__c":$price,"Charge_Code__c":"ManualRefund_Cancellation"}}]}"""
     ),
-      HTTPResponse(200, """{ "compositeResponse" : []}""".stripMargin)
+      HTTPResponse(200, """{ "compositeResponse" : [ { "httpStatusCode": 200 } ]}""".stripMargin)
   )
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -7,13 +7,15 @@ import java.util.UUID
 import ai.x.play.json.Jsonx
 import com.gu.holiday_stops.subscription.{StoppedProduct, Subscription}
 import com.gu.salesforce.RecordsWrapperCaseClass
+import com.gu.salesforce.SalesforceClient.SalesforceErrorResponseBody
 import com.gu.salesforce.SalesforceConstants._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
 import com.gu.salesforce.holiday_stops.SalesforceSFSubscription.SubscriptionForSubscriptionNameAndContact._
 import com.gu.util.Logging
+import com.gu.util.resthttp.HttpOp.HttpOpWrapper
 import com.gu.util.resthttp.RestOp._
 import com.gu.util.resthttp.RestRequestMaker._
-import com.gu.util.resthttp.Types.ClientFailableOp
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, CustomError}
 import com.gu.util.resthttp.{HttpOp, RestRequestMaker}
 import play.api.libs.json._
 
@@ -234,12 +236,44 @@ object SalesforceHolidayStopRequest extends Logging {
   )
   implicit val writesCompositeRequest = Json.writes[CompositeRequest]
 
+  case class CompositeResponsePart (
+    httpStatusCode: Int,
+    body: Option[JsValue]
+  )
+  implicit val readsCompositeResponsePart = Json.reads[CompositeResponsePart]
+  case class CompositeResponse (
+    compositeResponse: List[CompositeResponsePart]
+  )
+  implicit val readsCompositeResponse = Json.reads[CompositeResponse]
+
+  lazy val successStatusCodes = 200 to 299
+
+  val safeSalesforceCompositeRequest = HttpOpWrapper[CompositeRequest, PostRequest, CompositeResponse, CompositeResponse](
+    (requestBody: CompositeRequest) => PostRequest(requestBody, RelativePath(compositeBaseUrl)),
+    // this is necessary because for some bizarre reason composite requests return a 200 even if the sub-requests fail
+    // see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/requests_composite.htm
+    (response: CompositeResponse) => {
+      val failures = response.compositeResponse
+        .filter(resp => !successStatusCodes.contains(resp.httpStatusCode))
+      if(failures.isEmpty) {
+        ClientSuccess(response)
+      } else {
+        logger.error(response.toString)
+        val failuresStr: String = failures
+          .flatMap(_.body.map(_.validate[List[SalesforceErrorResponseBody]].asOpt)).flatten
+          .mkString(", ")
+        CustomError(s"MULTIPLE ERRORS : ${failuresStr.take(500)}${if (failuresStr.length > 500) "..." else "" }")
+      }
+    }
+  )
+
   object AmendHolidayStopRequest {
 
-    def apply(sfPost: HttpOp[RestRequestMaker.PostRequest, JsValue]): CompositeRequest => ClientFailableOp[JsValue] =
-      sfPost.setupRequest[CompositeRequest] { amendHolidayStopRequestWithDetail =>
-        PostRequest(amendHolidayStopRequestWithDetail, RelativePath(compositeBaseUrl))
-      }.runRequest
+    def apply(sfPost: HttpOp[RestRequestMaker.PostRequest, JsValue]): CompositeRequest => ClientFailableOp[CompositeResponse] =
+      sfPost
+        .parse[CompositeResponse]
+        .wrapWith(safeSalesforceCompositeRequest)
+        .runRequest
 
     case class AmendHolidayStopRequestItselfBody (
       Start_Date__c: HolidayStopRequestStartDate,
@@ -320,10 +354,11 @@ object SalesforceHolidayStopRequest extends Logging {
       Charge_Code__c: Option[HolidayStopRequestsDetailChargeCode]
     )
 
-    def apply(sfPost: HttpOp[RestRequestMaker.PostRequest, JsValue]): CompositeRequest => ClientFailableOp[JsValue] =
-      sfPost.setupRequest[CompositeRequest] { cancelHolidayStopRequestsWithDetail =>
-        PostRequest(cancelHolidayStopRequestsWithDetail, RelativePath(compositeBaseUrl))
-      }.runRequest
+    def apply(sfPost: HttpOp[RestRequestMaker.PostRequest, JsValue]): CompositeRequest => ClientFailableOp[CompositeResponse] =
+      sfPost
+        .parse[CompositeResponse]
+        .wrapWith(safeSalesforceCompositeRequest)
+        .runRequest
 
 
     def buildBody(


### PR DESCRIPTION
### Background
So it turns out that despite having `allOrNone: true` on our `composite` requests to Salesforce it will still return a 200 even if some/all of the sub-requests fail, which is **subtly** documented...
![image](https://user-images.githubusercontent.com/19289579/69956668-855b0080-14f8-11ea-840b-bf3009aa9344.png)
https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/requests_composite.htm

### The FIX

- Introduced new case classes for reading the `CompositeResponse`
- via a new `HttpOpWrapper` added via `wrapWith` on the response we detect if any of the sub-responses have non-success status codes, if so it logs the response and returns a `CustomError` with the error message(s) collated (and truncated if long) - which is delivered as a 500 from the API Gateway
