### PR TITLE
Add SV_DeliveryProblemConfirmation email

### DIFF
--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
@@ -55,7 +55,9 @@ object EmailBatch {
       repeatDeliveryProblem: String,
       issuesAffected: String,
       deliveries: List[WireDelivery],
-      typeOfProblem: String
+      typeOfProblem: String,
+      currencySymbol: String,
+      caseNumber: String
     )
     case class WireDelivery(
       Case__c: String,
@@ -149,10 +151,12 @@ object EmailBatch {
           // Delivery Problem
           delivery_problem_action = emailBatchPayload.delivery_problem.map(_.actionTaken),
           delivery_problem_total_affected = emailBatchPayload.delivery_problem.map(_.issuesAffected),
-          delivery_problem_affected_dates = emailBatchPayload.delivery_problem.map(_.deliveries.map(_.Delivery_Date__c).mkString(", ")),
+          delivery_problem_affected_dates = emailBatchPayload.delivery_problem.map(_.deliveries.map(d => fromSfDateToDisplayDate(d.Delivery_Date__c)).mkString(", ")),
           delivery_problem_total_credit = emailBatchPayload.delivery_problem.map(_.totalCreditAmount),
-          delivery_problem_invoice_date = emailBatchPayload.delivery_problem.flatMap(_.deliveries.map(_.Invoice_Date__c).headOption),
+          delivery_problem_invoice_date = emailBatchPayload.delivery_problem.flatMap(_.deliveries.map(_.Invoice_Date__c).headOption.map(fromSfDateToDisplayDate)),
           delivery_problem_type = emailBatchPayload.delivery_problem.map(_.typeOfProblem),
+          delivery_problem_currency_symbol = emailBatchPayload.delivery_problem.map(_.currencySymbol),
+          delivery_problem_case_number = emailBatchPayload.delivery_problem.map(_.caseNumber),
         ),
         object_name = wireEmailBatchItem.object_name
       )
@@ -204,7 +208,9 @@ case class EmailBatchItemPayload(
   delivery_problem_total_credit: Option[String] = None,
   delivery_problem_invoice_date: Option[String] = None,
   delivery_problem_type: Option[String] = None,
-  delivery_problem_affected_dates: Option[String] = None
+  delivery_problem_affected_dates: Option[String] = None,
+  delivery_problem_currency_symbol: Option[String] = None,
+  delivery_problem_case_number: Option[String] = None,
 )
 
 case class EmailBatchItem(payload: EmailBatchItemPayload, object_name: String)

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailBatch.scala
@@ -63,7 +63,7 @@ object EmailBatch {
       Case__c: String,
       Name: String,
       Delivery_Date__c: String,
-      Invoice_Date__c: String
+      Invoice_Date__c: Option[String]
     )
 
     implicit val holidayStopCreditDetailReads = Json.reads[WireHolidayStopCreditSummary]
@@ -153,7 +153,7 @@ object EmailBatch {
           delivery_problem_total_affected = emailBatchPayload.delivery_problem.map(_.issuesAffected),
           delivery_problem_affected_dates = emailBatchPayload.delivery_problem.map(_.deliveries.map(d => fromSfDateToDisplayDate(d.Delivery_Date__c)).mkString(", ")),
           delivery_problem_total_credit = emailBatchPayload.delivery_problem.map(_.totalCreditAmount),
-          delivery_problem_invoice_date = emailBatchPayload.delivery_problem.flatMap(_.deliveries.map(_.Invoice_Date__c).headOption.map(fromSfDateToDisplayDate)),
+          delivery_problem_invoice_date = emailBatchPayload.delivery_problem.flatMap(_.deliveries.flatMap(_.Invoice_Date__c).headOption.map(fromSfDateToDisplayDate)),
           delivery_problem_type = emailBatchPayload.delivery_problem.map(_.typeOfProblem),
           delivery_problem_currency_symbol = emailBatchPayload.delivery_problem.map(_.currencySymbol),
           delivery_problem_case_number = emailBatchPayload.delivery_problem.map(_.caseNumber),

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
@@ -35,7 +35,9 @@ case class EmailPayloadSubscriberAttributes(
   delivery_problem_affected_dates: Option[String] = None,
   delivery_problem_total_credit: Option[String] = None,
   delivery_problem_invoice_date: Option[String] = None, // Invoice_Date__c Is it the same for multiple issues ?
-  delivery_problem_type: Option[String] = None, // No delivery | Damaged paper
+  delivery_problem_type: Option[String] = None, // No delivery | Damaged paper,
+  delivery_problem_currency_symbol: Option[String] = None,
+  delivery_problem_case_number: Option[String] = None,
 )
 case class EmailPayloadDigitalVoucher(barcode_url: String)
 case class EmailPayloadStoppedCreditSummary(credit_amount: Double, credit_date: String)
@@ -88,7 +90,9 @@ object EmailToSend {
           delivery_problem_affected_dates = emailBatchItem.payload.delivery_problem_affected_dates,
           delivery_problem_total_credit = emailBatchItem.payload.delivery_problem_total_credit,
           delivery_problem_invoice_date = emailBatchItem.payload.delivery_problem_invoice_date,
-          delivery_problem_type = emailBatchItem.payload.delivery_problem_type
+          delivery_problem_type = emailBatchItem.payload.delivery_problem_type,
+          delivery_problem_currency_symbol = emailBatchItem.payload.delivery_problem_currency_symbol,
+          delivery_problem_case_number = emailBatchItem.payload.delivery_problem_case_number,
         )
       )
     )


### PR DESCRIPTION
Related membership-workflow PR: https://github.com/guardian/membership-workflow/pull/229

Example SQS message

```
{
  "To" : {
    "Address" : "bvtgedltoa@guardian.co.uk",
    "SubscriberKey" : "bvtgedltoa@guardian.co.uk",
    "ContactAttributes" : {
      "SubscriberAttributes" : {
        "first_name" : "bvtgedltoa",
        "last_name" : "bvtgedltoa",
        "subscriber_id" : "A-S00060454",
        "product" : "Guardian Weekly",
        "delivery_problem_action" : "Escalation",
        "delivery_problem_total_affected" : "1",
        "delivery_problem_affected_dates" : "24 February 2020",
        "delivery_problem_total_credit" : "0.00",
        "delivery_problem_invoice_date" : "20 June 2020",
        "delivery_problem_type" : "Damaged Paper",
        "delivery_problem_currency_symbol" : "£",
        "delivery_problem_case_number" : "00796584"
      }
    }
  },
  "DataExtensionName" : "SV_DeliveryProblemConfirmation",
  "SfContactId" : "0033E00001Chmk9QAB",
  "IdentityUserId" : "200002073"
}
```