### PR TITLE
Make digital voucher API methods closer to rest spec

### DIFF
--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
@@ -102,13 +102,13 @@ object DigitalVoucherApiRoutes {
     }
 
     HttpRoutes.of[F] {
-      case request @ PUT -> Root / "digital-voucher" / "create" / subscriptionId =>
+      case request @ POST -> Root / "digital-voucher" / "create" / subscriptionId =>
         handleCreateRequest(request, SfSubscriptionId(subscriptionId))
-      case request @ POST -> Root / "digital-voucher" / "replace" =>
+      case request @ PUT -> Root / "digital-voucher" / "replace" =>
         handleReplaceRequest(request)
       case GET -> Root / "digital-voucher" / subscriptionId =>
         handleGetRequest(subscriptionId)
-      case request @ POST -> Root / "digital-voucher" / "cancel" =>
+      case request @ DELETE -> Root / "digital-voucher" / "cancel" =>
         handleCancelRequest(request)
     }
   }

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -13,7 +13,8 @@ import io.circe.Decoder
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import io.circe.syntax._
-import org.http4s.{Method, Request, Response, Uri}
+import org.http4s.Method.{DELETE, GET, POST, PUT}
+import org.http4s.{Request, Response, Uri}
 import org.scalatest.EitherValues
 import org.scalatest.Inside.inside
 import org.scalatest.flatspec.AnyFlatSpec
@@ -48,7 +49,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     val app = createApp(imovoBackendStub)
     val response = app.run(
       Request(
-        method = Method.PUT,
+        method = POST,
         uri = Uri(path = s"/digital-voucher/create/${subscriptionId.value}")
       ).withEntity[String](CreateVoucherRequestBody("Everyday").asJson.spaces2)
     ).value.unsafeRunSync().get
@@ -79,7 +80,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     val app = createApp(imovoBackendStub)
     val response = app.run(
       Request(
-        method = Method.PUT,
+        method = POST,
         uri = Uri(path = s"/digital-voucher/create/${subscriptionId.value}")
       ).withEntity[String](CreateVoucherRequestBody("Everyday").asJson.spaces2)
     ).value.unsafeRunSync().get
@@ -117,7 +118,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     val app = createApp(imovoBackendStub)
     val response = app.run(
       Request(
-        method = Method.PUT,
+        method = POST,
         uri = Uri(path = s"/digital-voucher/create/${subscriptionId.value}")
       ).withEntity[String](CreateVoucherRequestBody("Everyday").asJson.spaces2)
     ).value.unsafeRunSync().get
@@ -144,7 +145,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     val app = createApp(imovoBackendStub)
     val response = app.run(
       Request(
-        method = Method.PUT,
+        method = POST,
         uri = Uri(path = s"/digital-voucher/create/${subscriptionId.value}")
       ).withEntity[String](CreateVoucherRequestBody("HomeDelivery").asJson.spaces2)
     ).value.unsafeRunSync().get
@@ -173,7 +174,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     val app = createApp(imovoBackendStub)
     val response = app.run(
       Request(
-        method = Method.POST,
+        method = PUT,
         Uri(path = "/digital-voucher/replace")
       ).withEntity[String](Voucher("card-test-voucher-code", "letter-test-voucher-code").asJson.spaces2)
     ).value.unsafeRunSync().get
@@ -202,7 +203,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     val app = createApp(imovoBackendStub)
     val response = app.run(
       Request(
-        method = Method.POST,
+        method = PUT,
         Uri(path = "/digital-voucher/replace")
       ).withEntity[String](Voucher("card-test-voucher-code", "letter-test-voucher-code").asJson.spaces2)
     ).value.unsafeRunSync().get
@@ -214,7 +215,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     val app = createApp(SttpBackendStub[IO, Nothing](new CatsMonadError[IO]))
     val response = app.run(
       Request(
-        method = Method.GET,
+        method = GET,
         Uri(path = "/digital-voucher/sub123456")
       )
     ).value.unsafeRunSync().get
@@ -237,7 +238,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     val app = createApp(imovoBackendStub)
     val response = app.run(
       Request(
-        method = Method.POST,
+        method = DELETE,
         Uri(path = "/digital-voucher/cancel")
       ).withEntity[String](CancelVoucherRequestBody("card-test-voucher-code", cancellationDate).asJson.spaces2)
     ).value.unsafeRunSync().get


### PR DESCRIPTION
This is splitting hairs but seems to be more consistent with how methods are meant to be used, and express lifecycle better.  There's a small window now when we can change these before it becomes more difficult.