### PR TITLE
fulfilment-date-calculator: scheduled in ALL environments/stages (not just PROD)

### DIFF
--- a/handlers/fulfilment-date-calculator/cfn.yaml
+++ b/handlers/fulfilment-date-calculator/cfn.yaml
@@ -97,7 +97,6 @@ Resources:
 
   FulfilmentDateCalculatorLambdaTriggerRule:
     Type: AWS::Events::Rule
-    Condition: IsProd
     Properties:
       Description: Trigger fulfilment-date-calculator lambda every day at 00:30 AM UTC
       ScheduleExpression: cron(30 0 * * ? *)
@@ -110,7 +109,6 @@ Resources:
 
   FulfilmentDateCalculatorLambdaTriggerPermission:
     Type: AWS::Lambda::Permission
-    Condition: IsProd
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Sub ${FulfilmentDateCalculatorLambda.Arn}


### PR DESCRIPTION
During local development of the consumers (e.g. manage-frontend - see https://github.com/guardian/manage-frontend/pull/338) its useful to have the files in the corresponding Stage, without having to manually kick off the lambda.