### PR TITLE
delivery-records-api : set case Status

### DIFF
--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryProblemCase.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryProblemCase.scala
@@ -32,7 +32,7 @@ case class SFApiCreateDeliveryProblemCase(
   ContactId: Option[String],
   SF_Subscription__r: SF_Subscription_ByName,
   Origin: String = "Self Service",
-  Status: String = "New",
+  Status: String,
   Subject: String,
   Description: Option[String],
   Product__c: String,
@@ -110,7 +110,10 @@ object SFApiCompositeCreateDeliveryProblem {
         SF_Subscription__r = SF_Subscription_ByName(
           Name = subscriptionNumber
         ),
-        Repeat_Delivery_Issue__c = detail.repeatDeliveryProblem.contains(true)
+        Repeat_Delivery_Issue__c = detail.repeatDeliveryProblem.contains(true),
+        Status = if (detail.repeatDeliveryProblem.contains(true) ||
+          detail.deliveryRecords.exists(_.invoiceDate.isEmpty) // i.e. we're not auto-crediting
+          ) "New" else "Closed"
       )
     )) ++ detail.deliveryRecords.map(deliveryRecord => SFApiCompositePart[SFApiCompositePartBody](
       referenceId = s"LinkDeliveryRecord-${deliveryRecord.id}",


### PR DESCRIPTION
Case `Status` will be...

- 'New' if repeat delivery issue or no credit is requested
- otherwise 'Closed' (i.e. straight forward auto-crediting scenario)

This is accompanied by https://github.com/guardian/salesforce/pull/161 - which assigns a queue based on this `Status`.