### PR TITLE
Add Home Delivery to fulfilment-dates-calculator

### DIFF
--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala
@@ -26,7 +26,7 @@ object GuardianWeeklyFulfilmentDates extends FulfilmentConstants(
       acquisitionsStartDate(today),
       deliveryAddressChangeEffectiveDate(today),
       holidayStopFirstAvailableDate(today),
-      finalFulfilmentFileGenerationDate(today),
+//      finalFulfilmentFileGenerationDate(today),
       nextAffectablePublicationDateOnFrontCover(today)
     )
 
@@ -61,11 +61,11 @@ object GuardianWeeklyFulfilmentDates extends FulfilmentConstants(
     today `with` nextFriday `with` nextFriday
   }
 
-  // When was the fulfilment file generated for the nextAffectablePublicationDateOnFrontCover
-  def finalFulfilmentFileGenerationDate(today: LocalDate): LocalDate = {
-    val previousThursday = TemporalAdjusters.previous(fulfilmentGenerationDayOfWeek)
-    nextAffectablePublicationDateOnFrontCover(today) `with` previousThursday `with` previousThursday
-  }
+//  // When was the fulfilment file generated for the nextAffectablePublicationDateOnFrontCover
+//  def finalFulfilmentFileGenerationDate(today: LocalDate): LocalDate = {
+//    val previousThursday = TemporalAdjusters.previous(fulfilmentGenerationDayOfWeek)
+//    nextAffectablePublicationDateOnFrontCover(today) `with` previousThursday `with` previousThursday
+//  }
 
 }
 

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
@@ -1,0 +1,75 @@
+package com.gu.supporter.fulfilment
+
+import java.time.{DayOfWeek, LocalDate}
+import DayOfWeek._
+
+object HomeDeliveryFulfilmentDates {
+  def apply(today: LocalDate, product: HomeDeliveryProduct): FulfilmentDates = {
+    FulfilmentDates(
+      today,
+      acquisitionsStartDate = effectiveDayByProduct(product, today),
+      deliveryAddressChangeEffectiveDate = effectiveDayByProduct(product, today),
+      holidayStopFirstAvailableDate = effectiveDayByProduct(product, today),
+      // finalFulfilmentFileGenerationDate = today, // TODO
+      nextAffectablePublicationDateOnFrontCover = effectiveDayByProduct(product, today)
+    )
+  }
+}
+
+sealed trait HomeDeliveryProduct
+case object Everyday extends HomeDeliveryProduct
+case object Sixday extends HomeDeliveryProduct
+case object Weekend extends HomeDeliveryProduct
+case object Saturday extends HomeDeliveryProduct
+case object Sunday extends HomeDeliveryProduct
+
+// Acq, Holiday & Address Change on Day
+// https://docs.google.com/spreadsheets/d/1aTQZPeCQHPbzcytS9Tdaci2ENI3eZBaIbSufeegWPe4/
+object effectiveDayByProduct {
+  def apply(product: HomeDeliveryProduct, today: LocalDate): LocalDate = {
+    val day = today.getDayOfWeek
+
+    (product, day) match {
+      case (Everyday, MONDAY) => today plusDays 3
+      case (Everyday, TUESDAY) => today plusDays 3
+      case (Everyday, WEDNESDAY) => today plusDays 3
+      case (Everyday, THURSDAY) => today plusDays 3
+      case (Everyday, FRIDAY) => today plusDays 4
+      case (Everyday, SATURDAY) => today plusDays 4
+      case (Everyday, SUNDAY) => today plusDays 3
+
+      case (Sixday, MONDAY) => today plusDays 3
+      case (Sixday, TUESDAY) => today plusDays 3
+      case (Sixday, WEDNESDAY) => today plusDays 3
+      case (Sixday, THURSDAY) => today plusDays 4
+      case (Sixday, FRIDAY) => today plusDays 4
+      case (Sixday, SATURDAY) => today plusDays 4
+      case (Sixday, SUNDAY) => today plusDays 3
+
+      case (Weekend, MONDAY) => today plusDays 5
+      case (Weekend, TUESDAY) => today plusDays 4
+      case (Weekend, WEDNESDAY) => today plusDays 3
+      case (Weekend, THURSDAY) => today plusDays 9
+      case (Weekend, FRIDAY) => today plusDays 8
+      case (Weekend, SATURDAY) => today plusDays 7
+      case (Weekend, SUNDAY) => today plusDays 6
+
+      case (Saturday, MONDAY) => today plusDays 5
+      case (Saturday, TUESDAY) => today plusDays 4
+      case (Saturday, WEDNESDAY) => today plusDays 3
+      case (Saturday, THURSDAY) => today plusDays 9
+      case (Saturday, FRIDAY) => today plusDays 8
+      case (Saturday, SATURDAY) => today plusDays 7
+      case (Saturday, SUNDAY) => today plusDays 6
+
+      case (Sunday, MONDAY) => today plusDays 6
+      case (Sunday, TUESDAY) => today plusDays 5
+      case (Sunday, WEDNESDAY) => today plusDays 4
+      case (Sunday, THURSDAY) => today plusDays 3
+      case (Sunday, FRIDAY) => today plusDays 9
+      case (Sunday, SATURDAY) => today plusDays 8
+      case (Sunday, SUNDAY) => today plusDays 7
+    }
+  }
+}
+

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/GuardianWeeklyFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/GuardianWeeklyFulfilmentDatesSpec.scala
@@ -1,6 +1,5 @@
 package com.gu.supporter.fulfilment
 
