### PR TITLE
Extract the Salesforce ID of every SF Subscription

### DIFF
--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -156,7 +156,8 @@ object SfQueries {
       |Version__c,
       |Zuora_Id__c,
       |ReaderType__c,
-      |GW_Offer__c
+      |GW_Offer__c,
+      |Id
       |from SF_Subscription__c
       |where Buyer__r.Account.GDPR_Deletion_Pending__c = false
       |


### PR DESCRIPTION
Without this field in the Data Lake, we cannot join a Case to the SF Subscription which it references.

cc @wojtek-tg @david-pepper 

TODO:
- [x] Figure out how to test this
- [x] Ensure the cleaner is compatible with, and picks up this change to update the clean table (see: https://github.com/guardian/ophan-data-lake/pull/5026)
- [ ] Update the Data Dictionary
- [x] Ensure the new Data Platform inherits the change