### PR TITLE
Digital voucher api: Fetching configuration from property store

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ val scalaSettings = Seq(
   },
 
   autoCompilerPlugins := true,
+  resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
 )
 
 // fixme this whole file needs splitting down appropriately
@@ -373,7 +374,7 @@ lazy val `digital-voucher-api` = all(project in file("handlers/digital-voucher-a
   .dependsOn(`effects-s3`, `config-core`)
   .settings(
     libraryDependencies ++=
-      Seq(http4sLambda, http4sDsl, http4sCirce, http4sServer, circe, sttpAsycHttpClientBackendCats, scalatest)
+      Seq(http4sLambda, http4sDsl, http4sCirce, http4sServer, circe, circeConfig, sttpAsycHttpClientBackendCats, scalatest, simpleConfig)
         ++ logging
   )
   .enablePlugins(RiffRaffArtifact)

--- a/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiTest.scala
+++ b/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiTest.scala
@@ -10,7 +10,7 @@ import com.softwaremill.sttp.impl.cats.CatsMonadError
 import com.softwaremill.sttp.testing.SttpBackendStub
 import io.circe.Decoder
 import org.http4s.{Header, Headers, Method, Query, Request, Response, Uri}
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.{EitherValues, FlatSpec, Inside, Matchers}
 import io.circe.generic.auto._
 import io.circe.parser._
 
@@ -273,6 +273,8 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
   }
 
   private def createApp(salesforceBackendStub: SttpBackendStub[IO, Nothing]) = {
-    DeliveryRecordsApiApp(config, salesforceBackendStub).value.unsafeRunSync().right.value
+    Inside.inside(DeliveryRecordsApiApp(config, salesforceBackendStub).value.unsafeRunSync()) {
+      case Right(value) => value
+    }
   }
 }

