### PR TITLE
Revert circe back to 0.11.1

### DIFF
--- a/handlers/delivery-records-api/cfn.yaml
+++ b/handlers/delivery-records-api/cfn.yaml
@@ -189,5 +189,5 @@ Resources:
         Namespace: AWS/ApiGateway
         Period: 3600
         Statistic: Sum
-        Threshold: 5
+        Threshold: 2
         TreatMissingData: notBreaching

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   
   val awsVersion = "1.11.574"
 
-  val circeVersion = "0.12.3"
+  val circeVersion = "0.11.1"
   val sttpVersion = "1.5.17"
   val http4sVersion = "0.20.3"
   val catsVersion = "1.6.1"
@@ -31,7 +31,7 @@ object Dependencies {
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val circe = "io.circe" %% "circe-generic" % circeVersion
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
-  val circeJava8 = "io.circe" %% "circe-java8" % "0.11.1"
+  val circeJava8 = "io.circe" %% "circe-java8" % circeVersion
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion
   val sttpCats = "com.softwaremill.sttp" %% "cats" % sttpVersion


### PR DESCRIPTION
There's a binary incompatibility in the `delivery-records-api` subproject, which is causing a runtime exception in Prod.

The  project has a dependency on `http4s-lambda % 0.4.0`, which has a transitive dependency on an earlier version of `circe-generic`.   There's no later version of `http4s-lambda` so will have to roll `circe` back until a new version is available.
