### PR TITLE
sf-move-subscriptions-api infra add and require API key

### DIFF
--- a/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
+++ b/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
@@ -107,11 +107,8 @@ export class SfMoveSubscriptionsStack extends cdk.Stack {
           },
         })
 
-      api.root.addProxy({
-        defaultMethodOptions: {
-          apiKeyRequired: true,
-        }
-      })
+      api.root.addMethod('ANY', new apigateway.LambdaIntegration(fn), { apiKeyRequired: true })
+      api.root.addProxy({ defaultMethodOptions: { apiKeyRequired: true } })
 
       Tag.add(api, 'App', appName)
       Tag.add(api, 'Stage', stageParameter.valueAsString)

--- a/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
+++ b/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
@@ -123,15 +123,15 @@ export class SfMoveSubscriptionsStack extends cdk.Stack {
         }
       )
 
-      new apigateway.UsagePlan(
+      const usagePlan = new apigateway.UsagePlan(
         this,
         'sfMoveSubscriptionsApiUsagePlan', {
         name: `${appName}-usage-plan-${stageParameter.valueAsString}`,
         apiKey: apiKey,
-        apiStages: [{
-          api: api,
-          stage: api.deploymentStage,
-        }]
+      })
+
+      usagePlan.addApiStage({
+        stage: api.deploymentStage,
       })
 
       return api

--- a/handlers/sf-move-subscriptions-api/cdk/test/sf-move-subscriptions.test.ts
+++ b/handlers/sf-move-subscriptions-api/cdk/test/sf-move-subscriptions.test.ts
@@ -10,4 +10,7 @@ test('lambda with Rest API gateway Created', () => {
     expectCDK(stack).to(haveResource("AWS::IAM::Role"))
     expectCDK(stack).to(haveResource("AWS::Lambda::Function"))
     expectCDK(stack).to(haveResource("AWS::ApiGateway::RestApi"))
+    expectCDK(stack).to(haveResource("AWS::ApiGateway::UsagePlan"))
+    expectCDK(stack).to(haveResource("AWS::ApiGateway::UsagePlanKey"))
+    expectCDK(stack).to(haveResource("AWS::ApiGateway::ApiKey"))
 });


### PR DESCRIPTION
## Overview
sf-move-subscriptions-api infra add and require API key

AWS CDK changes:
- create api key
- require API key on all proxy resources
- add usage plan for api

## Tests
- [x] in CODE 