### PR TITLE
Fix digital voucher status on cancellation

### DIFF
--- a/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorService.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorService.scala
@@ -18,7 +18,7 @@ object DigitalVoucherCancellationProcessorService extends LazyLogging {
   private val ImovoSubscriptionDoesNotExistMessage = "no live subscription vouchers exist for the supplied subscription id"
   case class CObjectAttribues(url: String)
   case class DigitalVoucherQueryResult(Id: String, attributes: CObjectAttribues, SF_Subscription__r: SubscriptionQueryResult)
-  case class DigitalVoucherUpdate(Cancellation_Processed_At__c: Instant)
+  case class DigitalVoucherUpdate(Cancellation_Processed_At__c: Instant, Status__c: String)
   case class SubscriptionQueryResult(Id: String, attributes: CObjectAttribues)
   case class DigitalVoucherCancellationProcessorServiceError(message: String)
   case class ImovoCancellationResults(
@@ -93,7 +93,7 @@ object DigitalVoucherCancellationProcessorService extends LazyLogging {
                   voucherToMarkAsProcessed.Id,
                   "PATCH",
                   voucherToMarkAsProcessed.attributes.url,
-                  DigitalVoucherUpdate(now)
+                  DigitalVoucherUpdate(now, "Deactivated")
                 )
               })
           )

--- a/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
@@ -54,7 +54,7 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
       s"digital-voucher-id-$resultId",
       "PATCH",
       s"/services/data/v29.0/sobjects/Digital_Voucher__c/digital-voucher-id-$resultId",
-      DigitalVoucherUpdate(now)
+      DigitalVoucherUpdate(now, "Deactivated")
     )
   }
 


### PR DESCRIPTION
This PR fixes a bug the the digital voucher cancellation processor where the Digital_Voucher objects in salesforce would remain in an 'Active' state after they had been deactivated in Imovo.