### PR TITLE
fulfilment-date-calculator: add optional 'holidayStopProcessorTargetDate' for all products

### DIFF
--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
@@ -1,8 +1,8 @@
 package com.gu.supporter.fulfilment
 
 import java.time.DayOfWeek._
-import java.time.LocalDate
 import java.time.format.TextStyle.FULL
+import java.time.{DayOfWeek, LocalDate}
 import java.util.Locale.ENGLISH
 
 import com.gu.fulfilmentdates.FulfilmentDates
@@ -11,7 +11,7 @@ import scala.collection.immutable.ListMap
 
 object VoucherBookletFulfilmentDates {
 
-  lazy val VoucherHolidayStopProcessorLeadTime: Int = 1
+  lazy val VoucherHolidayStopNoticePeriodDays = 1
 
   def apply(today: LocalDate): ListMap[String, FulfilmentDates] =
     ListMap( // to preserve insertion order, so the file is easier to read
@@ -19,10 +19,18 @@ object VoucherBookletFulfilmentDates {
         targetDayOfWeek.getDisplayName(FULL, ENGLISH) -> FulfilmentDates(
           today,
           holidayStopFirstAvailableDate(today),
-        )
-      ):_*
+          holidayStopProcessorTargetDate(targetDayOfWeek, today)
+        )): _*
     )
 
-  def holidayStopFirstAvailableDate(today: LocalDate): LocalDate = today plusDays VoucherHolidayStopProcessorLeadTime
+  def holidayStopFirstAvailableDate(today: LocalDate): LocalDate = today plusDays VoucherHolidayStopNoticePeriodDays
+
+  def holidayStopProcessorTargetDate(targetDayOfWeek: DayOfWeek, today: LocalDate): Option[LocalDate] = {
+    if (today.getDayOfWeek == targetDayOfWeek) {
+      Some(today) // we process voucher holiday stops on the day they're scheduled for
+    } else {
+      None
+    }
+  }
 
 }

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/GuardianWeeklyFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/GuardianWeeklyFulfilmentDatesSpec.scala
@@ -1,10 +1,27 @@
 package com.gu.supporter.fulfilment
 
+import java.time.LocalDate
+
 import org.scalatest.{FlatSpec, Matchers}
 
 class GuardianWeeklyFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
 
-  "GuardianWeeklyFulfilmentDates" should "calculate deliveryAddressChangeEffectiveDate" in {
+  it should "calculate holidayStopProcessorTargetDate" in {
+    GuardianWeeklyFulfilmentDates( /* Monday    */ "2019-12-02").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Tuesday   */ "2019-12-03").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Wednesday */ "2019-12-04").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-13")
+    GuardianWeeklyFulfilmentDates( /* Thursday  */ "2019-12-05").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Friday    */ "2019-12-06").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Saturday  */ "2019-12-07").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Sunday    */ "2019-12-08").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Monday    */ "2019-12-09").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Tuesday   */ "2019-12-10").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Wednesday */ "2019-12-11").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-20")
+    GuardianWeeklyFulfilmentDates( /* Thursday  */ "2019-12-12").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    GuardianWeeklyFulfilmentDates( /* Friday    */ "2019-12-13").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+  }
+
+  it should "calculate deliveryAddressChangeEffectiveDate" in {
     GuardianWeeklyFulfilmentDates("2019-12-02")("Friday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-13")
     GuardianWeeklyFulfilmentDates("2019-12-03")("Friday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-13")
     GuardianWeeklyFulfilmentDates("2019-12-04")("Friday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-13")

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
@@ -10,6 +10,23 @@ class HomeDeliveryFulfilmentDatesSpec extends FlatSpec with Matchers with DateSu
     BankHolidays(Nil) // TODO reuse sampleBankHolidays from LocalDateHelpersSpec with some test cases below
   )
 
+  "HomeDeliveryFulfilmentDates" should "should contain correct holidayStopProcessorTargetDate(s)" in {
+    apply( /* Wednesday */ "2019-12-04").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-06")
+    apply( /* Thursday  */ "2019-12-05").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-09", "2019-12-07", "2019-12-08")
+    apply( /* Friday    */ "2019-12-06").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    apply( /* Saturday  */ "2019-12-07").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    apply( /* Sunday    */ "2019-12-08").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-10")
+    apply( /* Monday    */ "2019-12-09").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-11")
+    apply( /* Tuesday   */ "2019-12-10").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-12")
+    apply( /* Wednesday */ "2019-12-11").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-13")
+    apply( /* Thursday  */ "2019-12-12").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-16", "2019-12-14", "2019-12-15")
+    apply( /* Friday    */ "2019-12-13").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    apply( /* Saturday  */ "2019-12-14").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe Nil
+    apply( /* Sunday    */ "2019-12-15").values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List[LocalDate]("2019-12-17")
+
+    // TODO add some bank holiday examples
+  }
+
   "MONDAY HomeDeliveryFulfilmentDates" should "have correct deliveryAddressChangeEffectiveDate" in {
     apply( /* Wednesday */ "2019-12-04")("Monday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-09")
     apply( /* Thursday  */ "2019-12-05")("Monday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-09")

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/VoucherBookletFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/VoucherBookletFulfilmentDatesSpec.scala
@@ -1,0 +1,36 @@
+package com.gu.supporter.fulfilment
+
+import java.time.LocalDate
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class VoucherBookletFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
+
+  def shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek(
+    today: LocalDate,
+    expectedDayOfWeek: String,
+    expectedDate: LocalDate
+  ) = {
+    val result = VoucherBookletFulfilmentDates(today)
+    result.values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List(expectedDate)
+    result(expectedDayOfWeek).holidayStopProcessorTargetDate.get should equalDate(expectedDate)
+  }
+
+  it should "calculate holidayStopProcessorTargetDate" in {
+
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-02", "Monday", "2019-12-02")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-03", "Tuesday", "2019-12-03")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-04", "Wednesday", "2019-12-04")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-05", "Thursday", "2019-12-05")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-06", "Friday", "2019-12-06")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-07", "Saturday", "2019-12-07")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-08", "Sunday", "2019-12-08")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-09", "Monday", "2019-12-09")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-10", "Tuesday", "2019-12-10")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-11", "Wednesday", "2019-12-11")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-12", "Thursday", "2019-12-12")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-13", "Friday", "2019-12-13")
+
+  }
+
+}

