### PR TITLE
delivery-records-api : expose 'CaseNumber' as 'ref'

### DIFF
--- a/handlers/delivery-records-api/README.md
+++ b/handlers/delivery-records-api/README.md
@@ -64,6 +64,7 @@ All endpoints require...
     "deliveryProblemMap": {
         "5003E00000FwUMYQA3": {
             "id": "5003E00000FwUMYQA3",
+            "ref": "1234567",
             "subject": "[Self Service] Delivery Problem : No Delivery (Guardian Weekly - A-S00080535)",
             "description": "description",
             "problemType": "No Delivery"

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsService.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsService.scala
@@ -38,6 +38,7 @@ final case class DeliveryRecord(
 
 final case class DeliveryProblemCase(
   id: String,
+  ref: String,
   subject: Option[String],
   description: Option[String],
   problemType: Option[String]
@@ -147,6 +148,7 @@ object DeliveryRecordsService {
           _.Case__r.map(
             problemCase => problemCase.Id -> DeliveryProblemCase(
               id = problemCase.Id,
+              ref = problemCase.CaseNumber,
               subject = problemCase.Subject,
               description = problemCase.Description,
               problemType = problemCase.Case_Closure_Reason__c
@@ -212,7 +214,7 @@ object DeliveryRecordsService {
     s"""SELECT Buyer__r.Id, Buyer__r.Phone, Buyer__r.HomePhone, Buyer__r.MobilePhone, Buyer__r.OtherPhone, (
        |    SELECT Id, Delivery_Date__c, Delivery_Address__c, Delivery_Instructions__c, Has_Holiday_Stop__c,
        |           Address_Line_1__c,Address_Line_2__c, Address_Line_3__c, Address_Town__c, Address_Country__c, Address_Postcode__c,
-       |           Case__c, Case__r.Id, Case__r.Subject, Case__r.Description, Case__r.Case_Closure_Reason__c,
+       |           Case__c, Case__r.Id, Case__r.CaseNumber, Case__r.Subject, Case__r.Description, Case__r.Case_Closure_Reason__c,
        |           Credit_Amount__c, Is_Actioned__c, Invoice_Date__c
        |    FROM Delivery_Records__r
        |    ${deliveryDateFilter(optionalStartDate, optionalEndDate)}

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryProblemCase.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryProblemCase.scala
@@ -11,6 +11,7 @@ import io.circe.syntax._
 
 case class SFApiDeliveryProblemCase(
   Id: String,
+  CaseNumber: String,
   Subject: Option[String],
   Description: Option[String],
   Case_Closure_Reason__c: Option[String] // this is actually the case sub-category (e.g. 'No Delivery', 'Damaged Delivery' etc.)

--- a/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiTest.scala
+++ b/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiTest.scala
@@ -39,6 +39,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
   val doesntHaveHolidayStop = true
   val sfProblemCase = SFApiDeliveryProblemCase(
     Id = "case_id",
+    CaseNumber = "123456",
     Subject = Some("subject"),
     Description = Some("blah blah"),
     Case_Closure_Reason__c = Some("Paper Damaged")
@@ -151,6 +152,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
     Map(
       sfProblemCase.Id -> DeliveryProblemCase(
         id = sfProblemCase.Id,
+        ref = sfProblemCase.CaseNumber,
         subject = sfProblemCase.Subject,
         description = sfProblemCase.Description,
         problemType = sfProblemCase.Case_Closure_Reason__c


### PR DESCRIPTION
...since this is the customer facing reference number (which needs to be displayed in the client, as per UX designs)