### PR TITLE
Fix returning success on failed SQS send message

### DIFF
--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
@@ -41,7 +41,7 @@ object Handler extends Logging {
     val queueName = if (RawEffects.stage.isProd) QueueName("contributions-thanks") else QueueName("contributions-thanks-dev")
     brazeMessages flatMap { msg =>
       val payloadString = Json.prettyPrint(Json.toJson(msg))
-      Try(AwsSQSSend.sendSync(queueName)(Payload(payloadString))) match {
+      AwsSQSSend.sendSync(queueName)(Payload(payloadString)) match {
         case Success(_) => None
         case Failure(_) => Some(msg.recordId)
       }


### PR DESCRIPTION
This fixes one of the silent errors. The remaining problems are at least

- silent errors on parsing errors
- no alarms on any error
- what does Salesforce do on non-200 reponse?

This PR addresses the following situation

```
Try(Try(throw new RuntimeException("boom"))) match {
  case Success(_) => "ok"
  case Failure(_) => "boom"
}
```

which always returns `ok` due to double `Try`. 

The issue was there probably since inception of batch-email-sender.