-import java.time.LocalDate
 import org.scalatest.{FlatSpec, Matchers}
 
 class GuardianWeeklyFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
@@ -64,18 +63,18 @@ class GuardianWeeklyFulfilmentDatesSpec extends FlatSpec with Matchers with Date
     GuardianWeeklyFulfilmentDates("2019-12-13").holidayStopFirstAvailableDate should equalDate("2019-12-21")
   }
 
-  it should "calculate finalFulfilmentFileGenerationDate" in {
-    GuardianWeeklyFulfilmentDates("2019-12-02").finalFulfilmentFileGenerationDate should equalDate("2019-12-05")
-    GuardianWeeklyFulfilmentDates("2019-12-03").finalFulfilmentFileGenerationDate should equalDate("2019-12-05")
-    GuardianWeeklyFulfilmentDates("2019-12-04").finalFulfilmentFileGenerationDate should equalDate("2019-12-05")
-    GuardianWeeklyFulfilmentDates("2019-12-05").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
-    GuardianWeeklyFulfilmentDates("2019-12-06").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
-    GuardianWeeklyFulfilmentDates("2019-12-07").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
-    GuardianWeeklyFulfilmentDates("2019-12-08").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
-    GuardianWeeklyFulfilmentDates("2019-12-09").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
-    GuardianWeeklyFulfilmentDates("2019-12-10").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
-    GuardianWeeklyFulfilmentDates("2019-12-11").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
-    GuardianWeeklyFulfilmentDates("2019-12-12").finalFulfilmentFileGenerationDate should equalDate("2019-12-19")
-    GuardianWeeklyFulfilmentDates("2019-12-13").finalFulfilmentFileGenerationDate should equalDate("2019-12-19")
-  }
+  //  it should "calculate finalFulfilmentFileGenerationDate" in {
+  //    GuardianWeeklyFulfilmentDates("2019-12-02").finalFulfilmentFileGenerationDate should equalDate("2019-12-05")
+  //    GuardianWeeklyFulfilmentDates("2019-12-03").finalFulfilmentFileGenerationDate should equalDate("2019-12-05")
+  //    GuardianWeeklyFulfilmentDates("2019-12-04").finalFulfilmentFileGenerationDate should equalDate("2019-12-05")
+  //    GuardianWeeklyFulfilmentDates("2019-12-05").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
+  //    GuardianWeeklyFulfilmentDates("2019-12-06").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
+  //    GuardianWeeklyFulfilmentDates("2019-12-07").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
+  //    GuardianWeeklyFulfilmentDates("2019-12-08").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
+  //    GuardianWeeklyFulfilmentDates("2019-12-09").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
+  //    GuardianWeeklyFulfilmentDates("2019-12-10").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
+  //    GuardianWeeklyFulfilmentDates("2019-12-11").finalFulfilmentFileGenerationDate should equalDate("2019-12-12")
+  //    GuardianWeeklyFulfilmentDates("2019-12-12").finalFulfilmentFileGenerationDate should equalDate("2019-12-19")
+  //    GuardianWeeklyFulfilmentDates("2019-12-13").finalFulfilmentFileGenerationDate should equalDate("2019-12-19")
+  //  }
 }

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
@@ -1,0 +1,20 @@
+package com.gu.supporter.fulfilment
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class HomeDeliveryFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
+  "Everyday" should "calculate fulfilment dates" in {
+    HomeDeliveryFulfilmentDates("2019-12-02", Everyday).deliveryAddressChangeEffectiveDate should equalDate("2019-12-05")
+    HomeDeliveryFulfilmentDates("2019-12-02", Everyday).holidayStopFirstAvailableDate should equalDate("2019-12-05")
+    HomeDeliveryFulfilmentDates("2019-12-02", Everyday).nextAffectablePublicationDateOnFrontCover should equalDate("2019-12-05")
+    HomeDeliveryFulfilmentDates("2019-12-02", Everyday).acquisitionsStartDate should equalDate("2019-12-05")
+  }
+
+  "Saturday" should "calculate fulfilment dates" in {
+    HomeDeliveryFulfilmentDates("2019-12-02", Saturday).deliveryAddressChangeEffectiveDate should equalDate("2019-12-07")
+    HomeDeliveryFulfilmentDates("2019-12-02", Saturday).holidayStopFirstAvailableDate should equalDate("2019-12-07")
+    HomeDeliveryFulfilmentDates("2019-12-02", Saturday).nextAffectablePublicationDateOnFrontCover should equalDate("2019-12-07")
+    HomeDeliveryFulfilmentDates("2019-12-02", Saturday).acquisitionsStartDate should equalDate("2019-12-07")
+  }
+
+}


### PR DESCRIPTION
This implementation is on the basis of https://docs.google.com/spreadsheets/d/1aTQZPeCQHPbzcytS9Tdaci2ENI3eZBaIbSufeegWPe4

It generates file such as `fulfilment-dates-calculator-code/Weekend/2019-12-06_Weekend.json`

It does not handle echo plans. We will try to address them in subsequent PR.