### PR TITLE
[delivery-records-api] expose delivery problem cases

### DIFF
--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordApiRoutes.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordApiRoutes.scala
@@ -34,18 +34,15 @@ object DeliveryRecordApiRoutes {
       contact: Contact,
       optionalStartDate: Option[LocalDate],
       optionalEndDate: Option[LocalDate]
-    ): EitherT[F, F[Response[F]], DeliveryRecordsApiResponse[DeliveryRecord]] = {
+    ): EitherT[F, F[Response[F]], DeliveryRecordsApiResponse] = {
       deliveryRecordsService
         .getDeliveryRecordsForSubscription(subscriptionNumber, contact, optionalStartDate, optionalEndDate)
-        .bimap(
-          {
-            case error: DeliveryRecordServiceSubscriptionNotFound =>
-              NotFound(error)
-            case error: DeliveryRecordServiceGenericError =>
-              InternalServerError(error)
-          },
-          deliveryRecords => DeliveryRecordsApiResponse(deliveryRecords)
-        )
+        .leftMap {
+          case error: DeliveryRecordServiceSubscriptionNotFound =>
+            NotFound(error)
+          case error: DeliveryRecordServiceGenericError =>
+            InternalServerError(error)
+        }
     }
 
     def parseDateFromQueryString(request: Request[F], queryParameterKey: String): EitherT[F, F[Response[F]], Option[LocalDate]] = {

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsApiResponse.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsApiResponse.scala
@@ -1,3 +1,6 @@
 package com.gu.delivery_records_api
 
-case class DeliveryRecordsApiResponse[A](results: List[A])
+case class DeliveryRecordsApiResponse(
+  results: List[DeliveryRecord],
+  deliveryProblemMap: Map[String, DeliveryProblemCase]
+)

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsService.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsService.scala
@@ -4,11 +4,11 @@ import java.time.LocalDate
 
 import cats.Monad
 import cats.data.EitherT
-import com.gu.salesforce.{Contact, RecordsWrapperCaseClass, SFApiDeliveryRecord}
-import com.gu.salesforce.SalesforceQueryConstants.deliveryRecordsQuery
+import com.gu.salesforce.{Contact, RecordsWrapperCaseClass}
 import com.gu.salesforce.sttp.SalesforceClient
 import io.circe.generic.auto._
 import cats.implicits._
+import com.gu.salesforce.SalesforceQueryConstants.{contactToWhereClausePart, escapeString}
 
 final case class DeliveryRecord(
   deliveryDate: Option[LocalDate],
@@ -20,8 +20,15 @@ final case class DeliveryRecord(
   addressTown: Option[String],
   addressCountry: Option[String],
   addressPostcode: Option[String],
-  hasHolidayStop: Option[Boolean]
+  hasHolidayStop: Option[Boolean],
+  problemCaseId: Option[String]
+)
 
+final case class DeliveryProblemCase(
+  id: String,
+  subject: Option[String],
+  description: Option[String],
+  problemType: Option[String]
 )
 
 sealed trait DeliveryRecordServiceError
@@ -36,7 +43,7 @@ trait DeliveryRecordsService[F[_]] {
     contact: Contact,
     optionalStartDate: Option[LocalDate],
     optionalEndDate: Option[LocalDate]
-  ): EitherT[F, DeliveryRecordServiceError, List[DeliveryRecord]]
+  ): EitherT[F, DeliveryRecordServiceError, DeliveryRecordsApiResponse]
 }
 
 object DeliveryRecordsService {
@@ -51,7 +58,7 @@ object DeliveryRecordsService {
       contact: Contact,
       optionalStartDate: Option[LocalDate],
       optionalEndDate: Option[LocalDate]
-    ): EitherT[F, DeliveryRecordServiceError, List[DeliveryRecord]] =
+    ): EitherT[F, DeliveryRecordServiceError, DeliveryRecordsApiResponse] =
       for {
         queryResult <- queryForDeliveryRecords(
           salesforceClient,
@@ -72,10 +79,21 @@ object DeliveryRecordsService {
             addressCountry = queryRecord.Address_Country__c,
             addressPostcode = queryRecord.Address_Postcode__c,
             deliveryInstruction = queryRecord.Delivery_Instructions__c,
-            hasHolidayStop = queryRecord.Has_Holiday_Stop__c
+            hasHolidayStop = queryRecord.Has_Holiday_Stop__c,
+            problemCaseId = queryRecord.Case__r.map(_.Id)
           )
         }
-      } yield results
+        deliveryProblemMap = records.flatMap(
+          _.Case__r.map(
+            problemCase => problemCase.Id -> DeliveryProblemCase(
+              id = problemCase.Id,
+              subject = problemCase.Subject,
+              description = problemCase.Description,
+              problemType = problemCase.Case_Closure_Reason__c
+            )
+          )
+        ).toMap
+      } yield DeliveryRecordsApiResponse(results, deliveryProblemMap)
 
     private def queryForDeliveryRecords(
       salesforceClient: SalesforceClient[F],
@@ -106,6 +124,34 @@ object DeliveryRecordsService {
         )
         .map(deliverRecordsOption => deliverRecordsOption.Delivery_Records__r.map(_.records).getOrElse(Nil))
     }
