### PR TITLE
Fix silent Salesforce parsing email errors

### DIFF
--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
@@ -17,6 +17,9 @@ import play.api.libs.json.Json
 
 import scala.util.{Failure, Success}
 
+/**
+ * FIXME: batch-email-sender seems to be implemented on partial success principle in which case what should the response code be?
+ */
 object Handler extends Logging {
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
     ApiGatewayHandler(LambdaIO(inputStream, outputStream, context)) {


### PR DESCRIPTION
Related PR: https://github.com/guardian/support-service-lambdas/pull/635

This fixes one of the silent errors - returning success on parsing errors. The remaining problems are at least

- no alarms on any error
- what does Salesforce do with non-200 reponse?

```
FIXME: batch-email-sender seems to be implemented on partial success principle in which case what should the response code be?
```

The issue was there probably since inception of batch-email-sender.