### PR TITLE
Batch email sender: digital voucher support

### DIFF
--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
@@ -28,7 +28,8 @@ object EmailBatch {
       first_name: String,
       email_stage: String,
       modified_by_customer: Option[Boolean],
-      holiday_stop_request: Option[WireHolidayStopRequest]
+      holiday_stop_request: Option[WireHolidayStopRequest],
+      digital_voucher: Option[WireDigitalVoucher]
     )
     case class WireHolidayStopRequest(
       holiday_start_date: String,
@@ -39,9 +40,11 @@ object EmailBatch {
       stopped_credit_summaries: Option[List[WireHolidayStopCreditSummary]]
     )
     case class WireHolidayStopCreditSummary(credit_amount: Double, credit_date: String)
+    case class WireDigitalVoucher(card_url: String)
 
     implicit val holidayStopCreditDetailReads = Json.reads[WireHolidayStopCreditSummary]
     implicit val holidayStopRequestReads = Json.reads[WireHolidayStopRequest]
+    implicit val digitalVoucherReads = Json.reads[WireDigitalVoucher]
     implicit val emailBatchItemPayloadReads = Json.reads[WireEmailBatchItemPayload]
     implicit val emailBatchItemReads = Json.reads[WireEmailBatchItem]
     implicit val emailBatch = Json.reads[WireEmailBatch]
@@ -113,7 +116,11 @@ object EmailBatch {
                   StoppedCreditSummaryDate(fromSfDateToDisplayDate(detail.credit_date))
                 )
               }
-            } yield stoppedCreditSummaries
+            } yield stoppedCreditSummaries,
+          digital_voucher = wireEmailBatchItem
+            .payload
+            .digital_voucher
+            .map(wireVoucher => DigitalVoucher(DigitalVoucherUrl(wireVoucher.card_url)))
         ),
         object_name = wireEmailBatchItem.object_name
       )
@@ -135,6 +142,8 @@ case class StoppedIssueCount(value: String) extends AnyVal
 case class StoppedCreditSummary(credit_amount: StoppedCreditSummaryAmount, credit_date: StoppedCreditSummaryDate)
 case class StoppedCreditSummaryAmount(value: Double) extends AnyVal
 case class StoppedCreditSummaryDate(value: String) extends AnyVal
+case class DigitalVoucherUrl(value: String) extends AnyVal
+case class DigitalVoucher(cardUrl: DigitalVoucherUrl)
 
 case class EmailBatchItemPayload(
   record_id: EmailBatchItemId,
@@ -153,7 +162,8 @@ case class EmailBatchItemPayload(
   stopped_credit_sum: Option[StoppedCreditSum],
   currency_symbol: Option[CurrencySymbol],
   stopped_issue_count: Option[StoppedIssueCount],
-  stopped_credit_summaries: Option[List[StoppedCreditSummary]]
+  stopped_credit_summaries: Option[List[StoppedCreditSummary]],
+  digital_voucher: Option[DigitalVoucher]
 )
 
 case class EmailBatchItem(payload: EmailBatchItemPayload, object_name: String)

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
@@ -40,7 +40,7 @@ object EmailBatch {
       stopped_credit_summaries: Option[List[WireHolidayStopCreditSummary]]
     )
     case class WireHolidayStopCreditSummary(credit_amount: Double, credit_date: String)
-    case class WireDigitalVoucher(card_url: String)
+    case class WireDigitalVoucher(barcode_url: String)
 
     implicit val holidayStopCreditDetailReads = Json.reads[WireHolidayStopCreditSummary]
     implicit val holidayStopRequestReads = Json.reads[WireHolidayStopRequest]
@@ -120,7 +120,7 @@ object EmailBatch {
           digital_voucher = wireEmailBatchItem
             .payload
             .digital_voucher
-            .map(wireVoucher => DigitalVoucher(DigitalVoucherUrl(wireVoucher.card_url)))
+            .map(wireVoucher => DigitalVoucher(DigitalVoucherUrl(wireVoucher.barcode_url)))
         ),
         object_name = wireEmailBatchItem.object_name
       )
