### PR TITLE
[sf-move-subscriptions-api] Updating identity id while moving subscription in ZUORA

### DIFF
--- a/handlers/sf-move-subscriptions-api/README.md
+++ b/handlers/sf-move-subscriptions-api/README.md
@@ -20,7 +20,7 @@ endpoints:
    "zuoraSubscriptionId": "Zuora Subscription Id",
    "sfAccountId": "SF Account Id",
    "sfFullContactId": "SF Full contact Id",
-   "identityId": "id from guardian identity service, if not set in SF send blank"
+   "identityId": "id from guardian identity service, if not set in SF send blank value (empty string)"
 }
 ```
 

--- a/handlers/sf-move-subscriptions-api/README.md
+++ b/handlers/sf-move-subscriptions-api/README.md
@@ -15,13 +15,14 @@ endpoints:
 - `self doc` method=GET, path=`/`
 - `moving subscription` method=POST, path=`/subscription/move`, body=
 
-    json```
-    {
-       "zuoraSubscriptionId": "Zuora Subscription Id",
-       "sfAccountId": "SF Account Id",
-       "sfFullContactId": "SF Full contact Id",
-       "identityId": "id from guardian identity service, if not set in SF send blank"
-    }```
+```json
+{
+   "zuoraSubscriptionId": "Zuora Subscription Id",
+   "sfAccountId": "SF Account Id",
+   "sfFullContactId": "SF Full contact Id",
+   "identityId": "id from guardian identity service, if not set in SF send blank"
+}
+```
 
 # how to generate/update cfn.yml by AWS CDK
 

--- a/handlers/sf-move-subscriptions-api/README.md
+++ b/handlers/sf-move-subscriptions-api/README.md
@@ -10,6 +10,19 @@ All endpoints require...
 
 API have a self doc endpoint at root `/` which will display example req body for (`POST`) method
 
+endpoints:
+
+- `self doc` method=GET, path=`/`
+- `moving subscription` method=POST, path=`/subscription/move`, body=
+
+    json```
+    {
+       "zuoraSubscriptionId": "Zuora Subscription Id",
+       "sfAccountId": "SF Account Id",
+       "sfFullContactId": "SF Full contact Id",
+       "identityId": "id from guardian identity service, if not set in SF send blank"
+    }```
+
 # how to generate/update cfn.yml by AWS CDK
 
 - go to /cdk

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
@@ -3,7 +3,8 @@ package com.gu.sf.move.subscriptions.api
 final case class MoveSubscriptionReqBody(
   zuoraSubscriptionId: String,
   sfAccountId: String,
-  sfFullContactId: String
+  sfFullContactId: String,
+  identityId: String
 )
 
 final case class MoveSubscriptionApiConfig(

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -25,7 +25,7 @@ object SFMoveSubscriptionsApiRoutes extends LazyLogging {
             zuoraSubscriptionId = "Zuora Subscription Id",
             sfAccountId = "SF Account Id",
             sfFullContactId = "SF Full contact Id",
-            identityId = "id from guardian identity service, if not set in SF send blank"
+            identityId = "id from guardian identity service, if not set in SF send blank value (empty string)"
           )
         )
       )

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
@@ -7,7 +7,6 @@ import com.gu.zuora.Zuora.{accessTokenGetResponseV2, subscriptionGetResponse, up
 import com.gu.zuora._
 import com.gu.zuora.subscription._
 import com.softwaremill.sttp._
-import com.typesafe.scalalogging.LazyLogging
 
 final case class MoveSubscriptionServiceSuccess(message: String)
 
@@ -24,7 +23,7 @@ case class UpdateZuoraAccountError(message: String) extends MoveSubscriptionServ
 class SFMoveSubscriptionsService[F[_]: Monad](
   apiCfg: MoveSubscriptionApiConfig,
   backend: SttpBackend[Id, Nothing]
-) extends LazyLogging {
+) {
 
   private val ZuoraConfig = ZuoraRestOauthConfig(
     baseUrl = apiCfg.zuoraBaseUrl,
@@ -36,12 +35,11 @@ class SFMoveSubscriptionsService[F[_]: Monad](
 
   def moveSubscription(moveSubscriptionData: MoveSubscriptionReqBody): EitherT[F, MoveSubscriptionServiceError, MoveSubscriptionServiceSuccess] = {
     import moveSubscriptionData._
-    logger.info(s"attempt to move $zuoraSubscriptionId subscription to " +
-      s"(Account Id=$sfAccountId ,Full contact Id=$sfFullContactId) SalesForce Contact")
 
     val moveSubCommand = ZuoraAccountMoveSubscriptionCommand(
       crmId = sfAccountId,
-      sfContactId__c = sfFullContactId
+      sfContactId__c = sfFullContactId,
+      IdentityId__c = identityId
     )
 
     (for {

--- a/handlers/sf-move-subscriptions-api/src/test/scala/com/gu/sf/move/subscriptions/api/ZuoraTestBackendMixin.scala
+++ b/handlers/sf-move-subscriptions-api/src/test/scala/com/gu/sf/move/subscriptions/api/ZuoraTestBackendMixin.scala
@@ -17,6 +17,7 @@ trait ZuoraTestBackendMixin {
     zuoraSubscriptionId = "test-zuora-sub-id",
     sfAccountId = "test-sf-account-id",
     sfFullContactId = "test-sf-full-contact-id",
+    identityId = "test-guardian-identity-id"
   )
 
   private val sub = mkAnySubscription().copy(
@@ -43,10 +44,10 @@ trait ZuoraTestBackendMixin {
     Response.error("update ZuoraAccount failure", StatusCodes.InternalServerError)
 
   def createZuoraBackendStub(
-                                 oauthResponse: Response[Either[Nothing, AccessToken]],
-                                 getSubscriptionRes: Response[Either[Nothing, Subscription]],
-                                 updateAccountRes: Response[Either[Nothing, MoveSubscriptionAtZuoraAccountResponse]]
-                               ): SttpBackendStub[Id, Nothing] = {
+    oauthResponse: Response[Either[Nothing, AccessToken]],
+    getSubscriptionRes: Response[Either[Nothing, Subscription]],
+    updateAccountRes: Response[Either[Nothing, MoveSubscriptionAtZuoraAccountResponse]]
+  ): SttpBackendStub[Id, Nothing] = {
     SttpBackendStub.synchronous
       .whenRequestMatchesPartial {
         case request if request.uri.toString() == s"$zuoraTestBaseUrl/oauth/token" =>

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/Zuora.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/Zuora.scala
@@ -5,7 +5,11 @@ import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 import io.circe.generic.auto._
 
-case class ZuoraAccountMoveSubscriptionCommand(crmId: String, sfContactId__c: String)
+case class ZuoraAccountMoveSubscriptionCommand(
+  crmId: String,
+  sfContactId__c: String,
+  IdentityId__c: String
+)
 
 case class MoveSubscriptionAtZuoraAccountResponse(message: String)
 


### PR DESCRIPTION
## Overview
[sf-move-subscriptions-api] Updating identity id while moving subscription in ZUORA

## what was done
- introducing additional required field in `MoveSubscriptionReqBody`
- code formatting

## trick
if in SF we do not have proper `identityId` identityId field in ZUORA should be blanked
but the API caller should be responsible on deciding that

## Tests
- [x] locally
- [x] CODE