### PR TITLE
Bump play-json lib to 2.8.0

### DIFF
--- a/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/GetJobResult.scala
+++ b/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/GetJobResult.scala
@@ -53,9 +53,24 @@ sealed trait JobResult {
   def tries: Int
 }
 
-case class Completed(name: String, jobId: String, batches: Seq[Batch], dryRun: Boolean, tries: Int) extends JobResult
+case class Completed(name: String, jobId: String, batches: Seq[Batch], dryRun: Boolean, tries: Int)
+  extends JobResult
+
+object Completed {
+  implicit val writes: Writes[Completed] = result => {
+    val wireResult = JobResultWire.fromJobResult(result)
+    JobResultWire.writes.writes(wireResult)
+  }
+}
 
 case class Pending(name: String, jobId: String, dryRun: Boolean, tries: Int) extends JobResult
+
+object Pending {
+  implicit val writes: Writes[Pending] = result => {
+    val wireResult = JobResultWire.fromJobResult(result)
+    JobResultWire.writes.writes(wireResult)
+  }
+}
 
 case class JobResultWire(
   name: String,
@@ -83,4 +98,3 @@ object JobResult {
     }
   }
 }
-

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   )
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.18"
-  val playJson = "com.typesafe.play" %% "play-json" % "2.6.9"
+  val playJson = "com.typesafe.play" %% "play-json" % "2.8.0"
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.30.1"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.0" % Test


### PR DESCRIPTION
Following recommendation from Snyk.

This update requires a `Writes` for each of the implementations of `JobResult`.  I'm not sure why this is required now but wasn't before.  