@@ -143,7 +143,7 @@ case class StoppedCreditSummary(credit_amount: StoppedCreditSummaryAmount, credi
 case class StoppedCreditSummaryAmount(value: Double) extends AnyVal
 case class StoppedCreditSummaryDate(value: String) extends AnyVal
 case class DigitalVoucherUrl(value: String) extends AnyVal
-case class DigitalVoucher(cardUrl: DigitalVoucherUrl)
+case class DigitalVoucher(barcodeUrl: DigitalVoucherUrl)
 
 case class EmailBatchItemPayload(
   record_id: EmailBatchItemId,

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
@@ -15,15 +15,18 @@ case class EmailPayloadSubscriberAttributes(
   stopped_credit_sum: Option[String],
   currency_symbol: Option[String],
   stopped_issue_count: Option[String],
-  stopped_credit_summaries: Option[List[EmailPayloadStoppedCreditSummary]]
+  stopped_credit_summaries: Option[List[EmailPayloadStoppedCreditSummary]],
+  digital_voucher: Option[EmailPayloadDigitalVoucher]
 )
 case class EmailPayloadContactAttributes(SubscriberAttributes: EmailPayloadSubscriberAttributes)
 case class EmailPayloadTo(Address: String, SubscriberKey: String, ContactAttributes: EmailPayloadContactAttributes)
 case class EmailToSend(To: EmailPayloadTo, DataExtensionName: String, SfContactId: Option[String], IdentityUserId: Option[String])
+case class EmailPayloadDigitalVoucher(CardUrl: String)
 
 object EmailToSend {
 
   implicit val emailPayloadStoppedCreditDetailWriter = Json.writes[EmailPayloadStoppedCreditSummary]
+  implicit val emailPayloadDigitalVoucherWriter = Json.writes[EmailPayloadDigitalVoucher]
   implicit val emailPayloadSubscriberAttributesWriter = Json.writes[EmailPayloadSubscriberAttributes]
   implicit val emailPayloadContactAttributesWriter = Json.writes[EmailPayloadContactAttributes]
   implicit val emailPayloadToWriter = Json.writes[EmailPayloadTo]
@@ -50,7 +53,11 @@ object EmailToSend {
             creditDetails.map { creditDetail =>
               EmailPayloadStoppedCreditSummary(creditDetail.credit_amount.value, creditDetail.credit_date.value)
             }
-          }
+          },
+          emailBatchItem
+            .payload
+            .digital_voucher
+            .map(digitalVoucher => EmailPayloadDigitalVoucher(digitalVoucher.cardUrl.value))
         )
       )
     )

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
@@ -2,7 +2,7 @@ package com.gu.batchemailsender.api.batchemail.model
 
 import play.api.libs.json.Json
 
-case class EmailPayloadDigitalVoucher(card_url: String)
+case class EmailPayloadDigitalVoucher(barcode_url: String)
 case class EmailPayloadStoppedCreditSummary(credit_amount: Double, credit_date: String)
 case class EmailPayloadSubscriberAttributes(
   first_name: String,
@@ -57,7 +57,7 @@ object EmailToSend {
           emailBatchItem
             .payload
             .digital_voucher
-            .map(digitalVoucher => EmailPayloadDigitalVoucher(digitalVoucher.cardUrl.value))
+            .map(digitalVoucher => EmailPayloadDigitalVoucher(digitalVoucher.barcodeUrl.value))
         )
       )
     )

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
@@ -83,6 +83,8 @@ object EmailToSend {
       case ("Holiday_Stop_Request__c", "create") => "SV_HolidayStopConfirmation"
       case ("Holiday_Stop_Request__c", "amend") => "SV_HolidayStopAmend"
       case ("Holiday_Stop_Request__c", "withdraw") => "SV_HolidayStopWithdrawal"
+      case ("Digital_Voucher__c", "create") => "SV_VO_NewCard"
+      case ("Digital_Voucher__c", "replace") => "SV_VO_ReplacementCard"
       case (objectName, emailStage) => throw new RuntimeException(s"Unrecognized (object_name, email_stage) = ($objectName, $emailStage). Please fix SF trigger.")
     }
 }

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
@@ -2,6 +2,7 @@ package com.gu.batchemailsender.api.batchemail.model
 
 import play.api.libs.json.Json
 
