### PR TITLE
Enable empty responses to be decoded as a Unit

### DIFF
--- a/lib/salesforce/sttp-test-stub/src/main/scala/com/gu/salesforce/sttp/SalesforceStub.scala
+++ b/lib/salesforce/sttp-test-stub/src/main/scala/com/gu/salesforce/sttp/SalesforceStub.scala
@@ -25,7 +25,7 @@ object SalesforceStub {
     def stubPatch(auth: SalesforceAuth): SttpBackendStub[F, S] = {
       sttpStub.whenRequestMatchesPartial {
         case request: Request[_, _] if matchesPatchRequest(auth, request) =>
-          Response(Right("{}"), 204, "")
+          Response(Right(""), 204, "")
       }
     }
 


### PR DESCRIPTION
A 204 response typically has an empty body, which causes Circe to throw a `DecodingException` because an empty String isn't valid json.  This change is to fix the problem.