### PR TITLE
enable digipack access for paper customers (voucher & HD)

### DIFF
--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiry.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiry.scala
@@ -46,8 +46,8 @@ object GetSubscriptionExpiry {
     def isActiveDigipack(charge: RatePlanCharge) = isDigipackName(charge.name) && chargeSpansDate(charge)
     val hasActiveDigipackCharges = subscription.ratePlans.flatMap(_.ratePlanCharges).exists(isActiveDigipack)
 
-    // FIXME should only exist during Coronavirus measures (where digipack access is expanded to cover paper customers)
-    @deprecated def isNewspaper(ratePlan: RatePlan) = ratePlan.productName.toUpperCase.startsWith("NEWSPAPER")
+    @deprecated("should only exist during Coronavirus measures (where digipack access is expanded to cover paper customers)") //FIXME remove after Coronavirus
+    def isNewspaper(ratePlan: RatePlan) = ratePlan.productName.toUpperCase.startsWith("NEWSPAPER")
     val isValidNewspaperSub = subscription.ratePlans.filter(isNewspaper).flatMap(_.ratePlanCharges).exists(chargeSpansDate)
 
     if (hasActiveDigipackCharges || isValidNewspaperSub) {

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetAccountSummaryEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetAccountSummaryEffectsTest.scala
@@ -29,7 +29,7 @@ class GetAccountSummaryEffectsTest extends FlatSpec with Matchers {
       billToPostcode = Some("SW13 8EB"),
       soldToLastName = "Brown",
       soldToPostcode = Some("SW13 8EB"),
-      identityId = None
+      identityId = Some("30001864")
     )
 
     actual should be(ContinueProcessing(expected))

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionEffectsTest.scala
@@ -32,10 +32,10 @@ class GetSubscriptionEffectsTest extends FlatSpec with Matchers {
     val testSubscriptionId = SubscriptionId("A-S00044160")
 
     val customerAcceptanceDate = LocalDate.of(2017, 12, 15)
-    val startDate = LocalDate.of(2018, 11, 29)
+    val startDate = LocalDate.of(2019, 11, 29)
     val expected = SubscriptionResult(
       testSubscriptionId,
-      SubscriptionName("2c92c08567580c5901675ec91ccb0f17"),
+      SubscriptionName("2c92c0856eb600ac016eb68ca2727298"),
       AccountId("2c92c0f860017cd501600893130317a7"),
       Some("2018-04-18T14:59:49.368"),
       customerAcceptanceDate,
@@ -55,7 +55,7 @@ class GetSubscriptionEffectsTest extends FlatSpec with Matchers {
           List(RatePlanCharge(
             name = "Digital Pack Monthly",
             effectiveStartDate = LocalDate.of(2017, 12, 15),
-            effectiveEndDate = LocalDate.of(2019, 11, 29)
+            effectiveEndDate = LocalDate.of(2020, 11, 29)
           ))
         )
       )

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiryTest.scala
@@ -28,6 +28,13 @@ class GetSubscriptionExpiryTest extends FlatSpec {
     ratePlans = List(RatePlan("Monthly Contribution", List(RatePlanCharge("Montly Contribution", lastWeek, nextWeek))))
   )
 
+  val newspaperHomeDelivery = digitalPack.copy(
+    ratePlans = List(RatePlan("Newspaper Delivery", List(RatePlanCharge("Sunday", lastWeek, nextWeek))))
+  )
+  val newspaperVoucher = digitalPack.copy(
+    ratePlans = List(RatePlan("Newspaper Voucher", List(RatePlanCharge("Sunday", lastWeek, nextWeek))))
+  )
+
   val accountSummary = AccountSummaryResult(
     accountId = AccountId("accountId"),
     billToLastName = "billingLastName",
@@ -135,6 +142,13 @@ class GetSubscriptionExpiryTest extends FlatSpec {
   it should "return not found for non digipack subscription" in {
     val actualResponse = GetSubscriptionExpiry(today)("billingLastName", monthlyContribution, accountSummary)
     actualResponse shouldEqual notFoundResponse
+  }
+
+  it should "[due to Coronavirus] recognise paper subscriptions as having digipack access for the time being" in {
+    val actualHomeDeliveryResponse = GetSubscriptionExpiry(today)("billingLastName", newspaperHomeDelivery, accountSummary)
+    actualHomeDeliveryResponse shouldEqual expectedResponse
+    val actualVoucherResponse = GetSubscriptionExpiry(today)("billingLastName", newspaperVoucher, accountSummary)
+    actualVoucherResponse shouldEqual expectedResponse
   }
 
   it should "return not found for expired subscription" in {


### PR DESCRIPTION
...because Coronavirus

Much like https://github.com/guardian/members-data-api/pull/431 (which was for identity users), this does the same for those who use `Surname`/`PostCode` AND `Subscription ID` to authenticate.

![image](https://user-images.githubusercontent.com/19289579/77088802-e43b7b80-69fc-11ea-997e-4b75a1bdc623.png)