### PR TITLE
Extracting imovo sttp client and stub into a shared library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -226,6 +226,18 @@ lazy val `credit-processor` = all(project in file("lib/credit-processor"))
     libraryDependencies ++= logging
   )
 
+lazy val `imovo-sttp-client` = all(project in file("lib/imovo/imovo-sttp-client"))
+  .settings(
+    libraryDependencies ++=
+      Seq(sttp, sttpCirce, sttpCats % Test, scalatest, catsCore, catsEffect, circe, circeJava8) ++ logging
+  )
+
+lazy val `imovo-sttp-test-stub` = all(project in file("lib/imovo/imovo-sttp-test-stub"))
+  .dependsOn(`imovo-sttp-client`)
+  .settings(
+    libraryDependencies ++= Seq(scalatest)
+  )
+
 lazy val `zuora-callout-apis` = all(project in file("handlers/zuora-callout-apis"))
   .enablePlugins(RiffRaffArtifact)
   .dependsOn(zuora, handler, effectsDepIncludingTestFolder, `effects-sqs`, testDep)
@@ -355,31 +367,31 @@ lazy val `delivery-records-api` = all(project in file("handlers/delivery-records
   .enablePlugins(RiffRaffArtifact)
 
 lazy val `digital-voucher-api` = all(project in file("handlers/digital-voucher-api"))
-  .dependsOn(`effects-s3`, `config-cats`)
+  .dependsOn(`effects-s3`, `config-cats`, `imovo-sttp-client`, `imovo-sttp-test-stub` % Test)
   .settings(
     libraryDependencies ++=
-    Seq(
-      http4sLambda,
-      http4sDsl,
-      http4sCirce,
-      http4sServer,
-      sttp,
-      sttpCirce,
-      sttpAsycHttpClientBackendCats,
-      scalatest,
-      diffx
-    )
-    ++ logging
+      Seq(
+        http4sLambda,
+        http4sDsl,
+        http4sCirce,
+        http4sServer,
+        sttpAsycHttpClientBackendCats,
+        scalatest,
+        diffx
+      )
+      ++ logging
   )
   .enablePlugins(RiffRaffArtifact)
 
 lazy val `digital-voucher-cancellation-processor` = all(project in file("handlers/digital-voucher-cancellation-processor"))
-  .dependsOn(`effects-s3`, `config-cats`, `salesforce-sttp-client`, `salesforce-sttp-test-stub` % Test)
+  .dependsOn(
+    `config-cats`, `salesforce-sttp-client`, `salesforce-sttp-test-stub` % Test, `imovo-sttp-client`,
+    `imovo-sttp-test-stub` % Test
+  )
   .settings(
     libraryDependencies ++=
     Seq(
       scalatest,
-      simpleConfig,
       diffx,
       sttpCats
     )

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
@@ -4,7 +4,7 @@ import cats.data.EitherT
 import cats.implicits._
 import cats.effect.{ContextShift, IO}
 import com.gu.AppIdentity
-import com.gu.digital_voucher_api.imovo.ImovoClient
+import com.gu.imovo.ImovoClient
 import com.gu.util.config.ConfigLoader
 import com.softwaremill.sttp.SttpBackend
 import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
@@ -12,6 +12,7 @@ import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{DecodeFailure, HttpRoutes, InvalidMessageBodyFailure, MalformedMessageBodyFailure, Request, Response}
+import com.gu.imovo.SfSubscriptionId
 
 case class DigitalVoucherApiRoutesError(message: String)
 

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import cats.Monad
 import cats.implicits._
 import cats.data.EitherT
-import com.gu.digital_voucher_api.imovo.{ImovoClient, ImovoSubscriptionResponse, ImovoSubscriptionType}
+import com.gu.imovo.{ImovoClient, ImovoSubscriptionResponse, ImovoSubscriptionType, SchemeName, SfSubscriptionId}
 
 trait DigitalVoucherService[F[_]] {
   def createVoucher(subscriptionId: SfSubscriptionId, ratePlanName: RatePlanName): EitherT[F, DigitalVoucherServiceError, SubscriptionVouchers]

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Model.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Model.scala
@@ -1,9 +1,5 @@
 package com.gu.digital_voucher_api
 
-case class SfSubscriptionId(value: String) extends AnyVal
-
 case class RatePlanName(value: String) extends AnyVal
-
-case class SchemeName(value: String) extends AnyVal
 
 case class SubscriptionVouchers(cardCode: String, letterCode: String)

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import cats.effect.IO
 import com.gu.DevIdentity
 import com.gu.digital_voucher_api.imovo.ImovoStub._
-import com.gu.digital_voucher_api.imovo.{ImovoErrorResponse, ImovoSubscriptionResponse, ImovoSubscriptionType, ImovoSuccessResponse, ImovoVoucherResponse}
+import com.gu.imovo.{ImovoErrorResponse, ImovoSubscriptionResponse, ImovoSubscriptionType, ImovoSuccessResponse, ImovoVoucherResponse, SfSubscriptionId}
 import com.softwaremill.diffx.scalatest.DiffMatcher
 import com.softwaremill.sttp.impl.cats.CatsMonadError
 import com.softwaremill.sttp.testing.SttpBackendStub

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/imovo/ImovoStub.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/imovo/ImovoStub.scala
@@ -8,6 +8,7 @@ import com.softwaremill.sttp.{Method, Request, Response}
 import io.circe.Encoder
 import io.circe.syntax._
 import cats.implicits._
+import com.gu.imovo.ImovoSubscriptionType
 
 object ImovoStub {
   class ImovoStubSttpBackendStubOps[F[_], S](sttpStub: SttpBackendStub[F, S]) {

--- a/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorApp.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorApp.scala
@@ -6,6 +6,7 @@ import cats.arrow.FunctionK
 import cats.data.EitherT
 import cats.effect.{IO, Sync}
 import com.gu.AppIdentity
+import com.gu.imovo.ImovoConfig
 import com.gu.salesforce.SFAuthConfig
 import com.gu.salesforce.sttp.SalesforceClient
 import com.gu.util.config.ConfigLoader
@@ -15,7 +16,6 @@ import com.typesafe.scalalogging.LazyLogging
 
 case class DigitalVoucherCancellationProcessorAppError(message: String)
 
-case class ImovoConfig(imovoBaseUrl: String, imovoApiKey: String)
 case class DigitalVoucherCancellationProcessorConfig(imovo: ImovoConfig, salesforce: SFAuthConfig)
 
 object DigitalVoucherCancellationProcessorApp extends LazyLogging {

--- a/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorApp.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorApp.scala
@@ -2,7 +2,6 @@ package com.gu.digital_voucher_cancellation_processor
 
 import java.time.Clock
 
-import cats.Monad
 import cats.arrow.FunctionK
 import cats.data.EitherT
 import cats.effect.{IO, Sync}

--- a/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
+++ b/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
@@ -1,4 +1,4 @@
-package com.gu.digital_voucher_api.imovo
+package com.gu.imovo
 
 import java.net.URI
 import java.time.LocalDate
@@ -7,7 +7,6 @@ import java.time.format.DateTimeFormatter
 import cats.data.EitherT
 import cats.effect.Sync
 import cats.implicits._
-import com.gu.digital_voucher_api.{SchemeName, SfSubscriptionId}
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 import com.typesafe.scalalogging.LazyLogging
@@ -15,6 +14,8 @@ import io.circe.generic.auto._
 import io.circe.parser._
 import io.circe.{Decoder, Encoder}
 
+case class SfSubscriptionId(value: String) extends AnyVal
+case class SchemeName(value: String) extends AnyVal
 case class ImovoVoucherResponse(subscriptionType: String, voucherCode: String)
 case class ImovoSubscriptionResponse(
   schemeName: String,


### PR DESCRIPTION
Moving imovo sttp client and sttp test stub in to shared libraries.

This is to support their use by the digital-voucher-cancellation-processor