### PR TITLE
holiday-stop-api : expose new 'nextInvoiceDateAfterToday' on the 'potential' endpoint

### DIFF
--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -10,7 +10,7 @@ All endpoints require...
 
 | Method | Endpoint | Description |
 | --- | --- | --- | 
-| GET | `/{STAGE}/potential/{SUBSCRIPTION_NAME}?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}&estimateCredit={true`&#124;`false}` | returns a response containing dates for each issue impacted between the start and end parameters inclusively, for the subscription. Optionally the estimated credit can be calculated for each issue (which comes with the invoice date it will be appear on) |
+| GET | `/{STAGE}/potential/{SUBSCRIPTION_NAME}?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}` | returns a response containing dates for each issue impacted between the start and end parameters inclusively, for the subscription. Each one is accompanied by expected credit amount and the invoice date the credit will be appear on. |
 | GET | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}` | returns all holiday stops (past & present) for the specified subscription (user is verified as the 'bill to' contact of the subscription). Response includes an 'annualIssueLimit' and an 'issueSpecifics' array containing a series of objects each with calculated 'firstAvailableDate' and 'issueDayOfWeek'.|
 | POST | `/{STAGE}/hsr` | creates a new all holiday stop, example body `{ "startDate": "2023-06-10", "endDate": "2024-06-14", "subscriptionName": "A-S00071783" }`|
 | PATCH | `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}` | with the same body as create endpoint above, amends the holiday stop request (where holiday stop request `Id` matches `{SF_ID}`) to the newly specified dates and adds/removes the underlying detail records where appropriate |

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -179,8 +179,7 @@ object Handler extends Logging {
 
   case class PotentialHolidayStopsQueryParams(
     startDate: LocalDate,
-    endDate: LocalDate,
-    estimateCredit: Option[String]
+    endDate: LocalDate
   )
 
   def stepsForPotentialHolidayStop(

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -186,7 +186,7 @@ object Handler extends Logging {
   def stepsForPotentialHolidayStop(
     getAccessToken: () => Either[ApiFailure, AccessToken],
     getSubscription: (AccessToken, SubscriptionName) => Either[ApiFailure, Subscription],
-    getAccount: (AccessToken, String) => Either[ApiFailure, ZuoraAccount],
+    getAccount: (AccessToken, String) => Either[ApiFailure, ZuoraAccount]
   )(req: ApiGatewayRequest, unused: SfClient): ApiResponse = {
     implicit val reads: Reads[PotentialHolidayStopsQueryParams] = Json.reads[PotentialHolidayStopsQueryParams]
     (for {
@@ -198,16 +198,24 @@ object Handler extends Logging {
         .toApiGatewayOp(s"get subscription ${pathParams.subscriptionName}")
       account <- getAccount(accessToken, subscription.accountNumber)
         .toApiGatewayOp(s"get account ${subscription.accountNumber}")
-      issuesData <- SubscriptionData(subscription, account)
-        .map(_.issueDataForPeriod(queryParams.startDate, queryParams.endDate))
-        .toApiGatewayOp(s"calculating publication dates")
+      subscriptionData <- SubscriptionData(subscription, account)
+        .toApiGatewayOp(s"building SubscriptionData")
+      issuesData = subscriptionData.issueDataForPeriod(queryParams.startDate, queryParams.endDate)
       potentialHolidayStops = issuesData.map { issueData =>
         PotentialHolidayStop(
           issueData.issueDate,
           Credit(issueData.credit, issueData.nextBillingPeriodStartDate)
         )
       }
-    } yield ApiGatewayResponse("200", PotentialHolidayStopsResponse(potentialHolidayStops))).apiResponse
+      nextInvoiceDateAfterToday = subscriptionData
+        .issueDataForPeriod(MutableCalendar.today.minusDays(7), MutableCalendar.today.plusDays(7))
+        .filter(_.nextBillingPeriodStartDate.isAfter(MutableCalendar.today))
+        .minBy(_.nextBillingPeriodStartDate)(Ordering.by(_.toEpochDay))
+        .nextBillingPeriodStartDate
+    } yield ApiGatewayResponse(
+      "200",
+      PotentialHolidayStopsResponse(nextInvoiceDateAfterToday, potentialHolidayStops)
+    )).apiResponse
   }
 
   case class ListExistingPathParams(subscriptionName: SubscriptionName)

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/PotentialHolidayStops.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/PotentialHolidayStops.scala
@@ -33,7 +33,7 @@ object PotentialHolidayStop {
   }
 }
 
-case class PotentialHolidayStopsResponse(potentials: List[PotentialHolidayStop])
+case class PotentialHolidayStopsResponse(nextInvoiceDateAfterToday: LocalDate, potentials: List[PotentialHolidayStop])
 
 object PotentialHolidayStopsResponse {
 

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -120,7 +120,8 @@ class HandlerTest extends FlatSpec with Matchers {
           case JsSuccess(response, _) =>
             response should equal(
               PotentialHolidayStopsResponse(
-                List(
+                nextInvoiceDateAfterToday = LocalDate.parse("2019-04-01"),
+                potentials = List(
                   PotentialHolidayStop(LocalDate.of(2019, 1, 4), Credit(-2.89, LocalDate.parse("2019-04-01"))),
                   PotentialHolidayStop(LocalDate.of(2019, 1, 11), Credit(-2.89, LocalDate.parse("2019-04-01"))),
                 )

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -36,7 +36,7 @@ class HandlerTest extends FlatSpec with Matchers {
       HEADER_SALESFORCE_CONTACT_ID -> expectedSfContactIdCoreValue
     ))) shouldBe ContinueProcessing(SalesforceContactId(expectedSfContactIdCoreValue))
   }
-  "GET /potential/<<sub name>>?startDate=...&endDate=...&estimateCredit=true endpoint" should
+  "GET /potential/<<sub name>>?startDate=...&endDate=... endpoint" should
     "calculate potential holiday stop dates and estimated credit" in {
     MutableCalendar.setFakeToday(Some(LocalDate.parse("2019-02-01")))
     val subscriptionName = "Sub12344"
@@ -108,8 +108,7 @@ class HandlerTest extends FlatSpec with Matchers {
             productPrefix = "Guardian Weekly xxx",
             startDate = "2019-01-01",
             endDate = "2019-01-15",
-            subscriptionName = subscriptionName,
-            estimateCredit = true
+            subscriptionName = subscriptionName
           ))
       }
     ) {
@@ -385,13 +384,13 @@ class HandlerTest extends FlatSpec with Matchers {
   }
 
   private def legacyPotentialIssueDateRequest(productPrefix: String, startDate: String, endDate: String,
-                                        subscriptionName: String, estimateCredit: Boolean) = {
+                                        subscriptionName: String) = {
     ApiGatewayRequest(
       Some("GET"),
       Some(Map(
         "startDate" -> startDate,
         "endDate" -> endDate,
-        "estimateCredit" -> (if (estimateCredit) "true" else "false"))),
+      )),
       None,
       Some(Map("x-product-name-prefix" -> productPrefix)),
       Some(JsObject(Seq("subscriptionName" -> JsString(subscriptionName)))),
@@ -400,13 +399,12 @@ class HandlerTest extends FlatSpec with Matchers {
   }
 
   private def potentialIssueDateRequest(productType: String, productRatePlanName: String, startDate: String,
-                                        endDate: String, subscriptionName: String, estimateCredit: Boolean) = {
+                                        endDate: String, subscriptionName: String) = {
     ApiGatewayRequest(
       Some("GET"),
       Some(Map(
         "startDate" -> startDate,
         "endDate" -> endDate,
-        "estimateCredit" -> (if (estimateCredit) "true" else "false"),
         "productType" -> productType,
         "productRatePlanName" -> productRatePlanName
       )),

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/PotentialHolidayStopsResponseTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/PotentialHolidayStopsResponseTest.scala
@@ -9,7 +9,8 @@ import play.api.libs.json.Json
 class PotentialHolidayStopsResponseTest extends FlatSpec with Matchers {
 
   private val response = PotentialHolidayStopsResponse(
-    List(
+    nextInvoiceDateAfterToday = LocalDate.of(2019, 10, 1),
+    potentials = List(
       PotentialHolidayStop(
         publicationDate = LocalDate.of(2019, 9, 27),
         expectedCredit = Credit(
@@ -21,7 +22,7 @@ class PotentialHolidayStopsResponseTest extends FlatSpec with Matchers {
   )
 
   private val jsonString =
-    """{"potentials":[{"publicationDate":"2019-09-27","credit":-2.89,"invoiceDate":"2019-10-01"}]}"""
+    """{"nextInvoiceDateAfterToday":"2019-10-01","potentials":[{"publicationDate":"2019-09-27","credit":-2.89,"invoiceDate":"2019-10-01"}]}"""
 
   "parse" should "read json correctly" in {
     Json.parse(jsonString).as[PotentialHolidayStopsResponse] should equal(response)


### PR DESCRIPTION
The 'potential' endpoint is now being re-used for 'delivery problem reporting' credit previews, but the `invoiceDate`s in the response refer to the next bill date after each respective `stoppedPublicationDate`,  rather than the next bill date from '_today_'.
This introduces a new top level field `nextInvoiceDateAfterToday` which has the next bill date after today, which is when the credit will be locked in for.

ALSO removed all traces of optional `estimateCredit` query param on 'potential' endpoint, since we call Zuora anyway since the introduction of Home Delivery holiday stops (because it needs to know which days of the week - most notably Echo Legacy)