+  }
+
+  // this is done with a nested query so one can distinguish between the contact not owning subscription and there
+  // simply being no delivery records, due to the hierarchical nature of the Salesforce response
+  def deliveryRecordsQuery(
+    contact: Contact,
+    subscriptionNumber: String,
+    optionalStartDate: Option[LocalDate],
+    optionalEndDate: Option[LocalDate]
+  ) =
+    s"""SELECT (
+       |    SELECT Delivery_Date__c, Delivery_Address__c, Delivery_Instructions__c, Has_Holiday_Stop__c, Address_Line_1__c,
+       |           Address_Line_2__c, Address_Line_3__c, Address_Town__c, Address_Country__c, Address_Postcode__c,
+       |           Case__c, Case__r.Id, Case__r.Subject, Case__r.Description, Case__r.Case_Closure_Reason__c
+       |    FROM Delivery_Records__r
+       |    ${deliveryDateFilter(optionalStartDate, optionalEndDate)}
+       |)
+       |FROM SF_Subscription__c WHERE Name = '${escapeString(subscriptionNumber)}'
+       |                         AND ${contactToWhereClausePart(contact)}""".stripMargin
+
+  def deliveryDateFilter(optionalStartDate: Option[LocalDate], optionalEndDate: Option[LocalDate]) = {
+    List(
+      optionalStartDate.map(startDate => s"Delivery_Date__c >= $startDate "),
+      optionalEndDate.map(endDate => s"Delivery_Date__c <= $endDate")
+    ).flatten match {
+        case Nil => ""
+        case nonEmpty => s" WHERE ${nonEmpty.mkString(" AND ")}"
+      }
   }
 }
 

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryProblemCase.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryProblemCase.scala
@@ -1,0 +1,8 @@
+package com.gu.delivery_records_api
+
+case class SFApiDeliveryProblemCase(
+  Id: String,
+  Subject: Option[String],
+  Description: Option[String],
+  Case_Closure_Reason__c: Option[String] // this is actually the case sub-category (e.g. 'No Delivery', 'Damaged Delivery' etc.)
+)

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryRecord.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryRecord.scala
@@ -1,4 +1,4 @@
-package com.gu.salesforce
+package com.gu.delivery_records_api
 
 import java.time.LocalDate
 
