### PR TITLE
Remove redundant reference to play-json lib

### DIFF
--- a/root.sbt
+++ b/root.sbt
@@ -18,7 +18,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.squareup.okhttp3" % "okhttp" % "3.9.1",
   "org.scalaz" %% "scalaz-core" % "7.2.18",
-  "com.typesafe.play" %% "play-json" % "2.6.9",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "com.stripe" % "stripe-java" % "5.28.0",
   jacksonDatabind


### PR DESCRIPTION
Following on from #509 

As far as I can tell this dependency in `root.sbt` isn't being used.