+case class EmailPayloadDigitalVoucher(card_url: String)
 case class EmailPayloadStoppedCreditSummary(credit_amount: Double, credit_date: String)
 case class EmailPayloadSubscriberAttributes(
   first_name: String,
@@ -21,7 +22,6 @@ case class EmailPayloadSubscriberAttributes(
 case class EmailPayloadContactAttributes(SubscriberAttributes: EmailPayloadSubscriberAttributes)
 case class EmailPayloadTo(Address: String, SubscriberKey: String, ContactAttributes: EmailPayloadContactAttributes)
 case class EmailToSend(To: EmailPayloadTo, DataExtensionName: String, SfContactId: Option[String], IdentityUserId: Option[String])
-case class EmailPayloadDigitalVoucher(CardUrl: String)
 
 object EmailToSend {
 

--- a/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
@@ -190,7 +190,7 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
         |               ]
         |             },
         |             "digital_voucher" : {
-        |               "card_url": "http://imovo-card.url"
+        |               "barcode_url": "http://imovo-barcode.url"
         |             }
         |         },
         |         "object_name":"Holiday_Stop_Request__c"
@@ -226,7 +226,7 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
               )
             ),
             digital_voucher = Some(
-              DigitalVoucher(DigitalVoucherUrl("http://imovo-card.url"))
+              DigitalVoucher(DigitalVoucherUrl("http://imovo-barcode.url"))
             )
           ),
           object_name = "Holiday_Stop_Request__c"

--- a/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
@@ -53,7 +53,8 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
             stopped_credit_sum = None,
             currency_symbol = None,
             stopped_issue_count = None,
-            stopped_credit_summaries = None
+            stopped_credit_summaries = None,
+            digital_voucher = None
           ),
           object_name = "Card_Expiry__c"
         )
@@ -139,7 +140,8 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
             stopped_credit_sum = None,
             currency_symbol = None,
             stopped_issue_count = None,
-            stopped_credit_summaries = None
+            stopped_credit_summaries = None,
+            digital_voucher = None
           ),
           object_name = "Card_Expiry__c"
         )
@@ -151,7 +153,7 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
 
   }
 