@@ -12,5 +12,6 @@ case class SFApiDeliveryRecord(
   Address_Country__c: Option[String],
   Address_Postcode__c: Option[String],
   Delivery_Instructions__c: Option[String],
-  Has_Holiday_Stop__c: Option[Boolean]
+  Has_Holiday_Stop__c: Option[Boolean],
+  Case__r: Option[SFApiDeliveryProblemCase]
 )

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiSubscription.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiSubscription.scala
@@ -1,3 +1,5 @@
-package com.gu.salesforce
+package com.gu.delivery_records_api
+
+import com.gu.salesforce.RecordsWrapperCaseClass
 
 case class SFApiSubscription(Delivery_Records__r: Option[RecordsWrapperCaseClass[SFApiDeliveryRecord]])

--- a/lib/salesforce/core/src/main/scala/com/gu/salesforce/SalesforceQueryConstants.scala
+++ b/lib/salesforce/core/src/main/scala/com/gu/salesforce/SalesforceQueryConstants.scala
@@ -1,37 +1,10 @@
 package com.gu.salesforce
 
-import java.time.LocalDate
-
 object SalesforceQueryConstants {
 
   def contactToWhereClausePart(contact: Contact) = contact match {
     case IdentityId(identityId) => s"Buyer__r.IdentityID__c = '${escapeString(identityId)}'"
     case SalesforceContactId(sfContactId) => s"Buyer__r.Id = '${escapeString(sfContactId)}'"
-  }
-
-  def deliveryRecordsQuery(
-    contact: Contact,
-    subscriptionNumber: String,
-    optionalStartDate: Option[LocalDate],
-    optionalEndDate: Option[LocalDate]
-  ) =
-    s"""SELECT (
-    |    SELECT Delivery_Date__c, Delivery_Address__c, Delivery_Instructions__c, Has_Holiday_Stop__c, Address_Line_1__c,
-    |           Address_Line_2__c, Address_Line_3__c, Address_Town__c, Address_Country__c, Address_Postcode__c
-    |    FROM Delivery_Records__r
-    |    ${deliveryDateFilter(optionalStartDate, optionalEndDate)}
-    |)
-    |FROM SF_Subscription__c WHERE Name = '${escapeString(subscriptionNumber)}'
-    |                         AND ${contactToWhereClausePart(contact)}""".stripMargin
-
-  def deliveryDateFilter(optionalStartDate: Option[LocalDate], optionalEndDate: Option[LocalDate]) = {
-    List(
-      optionalStartDate.map(startDate => s"Delivery_Date__c >= $startDate "),
-      optionalEndDate.map(endDate => s"Delivery_Date__c <= $endDate")
-    ).flatten match {
-        case Nil => ""
-        case nonEmpty => s" WHERE ${nonEmpty.mkString(" AND ")}"
-      }
   }
 
   def escapeString(string: String) =
@@ -45,3 +18,4 @@ object SalesforceQueryConstants {
       .replace("\"", "\\\"")
       .replace("\'", "\\'")
 }
+

--- a/lib/salesforce/sttp-test-stub/src/main/scala/com/gu/salesforce/sttp/SalesforceStub.scala
+++ b/lib/salesforce/sttp-test-stub/src/main/scala/com/gu/salesforce/sttp/SalesforceStub.scala
@@ -50,7 +50,7 @@ object SalesforceStub {
   private def matchesQueryRequest[S, F[_]](auth: SalesforceAuth, query: String, request: Request[_, _]) = {
     val urlMatches = urlNoQueryString(request) == auth.instance_url + SalesforceConstants.soqlQueryBaseUrl
     val methodMatches = request.method == Method.GET
-    val queryParamMatches = request.uri.paramsMap.get("q") == Some(query)
+    val queryParamMatches = request.uri.paramsMap.get("q").contains(query)
     urlMatches && methodMatches && queryParamMatches
   }
 


### PR DESCRIPTION
On each delivery record in the `results` list there is now a `problemCaseId` if that delivery record has a problem case associated.

There is also a new top level key `deliveryProblemMap`, which holds extra detail about the cases with ID's specified above, like...

- `subject`
- `description`
- `problemType` (from the 'Case Subcategory` in Salesforce)