### PR TITLE
Ability to perform dry run for [zuora-auto-cancel] api

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/email/EmailSendSteps.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/email/EmailSendSteps.scala
@@ -1,9 +1,6 @@
 package com.gu.util.email
 
 import com.gu.effects.sqs.AwsSQSSend.Payload
-import com.gu.util.apigateway.ResponseModels.ApiResponse
-import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
-import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{Json, Writes, _}

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -3,11 +3,12 @@ package com.gu.util.zuora
 import java.time.LocalDate
 
 import com.gu.util.resthttp.RestRequestMaker.Requests
-import com.gu.util.resthttp.Types.ClientFailableOp
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
 import com.gu.util.zuora.ZuoraGetAccountSummary.SubscriptionId
+import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsSuccess, Json, Reads, Writes}
 
-object ZuoraCancelSubscription {
+object ZuoraCancelSubscription extends LazyLogging {
 
   case class SubscriptionCancellation(cancellationEffectiveDate: LocalDate)
 
@@ -22,7 +23,18 @@ object ZuoraCancelSubscription {
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))
 
-  def apply(requests: Requests)(subscription: SubscriptionId, cancellationDate: LocalDate): ClientFailableOp[Unit] =
-    requests.put(SubscriptionCancellation(cancellationDate), s"subscriptions/${subscription.id}/cancel"): ClientFailableOp[Unit]
+  private def toBodyAndPath(subscription: SubscriptionId, cancellationDate: LocalDate) =
+    (SubscriptionCancellation(cancellationDate), s"subscriptions/${subscription.id}/cancel")
 
+  def apply(requests: Requests)(subscription: SubscriptionId, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
+    val (body, path) = toBodyAndPath(subscription, cancellationDate)
+    requests.put(body, path)
+  }
+
+  def dryRun(requests: Requests)(subscription: SubscriptionId, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
+    val (body, path) = toBodyAndPath(subscription, cancellationDate)
+    val msg = s"DryRun for ZuoraCancelSubscription: body=$body, path=$path"
+    logger.info(msg)
+    ClientSuccess(())
+  }
 }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraDisableAutoPay.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraDisableAutoPay.scala
@@ -1,10 +1,11 @@
 package com.gu.util.zuora
 
 import com.gu.util.resthttp.RestRequestMaker.Requests
-import com.gu.util.resthttp.Types.ClientFailableOp
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
+import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsSuccess, Json, Reads, Writes}
 
-object ZuoraDisableAutoPay {
+object ZuoraDisableAutoPay extends LazyLogging {
 
   case class AccountUpdate(autoPay: Boolean)
 
@@ -17,7 +18,20 @@ object ZuoraDisableAutoPay {
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))
 
-  def apply(requests: Requests)(accountId: String): ClientFailableOp[Unit] =
+  private def toBodyAndPath(accountId: String) =
+    (AccountUpdate(autoPay = false), s"accounts/$accountId")
+
+  def apply(requests: Requests)(accountId: String): ClientFailableOp[Unit] = {
+    val (body, path) = toBodyAndPath(accountId)
+    requests.put(body, path): ClientFailableOp[Unit]
+  }
+
+  def dryRun(requests: Requests)(accountId: String): ClientFailableOp[Unit] = {
+    val (body, path) = toBodyAndPath(accountId)
     requests.put(AccountUpdate(autoPay = false), s"accounts/$accountId"): ClientFailableOp[Unit]
+    val msg = s"DryRun for ZuoraDisableAutoPay: body=$body, path=$path"
+    logger.info(msg)
+    ClientSuccess(())
+  }
 
 }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraUpdateCancellationReason.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraUpdateCancellationReason.scala
@@ -1,11 +1,12 @@
 package com.gu.util.zuora
 
 import com.gu.util.resthttp.RestRequestMaker.Requests
-import com.gu.util.resthttp.Types.ClientFailableOp
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
 import com.gu.util.zuora.ZuoraGetAccountSummary.SubscriptionId
+import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsSuccess, Json, Reads, Writes}
 
