### PR TITLE
holiday-stop-api : historical cut-off on the 'list existing' endpoint

### DIFF
--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -216,7 +216,12 @@ class HandlerTest extends AnyFlatSpec with Matchers {
       unwrappedOp(Handler.operationForEffects(
         new TestingRawEffects(
           responses = Map(
-            SalesForceHolidayStopsEffects.listHolidayStops(contactId, subscriptionName, List(holidayStopRequest))
+            SalesForceHolidayStopsEffects.listHolidayStops(
+              contactId,
+              subscriptionName,
+              List(holidayStopRequest),
+              Some(MutableCalendar.today.minusMonths(6))
+            )
           ),
           postResponses = Map(
             SFTestEffects.authSuccess,
@@ -231,9 +236,7 @@ class HandlerTest extends AnyFlatSpec with Matchers {
           .steps(
             existingHolidayStopsRequest(
               subscriptionName,
-              contactId,
-              "Newspaper - Voucher Book",
-              "Sunday"
+              contactId
             )
           )
       }
@@ -412,30 +415,10 @@ class HandlerTest extends AnyFlatSpec with Matchers {
     )
   }
 
-  private def potentialIssueDateRequest(productType: String, productRatePlanName: String, startDate: String,
-                                        endDate: String, subscriptionName: String) = {
+  private def existingHolidayStopsRequest(subscriptionName: String, sfContactId: String) = {
     ApiGatewayRequest(
       Some("GET"),
-      Some(Map(
-        "startDate" -> startDate,
-        "endDate" -> endDate,
-        "productType" -> productType,
-        "productRatePlanName" -> productRatePlanName
-      )),
       None,
-      None,
-      Some(JsObject(Seq("subscriptionName" -> JsString(subscriptionName)))),
-      Some(s"/potential/$subscriptionName ")
-    )
-  }
-
-  private def existingHolidayStopsRequest(subscriptionName: String, sfContactId: String, productType: String, produtRatePlanName: String) = {
-    ApiGatewayRequest(
-      Some("GET"),
-      Some(Map(
-        "productType" -> productType,
-        "productRatePlanName" -> produtRatePlanName
-      )),
       None,
       Some(Map("x-salesforce-contact-id" -> sfContactId)),
       Some(JsObject(Seq("subscriptionName" -> JsString(subscriptionName)))),


### PR DESCRIPTION
The upcoming backfill (of all Home Delivery Holiday Stops created using the old platform), will produce lots of historical holiday stop requests. 

To avoid too much visual noise for self-service users, we need to add a cut off on the 'list existing' endpoint of the `holiday-stop-api`.

This cut-off, will exclude holiday stop requests where the `Max_Expected_Invoice_Date__c`* is older than 6 months, however for some records that field will be null (from before we calculated this value), so if it's null we exclude based on `End_Date__c` being older than 6 months.

ALSO
- in addition documenting the above in the README, restructured it away from tabular, which makes it easier to read.
- cleaned up tests and removed some old redundant functions.

---

*`Max_Expected_Invoice_Date__c` is a new 'rollup' field created on the `Holiday_Stop_Request__c` object [to facilitate this PR] - it finds the maximum `Expected_Invoice_Date__c` among the child `Holiday_Stop_Requests_Detail__c` records.