### PR TITLE
Raise alarm whenever a digital voucher call fails

### DIFF
--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -205,5 +205,5 @@ Resources:
         Namespace: AWS/ApiGateway
         Period: 3600
         Statistic: Sum
-        Threshold: 5
+        Threshold: 1
         TreatMissingData: notBreaching


### PR DESCRIPTION
I was hoping to be able to filter 502 calls but I can't.  So the best I can do is lower the threshold on the 5XX response alarm.