-  "EmailBatch.fromWire" should "transform a holiday-stop create confirmation correctly" in {
+  "EmailBatch.fromWire" should "transform a holiday-stop and digital voucher create confirmation correctly" in {
     val sampleBatch =
       """
         |{
@@ -186,6 +188,9 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
         |                   "credit_date": "2019-02-23"
         |                 }
         |               ]
+        |             },
+        |             "digital_voucher" : {
+        |               "card_url": "http://imovo-card.url"
         |             }
         |         },
         |         "object_name":"Holiday_Stop_Request__c"
@@ -219,6 +224,9 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
                 StoppedCreditSummary(StoppedCreditSummaryAmount(1.23), StoppedCreditSummaryDate("22 November 2019")),
                 StoppedCreditSummary(StoppedCreditSummaryAmount(2.34), StoppedCreditSummaryDate("23 February 2019"))
               )
+            ),
+            digital_voucher = Some(
+              DigitalVoucher(DigitalVoucherUrl("http://imovo-card.url"))
             )
           ),
           object_name = "Holiday_Stop_Request__c"
@@ -343,7 +351,8 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
                   WireHolidayStopCreditSummary(1.23, "2019-11-22"),
                   WireHolidayStopCreditSummary(2.34, "2019-02-23")
                 ))
-              ))
+              )),
+              digital_voucher = None
             ),
             "Holiday_Stop_Request__c"
           )
@@ -461,7 +470,8 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
                   WireHolidayStopCreditSummary(1.23, "2019-11-22"),
                   WireHolidayStopCreditSummary(2.34, "2019-02-23")
                 ))
-              ))
+              )),
+              digital_voucher = None
             ),
             "Holiday_Stop_Request__c"
           ),
@@ -488,7 +498,8 @@ class EmailBatchTest extends FlatSpec with Matchers with DiffMatcher {
                   WireHolidayStopCreditSummary(1.23, "2019-11-22"),
                   WireHolidayStopCreditSummary(2.34, "2019-02-23")
                 ))
-              ))
+              )),
+              digital_voucher = None
             ),
             "Holiday_Stop_Request__c"
           )

--- a/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/SqsSendBatchTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/SqsSendBatchTest.scala
@@ -50,7 +50,8 @@ object SqsSendBatchTestData {
       stopped_credit_sum = None,
       currency_symbol = None,
       stopped_issue_count = None,
-      stopped_credit_summaries = None
+      stopped_credit_summaries = None,
+      digital_voucher = None
     ),
     object_name = "Card_Expiry__c"
   )
@@ -73,7 +74,8 @@ object SqsSendBatchTestData {
       stopped_credit_sum = None,
       currency_symbol = None,
       stopped_issue_count = None,
-      stopped_credit_summaries = None
+      stopped_credit_summaries = None,
+      digital_voucher = None
     ),
     object_name = "Card_Expiry__c"
   )

--- a/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSendTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSendTest.scala
@@ -23,7 +23,8 @@ class EmailToSendTest extends FlatSpec {
       stopped_credit_sum = None,
       currency_symbol = None,
       stopped_issue_count = None,
-      stopped_credit_summaries = None
+      stopped_credit_summaries = None,
+      digital_voucher = None
     )
 
   val emailBatchItemStub = EmailBatchItem(

--- a/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSendTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSendTest.scala
@@ -50,7 +50,8 @@ class EmailToSendTest extends FlatSpec {
             stopped_credit_sum = None,
             currency_symbol = None,
             stopped_issue_count = None,
-            stopped_credit_summaries = None
+            stopped_credit_summaries = None,
+            digital_voucher = None
           )
       )
     ),
@@ -238,6 +239,51 @@ class EmailToSendTest extends FlatSpec {
         )
       ),
       DataExtensionName = "SV_HolidayStopConfirmation"
+    )
+    assert(EmailToSend.fromEmailBatchItem(emailBatchItem) == expected)
+  }
+
+  it should "create digital_voucher creation confirmation email to send" in {
+    val emailBatchItem = emailBatchItemStub.copy(
+      object_name = "Digital_Voucher__c",
+      payload = emailBatchItemPayloadStub.copy(
+        email_stage = "create",
+        modified_by_customer = Some(true),
+        digital_voucher = Some(DigitalVoucher(DigitalVoucherUrl("http://digital-voucher-url")))
+      )
+    )
+    val expected = expectedStub.copy(
+      To = expectedStub.To.copy(
+        ContactAttributes = expectedStub.To.ContactAttributes.copy(
+          expectedStub.To.ContactAttributes.SubscriberAttributes.copy(
+            modified_by_customer = Some(true),
+            digital_voucher = Some(EmailPayloadDigitalVoucher("http://digital-voucher-url"))
+          )
+        )
+      ),
+      DataExtensionName = "SV_VO_NewCard"
+    )
+    assert(EmailToSend.fromEmailBatchItem(emailBatchItem) == expected)
+  }
+  it should "create digital_voucher replace confirmation email to send" in {
+    val emailBatchItem = emailBatchItemStub.copy(
+      object_name = "Digital_Voucher__c",
+      payload = emailBatchItemPayloadStub.copy(
+        email_stage = "replace",
+        modified_by_customer = Some(true),
+        digital_voucher = Some(DigitalVoucher(DigitalVoucherUrl("http://digital-voucher-url")))
+      )
+    )
+    val expected = expectedStub.copy(
+      To = expectedStub.To.copy(
+        ContactAttributes = expectedStub.To.ContactAttributes.copy(
+          expectedStub.To.ContactAttributes.SubscriberAttributes.copy(
+            modified_by_customer = Some(true),
+            digital_voucher = Some(EmailPayloadDigitalVoucher("http://digital-voucher-url"))
+          )
+        )
+      ),
+      DataExtensionName = "SV_VO_ReplacementCard"
     )
     assert(EmailToSend.fromEmailBatchItem(emailBatchItem) == expected)
   }


### PR DESCRIPTION
This contains the changes to the batch email sender api to add support for sending digital voucher emails. This includes
- Adding support for additional digital_voucher.card_url field to the email batch item payload, which is forwarded on to the membership_workflow app via sqs.
- Adding mappings for the following object name/email stage combinations
  -  Digital_Voucher__c/create -> SV_VO_NewCard (email containing voucher barcode link to support immediate redemption) 
  - Digital_Voucher__c/replace -> SV_VO_ReplacementCard (email containing new voucher barcode link to support replacement of digital voucher due to loss misuse of card/fulfilment details)