### PR TITLE
Handle auto cancellation for accounts with multiple active subscriptions [zuora-auto-cancel-api]

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -7,24 +7,29 @@ import com.gu.stripeCustomerSourceUpdated.TypeConvert._
 import com.gu.util.Logging
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.RestRequestMaker.Requests
-import com.gu.util.zuora.ZuoraGetAccountSummary.SubscriptionId
-import com.gu.util.zuora.{ZuoraCancelSubscription, ZuoraDisableAutoPay, ZuoraUpdateCancellationReason}
+import com.gu.util.zuora.{SubscriptionNumber, ZuoraCancelSubscription, ZuoraUpdateCancellationReason}
 
 object AutoCancel extends Logging {
 
-  case class AutoCancelRequest(accountId: String, subToCancel: SubscriptionId, cancellationDate: LocalDate)
+  case class AutoCancelRequest(accountId: String, subToCancel: SubscriptionNumber, cancellationDate: LocalDate)
 
-  def apply(requests: Requests)(acRequest: AutoCancelRequest, urlParams: AutoCancelUrlParams): ApiGatewayOp[Unit] = {
-    val dryRun = urlParams.dryRun
+  def apply(requests: Requests)(acRequests: List[AutoCancelRequest], urlParams: AutoCancelUrlParams): ApiGatewayOp[Unit] = {
+    logger.info(s"dryRun: ${urlParams.dryRun}")
+    val ac = executeCancel(requests, urlParams.dryRun) _
+    val responses = acRequests.map(cancelReq => ac(cancelReq))
+    logger.info(s"AutoCancel responses: $responses")
+    // TODO it should not call head
+    responses.head
+  }
+
+  private def executeCancel(requests: Requests, dryRun: Boolean)(acRequest: AutoCancelRequest): ApiGatewayOp[Unit] = {
     val AutoCancelRequest(accountId, subToCancel, cancellationDate) = acRequest
-    logger.info(s"Attempting to perform auto-cancellation on account: $accountId for subscription: ${subToCancel.id}")
+    logger.info(s"Attempting to perform auto-cancellation on account: $accountId for subscription: ${subToCancel.value}")
     val zuoraUpdateCancellationReasonF = if (dryRun) ZuoraUpdateCancellationReason.dryRun(requests) _ else ZuoraUpdateCancellationReason(requests) _
     val zuoraCancelSubscriptionF = if (dryRun) ZuoraCancelSubscription.dryRun(requests) _ else ZuoraCancelSubscription(requests) _
-    val zuoraDisableAutoPayF = if (dryRun) ZuoraDisableAutoPay.dryRun(requests) _ else ZuoraDisableAutoPay(requests) _
     val zuoraOp = for {
       _ <- zuoraUpdateCancellationReasonF(subToCancel).withLogging("updateCancellationReason")
       _ <- zuoraCancelSubscriptionF(subToCancel, cancellationDate).withLogging("cancelSubscription")
-      _ <- zuoraDisableAutoPayF(accountId).withLogging("disableAutoPay")
     } yield ()
     zuoraOp.toApiGatewayOp("AutoCancel failed")
   }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -18,7 +18,7 @@ object AutoCancel extends Logging {
     val ac = executeCancel(requests, urlParams.dryRun) _
     val responses = acRequests.map(cancelReq => ac(cancelReq))
     logger.info(s"AutoCancel responses: $responses")
-    // TODO it should not call head
+    // TODO to refactor it should not call head
     responses.head
   }
 

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
@@ -3,65 +3,61 @@ package com.gu.autoCancel
 import java.time.LocalDate
 
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
+import com.gu.stripeCustomerSourceUpdated.TypeConvert._
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse.noActionRequired
 import com.gu.util.reader.Types.ApiGatewayOp._
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.ClientFailableOp
-import com.gu.util.zuora.ZuoraGetAccountSummary.{AccountSummary, Invoice, SubscriptionId}
-import com.gu.stripeCustomerSourceUpdated.TypeConvert._
+import com.gu.util.zuora.SubscriptionNumber
+import com.gu.util.zuora.ZuoraGetAccountSummary.{AccountSummary, Invoice}
 
 object AutoCancelDataCollectionFilter extends Logging {
 
   def apply(
     now: LocalDate,
-    getAccountSummary: String => ClientFailableOp[AccountSummary]
-  )(autoCancelCallout: AutoCancelCallout): ApiGatewayOp[AutoCancelRequest] = {
-    val accountId = autoCancelCallout.accountId
+    getAccountSummary: String => ClientFailableOp[AccountSummary],
+    getSubsNamesOnInvoice: String => ClientFailableOp[List[SubscriptionNumber]]
+  )(autoCancelCallout: AutoCancelCallout): ApiGatewayOp[List[AutoCancelRequest]] = {
+    import autoCancelCallout._
+
     for {
       accountSummary <- getAccountSummary(accountId).toApiGatewayOp("getAccountSummary").withLogging("getAccountSummary")
-      subToCancel <- getSubscriptionToCancel(accountSummary).withLogging("getSubscriptionToCancel")
-      cancellationDate <- getCancellationDateFromInvoices(accountSummary, now).withLogging("getCancellationDateFromInvoices")
-    } yield AutoCancelRequest(accountId, subToCancel, cancellationDate)
+      subsNames <- getSubsNamesOnInvoice(invoiceId).toApiGatewayOp("getSubsNamesOnInvoice").withLogging("getSubsNamesOnInvoice")
+      cancellationDate <- getCancellationDateFromInvoice(invoiceId, accountSummary, now).withLogging("getCancellationDateFromInvoice")
+    } yield subsNames
+      .map { subToCancel =>
+        AutoCancelRequest(accountId, subToCancel, cancellationDate)
+      }
   }
 
-  def getCancellationDateFromInvoices(accountSummary: AccountSummary, dateToday: LocalDate): ApiGatewayOp[LocalDate] = {
-    val unpaidAndOverdueInvoices = accountSummary.invoices.filter { invoice => invoiceOverdue(invoice, dateToday) }
-    if (unpaidAndOverdueInvoices.isEmpty) {
-      logger.error(s"Failed to find an unpaid invoice that was overdue. The invoices we got were: ${accountSummary.invoices}")
-      ReturnWithResponse(noActionRequired("No unpaid and overdue invoices found!"))
-    } else {
-      logger.info(s"Found at least one unpaid invoices for account: ${accountSummary.basicInfo.id}. Invoice id(s): ${unpaidAndOverdueInvoices.map(_.id)}")
-      implicit val localDateOrdering: Ordering[LocalDate] = Ordering.by(_.toEpochDay)
-      val earliestDueDate = unpaidAndOverdueInvoices.map(_.dueDate).min
-      logger.info(s"Earliest overdue invoice for account ${accountSummary.basicInfo.id} has due date: $earliestDueDate. Setting this as the cancellation date.")
-      ContinueProcessing(earliestDueDate)
-    }
+  def getCancellationDateFromInvoice(invoiceId: String, accountSummary: AccountSummary, dateToday: LocalDate): ApiGatewayOp[LocalDate] = {
+    accountSummary.invoices
+      .find(inv => {
+        logger.info(s"found callout invoice in accountSummary: $inv")
+        inv.id == invoiceId
+      })
+      .find(invoiceOverdue(_, dateToday)) match {
+        case None =>
+          logger.error(s"Failed on Validating Unpaid invoice that was overdue, invoiceId: $invoiceId")
+          ReturnWithResponse(noActionRequired("No unpaid and overdue invoices found!"))
+        case Some(inv) =>
+          logger.info(s"Found Valid Unpaid invoice for account: ${accountSummary.basicInfo.id}. Invoice: ${inv}")
+          ContinueProcessing(inv.dueDate)
+      }
   }
 
   def invoiceOverdue(invoice: Invoice, dateToday: LocalDate): Boolean = {
+    /**
+     * TODO invoice.balance > 0 may not be necessary as the trigger is on Invoice payment overdue event
+     * but i am not sure at this moment
+     */
     if (invoice.balance > 0 && invoice.status == "Posted") {
       val zuoraGracePeriod = 14L // This needs to match with the timeframe for the 3rd payment retry attempt in Zuora
       val invoiceOverdueDate = invoice.dueDate.plusDays(zuoraGracePeriod)
       logger.info(s"Zuora grace period is: $zuoraGracePeriod days. Due date for Invoice id ${invoice.id} is ${invoice.dueDate}, so it will be considered overdue on: $invoiceOverdueDate.")
       dateToday.isEqual(invoiceOverdueDate) || dateToday.isAfter(invoiceOverdueDate)
     } else false
-  }
-
-  def getSubscriptionToCancel(accountSummary: AccountSummary): ApiGatewayOp[SubscriptionId] = {
-    val activeSubs = accountSummary.subscriptions.filter(_.status == "Active")
-    activeSubs match {
-      case sub :: Nil =>
-        logger.info(s"Determined that we should cancel SubscriptionId: ${sub.id} (for AccountId: ${accountSummary.basicInfo.id})")
-        ContinueProcessing(sub.id)
-      case Nil =>
-        logger.error(s"Didn't find any active subscriptions. The full list of subs for this account was: ${accountSummary.subscriptions}")
-        ReturnWithResponse(noActionRequired("No Active subscriptions to cancel!"))
-      case subs =>
-        // This should be a pretty rare scenario, because the Billing Account to Sub relationship is (supposed to be) 1-to-1
-        logger.error(s"More than one subscription is Active on account: ${accountSummary.basicInfo.id}. Subscription ids are: ${activeSubs.map(_.id)}")
-        ReturnWithResponse(noActionRequired("More than one active sub found!")) // Don't continue because we don't know which active sub to cancel
-    }
   }
 
 }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -2,6 +2,7 @@ package com.gu.autoCancel
 
 import java.io.{InputStream, OutputStream}
 import java.time.LocalDateTime
+
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.sqs.AwsSQSSend
 import com.gu.effects.sqs.AwsSQSSend.{Payload, QueueName}
@@ -15,8 +16,9 @@ import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config._
 import com.gu.util.email.EmailSendSteps
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.{ZuoraGetAccountSummary, ZuoraGetInvoiceTransactions, ZuoraRestConfig, ZuoraRestRequestMaker}
+import com.gu.util.zuora._
 import okhttp3.{Request, Response}
+
 import scala.util.Try
 
 object AutoCancelHandler extends App with Logging {
@@ -32,10 +34,17 @@ object AutoCancelHandler extends App with Logging {
     for {
       zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
     } yield {
-      val zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)
+      val zuoraRequest = ZuoraRestRequestMaker(response, zuoraRestConfig)
+
+      val cancelRequestsProducer = AutoCancelDataCollectionFilter(
+        now().toLocalDate,
+        ZuoraGetAccountSummary(zuoraRequest),
+        ZuoraGetSubsNamesOnInvoice(zuoraRequest)
+      ) _
+
       AutoCancelSteps(
-        AutoCancel.apply(zuoraRequests),
-        AutoCancelDataCollectionFilter.apply(now().toLocalDate, ZuoraGetAccountSummary(zuoraRequests)),
+        AutoCancel.apply(zuoraRequest),
+        cancelRequestsProducer,
         ZuoraEmailSteps.sendEmailRegardingAccount(
           EmailSendSteps(awsSQSSend(emailQueueFor(stage))),
           ZuoraGetInvoiceTransactions(ZuoraRestRequestMaker(response, zuoraRestConfig))

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -39,6 +39,7 @@ object AutoCancelHandler extends App with Logging {
       val cancelRequestsProducer = AutoCancelDataCollectionFilter(
         now().toLocalDate,
         ZuoraGetAccountSummary(zuoraRequest),
+        ZuoraGetAccountSubscriptions(zuoraRequest),
         ZuoraGetSubsNamesOnInvoice(zuoraRequest)
       ) _
 

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelInputFilter.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelInputFilter.scala
@@ -2,9 +2,8 @@ package com.gu.autoCancel
 
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse.noActionRequired
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.reader.Types._
-
-import ApiGatewayOp.{ReturnWithResponse, ContinueProcessing}
 
 object AutoCancelInputFilter extends Logging {
   def apply(callout: AutoCancelCallout, onlyCancelDirectDebit: Boolean): ApiGatewayOp[Unit] = {

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
@@ -7,8 +7,8 @@ import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayHandler.Operation
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.email.{EmailId, EmailMessage}
-import com.gu.util.reader.Types._
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
+import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientFailure, ClientSuccess}
 import play.api.libs.json._
 
@@ -29,16 +29,16 @@ object AutoCancelSteps extends Logging {
   }
 
   def apply(
-    autoCancel: (AutoCancelRequest, AutoCancelUrlParams) => ApiGatewayOp[Unit],
-    autoCancelFilter: AutoCancelCallout => ApiGatewayOp[AutoCancelRequest],
+    callZuoraAutoCancel: (List[AutoCancelRequest], AutoCancelUrlParams) => ApiGatewayOp[Unit],
+    autoCancelReqProducer: AutoCancelCallout => ApiGatewayOp[List[AutoCancelRequest]],
     sendEmailRegardingAccount: (String, PaymentFailureInformation => Either[String, EmailMessage]) => ClientFailableOp[Unit]
   ): Operation = Operation.noHealthcheck({ apiGatewayRequest: ApiGatewayRequest =>
     (for {
       autoCancelCallout <- apiGatewayRequest.bodyAsCaseClass[AutoCancelCallout]()
       urlParams <- apiGatewayRequest.queryParamsAsCaseClass[AutoCancelUrlParams]()
       _ <- AutoCancelInputFilter(autoCancelCallout, onlyCancelDirectDebit = urlParams.onlyCancelDirectDebit)
-      acRequest <- autoCancelFilter(autoCancelCallout).withLogging(s"auto-cancellation filter for ${autoCancelCallout.accountId}")
-      _ <- autoCancel(acRequest, urlParams).withLogging(s"auto-cancellation for ${autoCancelCallout.accountId}")
+      autoCancelRequests <- autoCancelReqProducer(autoCancelCallout).withLogging(s"auto-cancellation requests for ${autoCancelCallout.accountId}")
+      _ <- callZuoraAutoCancel(autoCancelRequests, urlParams).withLogging(s"auto-cancellation for ${autoCancelCallout.accountId}")
       request = makeRequest(autoCancelCallout) _
       _ <- handleSendPaymentFailureEmail(autoCancelCallout.accountId, request, sendEmailRegardingAccount, urlParams)
     } yield ApiGatewayResponse.successfulExecution).apiResponse

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
@@ -19,6 +19,8 @@ object GetPaymentData extends Logging {
       case Some(invoice) => {
         logger.info(s"Found the following unpaid invoice: $invoice")
         val positiveInvoiceItems = invoice.invoiceItems.filter(item => invoiceItemFilter(item))
+        // TODO payment failure may be subjected to invoice that have multiple items not only one
+        // here we are generating PaymentFailureInformation based on the head of InvoiceItems
         val maybePaymentFailureInfo = positiveInvoiceItems.headOption.map {
           item =>
             {

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/email/EmailSendSteps.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/email/EmailSendSteps.scala
@@ -94,6 +94,7 @@ trait EmailSqsSerialisation {
 
 object EmailSendSteps extends EmailSqsSerialisation with LazyLogging {
   def apply(sqsSend: Payload => Try[Unit])(emailRequest: EmailMessage): ClientFailableOp[Unit] = {
+    logger.info(s"EmailSendSteps msg: $emailRequest")
     sqsSend(Payload(Json.toJson(emailRequest).toString)) match {
       case Success(_) =>
         ClientSuccess(())

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -4,7 +4,6 @@ import java.time.LocalDate
 
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
-import com.gu.util.zuora.ZuoraGetAccountSummary.SubscriptionId
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsSuccess, Json, Reads, Writes}
 
@@ -23,15 +22,15 @@ object ZuoraCancelSubscription extends LazyLogging {
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))
 
-  private def toBodyAndPath(subscription: SubscriptionId, cancellationDate: LocalDate) =
-    (SubscriptionCancellation(cancellationDate), s"subscriptions/${subscription.id}/cancel")
+  private def toBodyAndPath(subscription: SubscriptionNumber, cancellationDate: LocalDate) =
+    (SubscriptionCancellation(cancellationDate), s"subscriptions/${subscription.value}/cancel")
 
-  def apply(requests: Requests)(subscription: SubscriptionId, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
+  def apply(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
     val (body, path) = toBodyAndPath(subscription, cancellationDate)
     requests.put(body, path)
   }
 
-  def dryRun(requests: Requests)(subscription: SubscriptionId, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
+  def dryRun(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
     val (body, path) = toBodyAndPath(subscription, cancellationDate)
     val msg = s"DryRun for ZuoraCancelSubscription: body=$body, path=$path"
     logger.info(msg)

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraGetAccountSubscriptions.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraGetAccountSubscriptions.scala
@@ -1,0 +1,26 @@
+package com.gu.util.zuora
+
+import com.gu.util.resthttp.RestRequestMaker.Requests
+import com.gu.util.resthttp.Types.ClientFailableOp
+import play.api.libs.json.{JsArray, JsValue}
+
+final case class SubscriptionNumberWithStatus(number: String, status: String)
+
+object ZuoraGetAccountSubscriptions {
+
+  // pageSize by default is 20
+  // TODO setting here to 40, consider changing that value in the future
+
+  def apply(requests: Requests)(accountId: String): ClientFailableOp[List[SubscriptionNumberWithStatus]] = {
+    requests.get[JsValue](s"subscriptions/accounts/$accountId?pageSize=40").map { topJson =>
+      val jsonArr = (topJson \ "subscriptions").as[JsArray]
+      val accSubs = jsonArr.value.map { json =>
+        val subNum = (json \ "subscriptionNumber").as[String]
+        val subStatus = (json \ "status").as[String]
+        SubscriptionNumberWithStatus(subNum, subStatus)
+      }.toList
+      accSubs
+    }
+  }
+
+}

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraGetSubsNamesOnInvoice.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraGetSubsNamesOnInvoice.scala
@@ -1,0 +1,27 @@
+package com.gu.util.zuora
+
+import com.gu.util.resthttp.RestRequestMaker.Requests
+import com.gu.util.resthttp.Types.ClientFailableOp
+import com.typesafe.scalalogging.LazyLogging
+import play.api.libs.json.JsValue
+
+final case class SubscriptionNumber(value: String)
+
+object ZuoraGetSubsNamesOnInvoice extends LazyLogging {
+
+  def apply(requests: Requests)(invoiceId: String): ClientFailableOp[List[SubscriptionNumber]] = {
+    requests.get[JsValue](s"invoices/$invoiceId/items").map { json =>
+      invoiceItemsToSubscriptionsIds(json)
+    }
+  }
+
+  private def invoiceItemsToSubscriptionsIds(json: JsValue): List[SubscriptionNumber] = {
+    val parsed = (json \ "invoiceItems" \\ "subscriptionName")
+      .map(_.as[String])
+      .toSet
+      .map(n => SubscriptionNumber(n))
+    logger.info(s"invoice unique subscriptions ids: $parsed")
+    parsed.toList
+  }
+
+}

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraUpdateCancellationReason.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraUpdateCancellationReason.scala
@@ -2,7 +2,6 @@ package com.gu.util.zuora
 
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
-import com.gu.util.zuora.ZuoraGetAccountSummary.SubscriptionId
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsSuccess, Json, Reads, Writes}
 
@@ -19,15 +18,15 @@ object ZuoraUpdateCancellationReason extends LazyLogging {
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))
 
-  private def toBodyAndPath(subscription: SubscriptionId) =
-    (SubscriptionUpdate("System AutoCancel"), s"subscriptions/${subscription.id}")
+  private def toBodyAndPath(subscription: SubscriptionNumber) =
+    (SubscriptionUpdate("System AutoCancel"), s"subscriptions/${subscription.value}")
 
-  def apply(requests: Requests)(subscription: SubscriptionId): ClientFailableOp[Unit] = {
+  def apply(requests: Requests)(subscription: SubscriptionNumber): ClientFailableOp[Unit] = {
     val (body, path) = toBodyAndPath(subscription)
     requests.put(body, path): ClientFailableOp[Unit]
   }
 
-  def dryRun(requests: Requests)(subscription: SubscriptionId): ClientFailableOp[Unit] = {
+  def dryRun(requests: Requests)(subscription: SubscriptionNumber): ClientFailableOp[Unit] = {
     val (body, path) = toBodyAndPath(subscription)
     val msg = s"DryRun for ZuoraUpdateCancellationReason: body=$body, path=$path"
     logger.info(msg)

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
@@ -11,15 +11,16 @@ class AutoCancelDataCollectionFilterTest extends FlatSpec {
 
   import AutoCancelDataCollectionFilter._
 
-  val basicInfo = BasicAccountInfo(AccountId("id123"), 11.99, PaymentMethodId("pmid"))
-  val subscription = SubscriptionSummary(SubscriptionId("id123"), "A-S123", "Active")
-  val twoSubscriptions = List(SubscriptionSummary(SubscriptionId("id123"), "A-S123", "Active"), SubscriptionSummary(SubscriptionId("id321"), "A-S321", "Active"))
-  val inactiveSubscriptions = List(SubscriptionSummary(SubscriptionId("id456"), "A-S123", "Cancelled"), SubscriptionSummary(SubscriptionId("id789"), "A-S321", "Expired"))
-  val invoiceNotPosted = Invoice("inv123", LocalDate.now.minusDays(5), 11.99, "Cancelled")
-  val invoiceZeroBalance = Invoice("inv123", LocalDate.now.minusDays(1), 0.00, "Posted")
-  val invoiceNotDue = Invoice("inv123", LocalDate.now.minusDays(3), 11.99, "Posted")
-  val singleOverdueInvoice = Invoice("inv123", LocalDate.now.minusDays(14), 11.99, "Posted")
-  val twoOverdueInvoices = List(Invoice("inv123", LocalDate.now.minusDays(21), 11.99, "Posted"), Invoice("inv321", LocalDate.now.minusDays(35), 11.99, "Posted"))
+  private val basicInfo = BasicAccountInfo(AccountId("id123"), 11.99, PaymentMethodId("pmid"))
+  private val subscription = SubscriptionSummary(SubscriptionId("id123"), "A-S123", "Active")
+  private val invoiceNotPosted = Invoice("inv123", LocalDate.now.minusDays(5), 11.99, "Cancelled")
+  private val invoiceZeroBalance = Invoice("inv123", LocalDate.now.minusDays(1), 0.00, "Posted")
+  private val invoiceNotDue = Invoice("inv123", LocalDate.now.minusDays(3), 11.99, "Posted")
+  private val singleOverdueInvoice = Invoice("inv123", LocalDate.now.minusDays(14), 11.99, "Posted")
+  private val twoOverdueInvoices = List(
+    Invoice("inv123", LocalDate.now.minusDays(21), 11.99, "Posted"),
+    Invoice("inv321", LocalDate.now.minusDays(35), 11.99, "Posted")
+  )
 
   "invoiceOverdue" should "return false if the invoice is not in a 'Posted' state" in {
     assert(invoiceOverdue(invoiceNotPosted, LocalDate.now) == false)
@@ -38,43 +39,25 @@ class AutoCancelDataCollectionFilterTest extends FlatSpec {
   }
 
   "getCancellationDateFromInvoices" should "return a left if no overdue invoices are found" in {
-    val apiGatewayOp = getCancellationDateFromInvoices(AccountSummary(basicInfo, List(subscription), List(invoiceZeroBalance, invoiceNotDue, invoiceNotPosted)), LocalDate.now)
+    val apiGatewayOp = getCancellationDateFromInvoice(
+      invoiceZeroBalance.id,
+      AccountSummary(basicInfo, List(subscription), List(invoiceZeroBalance, invoiceNotDue, invoiceNotPosted)), LocalDate.now
+    )
     assert(apiGatewayOp.toDisjunction == Left(noActionRequired("No unpaid and overdue invoices found!")))
   }
 
   "getCancellationDateFromInvoices" should "return the due date of an invoice, if exactly one overdue invoice is found on the account" in {
-    val apiGatewayOp = getCancellationDateFromInvoices(AccountSummary(basicInfo, List(subscription), List(singleOverdueInvoice)), LocalDate.now)
+    val apiGatewayOp = getCancellationDateFromInvoice(
+      singleOverdueInvoice.id,
+      AccountSummary(basicInfo, List(subscription), List(singleOverdueInvoice)), LocalDate.now
+    )
     assert(apiGatewayOp.toDisjunction == Right(LocalDate.now.minusDays(14)))
   }
 
-  "getCancellationDateFromInvoices" should "return the earliest due date of all unpaid invoices, if there is more than one overdue invoice on the account" in {
+  "getCancellationDateFromInvoices" should "return the due date of invoice that triggered ZUORA Callout, if there is more than one overdue invoice on the account summary" in {
     val accountSummaryUnpaidInvs = AccountSummary(basicInfo, List(subscription), twoOverdueInvoices)
-    val apiGatewayOp = getCancellationDateFromInvoices(accountSummaryUnpaidInvs, LocalDate.now)
-    assert(apiGatewayOp.toDisjunction == Right(LocalDate.now.minusDays(35)))
-  }
-
-  "getSubscriptionToCancel" should "return a left if there is more than one active sub on the account summary" in {
-    val accountSummaryWithTwoSubs = AccountSummary(basicInfo, twoSubscriptions, twoOverdueInvoices)
-    val apiGatewayOp = getSubscriptionToCancel(accountSummaryWithTwoSubs)
-    assert(apiGatewayOp.toDisjunction == Left(noActionRequired("More than one active sub found!")))
-  }
-
-  "getSubscriptionToCancel" should "return a left if there are no subs on the account summary" in {
-    val accountSummaryWithCancelledSub = AccountSummary(basicInfo, List(), List(invoiceNotDue))
-    val apiGatewayOp = getSubscriptionToCancel(accountSummaryWithCancelledSub)
-    assert(apiGatewayOp.toDisjunction == Left(noActionRequired("No Active subscriptions to cancel!")))
-  }
-
-  "getSubscriptionToCancel" should "return a left if the account summary only contains cancelled and expired subs" in {
-    val accountSummaryCancelledSub = AccountSummary(basicInfo, inactiveSubscriptions, List(singleOverdueInvoice))
-    val apiGatewayOp = getSubscriptionToCancel(accountSummaryCancelledSub)
-    assert(apiGatewayOp.toDisjunction == Left(noActionRequired("No Active subscriptions to cancel!")))
-  }
-
-  "getSubscriptionToCancel" should "return a right[Subscription] if there is exactly one active sub on the account summary" in {
-    val accountSummaryWithSingleSub = AccountSummary(basicInfo, List(subscription), List(invoiceNotDue))
-    val apiGatewayOp = getSubscriptionToCancel(accountSummaryWithSingleSub)
-    assert(apiGatewayOp.toDisjunction == Right(subscription.id))
+    val apiGatewayOp = getCancellationDateFromInvoice(twoOverdueInvoices.head.id, accountSummaryUnpaidInvs, LocalDate.now)
+    assert(apiGatewayOp.toDisjunction == Right(twoOverdueInvoices.head.dueDate))
   }
 
 }

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -2,63 +2,53 @@ package com.gu.autoCancel
 
 import java.time.LocalDate
 
-import com.gu.TestData
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
-import com.gu.autoCancel.AutoCancelSteps.AutoCancelUrlParams
-import com.gu.effects.TestingRawEffects
-import com.gu.effects.TestingRawEffects.BasicRequest
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.ClientSuccess
+import com.gu.util.zuora.SubscriptionNumber
 import com.gu.util.zuora.ZuoraGetAccountSummary.ZuoraAccount.{AccountId, PaymentMethodId}
 import com.gu.util.zuora.ZuoraGetAccountSummary.{AccountSummary, BasicAccountInfo, Invoice, SubscriptionId, SubscriptionSummary}
 import org.scalatest._
 
 class AutoCancelStepsTest extends FlatSpec with Matchers {
 
-  val basicInfo = BasicAccountInfo(AccountId("id123"), 11.99, PaymentMethodId("pmid"))
-  val subscription = SubscriptionSummary(SubscriptionId("sub123"), "A-S123", "Active")
-  val singleOverdueInvoice = Invoice("inv123", LocalDate.now.minusDays(14), 11.99, "Posted")
+  private val basicInfo = BasicAccountInfo(AccountId("accId123"), 11.99, PaymentMethodId("pmid"))
+  private val newSubscription = SubscriptionSummary(SubscriptionId("sub789"), "A-S789", "Active")
+  private val invoiceDueMultipleSubscriptions = List(
+    SubscriptionSummary(SubscriptionId("sub123"), "A-S123", "Active"),
+    SubscriptionSummary(SubscriptionId("sub456"), "A-S456", "Active")
+  )
+  private val calloutInvoiceId = "inv123"
+  private val twoOverdueInvoices = List(
+    Invoice("inv123", LocalDate.now.minusDays(14), 11.99, "Posted"),
+    Invoice("inv321", LocalDate.now.minusDays(35), 11.99, "Posted")
+  )
 
-  "auto cancel filter 2" should "cancel attempt" in {
-    val ac = AutoCancelDataCollectionFilter(
+  it should "prepare correct AutoCancelRequests" in {
+    val autoCancelReqestsProducer = AutoCancelDataCollectionFilter(
       now = LocalDate.now,
-      getAccountSummary = _ => ClientSuccess(AccountSummary(basicInfo, List(subscription), List(singleOverdueInvoice)))
+      getAccountSummary = _ => ClientSuccess(
+        AccountSummary(basicInfo, invoiceDueMultipleSubscriptions ++ List(newSubscription), twoOverdueInvoices)
+      ),
+      getSubsNamesOnInvoice = _ => ClientSuccess(invoiceDueMultipleSubscriptions.map(s => SubscriptionNumber(s.subscriptionNumber)))
     ) _
-    val autoCancelCallout = AutoCancelHandlerTest.fakeCallout(true)
-    val cancel: ApiGatewayOp[AutoCancelRequest] = ac(autoCancelCallout)
+    val autoCancelCallout = AutoCancelHandlerTest
+      .fakeCallout(true)
+      .copy(
+        invoiceId = calloutInvoiceId,
+        accountId = basicInfo.id.value
+      )
 
-    cancel.toDisjunction should be(Right(AutoCancelRequest("id123", SubscriptionId("sub123"), LocalDate.now.minusDays(14))))
+    val actual: ApiGatewayOp[List[AutoCancelRequest]] = autoCancelReqestsProducer(autoCancelCallout)
+
+    val expected = Right(
+      List(
+        AutoCancelRequest("accId123", SubscriptionNumber("A-S123"), LocalDate.now.minusDays(14)),
+        AutoCancelRequest("accId123", SubscriptionNumber("A-S456"), LocalDate.now.minusDays(14))
+      )
+    )
+
+    actual.toDisjunction should be(expected)
   }
-
-  "auto cancel" should "turn off auto pay" in {
-    val effects = new TestingRawEffects(200)
-    val urlParams = AutoCancelUrlParams(onlyCancelDirectDebit = false, dryRun = false)
-    AutoCancel(TestData.zuoraDeps(effects))(AutoCancelRequest("AID", SubscriptionId("subid"), LocalDate.now), urlParams)
-
-    effects.requestsAttempted should contain(BasicRequest("PUT", "/accounts/AID", "{\"autoPay\":false}"))
-  }
-
-  //  // todo need an ACSDeps so we don't need so many mock requests
-  //  "auto cancel step" should "turn off auto pay and send email" in {
-  //    val effects = new TestingRawEffects(false, 200)
-  //    val autoCancelJson =
-  //      """
-  //        |{"accountId": "AID", "autoPay": "true", "paymentMethodType": "GoldBars"}
-  //      """.stripMargin // should probaly base on a real payload
-  //    val fakeRequest = ApiGatewayRequest(Some(URLParams(None, None, Some("false"))), autoCancelJson)
-  //    val acDeps = ACSDeps()
-  //    AutoCancelSteps(acDeps)(AutoCancelRequest("AID", SubscriptionId("subid"), LocalDate.now)).run.run(effects.configHttp)
-  //
-  //    val requests = effects.result.map { request =>
-  //      val buffer = new Buffer()
-  //      request.body().writeTo(buffer)
-  //      val body = buffer.readString(UTF_8)
-  //      val url = request.url
-  //      (request.method(), url.encodedPath(), body)
-  //    }
-  //
-  //    requests should contain(("PUT", "/accounts/AID", "{\"autoPay\":false}"))
-  //    requests should contain(("POST", "/EMAILSEND/AID", "{\"autoPay\":false}"))
-  //  }
 
 }

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -5,19 +5,28 @@ import java.time.LocalDate
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.ClientSuccess
-import com.gu.util.zuora.SubscriptionNumber
 import com.gu.util.zuora.ZuoraGetAccountSummary.ZuoraAccount.{AccountId, PaymentMethodId}
 import com.gu.util.zuora.ZuoraGetAccountSummary.{AccountSummary, BasicAccountInfo, Invoice, SubscriptionId, SubscriptionSummary}
+import com.gu.util.zuora.{SubscriptionNumber, SubscriptionNumberWithStatus}
 import org.scalatest._
 
 class AutoCancelStepsTest extends FlatSpec with Matchers {
 
   private val basicInfo = BasicAccountInfo(AccountId("accId123"), 11.99, PaymentMethodId("pmid"))
-  private val newSubscription = SubscriptionSummary(SubscriptionId("sub789"), "A-S789", "Active")
   private val invoiceDueMultipleSubscriptions = List(
     SubscriptionSummary(SubscriptionId("sub123"), "A-S123", "Active"),
-    SubscriptionSummary(SubscriptionId("sub456"), "A-S456", "Active")
+    SubscriptionSummary(SubscriptionId("sub456"), "A-S456", "Active"),
+    SubscriptionSummary(SubscriptionId("sub789"), "A-S789", "Cancelled") // for example if it was canceled manually after invoice was generated
   )
+  private val subscriptionsNotOnInvoice = List(
+    SubscriptionSummary(SubscriptionId("sub101112"), "A-S101112", "Active"),
+    SubscriptionSummary(SubscriptionId("sub111213"), "A-S111213", "Active"),
+    SubscriptionSummary(SubscriptionId("sub141516"), "A-S141516", "Active"),
+    SubscriptionSummary(SubscriptionId("sub171819"), "A-S171819", "Active"),
+  )
+
+  private val allAccountSubs = invoiceDueMultipleSubscriptions ++ subscriptionsNotOnInvoice
+
   private val calloutInvoiceId = "inv123"
   private val twoOverdueInvoices = List(
     Invoice("inv123", LocalDate.now.minusDays(14), 11.99, "Posted"),
@@ -28,9 +37,13 @@ class AutoCancelStepsTest extends FlatSpec with Matchers {
     val autoCancelReqestsProducer = AutoCancelDataCollectionFilter(
       now = LocalDate.now,
       getAccountSummary = _ => ClientSuccess(
-        AccountSummary(basicInfo, invoiceDueMultipleSubscriptions ++ List(newSubscription), twoOverdueInvoices)
+        AccountSummary(basicInfo, allAccountSubs, twoOverdueInvoices)
       ),
-      getSubsNamesOnInvoice = _ => ClientSuccess(invoiceDueMultipleSubscriptions.map(s => SubscriptionNumber(s.subscriptionNumber)))
+      getAccountSubscriptions = _ => ClientSuccess(
+        allAccountSubs
+          .map(s => SubscriptionNumberWithStatus(s.subscriptionNumber, s.status))
+      ),
+      getSubscriptionsOnInvoice = _ => ClientSuccess(invoiceDueMultipleSubscriptions.map(s => SubscriptionNumber(s.subscriptionNumber)))
     ) _
     val autoCancelCallout = AutoCancelHandlerTest
       .fakeCallout(true)


### PR DESCRIPTION
## Overview
Handle auto cancellation for accounts with multi active subscriptions [zuora-auto-cancel-api] 

Business Logic:

- we have ZUORA Callout: `Invoice Due | Unpaid Invoice Overdue | Trigger zuora-auto-cancel`
- get invoice items by invoiceId where we get the subscription id, name
- cancel those subscriptions
- keep autopay set to true on account
- send email about cancelation

## Tests
- [x] locally
- [x] Dev
- [ ] Code