### PR TITLE
Write delivery-credit invoice date back to Salesforce

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditResult.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditResult.scala
@@ -1,10 +1,13 @@
 package com.gu.deliveryproblemcreditprocessor
 
+import java.time.LocalDate
+
 import com.gu.creditprocessor.ZuoraCreditAddResult
 import com.gu.zuora.subscription.{Price, RatePlanChargeCode}
 
 case class DeliveryCreditResult(
   deliveryId: String,
   chargeCode: RatePlanChargeCode,
-  amountCredited: Price
+  amountCredited: Price,
+  invoiceDate: LocalDate
 ) extends ZuoraCreditAddResult


### PR DESCRIPTION
When Zuora successfully adds a delivery-problem credit amendment to a subscription, the invoice date as well as the credit amount is filled in in the SF delivery record.