--- a/lib/fulfilment-dates/src/main/scala/com/gu/fulfilmentdates/FulfilmentDates.scala
+++ b/lib/fulfilment-dates/src/main/scala/com/gu/fulfilmentdates/FulfilmentDates.scala
@@ -6,24 +6,28 @@ case class FulfilmentDates(
   today: LocalDate,
   deliveryAddressChangeEffectiveDate: Option[LocalDate],
   holidayStopFirstAvailableDate: LocalDate,
+  holidayStopProcessorTargetDate: Option[LocalDate],
   finalFulfilmentFileGenerationDate: Option[LocalDate]
 )
 
 object FulfilmentDates {
-  def apply(today: LocalDate, holidayStopFirstAvailableDate: LocalDate): FulfilmentDates =
+  def apply(today: LocalDate, holidayStopFirstAvailableDate: LocalDate, holidayStopProcessorTargetDate: Option[LocalDate]): FulfilmentDates =
     FulfilmentDates(
       today,
       deliveryAddressChangeEffectiveDate = None,
       holidayStopFirstAvailableDate,
+      holidayStopProcessorTargetDate,
       finalFulfilmentFileGenerationDate = None
     )
 
-  def apply(today: LocalDate, deliveryAddressChangeEffectiveDate: LocalDate, holidayStopFirstAvailableDate: LocalDate, finalFulfilmentFileGenerationDate: LocalDate): FulfilmentDates =
+  def apply(today: LocalDate, deliveryAddressChangeEffectiveDate: LocalDate, holidayStopFirstAvailableDate: LocalDate, holidayStopProcessorTargetDate: Option[LocalDate], finalFulfilmentFileGenerationDate: LocalDate): FulfilmentDates =
     FulfilmentDates(
       today,
       Some(deliveryAddressChangeEffectiveDate),
       holidayStopFirstAvailableDate,
+      holidayStopProcessorTargetDate,
       Some(finalFulfilmentFileGenerationDate)
     )
+
 }
 

--- a/lib/fulfilment-dates/src/test/scala/com/gu/fulfilmentdates/FulfilmentDatesFetcherTest.scala
+++ b/lib/fulfilment-dates/src/test/scala/com/gu/fulfilmentdates/FulfilmentDatesFetcherTest.scala
@@ -38,6 +38,7 @@ class FulfilmentDatesFetcherTest extends FlatSpec {
                 today = LocalDate.parse("2019-12-11"),
                 deliveryAddressChangeEffectiveDate = LocalDate.parse("2019-12-16"),
                 holidayStopFirstAvailableDate = LocalDate.parse("2019-12-16"),
+                holidayStopProcessorTargetDate = None,
                 finalFulfilmentFileGenerationDate = LocalDate.parse("2019-12-12"),
               )
             )


### PR DESCRIPTION
To support home delivery holiday stops, each day the `holiday-stop-processor` runs we need to know what publications to process (credit in Zuora and mark as actioned) - this is a bit more complicated for Home Delivery.

This PR is the implementation for Home Delivery 🆕 and a replica of the functionality for Guardian Weekly and Voucher Booklet, which currently resides in `holiday-stop-processor` see https://github.com/guardian/support-service-lambdas/blob/38fbc526b959476528b04d7a99df505c83c37038/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala#L16-L27
... which is then used in a Salesforce query, see https://github.com/guardian/support-service-lambdas/blob/dbb8f4dd71a242185e46bfbf17f55717d0e1977d/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala#L85)

### The consumption of `holidayStopProcessorTargetDate` by `holiday-stop-processor` will come in a follow up PR. 

The tests should demonstrate the pattern of dates fairly nicely and provides a template for how to consume (i.e. query salesforce for publications with `Stopped_Publication_Date__c` **`IN`** `.values.flatMap(_.holidayStopProcessorTargetDate)`)
