### PR TITLE
Don't write delivery-credit invoice date back to Salesforce

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -141,7 +141,6 @@ object DeliveryCreditProcessor extends Logging {
     deliveryId = request.Id,
     chargeCode = RatePlanChargeCode(addedCharge.number),
     amountCredited = Price(addedCharge.price),
-    invoiceDate = addedCharge.effectiveStartDate
   )
 
   def getCreditRequestsFromSalesforce(sfAuthConfig: SFAuthConfig)(
@@ -192,7 +191,6 @@ object DeliveryCreditProcessor extends Logging {
     Charge_Code__c: String,
     Credit_Amount__c: Double,
     Actioned_On__c: LocalDateTime,
-    Invoice_Date__c: LocalDate
   )
 
   def writeCreditResultsToSalesforce(sfAuthConfig: SFAuthConfig)(
@@ -209,7 +207,6 @@ object DeliveryCreditProcessor extends Logging {
           Charge_Code__c = result.chargeCode.value,
           Credit_Amount__c = result.amountCredited.value,
           Actioned_On__c = LocalDateTime.now,
-          Invoice_Date__c = result.invoiceDate
         )
         salesforceClient.patch(
           deliveryObject,

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditResult.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditResult.scala
@@ -1,7 +1,5 @@
 package com.gu.deliveryproblemcreditprocessor
 
-import java.time.LocalDate
-
 import com.gu.creditprocessor.ZuoraCreditAddResult
 import com.gu.zuora.subscription.{Price, RatePlanChargeCode}
 
@@ -9,5 +7,4 @@ case class DeliveryCreditResult(
   deliveryId: String,
   chargeCode: RatePlanChargeCode,
   amountCredited: Price,
-  invoiceDate: LocalDate
 ) extends ZuoraCreditAddResult


### PR DESCRIPTION
We're now reading the invoice date in from Salesforce with the credit request so it's redundant to write it back to Salesforce, as it won't have changed.