### PR TITLE
fulfilment-date-calculator: remove acquisitionsStartDate for the time being

### DIFF
--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/FulfilmentDateCalculator.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/FulfilmentDateCalculator.scala
@@ -16,7 +16,7 @@ import io.circe.syntax._
 
 case class FulfilmentDates(
   today: LocalDate,
-  acquisitionsStartDate: LocalDate,
+  // acquisitionsStartDate: LocalDate, FIXME reinstate when we officially support this feature
   deliveryAddressChangeEffectiveDate: LocalDate,
   holidayStopFirstAvailableDate: LocalDate,
   finalFulfilmentFileGenerationDate: LocalDate,

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala
@@ -22,7 +22,6 @@ object GuardianWeeklyFulfilmentDates extends FulfilmentConstants(
   def apply(today: LocalDate): FulfilmentDates =
     FulfilmentDates(
       today,
-      acquisitionsStartDate(today),
       deliveryAddressChangeEffectiveDate(today),
       holidayStopFirstAvailableDate(today),
       finalFulfilmentFileGenerationDate(today),
@@ -43,7 +42,6 @@ object GuardianWeeklyFulfilmentDates extends FulfilmentConstants(
   def deliveryAddressChangeEffectiveDate(today: LocalDate): LocalDate =
     nextAffectablePublicationDateOnFrontCover(today)
 
-  // TODO: Take into account bank holidays
   def nextAffectablePublicationDateOnFrontCover(today: LocalDate): LocalDate = {
     val nextFriday = TemporalAdjusters.next(issueDayOfWeek)
 
@@ -55,10 +53,11 @@ object GuardianWeeklyFulfilmentDates extends FulfilmentConstants(
       (today `with` nextFriday `with` nextFriday)
   }
 
-  def acquisitionsStartDate(today: LocalDate): LocalDate = {
-    val nextFriday = TemporalAdjusters.next(issueDayOfWeek)
-    today `with` nextFriday `with` nextFriday
-  }
+//  FIXME reinstate when we officially support this feature
+//  def acquisitionsStartDate(today: LocalDate): LocalDate = {
+//    val nextFriday = TemporalAdjusters.next(issueDayOfWeek)
+//    today `with` nextFriday `with` nextFriday
+//  }
 
   // When was the fulfilment file generated for the nextAffectablePublicationDateOnFrontCover
   def finalFulfilmentFileGenerationDate(today: LocalDate): LocalDate = {

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
@@ -14,7 +14,6 @@ object HomeDeliveryFulfilmentDates {
     List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(targetDayOfWeek =>
       targetDayOfWeek.getDisplayName(FULL, ENGLISH) -> FulfilmentDates(
         today,
-        acquisitionsStartDate = nextAffectablePublicationDateOnFrontCover(targetDayOfWeek, today), //TODO
         deliveryAddressChangeEffectiveDate(targetDayOfWeek, today),
         holidayStopFirstAvailableDate = nextAffectablePublicationDateOnFrontCover(targetDayOfWeek, today), //TODO
         finalFulfilmentFileGenerationDate(targetDayOfWeek, today),


### PR DESCRIPTION
just adding complexity before subs team get round to using it