### PR TITLE
Process fewer holiday credits more often

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -121,7 +121,7 @@ Resources:
     Properties:
       Description: Trigger processing of holiday stops every hour (to give 24 attempts a day)
       Name: !FindInMap [StageMap, !Ref Stage, ScheduleName]
-      ScheduleExpression: "cron(0 * ? * * *)"
+      ScheduleExpression: "cron(0/20 * ? * * *)"
       State: ENABLED
       Targets:
         - Arn: !GetAtt HolidayStopProcessor.Arn

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -119,7 +119,7 @@ Resources:
   HolidayStopProcessorScheduleRule:
     Type: AWS::Events::Rule
     Properties:
-      Description: Trigger processing of holiday stops every hour (to give 24 attempts a day)
+      Description: Trigger processing of holiday stops every 20 mins (to ensure successful processing of all batches within 24 hours)
       Name: !FindInMap [StageMap, !Ref Stage, ScheduleName]
       ScheduleExpression: "cron(0/20 * ? * * *)"
       State: ENABLED

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -21,7 +21,7 @@ object Salesforce extends LazyLogging {
    * Beware! This isn't a scalable solution.  If all the products between them
    * have > 7200 credit requests to be processed in a 24 hour window some will be missed.
    */
-  private val batchSize = 300
+  private val batchSize = 100
 
   def holidayStopRequests(sfCredentials: SFAuthConfig)(productVariant: ZuoraProductType, datesToProcess: List[LocalDate]): SalesforceApiResponse[List[HolidayStopRequestsDetail]] = {
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -21,7 +21,7 @@ object Salesforce extends LazyLogging {
    * Beware! This isn't a scalable solution.  If all the products between them
    * have > 7200 credit requests to be processed in a 24 hour window some will be missed.
    */
-  private val batchSize = 100
+  private val batchSize = 120
 
   def holidayStopRequests(sfCredentials: SFAuthConfig)(productVariant: ZuoraProductType, datesToProcess: List[LocalDate]): SalesforceApiResponse[List[HolidayStopRequestsDetail]] = {
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>


### PR DESCRIPTION
This is to avoid the holiday-stop processing lambda timing out.

Following this change, it will have the same capacity but should be far less likely to time out.
If Zuora slows down or we add more products we'll have to look at it again.
