### PR TITLE
Read in delivery-problem credit invoice date from Salesforce

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,7 +347,8 @@ lazy val `delivery-problem-credit-processor` =
         circe,
         zio,
         sttpAsycHttpClientBackendCats,
-        scalatest
+        scalatest,
+        diffx
       )
     )
     .enablePlugins(RiffRaffArtifact)

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -124,9 +124,15 @@ object DeliveryCreditProcessor extends Logging {
     creditProduct: CreditProduct,
     subscription: Subscription,
     account: ZuoraAccount,
-    deliveryDate: AffectedPublicationDate
+    request: DeliveryCreditRequest
   ): ZuoraApiResponse[SubscriptionUpdate] =
-    SubscriptionUpdate.apply(creditProduct, subscription, account, deliveryDate)
+    SubscriptionUpdate(
+      creditProduct,
+      subscription,
+      account,
+      AffectedPublicationDate(request.Delivery_Date__c),
+      Some(InvoiceDate(request.Invoice_Date__c))
+    )
 
   def resultOfZuoraCreditAdd(
     request: DeliveryCreditRequest,
@@ -158,7 +164,7 @@ object DeliveryCreditProcessor extends Logging {
 
     def deliveryRecordsQuery(productType: ZuoraProductType) =
       s"""
-         |SELECT Id, SF_Subscription__r.Name, Delivery_Date__c, Charge_Code__c
+         |SELECT Id, SF_Subscription__r.Name, Delivery_Date__c, Charge_Code__c, Invoice_Date__c
          |FROM Delivery__c
          |WHERE SF_Subscription__r.Product_Type__c = '${productType.name}'
          |AND Credit_Requested__c = true

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequest.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequest.scala
@@ -8,7 +8,8 @@ case class DeliveryCreditRequest(
   Id: String,
   SF_Subscription__r: DeliveryCreditSubscription,
   Delivery_Date__c: LocalDate,
-  Charge_Code__c: Option[String]
+  Charge_Code__c: Option[String],
+  Invoice_Date__c: LocalDate
 ) extends CreditRequest {
   val subscriptionName: SubscriptionName = SubscriptionName(SF_Subscription__r.Name)
   val publicationDate: AffectedPublicationDate = AffectedPublicationDate(Delivery_Date__c)

--- a/handlers/delivery-problem-credit-processor/src/test/resources/sf-credit-request.json
+++ b/handlers/delivery-problem-credit-processor/src/test/resources/sf-credit-request.json
@@ -16,7 +16,8 @@
         "Name": "A-S00001"
       },
       "Delivery_Date__c": "2019-12-06",
-      "Charge_Code__c": null
+      "Charge_Code__c": null,
+      "Invoice_Date__c": "2020-02-10"
     },
     {
       "attributes": {
@@ -32,7 +33,8 @@
         "Name": "A-S00002"
       },
       "Delivery_Date__c": "2019-12-13",
-      "Charge_Code__c": "C12345"
+      "Charge_Code__c": "C12345",
+      "Invoice_Date__c": "2020-03-01"
     }
   ]
 }

--- a/handlers/delivery-problem-credit-processor/src/test/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequestTest.scala
+++ b/handlers/delivery-problem-credit-processor/src/test/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequestTest.scala
@@ -3,34 +3,38 @@ package com.gu.deliveryproblemcreditprocessor
 import java.time.LocalDate
 
 import com.gu.salesforce.RecordsWrapperCaseClass
+import com.softwaremill.diffx.scalatest.DiffMatcher
 import io.circe.generic.auto._
 import io.circe.parser._
-import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source
 
 class DeliveryCreditRequestTest
-  extends FlatSpec
+  extends AnyFlatSpec
   with Matchers
-  with EitherValues
-  with TypeCheckedTripleEquals {
+  with DiffMatcher
+  with EitherValues {
 
   "Json decode" should "decode SF response correctly" in {
     val json = Source.fromResource("sf-credit-request.json").mkString
-    decode[RecordsWrapperCaseClass[DeliveryCreditRequest]](json).right.value should ===(
+    decode[RecordsWrapperCaseClass[DeliveryCreditRequest]](json).right.value should matchTo(
       RecordsWrapperCaseClass(List(
         DeliveryCreditRequest(
           Id = "r1",
           SF_Subscription__r = DeliveryCreditSubscription(Name = "A-S00001"),
           Delivery_Date__c = LocalDate.of(2019, 12, 6),
-          Charge_Code__c = None
+          Charge_Code__c = None,
+          Invoice_Date__c = LocalDate.of(2020, 2, 10)
         ),
         DeliveryCreditRequest(
           Id = "r2",
           SF_Subscription__r = DeliveryCreditSubscription(Name = "A-S00002"),
           Delivery_Date__c = LocalDate.of(2019, 12, 13),
-          Charge_Code__c = Some("C12345")
+          Charge_Code__c = Some("C12345"),
+          Invoice_Date__c = LocalDate.of(2020, 3, 1)
         )
       ))
     )

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -11,10 +11,12 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
 import com.gu.zuora.ZuoraProductTypes
 import com.gu.zuora.ZuoraProductTypes.ZuoraProductType
 import com.gu.zuora.subscription.Fixtures.mkGuardianWeeklySubscription
-import com.gu.zuora.subscription.{ZuoraAccount, _}
-import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
+import com.gu.zuora.subscription._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{EitherValues, OptionValues}
 
-class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues with OptionValues {
+class HolidayStopProcessTest extends AnyFlatSpec with Matchers with EitherValues with OptionValues {
   MutableCalendar.setFakeToday(Some(LocalDate.parse("2019-07-12")))
   val effectiveStartDate = LocalDate.of(2019, 5, 11)
 
@@ -64,12 +66,26 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
 
   private val creditProduct = HolidayCreditProduct.Dev
 
+  private def updateToApply(
+    creditProduct: CreditProduct,
+    subscription: Subscription,
+    account: ZuoraAccount,
+    request: HolidayStopRequestsDetail
+  ) =
+    SubscriptionUpdate(
+      creditProduct,
+      subscription,
+      account,
+      request.Stopped_Publication_Date__c,
+      None
+    )
+
   "HolidayStopProcess" should "give correct added charge" in {
     val response = Processor.addCreditToSubscription(
       creditProduct,
       _ => Right(Fixtures.mkSubscriptionWithHolidayStops()),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Right(())),
       ZuoraHolidayCreditAddResult.apply
     )(request)
@@ -90,7 +106,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       creditProduct,
       _ => Right(subscription),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Left(ZuoraApiFailure("update went wrong"))),
       ZuoraHolidayCreditAddResult.apply
     )(request)
@@ -102,7 +118,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       creditProduct,
       _ => Left(ZuoraApiFailure("get went wrong")),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Right(())),
       ZuoraHolidayCreditAddResult.apply
     )(request)
@@ -119,7 +135,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       creditProduct,
       _ => Right(Fixtures.mkSubscriptionWithHolidayStops().copy(autoRenew = false)),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Right(())),
       ZuoraHolidayCreditAddResult.apply
     )(request)
@@ -131,7 +147,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       creditProduct,
       _ => Right(subscription.copy(status = "Cancelled")),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Left(ZuoraApiFailure("shouldn't need to apply an update"))),
       ZuoraHolidayCreditAddResult.apply
     )(request)
@@ -143,7 +159,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       creditProduct,
       _ => Right(Fixtures.mkSubscriptionWithHolidayStops()),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Left(ZuoraApiFailure("shouldn't need to apply an update"))),
       ZuoraHolidayCreditAddResult.apply
     )(request)
@@ -163,7 +179,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       creditProduct,
       _ => Right(subscription),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Left(ZuoraApiFailure("shouldn't need to apply an update"))),
       ZuoraHolidayCreditAddResult.apply
     )(request)
@@ -183,7 +199,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       ZuoraProductTypes.GuardianWeekly,
       _ => Right(Fixtures.mkSubscriptionWithHolidayStops()),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Right(())),
       ZuoraHolidayCreditAddResult.apply,
       exportAmendments(Right(()))
@@ -220,7 +236,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       ZuoraProductTypes.GuardianWeekly,
       _ => Right(Fixtures.mkSubscriptionWithHolidayStops()),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Right(())),
       ZuoraHolidayCreditAddResult.apply,
       exportAmendments(Right(()))
@@ -240,7 +256,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       ZuoraProductTypes.GuardianWeekly,
       _ => Right(Fixtures.mkSubscriptionWithHolidayStops()),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Right(())),
       ZuoraHolidayCreditAddResult.apply,
       exportAmendments(Right(()))
@@ -260,7 +276,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       ZuoraProductTypes.GuardianWeekly,
       _ => Right(Fixtures.mkSubscriptionWithHolidayStops()),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Right(())),
       ZuoraHolidayCreditAddResult.apply,
       exportAmendments(Right(()))
@@ -291,7 +307,7 @@ class HolidayStopProcessTest extends FlatSpec with Matchers with EitherValues wi
       ZuoraProductTypes.GuardianWeekly,
       _ => Right(subscription),
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription(Right(())),
       ZuoraHolidayCreditAddResult.apply,
       exportAmendments(Left(SalesforceApiFailure("Export failed")))

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ProcessorErrorHandlingSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ProcessorErrorHandlingSpec.scala
@@ -10,13 +10,15 @@ import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.HolidayStopRequestsDetail
 import com.gu.zuora.ZuoraProductTypes
 import com.gu.zuora.ZuoraProductTypes.ZuoraProductType
-import com.gu.zuora.subscription.{ZuoraAccount, _}
-import org.scalatest._
+import com.gu.zuora.subscription._
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Make sure short-circuiting does not happen.
  */
-class ProcessorErrorHandlingSpec extends FlatSpec with Matchers with OptionValues {
+class ProcessorErrorHandlingSpec extends AnyFlatSpec with Matchers with OptionValues {
 
   MutableCalendar.setFakeToday(Some(LocalDate.parse("2019-08-01")))
 
@@ -51,6 +53,20 @@ class ProcessorErrorHandlingSpec extends FlatSpec with Matchers with OptionValue
 
   private val creditProduct = HolidayCreditProduct.Dev
 
+  private def updateToApply(
+    creditProduct: CreditProduct,
+    subscription: Subscription,
+    account: ZuoraAccount,
+    request: HolidayStopRequestsDetail
+  ) =
+    SubscriptionUpdate(
+      creditProduct,
+      subscription,
+      account,
+      request.Stopped_Publication_Date__c,
+      None
+    )
+
   "Error handling" should "not short-circuit if some writes to Zuora fail (but others succeed), and Salesforce write succeeds" in {
     val getSubscription: SubscriptionName => Either[ZuoraApiFailure, Subscription] = {
       case subName if subName.value == "A-S1" => Right(subscription)
@@ -68,7 +84,7 @@ class ProcessorErrorHandlingSpec extends FlatSpec with Matchers with OptionValue
       ZuoraProductTypes.GuardianWeekly,
       getSubscription,
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription,
       ZuoraHolidayCreditAddResult.apply,
       writeHolidayStopsToSalesforce
@@ -99,7 +115,7 @@ class ProcessorErrorHandlingSpec extends FlatSpec with Matchers with OptionValue
       ZuoraProductTypes.GuardianWeekly,
       getSubscription,
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription,
       ZuoraHolidayCreditAddResult.apply,
       writeHolidayStopsToSalesforce
@@ -130,7 +146,7 @@ class ProcessorErrorHandlingSpec extends FlatSpec with Matchers with OptionValue
       ZuoraProductTypes.GuardianWeekly,
       getSubscription,
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription,
       ZuoraHolidayCreditAddResult.apply,
       writeHolidayStopsToSalesforce
@@ -160,7 +176,7 @@ class ProcessorErrorHandlingSpec extends FlatSpec with Matchers with OptionValue
       ZuoraProductTypes.GuardianWeekly,
       getSubscription,
       getAccount(Fixtures.mkAccount().asRight),
-      SubscriptionUpdate.apply,
+      updateToApply,
       updateSubscription,
       ZuoraHolidayCreditAddResult.apply,
       writeHolidayStopsToSalesforce

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/InvoiceDate.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/InvoiceDate.scala
@@ -1,0 +1,5 @@
+package com.gu.zuora.subscription
+
+import java.time.LocalDate
+
+case class InvoiceDate(value: LocalDate) extends AnyVal

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SubscriptionUpdate.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SubscriptionUpdate.scala
@@ -19,7 +19,8 @@ object SubscriptionUpdate {
     creditProduct: CreditProduct,
     subscription: Subscription,
     account: ZuoraAccount,
-    affectedDate: AffectedPublicationDate
+    affectedDate: AffectedPublicationDate,
+    maybeInvoiceDate: Option[InvoiceDate]
   ): ZuoraApiResponse[SubscriptionUpdate] =
     for {
       subscriptionData <- SubscriptionData(subscription, account)
@@ -27,15 +28,16 @@ object SubscriptionUpdate {
     } yield {
       val maybeExtendedTerm = ExtendedTerm(issueData.nextBillingPeriodStartDate, subscription)
       val credit = Credit(issueData.credit, issueData.nextBillingPeriodStartDate)
+      val invoiceDate = maybeInvoiceDate.map(_.value).getOrElse(credit.invoiceDate)
       SubscriptionUpdate(
         currentTerm = maybeExtendedTerm.map(_.length),
         currentTermPeriodType = maybeExtendedTerm.map(_.unit),
         List(
           Add(
             productRatePlanId = creditProduct.productRatePlanId,
-            contractEffectiveDate = credit.invoiceDate,
-            customerAcceptanceDate = credit.invoiceDate,
-            serviceActivationDate = credit.invoiceDate,
+            contractEffectiveDate = invoiceDate,
+            customerAcceptanceDate = invoiceDate,
+            serviceActivationDate = invoiceDate,
             chargeOverrides = List(
               ChargeOverride(
                 productRatePlanChargeId = creditProduct.productRatePlanChargeId,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,7 @@ object Dependencies {
   val http4sServer = "org.http4s" %% "http4s-server" % http4sVersion
   val catsCore = "org.typelevel" %% "cats-core" % catsVersion
   val catsEffect = "org.typelevel" %% "cats-effect" % catsEffectVersion
-  val scalaLambda = "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0"
+  val scalaLambda = "io.github.mkotsur" %% "aws-lambda-scala" % "0.1.1"
   val zio = "dev.zio" %% "zio" % "1.0.0-RC17"
   val diffx = "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.17" % Test
 


### PR DESCRIPTION
For delivery-problem credits, we are going to process the credit using the invoice date already populated in Salesforce from the `potential` call in the API.
This should make no difference to holiday-stop credit processing.