### PR TITLE
Recreate voucher stub

### DIFF
--- a/handlers/digital-voucher-api/README.md
+++ b/handlers/digital-voucher-api/README.md
@@ -15,5 +15,5 @@ All endpoints require...
 | --- | --- | --- | --- | --- |
 | GET | `/{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> | | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Returns the Imovo digital subscription associated with the salesforce subscription id |
 | PUT | `/{STAGE}/digital-voucher/create/\<SALESFORCE_SUBSCRIPTION_ID\> | {"ratePlanName":"\<subscription rate plan name\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Creates an Imovo digital subscription or returns the details of the subscription if it already exists |
-| PUT | `/{STAGE}/digital-voucher/replace/\<SALESFORCE_SUBSCRIPTION_ID\> | {"ratePlanName":"\<subscription rate plan name\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Forces an Imovo a new digital subscription invalidating the existing subscription associated with the salesforce subscription id |
+| POST | `/{STAGE}/digital-voucher/replace | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Forces an Imovo a new digital subscription invalidating the existing subscription associated with the salesforce subscription id |
 | DELETE | `/{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> |  | | Deletes an Imovo digital subscription |

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
@@ -25,6 +25,4 @@ object DigitalVoucherApiApp extends LazyLogging {
       logAction = Some({ message: String => IO.delay(logger.info(message)) })
     )
   }
-
-  private val bucket = "gu-reader-revenue-private"
 }

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
@@ -80,7 +80,7 @@ object DigitalVoucherApiRoutes {
     HttpRoutes.of[F] {
       case request @ PUT -> Root / "digital-voucher" / "create" / subscriptionId =>
         handleCreateRequest(request, subscriptionId)
-      case request @ PUT -> Root / "digital-voucher" / "replace" =>
+      case request @ POST -> Root / "digital-voucher" / "replace" =>
         handleReplaceRequest(request)
       case GET -> Root / "digital-voucher" / subscriptionId =>
         handleGetRequest(subscriptionId)

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
@@ -50,13 +50,12 @@ object DigitalVoucherApiRoutes {
       )
     }
 
-    def handleReplaceRequest(request: Request[F], subscriptionId: String) = {
+    def handleReplaceRequest(request: Request[F]) = {
       toResponse(
         for {
-          requestBody <- parseRequest[CreateVoucherRequestBody](request)
+          requestBody <- parseRequest[Voucher](request)
           voucher <- digitalVoucherService.replaceVoucher(
-            subscriptionId,
-            requestBody.ratePlanName
+            requestBody
           ).leftMap(_ => InternalServerError())
         } yield voucher
       )
@@ -81,8 +80,8 @@ object DigitalVoucherApiRoutes {
     HttpRoutes.of[F] {
       case request @ PUT -> Root / "digital-voucher" / "create" / subscriptionId =>
         handleCreateRequest(request, subscriptionId)
-      case request @ PUT -> Root / "digital-voucher" / "replace" / subscriptionId =>
-        handleReplaceRequest(request, subscriptionId)
+      case request @ PUT -> Root / "digital-voucher" / "replace" =>
+        handleReplaceRequest(request)
       case GET -> Root / "digital-voucher" / subscriptionId =>
         handleGetRequest(subscriptionId)
       case DELETE -> Root / "digital-voucher" / subscriptionId =>

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
@@ -8,7 +8,7 @@ case class Voucher(cardCode: String, letterCode: String)
 
 trait DigitalVoucherService[F[_]] {
   def createVoucher(subscriptionId: String, ratePlanName: String): EitherT[F, DigitalVoucherServiceError, Voucher]
-  def replaceVoucher(subscriptionId: String, ratePlanName: String): EitherT[F, DigitalVoucherServiceError, Voucher]
+  def replaceVoucher(voucher: Voucher): EitherT[F, DigitalVoucherServiceError, Voucher]
   def getVoucher(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, Voucher]
   def deleteVoucherForSubscription(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, Unit]
 }
@@ -22,11 +22,10 @@ object DigitalVoucherService {
       EitherT.rightT[F, DigitalVoucherServiceError](Voucher(s"$subscriptionId-card-code", s"$subscriptionId-letter-code"))
 
     override def replaceVoucher(
-      subscriptionId: String,
-      ratePlanName: String
+      voucher: Voucher
     ): EitherT[F, DigitalVoucherServiceError, Voucher] =
       EitherT.rightT[F, DigitalVoucherServiceError](
-        Voucher(s"$subscriptionId-replaced-card-code", s"$subscriptionId-replaced-letter-code")
+        Voucher(s"${voucher.cardCode}-replaced-card-code", s"${voucher.letterCode}-replaced-letter-code")
       )
 
     override def deleteVoucherForSubscription(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, Unit] =

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -6,7 +6,7 @@ import io.circe.syntax._
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.http4s.{Method, Request, Response, Uri}
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.{EitherValues, FlatSpec, Inside, Matchers}
 
 class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
   "DigitalVoucherApi" should "return stubbed voucher details for create request" in {
@@ -58,7 +58,9 @@ class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
   }
 
   private def createApp() = {
-    DigitalVoucherApiApp().value.unsafeRunSync().right.value
+    Inside.inside(DigitalVoucherApiApp().value.unsafeRunSync()) {
+      case Right(value) => value
+    }
   }
 
   private def getBody[A: Decoder](response: Response[IO]) = {

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -26,11 +26,11 @@ class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
     val response = app.run(
       Request(
         method = Method.PUT,
-        Uri(path = "/digital-voucher/replace/sub123456")
-      ).withEntity[String](CreateVoucherRequestBody("Rate-Plan-Name").asJson.spaces2)
+        Uri(path = "/digital-voucher/replace")
+      ).withEntity[String](Voucher("card-code", "letter-code").asJson.spaces2)
     ).value.unsafeRunSync().get
 
-    getBody[Voucher](response) should equal(Voucher("sub123456-replaced-card-code", "sub123456-replaced-letter-code"))
+    getBody[Voucher](response) should equal(Voucher("card-code-replaced-card-code", "letter-code-replaced-letter-code"))
     response.status.code should equal(200)
   }
   it should "return stubbed voucher details for get request" in {

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -25,7 +25,7 @@ class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
     val app = createApp()
     val response = app.run(
       Request(
-        method = Method.PUT,
+        method = Method.POST,
         Uri(path = "/digital-voucher/replace")
       ).withEntity[String](Voucher("card-code", "letter-code").asJson.spaces2)
     ).value.unsafeRunSync().get

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/RatePlanChargeBillingSchedule.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/RatePlanChargeBillingSchedule.scala
@@ -137,8 +137,8 @@ object RatePlanChargeBillingSchedule {
 
       billingSchedule <- selectScheduleThatPredictsProcessedThroughDate(
         NonEmptyList.of(
-          scheduleForCalculatedStartDate,
-          scheduleForEffectiveStartDate
+          scheduleForEffectiveStartDate,
+          scheduleForCalculatedStartDate
         ),
         processedThroughDate
       )


### PR DESCRIPTION
Reworking the replace endpoint of the digital voucher api.

This now takes the form:

```
POST /digital-voucher/replace
```
with body:
```
{
  "cardCode": "xx",
  "letterCode": "xx"
}
```