-object ZuoraUpdateCancellationReason {
+object ZuoraUpdateCancellationReason extends LazyLogging {
 
   case class SubscriptionUpdate(cancellationReason: String)
 
@@ -18,7 +19,19 @@ object ZuoraUpdateCancellationReason {
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))
 
-  def apply(requests: Requests)(subscription: SubscriptionId): ClientFailableOp[Unit] =
-    requests.put(SubscriptionUpdate("System AutoCancel"), s"subscriptions/${subscription.id}"): ClientFailableOp[Unit]
+  private def toBodyAndPath(subscription: SubscriptionId) =
+    (SubscriptionUpdate("System AutoCancel"), s"subscriptions/${subscription.id}")
+
+  def apply(requests: Requests)(subscription: SubscriptionId): ClientFailableOp[Unit] = {
+    val (body, path) = toBodyAndPath(subscription)
+    requests.put(body, path): ClientFailableOp[Unit]
+  }
+
+  def dryRun(requests: Requests)(subscription: SubscriptionId): ClientFailableOp[Unit] = {
+    val (body, path) = toBodyAndPath(subscription)
+    val msg = s"DryRun for ZuoraUpdateCancellationReason: body=$body, path=$path"
+    logger.info(msg)
+    ClientSuccess(())
+  }
 
 }

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -66,19 +66,19 @@ class DeserialiserTest extends FlatSpec with Matchers {
   "deserialise UrlParams" should "manage without the only direct debit param" in {
     val json = """{"apiToken": "a", "apiClientId": "b"}"""
 
-    Json.parse(json).validate[AutoCancelUrlParams] should be(JsSuccess(AutoCancelUrlParams(false)))
+    Json.parse(json).validate[AutoCancelUrlParams] should be(JsSuccess(AutoCancelUrlParams(false, false)))
   }
 
   it should "manage with the only direct debit param being false" in {
     val json = """{"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": "false"}"""
 
-    Json.parse(json).validate[AutoCancelUrlParams] should be(JsSuccess(AutoCancelUrlParams(false)))
+    Json.parse(json).validate[AutoCancelUrlParams] should be(JsSuccess(AutoCancelUrlParams(false, false)))
   }
 
   it should "manage with the only direct debit param being true" in {
-    val json = """{"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": "true"}"""
+    val json = """{"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": "true", "dryRun": "true"}"""
 
-    Json.parse(json).validate[AutoCancelUrlParams] should be(JsSuccess(AutoCancelUrlParams(true)))
+    Json.parse(json).validate[AutoCancelUrlParams] should be(JsSuccess(AutoCancelUrlParams(true, true)))
   }
 
 }

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.gu.TestData
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
+import com.gu.autoCancel.AutoCancelSteps.AutoCancelUrlParams
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.BasicRequest
 import com.gu.util.reader.Types._
@@ -22,7 +23,7 @@ class AutoCancelStepsTest extends FlatSpec with Matchers {
     val ac = AutoCancelDataCollectionFilter(
       now = LocalDate.now,
       getAccountSummary = _ => ClientSuccess(AccountSummary(basicInfo, List(subscription), List(singleOverdueInvoice)))
-    )_
+    ) _
     val autoCancelCallout = AutoCancelHandlerTest.fakeCallout(true)
     val cancel: ApiGatewayOp[AutoCancelRequest] = ac(autoCancelCallout)
 
@@ -31,7 +32,8 @@ class AutoCancelStepsTest extends FlatSpec with Matchers {
 
   "auto cancel" should "turn off auto pay" in {
     val effects = new TestingRawEffects(200)
-    AutoCancel(TestData.zuoraDeps(effects))(AutoCancelRequest("AID", SubscriptionId("subid"), LocalDate.now))
+    val urlParams = AutoCancelUrlParams(onlyCancelDirectDebit = false, dryRun = false)
+    AutoCancel(TestData.zuoraDeps(effects))(AutoCancelRequest("AID", SubscriptionId("subid"), LocalDate.now), urlParams)
 
     effects.requestsAttempted should contain(BasicRequest("PUT", "/accounts/AID", "{\"autoPay\":false}"))
   }


### PR DESCRIPTION
## Overview
Ability to perform dry run for [zuora-auto-cancel] api

## Why
- to be able to perform simple smoke test in PROD that will have no side effects but will log the intentions
- to be able to perform tests in dev without side effects because creation of new customer with subscriptions and invoices in ZUORA take some time

## HOW
you can perform dry run by adding `dryRun=true` url param

## Tests

- [x] locally
- [x] DEV
