### PR TITLE
[sf-move-subscriptions-api] lambda CDK changes to be able to pick-up APP config from AWS SSM at RUNTIME

### DIFF
--- a/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
+++ b/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
@@ -41,7 +41,7 @@ export class SfMoveSubscriptionsStack extends cdk.Stack {
 
       role.addToPolicy(new iam.PolicyStatement({
         actions: ['kms:Decrypt'],
-        resources: [`arn:aws:kms:${region}:${account}:key/*`],
+        resources: [`arn:aws:kms:${region}:${account}:alias/aws/ssm`],
       }))
 
       role.addToPolicy(new iam.PolicyStatement({

--- a/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
+++ b/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
@@ -44,6 +44,16 @@ export class SfMoveSubscriptionsStack extends cdk.Stack {
       }))
 
       role.addToPolicy(new iam.PolicyStatement({
+        actions: ['ssm:GetParametersByPath'],
+        resources: [`arn:aws:ssm:${region}:${account}:parameter/${stageParameter.valueAsString}/${stackName}/${appName}`],
+      }))
+
+      role.addToPolicy(new iam.PolicyStatement({
+        actions: ['kms:Decrypt'],
+        resources: [`arn:aws:kms:${region}:${account}:key/*`],
+      }))
+
+      role.addToPolicy(new iam.PolicyStatement({
         actions: ['logs:CreateLogGroup'],
         resources: [`arn:aws:logs:${region}:${account}:*`],
       }))

--- a/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
+++ b/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
@@ -35,15 +35,6 @@ export class SfMoveSubscriptionsStack extends cdk.Stack {
       })
 
       role.addToPolicy(new iam.PolicyStatement({
-        actions: ['s3:GetObject'],
-        resources: [
-          `arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${stageParameter.valueAsString}/sfAuth-${stageParameter.valueAsString}*.json`,
-          `arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${stageParameter.valueAsString}/zuoraRest-${stageParameter.valueAsString}*.json`
-          ,
-        ],
-      }))
-
-      role.addToPolicy(new iam.PolicyStatement({
         actions: ['ssm:GetParametersByPath'],
         resources: [`arn:aws:ssm:${region}:${account}:parameter/${stageParameter.valueAsString}/${stackName}/${appName}`],
       }))

--- a/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
+++ b/handlers/sf-move-subscriptions-api/cdk/lib/sf-move-subscriptions-stack.ts
@@ -79,6 +79,11 @@ export class SfMoveSubscriptionsStack extends cdk.Stack {
           ),
           handler: 'com.gu.sf.move.subscriptions.api.Handler::handle',
           role: fnRole,
+          environment: {
+            'App': appName,
+            'Stage': stageParameter.valueAsString,
+            'Stack': stackName
+          }
         },
       )
 


### PR DESCRIPTION
## Overview
`sf-move-subscriptions-api` lambda CDK changes to be able to pick-up APP config from AWS SSM at RUNTIME

## What changed
- adding lambda env vars to identify app on runtime and be able to pick proper config from parameter store
- removing permissions to s3 files as `sf-move-subscriptions-api` will use AWS SSM Parameter store instead
- adding permissions to AWS SSM Parameter store and KMS

## Tests
- [x] CODE