### PR TITLE
Decode expected body of request to create digital voucher

### DIFF
--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
@@ -15,7 +15,7 @@ import org.http4s.dsl.Http4sDsl
 
 case class DigitalVoucherApiRoutesError(message: String)
 
-case class CreateVoucherRequestBody(ratePlanName: RatePlanName)
+case class CreateVoucherRequestBody(ratePlanName: String)
 
 case class CancelVoucherRequestBody(cardCode: String, cancellationDate: LocalDate)
 
@@ -53,7 +53,7 @@ object DigitalVoucherApiRoutes {
       val response = for {
         requestBody <- parseRequest[CreateVoucherRequestBody](request)
         voucher <- digitalVoucherService
-          .createVoucher(subscriptionId, requestBody.ratePlanName)
+          .createVoucher(subscriptionId, RatePlanName(requestBody.ratePlanName))
           .leftMap {
             case DigitalVoucherApiException(InvalidArgumentException(msg)) =>
               // see https://tools.ietf.org/html/rfc4918#section-11.2

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/CreateVoucherRequestBodyTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/CreateVoucherRequestBodyTest.scala
@@ -1,0 +1,22 @@
+package com.gu.digital_voucher_api
+
+import com.softwaremill.diffx.scalatest.DiffMatcher
+import io.circe.generic.auto._
+import io.circe.parser.decode
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class CreateVoucherRequestBodyTest
+  extends AnyFlatSpec
+  with should.Matchers
+  with DiffMatcher
+  with EitherValues {
+
+  "Json decode" should "decode expected Json object successfully" in {
+    val json = """{"ratePlanName": "Weekend"}"""
+    decode[CreateVoucherRequestBody](json).right.value should matchTo(
+      CreateVoucherRequestBody("Weekend")
+    )
+  }
+}

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -50,7 +50,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.PUT,
         uri = Uri(path = s"/digital-voucher/create/${subscriptionId.value}")
-      ).withEntity[String](CreateVoucherRequestBody(RatePlanName("Everyday")).asJson.spaces2)
+      ).withEntity[String](CreateVoucherRequestBody("Everyday").asJson.spaces2)
     ).value.unsafeRunSync().get
 
     response.status.code should matchTo(201)
@@ -81,7 +81,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.PUT,
         uri = Uri(path = s"/digital-voucher/create/${subscriptionId.value}")
-      ).withEntity[String](CreateVoucherRequestBody(RatePlanName("Everyday")).asJson.spaces2)
+      ).withEntity[String](CreateVoucherRequestBody("Everyday").asJson.spaces2)
     ).value.unsafeRunSync().get
 
     response.status.code should matchTo(502)
@@ -119,7 +119,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.PUT,
         uri = Uri(path = s"/digital-voucher/create/${subscriptionId.value}")
-      ).withEntity[String](CreateVoucherRequestBody(RatePlanName("Everyday")).asJson.spaces2)
+      ).withEntity[String](CreateVoucherRequestBody("Everyday").asJson.spaces2)
     ).value.unsafeRunSync().get
 
     response.status.code should matchTo(502)
@@ -146,7 +146,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.PUT,
         uri = Uri(path = s"/digital-voucher/create/${subscriptionId.value}")
-      ).withEntity[String](CreateVoucherRequestBody(RatePlanName("HomeDelivery")).asJson.spaces2)
+      ).withEntity[String](CreateVoucherRequestBody("HomeDelivery").asJson.spaces2)
     ).value.unsafeRunSync().get
 
     response.status.code should matchTo(422)


### PR DESCRIPTION
We expect the body to look like `{"ratePlanName": "Weekend"}`,
rather than `{"ratePlanName": {"value": "Weekend"}}`