### PR TITLE
holiday-stops-api: fix 'amend' regression

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -321,7 +321,7 @@ object SalesforceHolidayStopRequest extends Logging {
 
       val detailRecordsToBeDeleted = existingPublicationsThatWereToBeStopped
         .filterNot(holidayStopRequestDetail =>
-          issuesData.contains(holidayStopRequestDetail.Stopped_Publication_Date__c.value)
+          issuesData.map(_.issueDate).contains(holidayStopRequestDetail.Stopped_Publication_Date__c.value)
         )
         .map( holidayStopRequestDetail => CompositePart(
           method = "DELETE",


### PR DESCRIPTION
This was comparing incompatible types, and thus always returning false, and thus always deleting all the existing `Holiday_Stop_Requests_Detail__c` entries.