### PR TITLE
Work around play-json 22 fields limit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -310,6 +310,7 @@ lazy val `zuora-datalake-export` = all(project in file("handlers/zuora-datalake-
 lazy val `batch-email-sender` = all(project in file("handlers/batch-email-sender"))
   .enablePlugins(RiffRaffArtifact)
   .dependsOn(handler, `effects-sqs`, effectsDepIncludingTestFolder, testDep)
+  .settings(libraryDependencies ++= Seq(playJsonExtensions))
 
 lazy val `braze-to-salesforce-file-upload` = all(project in file("handlers/braze-to-salesforce-file-upload"))
   .enablePlugins(RiffRaffArtifact)

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSend.scala
@@ -1,6 +1,7 @@
 package com.gu.batchemailsender.api.batchemail.model
 
 import play.api.libs.json.Json
+import ai.x.play.json.Jsonx
 
 /**
  * This is what actually gets sent to SQS and the fields correspond to Braze api_trigger_properties.
@@ -47,12 +48,12 @@ case class EmailToSend(To: EmailPayloadTo, DataExtensionName: String, SfContactI
 
 object EmailToSend {
 
-  implicit val emailPayloadStoppedCreditDetailWriter = Json.writes[EmailPayloadStoppedCreditSummary]
-  implicit val emailPayloadDigitalVoucherWriter = Json.writes[EmailPayloadDigitalVoucher]
-  implicit val emailPayloadSubscriberAttributesWriter = Json.writes[EmailPayloadSubscriberAttributes]
-  implicit val emailPayloadContactAttributesWriter = Json.writes[EmailPayloadContactAttributes]
-  implicit val emailPayloadToWriter = Json.writes[EmailPayloadTo]
-  implicit val emailToSendWriter = Json.writes[EmailToSend]
+  implicit val emailPayloadStoppedCreditDetailWriter = Jsonx.formatCaseClass[EmailPayloadStoppedCreditSummary]
+  implicit val emailPayloadDigitalVoucherWriter = Jsonx.formatCaseClass[EmailPayloadDigitalVoucher]
+  implicit val emailPayloadSubscriberAttributesWriter = Jsonx.formatCaseClass[EmailPayloadSubscriberAttributes]
+  implicit val emailPayloadContactAttributesWriter = Jsonx.formatCaseClass[EmailPayloadContactAttributes]
+  implicit val emailPayloadToWriter = Jsonx.formatCaseClass[EmailPayloadTo]
+  implicit val emailToSendWriter = Jsonx.formatCaseClass[EmailToSend]
 
   /**
    * Builds actual model from wire (DTO) model


### PR DESCRIPTION
We are currently at 22 fields which for some reason we send as a flat structure to Braze. 

Once I start adding further fields for delivery address change confirmation email `SV_DeliveryAddressChangeConfirmation` we will go above 22. 

22 limit is no longer the case for Scala, however it still seems to be for play-json macros: https://github.com/playframework/play-json/issues/3

@paulbrown1982 Is it indeed the case we have to send `api_trigger_properties` in a flat structure to Braze? 