### PR TITLE
sf-move-subscriptions-api lambda skeleton code 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -362,8 +362,13 @@ lazy val `metric-push-api` = all(project in file("handlers/metric-push-api"))
   .dependsOn()
 
 lazy val `sf-move-subscriptions-api` = all(project in file("handlers/sf-move-subscriptions-api"))
+  .dependsOn(`effects-s3`, `config-core`, `salesforce-sttp-client`, `salesforce-sttp-test-stub` % Test)
+  .settings(
+    libraryDependencies ++=
+      Seq(http4sLambda, http4sDsl, http4sCirce, http4sServer, circe, sttpAsycHttpClientBackendCats, scalatest)
+        ++ logging
+  )
   .enablePlugins(RiffRaffArtifact)
-  .dependsOn(handler)
 
 lazy val `fulfilment-date-calculator` = all(project in file("handlers/fulfilment-date-calculator"))
   .enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -365,7 +365,7 @@ lazy val `sf-move-subscriptions-api` = all(project in file("handlers/sf-move-sub
   .dependsOn(`effects-s3`, `config-core`, `salesforce-sttp-client`, `salesforce-sttp-test-stub` % Test)
   .settings(
     libraryDependencies ++=
-      Seq(http4sLambda, http4sDsl, http4sCirce, http4sServer, circe, sttpAsycHttpClientBackendCats, scalatest)
+      Seq(http4sLambda, http4sDsl, http4sCirce, http4sServer, circe, sttpAsycHttpClientBackendCats, scalatest, simpleConfig)
         ++ logging
   )
   .enablePlugins(RiffRaffArtifact)

--- a/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
+++ b/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
@@ -71,13 +71,13 @@ export class SfMoveSubscriptionsStack extends cdk.Stack {
         {
           functionName: `${appName}-${stageParameter.valueAsString}`,
           runtime: lambda.Runtime.JAVA_8,
-          memorySize: 192,
+          memorySize: 1536,
           timeout: Duration.seconds(300),
           code: Code.bucket(
             deployBucket,
             `membership/${stageParameter.valueAsString}/sf-move-subscriptions-api/sf-move-subscriptions-api.jar`
           ),
-          handler: 'com.gu.sf.move.subscriptions.api.Handler::apply',
+          handler: 'com.gu.sf.move.subscriptions.api.Handler::handle',
           role: fnRole,
         },
       )

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Handler.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Handler.scala
@@ -1,11 +1,6 @@
 package com.gu.sf.move.subscriptions.api
 
-import com.gu.util.Logging
+import io.github.howardjohn.lambda.http4s.Http4sLambdaHandler
 
-object Handler extends Logging {
+object Handler extends Http4sLambdaHandler(SFMoveSubscriptionsApiApp.apply())
 
-  def apply(): Unit = {
-    logger.info("Starting sf_move_subscriptions lambda")
-  }
-
-}

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Handler.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Handler.scala
@@ -1,6 +1,9 @@
 package com.gu.sf.move.subscriptions.api
 
+import com.gu.AppIdentity
 import io.github.howardjohn.lambda.http4s.Http4sLambdaHandler
 
-object Handler extends Http4sLambdaHandler(SFMoveSubscriptionsApiApp.apply())
+object Handler extends Http4sLambdaHandler(
+  SFMoveSubscriptionsApiApp.apply(AppIdentity.whoAmI(defaultAppName = "sf-move-subscriptions-api"))
+)
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
@@ -2,7 +2,7 @@ package com.gu.sf.move.subscriptions.api
 
 final case class MoveSubscriptionReqBody(sfAccountId: String, sfFullContactId: String, zuoraSubscriptionId: String)
 
-final case class SubscriptionMoved(message: String)
+final case class MoveSubscriptionRes(message: String)
 
 final case class MoveSubscriptionApiError(message: String)
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
@@ -1,5 +1,7 @@
 package com.gu.sf.move.subscriptions.api
 
-case class MoveSubscriptionReqBody(sfContactId: String, zuoraSubscriptionId: String)
+final case class MoveSubscriptionReqBody(sfContactId: String, zuoraSubscriptionId: String)
 
-case class SubscriptionMoved(message: String)
+final case class SubscriptionMoved(message: String)
+
+final case class MoveSubscriptionApiError(message: String)

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
@@ -1,6 +1,6 @@
 package com.gu.sf.move.subscriptions.api
 
-final case class MoveSubscriptionReqBody(sfContactId: String, zuoraSubscriptionId: String)
+final case class MoveSubscriptionReqBody(sfAccountId: String, sfFullContactId: String, zuoraSubscriptionId: String)
 
 final case class SubscriptionMoved(message: String)
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
@@ -5,3 +5,5 @@ final case class MoveSubscriptionReqBody(sfContactId: String, zuoraSubscriptionI
 final case class SubscriptionMoved(message: String)
 
 final case class MoveSubscriptionApiError(message: String)
+
+final case class MoveSubscriptionApiRoot(description: String)

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
@@ -1,0 +1,5 @@
+package com.gu.sf.move.subscriptions.api
+
+case class MoveSubscriptionReqBody(sfContactId: String, zuoraSubscriptionId: String)
+
+case class SubscriptionMoved(message: String)

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -1,10 +1,12 @@
 package com.gu.sf.move.subscriptions.api
 
 import cats.effect.{ContextShift, IO}
+import com.gu.AppIdentity
 import com.typesafe.scalalogging.LazyLogging
 import org.http4s.HttpRoutes
 import org.http4s.server.middleware.Logger
 import org.http4s.util.CaseInsensitiveString
+import com.gu.AppIdentity
 
 final case class SFMoveSubscriptionsApiError(message: String)
 
@@ -12,7 +14,8 @@ object SFMoveSubscriptionsApiApp extends LazyLogging {
 
   private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
-  def apply(): HttpRoutes[IO] = {
+  def apply(appIdentity: AppIdentity): HttpRoutes[IO] = {
+    logger.info(s"appIdentity = $appIdentity")
     createLogging()(SFMoveSubscriptionsApiRoutes())
   }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -15,7 +15,6 @@ object SFMoveSubscriptionsApiApp extends LazyLogging {
   private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def apply(appIdentity: AppIdentity): HttpRoutes[IO] = {
-    logger.info(s"appIdentity = $appIdentity")
     createLogging()(SFMoveSubscriptionsApiRoutes())
   }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -15,5 +15,4 @@ object SFMoveSubscriptionsApiApp extends LazyLogging {
 
     SFMoveSubscriptionsApiRoutes.apply()
   }
-
 }

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -1,0 +1,19 @@
+package com.gu.sf.move.subscriptions.api
+
+import cats.effect.IO
+import com.typesafe.scalalogging.LazyLogging
+import org.http4s.HttpRoutes
+
+final case class SFMoveSubscriptionsApiError(message: String)
+
+object SFMoveSubscriptionsApiApp extends LazyLogging {
+
+  //  private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
+
+  def apply(): HttpRoutes[IO] = {
+    logger.info("Starting sf_move_subscriptions lambda")
+
+    SFMoveSubscriptionsApiRoutes.apply()
+  }
+
+}

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -1,5 +1,6 @@
 package com.gu.sf.move.subscriptions.api
 
+import cats.data.EitherT
 import cats.effect.{ContextShift, IO}
 import com.gu.AppIdentity
 import com.typesafe.scalalogging.LazyLogging
@@ -14,7 +15,7 @@ object SFMoveSubscriptionsApiApp extends LazyLogging {
 
   private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
-  def apply(appIdentity: AppIdentity): HttpRoutes[IO] = {
+  def apply(appIdentity: AppIdentity) = {
     createLogging()(SFMoveSubscriptionsApiRoutes())
   }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -11,7 +11,7 @@ object SFMoveSubscriptionsApiApp extends LazyLogging {
   //  private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def apply(): HttpRoutes[IO] = {
-    logger.info("Starting sf_move_subscriptions lambda")
+    logger.info("Starting sf-move-subscriptions-api lambda")
 
     SFMoveSubscriptionsApiRoutes.apply()
   }

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -1,18 +1,27 @@
 package com.gu.sf.move.subscriptions.api
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import com.typesafe.scalalogging.LazyLogging
 import org.http4s.HttpRoutes
+import org.http4s.server.middleware.Logger
+import org.http4s.util.CaseInsensitiveString
 
 final case class SFMoveSubscriptionsApiError(message: String)
 
 object SFMoveSubscriptionsApiApp extends LazyLogging {
 
-  //  private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
+  private implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def apply(): HttpRoutes[IO] = {
-    logger.info("Starting sf-move-subscriptions-api lambda")
+    createLogging()(SFMoveSubscriptionsApiRoutes())
+  }
 
-    SFMoveSubscriptionsApiRoutes.apply()
+  private def createLogging(): HttpRoutes[IO] => HttpRoutes[IO] = {
+    Logger.httpRoutes(
+      logHeaders = true,
+      logBody = true,
+      redactHeadersWhen = { headerKey: CaseInsensitiveString => headerKey.value == "x-api-key" },
+      logAction = Some({ message: String => IO.delay(logger.info(message)) })
+    )
   }
 }

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -1,36 +1,41 @@
 package com.gu.sf.move.subscriptions.api
 
-import cats.effect.IO
+import cats.data.EitherT
+import cats.effect.Effect
+import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.circe.CirceEntityEncoder._
-import org.http4s.dsl.io._
-import org.http4s.{DecodeFailure, HttpRoutes, Request}
+import org.http4s.dsl.Http4sDsl
+import org.http4s.{DecodeFailure, HttpRoutes, Request, Response}
 
 object SFMoveSubscriptionsApiRoutes extends LazyLogging {
 
-  def apply(): HttpRoutes[IO] = {
+  def apply[F[_] : Effect](): HttpRoutes[F] = {
+    type RouteResult[A] = EitherT[F, F[Response[F]], A]
+    object http4sDsl extends Http4sDsl[F]
+    import http4sDsl._
 
     val rootInfo = MoveSubscriptionApiRoot("This is the sf-move-subscriptions-api")
 
-    def handleMoveRequest(request: Request[IO]) = {
+    def handleMoveRequest(request: Request[F]): F[Response[F]] = {
       (for {
         reqBody <- request.attemptAs[MoveSubscriptionReqBody]
           .leftMap { decodingFailure: DecodeFailure =>
             BadRequest(MoveSubscriptionApiError(s"Failed to decoded request body: $decodingFailure"))
           }
-        resp <- SFMoveSubscriptionsService.moveSubscription(reqBody)
+        resp <- SFMoveSubscriptionsService().moveSubscription(reqBody)
           .leftMap(
             error =>
               InternalServerError(MoveSubscriptionApiError(s"Failed create voucher: $error"))
           )
-      } yield Ok(resp)).merge.flatMap(x => x)
+      } yield Ok(resp)).merge.flatten
     }
 
-    HttpRoutes.of[IO] {
+    HttpRoutes.of[F] {
       case GET -> Root => Ok(rootInfo)
-      case request @ POST -> Root / "subscription" / "move" =>
+      case request@POST -> Root / "subscription" / "move" =>
         handleMoveRequest(request)
     }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -12,16 +12,18 @@ object SFMoveSubscriptionsApiRoutes extends LazyLogging {
 
   def apply(): HttpRoutes[IO] = {
 
+    val rootInfo = MoveSubscriptionApiRoot("This is the sf-move-subscriptions-api")
+
     def handleMoveRequest(request: Request[IO]) = {
       for {
-        req <- request.as[MoveSubscriptionReqBody]
-        _ <- Ok(SFMoveSubscriptionsService.moveSubscription(req))
+        reqBody <- request.as[MoveSubscriptionReqBody]
+        _ <- Ok(SFMoveSubscriptionsService.moveSubscription(reqBody))
         resp <- Ok(SubscriptionMoved("subscription moved successfully"))
       } yield resp
     }
 
     HttpRoutes.of[IO] {
-      case GET -> Root => Ok(MoveSubscriptionApiRoot("This is the sf-move-subscriptions-api"))
+      case GET -> Root => Ok(rootInfo)
       case request@POST -> Root / "subscription" / "move" => handleMoveRequest(request)
     }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -1,0 +1,16 @@
+package com.gu.sf.move.subscriptions.api
+
+import cats.effect.IO
+import org.http4s.HttpRoutes
+import org.http4s.dsl.io._
+
+object SFMoveSubscriptionsApiRoutes {
+
+  def apply(): HttpRoutes[IO] = {
+
+    HttpRoutes.of[IO] {
+      case GET -> Root / "hello" / name => Ok(s"Hello, $name!")
+    }
+  }
+
+}

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -1,6 +1,5 @@
 package com.gu.sf.move.subscriptions.api
 
-import cats.data.EitherT
 import cats.effect.Effect
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
@@ -12,8 +11,7 @@ import org.http4s.{DecodeFailure, HttpRoutes, Request, Response}
 
 object SFMoveSubscriptionsApiRoutes extends LazyLogging {
 
-  def apply[F[_] : Effect](): HttpRoutes[F] = {
-    type RouteResult[A] = EitherT[F, F[Response[F]], A]
+  def apply[F[_]: Effect](): HttpRoutes[F] = {
     object http4sDsl extends Http4sDsl[F]
     import http4sDsl._
 
@@ -25,7 +23,7 @@ object SFMoveSubscriptionsApiRoutes extends LazyLogging {
           .leftMap { decodingFailure: DecodeFailure =>
             BadRequest(MoveSubscriptionApiError(s"Failed to decoded request body: $decodingFailure"))
           }
-        resp <- SFMoveSubscriptionsService().moveSubscription(reqBody)
+        resp <- SFMoveSubscriptionsService.moveSubscription(reqBody)
           .leftMap(
             error =>
               InternalServerError(MoveSubscriptionApiError(s"Failed create voucher: $error"))
@@ -35,7 +33,7 @@ object SFMoveSubscriptionsApiRoutes extends LazyLogging {
 
     HttpRoutes.of[F] {
       case GET -> Root => Ok(rootInfo)
-      case request@POST -> Root / "subscription" / "move" =>
+      case request @ POST -> Root / "subscription" / "move" =>
         handleMoveRequest(request)
     }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -12,10 +12,6 @@ object SFMoveSubscriptionsApiRoutes extends LazyLogging {
 
   def apply(): HttpRoutes[IO] = {
 
-    val rootInfo = Map(
-      "description" -> "This is the sf-move-subscriptions-api"
-    )
-
     def handleMoveRequest(request: Request[IO]) = {
       for {
         req <- request.as[MoveSubscriptionReqBody]
@@ -25,7 +21,7 @@ object SFMoveSubscriptionsApiRoutes extends LazyLogging {
     }
 
     HttpRoutes.of[IO] {
-      case GET -> Root => Ok(rootInfo)
+      case GET -> Root => Ok(MoveSubscriptionApiRoot("This is the sf-move-subscriptions-api"))
       case request@POST -> Root / "subscription" / "move" => handleMoveRequest(request)
     }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -8,11 +8,6 @@ import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.dsl.io._
 import org.http4s.{HttpRoutes, Request}
 
-case class MoveSubscription(
-  sfContactId: String,
-  zuoraSubscriptionId: String
-)
-
 object SFMoveSubscriptionsApiRoutes extends LazyLogging {
 
   def apply(): HttpRoutes[IO] = {
@@ -22,16 +17,16 @@ object SFMoveSubscriptionsApiRoutes extends LazyLogging {
     )
 
     def handleMoveRequest(request: Request[IO]) = {
-      logger.info(s"handleMoveRequest received request: ${request.body}")
       for {
-        moveSub <- request.as[MoveSubscription]
-        resp <- Ok(moveSub)
+        req <- request.as[MoveSubscriptionReqBody]
+        _ <- Ok(SFMoveSubscriptionsService.moveSubscription(req))
+        resp <- Ok(SubscriptionMoved("subscription moved successfully"))
       } yield resp
     }
 
     HttpRoutes.of[IO] {
       case GET -> Root => Ok(rootInfo)
-      case request @ POST -> Root / "subscription" / "move" => handleMoveRequest(request)
+      case request@POST -> Root / "subscription" / "move" => handleMoveRequest(request)
     }
 
   }

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -2,15 +2,21 @@ package com.gu.sf.move.subscriptions.api
 
 import cats.effect.IO
 import org.http4s.HttpRoutes
+import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.dsl.io._
 
 object SFMoveSubscriptionsApiRoutes {
 
   def apply(): HttpRoutes[IO] = {
 
+    val rootInfo = Map(
+      "description" -> "This is the sf-move-subscriptions-api"
+    )
+
     HttpRoutes.of[IO] {
-      case GET -> Root / "hello" / name => Ok(s"Hello, $name!")
+      case GET -> Root => Ok(rootInfo)
     }
+
   }
 
 }

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -1,11 +1,19 @@
 package com.gu.sf.move.subscriptions.api
 
 import cats.effect.IO
-import org.http4s.HttpRoutes
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.generic.auto._
+import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.dsl.io._
+import org.http4s.{HttpRoutes, Request}
 
-object SFMoveSubscriptionsApiRoutes {
+case class MoveSubscription(
+  sfContactId: String,
+  zuoraSubscriptionId: String
+)
+
+object SFMoveSubscriptionsApiRoutes extends LazyLogging {
 
   def apply(): HttpRoutes[IO] = {
 
@@ -13,8 +21,17 @@ object SFMoveSubscriptionsApiRoutes {
       "description" -> "This is the sf-move-subscriptions-api"
     )
 
+    def handleMoveRequest(request: Request[IO]) = {
+      logger.info(s"handleMoveRequest received request: ${request.body}")
+      for {
+        moveSub <- request.as[MoveSubscription]
+        resp <- Ok(moveSub)
+      } yield resp
+    }
+
     HttpRoutes.of[IO] {
       case GET -> Root => Ok(rootInfo)
+      case request @ POST -> Root / "subscription" / "move" => handleMoveRequest(request)
     }
 
   }

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -30,7 +30,7 @@ object SFMoveSubscriptionsApiRoutes extends LazyLogging {
 
     HttpRoutes.of[IO] {
       case GET -> Root => Ok(rootInfo)
-      case request@POST -> Root / "subscription" / "move" =>
+      case request @ POST -> Root / "subscription" / "move" =>
         handleMoveRequest(request)
     }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
@@ -1,21 +1,14 @@
 package com.gu.sf.move.subscriptions.api
 
-import cats.Monad
 import cats.data.EitherT
+import cats.effect.Effect
 import com.typesafe.scalalogging.LazyLogging
 
-trait SFMoveSubscriptionsService[F[_]] {
-  def moveSubscription(req: MoveSubscriptionReqBody): EitherT[F, MoveSubscriptionApiError, MoveSubscriptionRes]
-}
-
 object SFMoveSubscriptionsService extends LazyLogging {
-
-  def apply[F[_] : Monad](): SFMoveSubscriptionsService[F] = new SFMoveSubscriptionsService[F] {
-    override def moveSubscription(req: MoveSubscriptionReqBody): EitherT[F, MoveSubscriptionApiError, MoveSubscriptionRes] = {
-      import req._
-      logger.info(s"attempt to move $zuoraSubscriptionId subscription to $sfAccountId , $sfFullContactId SalesForce Contact")
-      EitherT.rightT(MoveSubscriptionRes("subscription moved successfully"))
-    }
+  def moveSubscription[F[_]: Effect](req: MoveSubscriptionReqBody): EitherT[F, MoveSubscriptionApiError, MoveSubscriptionRes] = {
+    import req._
+    logger.info(s"attempt to move $zuoraSubscriptionId subscription to $sfAccountId , $sfFullContactId SalesForce Contact")
+    EitherT.rightT(MoveSubscriptionRes("subscription moved successfully"))
   }
-
 }
+

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
@@ -1,16 +1,21 @@
 package com.gu.sf.move.subscriptions.api
 
+import cats.Monad
 import cats.data.EitherT
-import cats.effect.IO
-import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
+
+trait SFMoveSubscriptionsService[F[_]] {
+  def moveSubscription(req: MoveSubscriptionReqBody): EitherT[F, MoveSubscriptionApiError, MoveSubscriptionRes]
+}
 
 object SFMoveSubscriptionsService extends LazyLogging {
 
-  def moveSubscription(req: MoveSubscriptionReqBody): EitherT[IO, MoveSubscriptionApiError, MoveSubscriptionRes] = {
-    import req._
-    logger.info(s"attempt to move $zuoraSubscriptionId subscription to $sfAccountId SalesForce Contact")
-    Either.right(MoveSubscriptionRes("subscription moved successfully")).toEitherT
+  def apply[F[_] : Monad](): SFMoveSubscriptionsService[F] = new SFMoveSubscriptionsService[F] {
+    override def moveSubscription(req: MoveSubscriptionReqBody): EitherT[F, MoveSubscriptionApiError, MoveSubscriptionRes] = {
+      import req._
+      logger.info(s"attempt to move $zuoraSubscriptionId subscription to $sfAccountId , $sfFullContactId SalesForce Contact")
+      EitherT.rightT(MoveSubscriptionRes("subscription moved successfully"))
+    }
   }
 
 }

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
@@ -6,7 +6,7 @@ object SFMoveSubscriptionsService extends LazyLogging {
 
   def moveSubscription(req: MoveSubscriptionReqBody) = {
     import req._
-    logger.info(s"attempt to move $zuoraSubscriptionId subscription to $sfContactId SalesForce Contact")
+    logger.info(s"attempt to move $zuoraSubscriptionId subscription to $sfAccountId SalesForce Contact")
     req
   }
 

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
@@ -1,0 +1,13 @@
+package com.gu.sf.move.subscriptions.api
+
+import com.typesafe.scalalogging.LazyLogging
+
+object SFMoveSubscriptionsService extends LazyLogging {
+
+  def moveSubscription(req: MoveSubscriptionReqBody) = {
+    import req._
+    logger.info(s"attempt to move $zuoraSubscriptionId subscription to $sfContactId SalesForce Contact")
+    req
+  }
+
+}

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
@@ -1,13 +1,16 @@
 package com.gu.sf.move.subscriptions.api
 
+import cats.data.EitherT
+import cats.effect.IO
+import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 
 object SFMoveSubscriptionsService extends LazyLogging {
 
-  def moveSubscription(req: MoveSubscriptionReqBody) = {
+  def moveSubscription(req: MoveSubscriptionReqBody): EitherT[IO, MoveSubscriptionApiError, MoveSubscriptionRes] = {
     import req._
     logger.info(s"attempt to move $zuoraSubscriptionId subscription to $sfAccountId SalesForce Contact")
-    req
+    Either.right(MoveSubscriptionRes("subscription moved successfully")).toEitherT
   }
 
 }


### PR DESCRIPTION
## Overview
sf-move-subscriptions-api lambda skeleton code 

- create skeleton with http4s
- adding routes 
-- GET with api description
-- POST with ability to send: `sfAccountId, sfFullContactId, zuoraSubscriptionId`

## Tested
- [x] in code