### PR TITLE
Remove reference to holiday stops in delivery credit log

### DIFF
--- a/lib/credit-processor/src/main/scala/com/gu/creditprocessor/ProcessResult.scala
+++ b/lib/credit-processor/src/main/scala/com/gu/creditprocessor/ProcessResult.scala
@@ -13,7 +13,7 @@ case class ProcessResult[ResultType <: ZuoraCreditAddResult](
 object ProcessResult extends LazyLogging {
   def log[ResultType <: ZuoraCreditAddResult](processResult: ProcessResult[ResultType]): Unit = {
     import processResult._
-    logger.info(s"${creditsToApply.size} holiday stops to apply:")
+    logger.info(s"${creditsToApply.size} credits to apply:")
     resultsToExport foreach (_.logDiscrepancies())
     creditsToApply.foreach(request => logger.info(request.toString))
     creditResults foreach {


### PR DESCRIPTION
This stops the delivery-problem credit processor making confusing references to holiday stops.

I've searched through the credit-processor lib for any other references to holidays but this is the only one.