### PR TITLE
[delivery-records-api] added new /cancel GET endpoint

### DIFF
--- a/handlers/delivery-records-api/README.md
+++ b/handlers/delivery-records-api/README.md
@@ -81,6 +81,11 @@ See [handlers/README](../README.md#3rd-party-service-environments) for informati
 }
 ```
 
+### **`GET`** `/{STAGE}/delivery-records/{SUBSCRIPTION_NAME}/cancel?effectiveCancellationDate={yyyy-MM-dd}`
+Similar to the main GET endpoint but takes an `effectiveCancellationDate` query argument and only brings back delivery records where credit has been requested and the invoice date is greater than or equal to the provided `effectiveCancellationDate`.
+
+Similar to the [`/cancel` endpoint of `holiday-stop-api`](https://github.com/guardian/support-service-lambdas/tree/master/handlers/holiday-stop-api#get-stagehsrsubscription_namecanceleffectivecancellationdateyyyy-mm-dd).
+
 ### `POST` `/{STAGE}/delivery-records/{SUBSCRIPTION_NAME}`
 
 - Creates a delivery problem case, linking the provided delivery records to the new case, then **returns the same as the `GET`** once the changes have been made.

--- a/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiTest.scala
+++ b/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiTest.scala
@@ -177,7 +177,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
     val salesforceBackendStub =
       SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
         .stubAuth(config, auth)
-        .stubQuery(auth, deliveryRecordsQuery(IdentityId(identityId), subscriptionNumber, None, None), validSalesforceResponseBody)
+        .stubQuery(auth, deliveryRecordsQuery(IdentityId(identityId), subscriptionNumber, None, None, None), validSalesforceResponseBody)
 
     val app = createApp(salesforceBackendStub)
     val response = app.run(
@@ -195,7 +195,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
     val salesforceBackendStub =
       SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
         .stubAuth(config, auth)
-        .stubQuery(auth, deliveryRecordsQuery(SalesforceContactId(buyerContactId), subscriptionNumber, None, None), validSalesforceResponseBody)
+        .stubQuery(auth, deliveryRecordsQuery(SalesforceContactId(buyerContactId), subscriptionNumber, None, None, None), validSalesforceResponseBody)
 
     val app = createApp(salesforceBackendStub)
     val response = app.run(
@@ -222,7 +222,8 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
             SalesforceContactId(buyerContactId),
             subscriptionNumber,
             Some(startDate),
-            Some(endDate)
+            Some(endDate),
+            None
           ),
           validSalesforceResponseBody
         )
@@ -248,7 +249,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
         .stubAuth(config, auth)
         .stubQuery(
           auth,
-          deliveryRecordsQuery(SalesforceContactId(buyerContactId), subscriptionNumber, None, None),
+          deliveryRecordsQuery(SalesforceContactId(buyerContactId), subscriptionNumber, None, None, None),
           RecordsWrapperCaseClass[SFApiSubscription](Nil)
         )
 
@@ -284,7 +285,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
       SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
         .stubAuth(config, auth)
         .stubComposite(auth, None, validCompositeResponse)
-        .stubQuery(auth, deliveryRecordsQuery(IdentityId(identityId), subscriptionNumber, None, None), validSalesforceResponseBody)
+        .stubQuery(auth, deliveryRecordsQuery(IdentityId(identityId), subscriptionNumber, None, None, None), validSalesforceResponseBody)
 
     val app = createApp(salesforceBackendStub)
     val response = app.run(
@@ -306,7 +307,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
       SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
         .stubAuth(config, auth)
         .stubComposite(auth, None, validCompositeResponse)
-        .stubQuery(auth, deliveryRecordsQuery(SalesforceContactId(buyerContactId), subscriptionNumber, None, None), validSalesforceResponseBody)
+        .stubQuery(auth, deliveryRecordsQuery(SalesforceContactId(buyerContactId), subscriptionNumber, None, None, None), validSalesforceResponseBody)
 
     val app = createApp(salesforceBackendStub)
     val response = app.run(
@@ -328,7 +329,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
       SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
         .stubAuth(config, auth)
         .stubComposite(auth, None, failedCompositeResponse)
-        .stubQuery(auth, deliveryRecordsQuery(IdentityId(identityId), subscriptionNumber, None, None), validSalesforceResponseBody)
+        .stubQuery(auth, deliveryRecordsQuery(IdentityId(identityId), subscriptionNumber, None, None, None), validSalesforceResponseBody)
 
     val app = createApp(salesforceBackendStub)
     val response = app.run(


### PR DESCRIPTION
…for use with the self-service cancellation flow (see https://github.com/guardian/manage-frontend/pull/391).

Similar to the [`/cancel` endpoint of `holiday-stop-api`](https://github.com/guardian/support-service-lambdas/tree/master/handlers/holiday-stop-api#get-stagehsrsubscription_namecanceleffectivecancellationdateyyyy-mm-dd).