### PR TITLE
using zuora "product type" to generate paths for fulfilment date files

### DIFF
--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/ZuoraProductTypes.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/ZuoraProductTypes.scala
@@ -1,0 +1,10 @@
+package com.gu.supporter.fulfilment
+
+object ZuoraProductTypes {
+  sealed case class ZuoraProductType(name: String)
+
+  object NewspaperHomeDelivery extends ZuoraProductType("Newspaper - Home Delivery")
+  object NewspaperVoucherBook extends ZuoraProductType("Newspaper - Voucher Book")
+  object GuardianWeekly extends ZuoraProductType("Guardian Weekly")
+}
+


### PR DESCRIPTION
This changes the path generation of fulfilment date files so they are written to paths based on the  zuora product type. 

eg:
```
s3://fulfilment-date-calculator-dev/Newspaper - Home Delivery/2019-12-11_Newspaper - Home Delivery.json
```
This avoid clients which have access to the zuora subscription from needing to store mappings from the product type to the identifiers used in these paths. 