### PR TITLE
fulfilment-data-calculator: add DEV as a valid Stage

### DIFF
--- a/handlers/fulfilment-date-calculator/cfn.yaml
+++ b/handlers/fulfilment-date-calculator/cfn.yaml
@@ -7,6 +7,7 @@ Parameters:
     Description: Stage name
     Type: String
     AllowedValues:
+      - DEV
       - CODE
       - PROD
     Default: CODE
@@ -16,6 +17,8 @@ Conditions:
 
 Mappings:
   StageMap:
+    DEV:
+      bucketName: "fulfilment-date-calculator-dev"
     CODE:
       bucketName: "fulfilment-date-calculator-code"
     PROD:


### PR DESCRIPTION
We need a `DEV` instance of the stack when developing other applications locally, for example `manage-frontend`.