### PR TITLE
Updating delivery holiday stops issue limit

### DIFF
--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -85,7 +85,7 @@ object SupportedProduct {
     SupportedProduct(
       name = "Newspaper Delivery",
       productType = NewspaperHomeDelivery,
-      annualIssueLimitPerEdition = 4,
+      annualIssueLimitPerEdition = 6,
       ratePlans = List(
         SupportedRatePlan("Echo-Legacy", everyDayCharges),
         SupportedRatePlan("Everyday", everyDayCharges),

--- a/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionDataDeliveryEveryDayPlusIntegrationTest.scala
+++ b/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionDataDeliveryEveryDayPlusIntegrationTest.scala
@@ -77,7 +77,7 @@ class SubscriptionDataDeliveryEveryDayPlusIntegrationTest extends FlatSpec {
       subscriptionFile = "DeliveryEveryDatePlusSubscription.json",
       startDate = startDate,
       expectedIssueData = expectedIssueData,
-      expectedTotalAnnualIssueLimitPerSubscription = 28,
+      expectedTotalAnnualIssueLimitPerSubscription = 42,
       expectedProductType = ZuoraProductTypes.NewspaperHomeDelivery,
       expectedEditionDaysOfWeek = List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
     )

--- a/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionDataEchoLegacyIntegrationTest.scala
+++ b/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionDataEchoLegacyIntegrationTest.scala
@@ -47,7 +47,7 @@ class SubscriptionDataEchoLegacyIntegrationTest extends FlatSpec {
       subscriptionFile = "EchoLegacySubscription.json",
       startDate = startDate,
       expectedIssueData = expectedIssueData,
-      expectedTotalAnnualIssueLimitPerSubscription = 8,
+      expectedTotalAnnualIssueLimitPerSubscription = 12,
       expectedProductType = ZuoraProductTypes.NewspaperHomeDelivery,
       expectedEditionDaysOfWeek = List(FRIDAY, SATURDAY),
       billCycleDay = 21


### PR DESCRIPTION
Increasing the per-edition annual issue limit for holiday stop to 6 in line with the old plaform.