### PR TITLE
fulfilment-date-calculator: day keys in home delivery file now in correct order

### DIFF
--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
@@ -8,16 +8,20 @@ import java.util.Locale.ENGLISH
 
 import com.gu.supporter.fulfilment.LocalDateHelpers.LocalDateWithWorkingDaySupport
 
+import scala.collection.immutable.ListMap
+
 object HomeDeliveryFulfilmentDates {
 
-  def apply(today: LocalDate)(implicit bankHolidays: BankHolidays): Map[String, FulfilmentDates] =
-    List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(targetDayOfWeek =>
-      targetDayOfWeek.getDisplayName(FULL, ENGLISH) -> FulfilmentDates(
-        today,
-        deliveryAddressChangeEffectiveDate(targetDayOfWeek, today),
-        holidayStopFirstAvailableDate(targetDayOfWeek, today),
-        finalFulfilmentFileGenerationDate(targetDayOfWeek, today)
-      )).toMap
+  def apply(today: LocalDate)(implicit bankHolidays: BankHolidays): ListMap[String, FulfilmentDates] =
+    ListMap( // to preserve insertion order, so the file is easier to read
+      List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(targetDayOfWeek =>
+        targetDayOfWeek.getDisplayName(FULL, ENGLISH) -> FulfilmentDates(
+          today,
+          deliveryAddressChangeEffectiveDate(targetDayOfWeek, today),
+          holidayStopFirstAvailableDate(targetDayOfWeek, today),
+          finalFulfilmentFileGenerationDate(targetDayOfWeek, today)
+        )):_*
+    )
 
   private def getFulfilmentFileGenerationDateForNextTargetDayOfWeek(
     targetDayOfWeek: DayOfWeek,


### PR DESCRIPTION
Just for ease of reading by a human they now appear in correct order...
![image](https://user-images.githubusercontent.com/19289579/70724862-49434f00-1cf3-11ea-8f97-cc17a340afc2.png)
