### PR TITLE
holiday-stop-api : FIX for subs that have not started

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -226,7 +226,7 @@ object Handler extends Logging {
         )
       }
       nextInvoiceDateAfterToday = subscriptionData
-        .issueDataForPeriod(MutableCalendar.today.minusDays(7), MutableCalendar.today.plusDays(7))
+        .issueDataForPeriod(MutableCalendar.today.minusDays(7), MutableCalendar.today.plusMonths(2))
         .filter(_.nextBillingPeriodStartDate.isAfter(MutableCalendar.today))
         .minBy(_.nextBillingPeriodStartDate)(Ordering.by(_.toEpochDay))
         .nextBillingPeriodStartDate


### PR DESCRIPTION
This fixes an issue in the calculation of the `nextInvoiceDateAfterToday` field in the holiday stops api.

When subs have not started they do not have any issues for the period around 'today', so the code fails.

This fix just extends the period around today to a couple of months in the future.

This probably needs more thought for a permanent fix.