--- a/handlers/digital-voucher-api/README.md
+++ b/handlers/digital-voucher-api/README.md
@@ -17,3 +17,40 @@ All endpoints require...
 | PUT | `/{STAGE}/digital-voucher/create/\<SALESFORCE_SUBSCRIPTION_ID\> | {"ratePlanName":"\<subscription rate plan name\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Creates an Imovo digital subscription or returns the details of the subscription if it already exists |
 | POST | `/{STAGE}/digital-voucher/replace | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Forces an Imovo a new digital subscription invalidating the existing subscription associated with the salesforce subscription id |
 | DELETE | `/{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> |  | | Deletes an Imovo digital subscription |
+
+Config
+======
+
+The configuration for this application is stored in the [aws parameter store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).
+
+The configuration can be updated using the [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html). 
+
+NOTE: Due to a 'feature' in the aws cli you either need to use v2 of the cli or have the following in your '~/.aws/config' file:
+
+```
+cli_follow_urlparam=false
+``` 
+
+For more details see: https://github.com/aws/aws-cli/issues/2507
+
+Each parameter has a key derived from the configuration case class used in the application. See:
+
+[com.gu.digital_voucher_api.DigitalVoucherApiConfig](src/main/scala/com/gu/digital_voucher_api/ConfigLoader.scala)
+
+To update a 'non-secret' parameter use the following aws cli command:
+
+```bash
+aws --profile membership ssm put-parameter --overwrite --type String --name /<stage>/membership-<stage>-digital-voucher-api/digital-voucher-api-<stage>/<parameter key> --value <parameter value>
+```
+
+To update a 'secret' parameter such as api keys and passwords use the following aws cli command:
+
+```bash
+aws --profile membership ssm put-parameter --overwrite --type SecureString --key-id 302bd430-2d97-4984-8625-b55a70691b49 --name /<stage>/membership-<stage>-digital-voucher-api/digital-voucher-api-<stage>/<parameter key> --value <parameter value>
+```
+
+For example:
+```$bash
+aws --profile membership ssm put-parameter --overwrite --type String --name /DEV/membership-DEV-digital-voucher-api/digital-voucher-api-DEV/imovoBaseUrl --value  https://core-uat-api.azurewebsites.net
+aws --profile membership ssm put-parameter --overwrite --type SecureString --key-id 302bd430-2d97-4984-8625-b55a70691b49 --name /DEV/membership-DEV-digital-voucher-api/digital-voucher-api-DEV/imovoApiKey --value xxxxxx
+```

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -58,7 +58,7 @@ Resources:
                       Statement:
                           - Effect: Allow
                             Action: ssm:GetParametersByPath
-                            Resource: !Sub arn:aws:ssm:::parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}
+                            Resource: !Sub arn:aws:ssm:::parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}/*
 
     DigitalVoucherApi:
         Type: "AWS::ApiGateway::RestApi"

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -57,8 +57,8 @@ Resources:
                   PolicyDocument:
                       Statement:
                           - Effect: Allow
-                            Action: ssm:GetParameters
-                            Resource: !Sub arn:aws:ssm:::parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}/*
+                            Action: ssm:GetParametersByPath
+                            Resource: !Sub arn:aws:ssm:::parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}
 
     DigitalVoucherApi:
         Type: "AWS::ApiGateway::RestApi"

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -80,6 +80,8 @@ Resources:
             Handler: com.gu.digital_voucher_api.Handler::handle
             Environment:
                 Variables:
+                  App: !Sub digital-voucher-api-${Stage}
+                  Stack: !Sub membership-${Stage}-digital-voucher-api
                   Stage: !Ref Stage
             Role:
                 Fn::GetAtt:

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -58,7 +58,7 @@ Resources:
                       Statement:
                           - Effect: Allow
                             Action: ssm:GetParametersByPath
-                            Resource: !Sub arn:aws:ssm:::parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}/*
+                            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}
 
     DigitalVoucherApi:
         Type: "AWS::ApiGateway::RestApi"

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -53,6 +53,12 @@ Resources:
                           - Effect: Allow
                             Action: s3:GetObject
                             Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/*
+                - PolicyName: ReadApplicationConfig
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action: ssm:GetParameters
+                            Resource: !Sub arn:aws:ssm:::parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}/*
 
     DigitalVoucherApi:
         Type: "AWS::ApiGateway::RestApi"

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -52,13 +52,21 @@ Resources:
                       Statement:
                           - Effect: Allow
                             Action: s3:GetObject
-                            Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/*
+                            Resource: !Sub "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/*"
                 - PolicyName: ReadApplicationConfig
                   PolicyDocument:
                       Statement:
                           - Effect: Allow
                             Action: ssm:GetParametersByPath
-                            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}
+                            Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stage}/membership-${Stage}-digital-voucher-api/digital-voucher-api-${Stage}"
+                - PolicyName: DecryptApplicationConfig
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action: kms:Decrypt
+                            Resource: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/302bd430-2d97-4984-8625-b55a70691b49"
+
+
 
     DigitalVoucherApi:
         Type: "AWS::ApiGateway::RestApi"

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/ConfigLoader.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/ConfigLoader.scala
@@ -1,0 +1,37 @@
+package com.gu.digital_voucher_api
+
+import cats.data.EitherT
+import cats.implicits._
+import cats.effect.Sync
+import com.gu.conf.{ResourceConfigurationLocation, SSMConfigurationLocation}
+import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
+import com.typesafe.config.Config
+import io.circe.generic.auto._
+import io.circe.config.syntax._
+
+case class DigitalVoucherApiConfig(imovoBaseUrl: String, imovoApiKey: String)
+
+case class ConfigError(message: String)
+
+object ConfigLoader {
+  def loadConfig[F[_]: Sync](): EitherT[F, ConfigError, DigitalVoucherApiConfig] = {
+    for {
+      typeSafeConfig <- loadConfigFromPropertyStore[F]()
+      parsedConfig <- typeSafeConfig
+        .as[DigitalVoucherApiConfig]
+        .leftMap(error => ConfigError(s"Failed to decode config: $error"))
+        .toEitherT[F]
+    } yield parsedConfig
+  }
+
+  private def loadConfigFromPropertyStore[F[_]: Sync](): EitherT[F, ConfigError, Config] =
+    EitherT(Sync[F].delay {
+      Either.catchNonFatal {
+        val identity = AppIdentity.whoAmI(defaultAppName = "digital-voucher-api")
+        com.gu.conf.ConfigurationLoader.load(identity) {
+          case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
+          case DevIdentity(myApp) => ResourceConfigurationLocation(s"${myApp}-secret-dev.conf")
+        }
+      }.leftMap(ex => ConfigError(s"Failed to load config: ${ex.getMessage}"))
+    })
+}

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
@@ -2,6 +2,7 @@ package com.gu.digital_voucher_api
 
 import cats.data.EitherT
 import cats.effect.{ContextShift, IO}
+import com.gu.AppIdentity
 import com.typesafe.scalalogging.LazyLogging
 import org.http4s.HttpRoutes
 import org.http4s.server.middleware.Logger
@@ -13,9 +14,9 @@ object DigitalVoucherApiApp extends LazyLogging {
 
   private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
-  def apply(): EitherT[IO, DigitalVoucherApiAppError, HttpRoutes[IO]] = {
+  def apply(appIdentity: AppIdentity): EitherT[IO, DigitalVoucherApiAppError, HttpRoutes[IO]] = {
     for {
-      config <- ConfigLoader.loadConfig[IO]().leftMap(error => DigitalVoucherApiAppError(error.toString))
+      config <- ConfigLoader.loadConfig[IO](appIdentity: AppIdentity).leftMap(error => DigitalVoucherApiAppError(error.toString))
       _ = logger.info(s"Loaded config: ${config.imovoBaseUrl}") //Temporary log message to check config is loaded
       routes <- EitherT.rightT[IO, DigitalVoucherApiAppError](createLogging()(DigitalVoucherApiRoutes(DigitalVoucherService())))
     } yield routes

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
@@ -13,8 +13,12 @@ object DigitalVoucherApiApp extends LazyLogging {
 
   private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
-  def apply[S](): EitherT[IO, DigitalVoucherApiAppError, HttpRoutes[IO]] = {
-    EitherT.rightT(createLogging()(DigitalVoucherApiRoutes(DigitalVoucherService())))
+  def apply(): EitherT[IO, DigitalVoucherApiAppError, HttpRoutes[IO]] = {
+    for {
+      config <- ConfigLoader.loadConfig[IO]().leftMap(error => DigitalVoucherApiAppError(error.toString))
+      _ = logger.info(s"Loaded config: ${config.imovoBaseUrl}") //Temporary log message to check config is loaded
+      routes <- EitherT.rightT[IO, DigitalVoucherApiAppError](createLogging()(DigitalVoucherApiRoutes(DigitalVoucherService())))
+    } yield routes
   }
 
   def createLogging(): HttpRoutes[IO] => HttpRoutes[IO] = {

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
@@ -19,13 +19,13 @@ object DigitalVoucherService {
       subscriptionId: String,
       ratePlanName: String
     ): EitherT[F, DigitalVoucherServiceError, Voucher] =
-      EitherT.rightT[F, DigitalVoucherServiceError](Voucher(s"$subscriptionId-card-code", s"$subscriptionId-letter-code"))
+      EitherT.rightT[F, DigitalVoucherServiceError](Voucher("1111111111", "2222222222"))
 
     override def replaceVoucher(
       voucher: Voucher
     ): EitherT[F, DigitalVoucherServiceError, Voucher] =
       EitherT.rightT[F, DigitalVoucherServiceError](
-        Voucher(s"${voucher.cardCode}-replaced-card-code", s"${voucher.letterCode}-replaced-letter-code")
+        Voucher("3333333333", "4444444444")
       )
 
     override def deleteVoucherForSubscription(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, Unit] =
@@ -33,7 +33,7 @@ object DigitalVoucherService {
 
     override def getVoucher(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, Voucher] =
       EitherT.rightT[F, DigitalVoucherServiceError](
-        Voucher(s"$subscriptionId-card-code", s"$subscriptionId-letter-code")
+        Voucher(s"5555555555", s"6666666666")
       )
   }
 }

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Handler.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Handler.scala
@@ -2,9 +2,10 @@ package com.gu.digital_voucher_api
 
 import io.github.howardjohn.lambda.http4s.Http4sLambdaHandler
 import cats.syntax.either._
+import com.gu.AppIdentity
 
 object Handler extends Http4sLambdaHandler(
-  DigitalVoucherApiApp()
+  DigitalVoucherApiApp(AppIdentity.whoAmI(defaultAppName = "digital-voucher-api"))
     .value
     .unsafeRunSync()
     .valueOr((error: DigitalVoucherApiAppError) => throw new RuntimeException(error.toString))

--- a/handlers/digital-voucher-api/src/test/resources/digital-voucher-api-secret-dev.conf
+++ b/handlers/digital-voucher-api/src/test/resources/digital-voucher-api-secret-dev.conf
@@ -1,0 +1,2 @@
+imovoApiKey: xxxxx
+imovoBaseUrl: "https://digital-voucher-api.thegulocal.com"

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -6,7 +6,7 @@ import io.circe.syntax._
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.http4s.{Method, Request, Response, Uri}
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.{EitherValues, FlatSpec, Inside, Matchers}
 
 class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
   "DigitalVoucherApi" should "return stubbed voucher details for create request" in {
@@ -58,7 +58,9 @@ class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
   }
 
   private def createApp() = {
-    DigitalVoucherApiApp().value.unsafeRunSync().right.value
+    Inside.inside(DigitalVoucherApiApp().value.unsafeRunSync()) {
+      case Right(value) => value
+    }
   }
 
   private def getBody[A: Decoder](response: Response[IO]) = {

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -1,6 +1,7 @@
 package com.gu.digital_voucher_api
 
 import cats.effect.IO
+import com.gu.DevIdentity
 import io.circe.Decoder
 import io.circe.syntax._
 import io.circe.generic.auto._
@@ -58,7 +59,7 @@ class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
   }
 
   private def createApp() = {
-    Inside.inside(DigitalVoucherApiApp().value.unsafeRunSync()) {
+    Inside.inside(DigitalVoucherApiApp(DevIdentity("digital-voucher-api")).value.unsafeRunSync()) {
       case Right(value) => value
     }
   }

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -19,7 +19,7 @@ class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
       ).withEntity[String](CreateVoucherRequestBody("Rate-Plan-Name").asJson.spaces2)
     ).value.unsafeRunSync().get
 
-    getBody[Voucher](response) should equal(Voucher("sub123456-card-code", "sub123456-letter-code"))
+    getBody[Voucher](response) should equal(Voucher("1111111111", "2222222222"))
     response.status.code should equal(200)
   }
   it should "return stubbed voucher details for replace request" in {
@@ -28,10 +28,10 @@ class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
       Request(
         method = Method.POST,
         Uri(path = "/digital-voucher/replace")
-      ).withEntity[String](Voucher("card-code", "letter-code").asJson.spaces2)
+      ).withEntity[String](Voucher("3333333333", "4444444444").asJson.spaces2)
     ).value.unsafeRunSync().get
 
-    getBody[Voucher](response) should equal(Voucher("card-code-replaced-card-code", "letter-code-replaced-letter-code"))
+    getBody[Voucher](response) should equal(Voucher("3333333333", "4444444444"))
     response.status.code should equal(200)
   }
   it should "return stubbed voucher details for get request" in {
@@ -43,7 +43,7 @@ class DigitalVoucherApiTest extends FlatSpec with Matchers with EitherValues {
       )
     ).value.unsafeRunSync().get
 
-    getBody[Voucher](response) should equal(Voucher("sub123456-card-code", "sub123456-letter-code"))
+    getBody[Voucher](response) should equal(Voucher("5555555555", "6666666666"))
     response.status.code should equal(200)
   }
   it should "return stubbed 200 response for delete request" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
   val circe = "io.circe" %% "circe-generic" % circeVersion
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val circeJava8 = "io.circe" %% "circe-java8" % circeVersion
+  val circeConfig =  "io.circe" %% "circe-config" % "0.6.1"
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion
   val sttpCats = "com.softwaremill.sttp" %% "cats" % sttpVersion
@@ -47,6 +48,7 @@ object Dependencies {
   val scalaLambda = "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0"
   val zio = "dev.zio" %% "zio" % "1.0.0-RC17"
   val diffx = "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.17" % Test
+  val simpleConfig = "com.gu" %% "simple-configuration-ssm" % "1.4.1"
 
   // to resolve merge clash of 'module-info.class'
   // see https://stackoverflow.com/questions/54834125/sbt-assembly-deduplicate-module-info-class


### PR DESCRIPTION
This PR adds the fetching of configuration for the digital voucher api from the aws parameter store. 

For more details see:
* Aws Parameter Store docs - https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html
* Simple config, the gu library integrating the parameter store with typesafe config - https://github.com/guardian/simple-configuration
* Circe config for binding typesafe config to case classes - https://github.com/circe/circe-config
* Typesafe config - https://github.com/lightbend/config

Note: there are a couple of minor changes to the digital voucher stubbing bundled up with this pr 