### PR TITLE
new product api: adding guardian weekly to catalog endpoint

### DIFF
--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -20,7 +20,7 @@ Mappings:
             ApiName: new-product-api-DEV
             DomainName: new-product-api-dev.membership.guardianapis.com
             ApiGatewayTargetDomainName: d-ecyddyj7nk.execute-api.eu-west-1.amazonaws.com
-            ZuoraCatalogLocation: arn:aws:s3:::gu-zuora-catalog/DEV/Zuora-UAT/catalog.json
+            ZuoraCatalogLocation: arn:aws:s3:::gu-zuora-catalog/CODE/Zuora-DEV/catalog.json
             ContributionThanksEmailQueue: contributions-thanks-dev
             SubsWelcomeEmailQueue: subs-welcome-email-dev
         CODE:
@@ -288,7 +288,7 @@ Resources:
       - NewProductUsagePlan
 
     NewProductDomainName:
-      Type: "AWS::ApiGateway::DomainName"
+      Type: "AWS::ApiGateway: :DomainName"
       Properties:
         RegionalCertificateArn: # only for *.membership.guardianapis.com
           !Sub arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -8,6 +8,7 @@ Parameters:
         AllowedValues:
             - PROD
             - CODE
+            - DEV
         Default: CODE
 
 Conditions:
@@ -15,6 +16,13 @@ Conditions:
 
 Mappings:
     StageMap:
+        DEV:
+            ApiName: new-product-api-DEV
+            DomainName: new-product-api-dev.membership.guardianapis.com
+            ApiGatewayTargetDomainName: d-ecyddyj7nk.execute-api.eu-west-1.amazonaws.com
+            ZuoraCatalogLocation: arn:aws:s3:::gu-zuora-catalog/DEV/Zuora-UAT/catalog.json
+            ContributionThanksEmailQueue: contributions-thanks-dev
+            SubsWelcomeEmailQueue: subs-welcome-email-dev
         CODE:
             ApiName: new-product-api-CODE
             DomainName: new-product-api-code.membership.guardianapis.com

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -19,7 +19,7 @@ Mappings:
         DEV:
             ApiName: new-product-api-DEV
             DomainName: new-product-api-dev.membership.guardianapis.com
-            ApiGatewayTargetDomainName: d-ecyddyj7nk.execute-api.eu-west-1.amazonaws.com
+            ApiGatewayTargetDomainName: d-papcvkgmc9.execute-api.eu-west-1.amazonaws.com
             ZuoraCatalogLocation: arn:aws:s3:::gu-zuora-catalog/CODE/Zuora-DEV/catalog.json
             ContributionThanksEmailQueue: contributions-thanks-dev
             SubsWelcomeEmailQueue: subs-welcome-email-dev

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -288,7 +288,7 @@ Resources:
       - NewProductUsagePlan
 
     NewProductDomainName:
-      Type: "AWS::ApiGateway: :DomainName"
+      Type: "AWS::ApiGateway::DomainName"
       Properties:
         RegionalCertificateArn: # only for *.membership.guardianapis.com
           !Sub arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -27,7 +27,7 @@ Mappings:
             ApiName: new-product-api-CODE
             DomainName: new-product-api-code.membership.guardianapis.com
             ApiGatewayTargetDomainName: d-ecyddyj7nk.execute-api.eu-west-1.amazonaws.com
-            ZuoraCatalogLocation: arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-UAT/catalog.json
+            ZuoraCatalogLocation: arn:aws:s3:::gu-zuora-catalog/CODE/Zuora-UAT/catalog.json
             ContributionThanksEmailQueue: contributions-thanks-dev
             SubsWelcomeEmailQueue: subs-welcome-email-dev
         PROD:

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -68,7 +68,7 @@ Resources:
                           - Effect: Allow
                             Action: s3:GetObject
                             Resource:
-                            - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}.*.json
+                            - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}*.json
                 - PolicyName: SQSAddEmailRequest
                   PolicyDocument:
                     Statement:

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -17,7 +17,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.Subscripti
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{WireCreateRequest, WireSubscription}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAccount
 import com.gu.newproduct.api.addsubscription.zuora._
-import com.gu.newproduct.api.productcatalog.PlanId.{GuardianWeeklyDomestic6for6, GuardianWeeklyDomesticQuarterly}
+import com.gu.newproduct.api.productcatalog.PlanId.{GuardianWeeklyDomestic6for6, GuardianWeeklyDomesticQuarterly, GuardianWeeklyROW6for6, GuardianWeeklyROWQuarterly}
 import com.gu.newproduct.api.productcatalog.{ContributionPlanId, _}
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
@@ -147,8 +147,8 @@ object Steps {
         createSubscription,
         awsSQSSend,
         queueNames,
-        GuardianWeeklyDomestic6for6,
-        GuardianWeeklyDomesticQuarterly
+        GuardianWeeklyROW6for6,
+        GuardianWeeklyROWQuarterly
       )
 
       addSubSteps = handleRequest(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidator.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidator.scala
@@ -33,10 +33,10 @@ object GuardianWeeklyROWAddressValidator {
 object GuardianWeeklyAddressValidator {
   val domesticCountries =
     CountryGroup.Australia.countries ++
-      CountryGroup.Canada.countries ++
-      CountryGroup.Europe.countries ++
-      CountryGroup.NewZealand.countries
-  CountryGroup.UK.countries ++
+    CountryGroup.Canada.countries ++
+    CountryGroup.Europe.countries ++
+    CountryGroup.NewZealand.countries ++
+    CountryGroup.UK.countries ++
     CountryGroup.US.countries
 
   def isDomesticDeliveryCountry(country: Country) = !CountryGroup.RestOfTheWorld.countries.contains(country)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidator.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidator.scala
@@ -31,6 +31,14 @@ object GuardianWeeklyROWAddressValidator {
 }
 
 object GuardianWeeklyAddressValidator {
+  val domesticCountries =
+    CountryGroup.Australia.countries ++
+      CountryGroup.Canada.countries ++
+      CountryGroup.Europe.countries ++
+      CountryGroup.NewZealand.countries
+  CountryGroup.UK.countries ++
+    CountryGroup.US.countries
+
   def isDomesticDeliveryCountry(country: Country) = !CountryGroup.RestOfTheWorld.countries.contains(country)
 
   def validateBillingAddress(billToAddress: BillToAddress) = {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidator.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidator.scala
@@ -33,11 +33,11 @@ object GuardianWeeklyROWAddressValidator {
 object GuardianWeeklyAddressValidator {
   val domesticCountries =
     CountryGroup.Australia.countries ++
-    CountryGroup.Canada.countries ++
-    CountryGroup.Europe.countries ++
-    CountryGroup.NewZealand.countries ++
-    CountryGroup.UK.countries ++
-    CountryGroup.US.countries
+      CountryGroup.Canada.countries ++
+      CountryGroup.Europe.countries ++
+      CountryGroup.NewZealand.countries ++
+      CountryGroup.UK.countries ++
+      CountryGroup.US.countries
 
   def isDomesticDeliveryCountry(country: Country) = !CountryGroup.RestOfTheWorld.countries.contains(country)
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -60,10 +60,7 @@ case class Catalog(
     homeDeliverySundayPlus,
     homeDeliverySaturdayPlus,
     digipackAnnual,
-    digipackMonthly
-  )
-
-  val createOnlyPlans = List(
+    digipackMonthly,
     guardianWeeklyDomesticSixForSix,
     guardianWeeklyDomesticQuarterly,
     guardianWeeklyDomesticAnnual,
@@ -72,7 +69,7 @@ case class Catalog(
     guardianWeeklyROWAnnual
   )
 
-  val planForId: Map[PlanId, Plan] = (createOnlyPlans ++ allPlans).map(x => x.id -> x).toMap
+  val planForId: Map[PlanId, Plan] = allPlans.map(x => x.id -> x).toMap
 }
 sealed trait VoucherPlanId
 sealed trait ContributionPlanId

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -177,17 +177,23 @@ object PlanId {
     DigipackMonthly
   )
 
-  val enabledGuardianWeeklyPlans = List(
+  val enabledGuardianWeeklyDomesticPlans = List(
     GuardianWeeklyDomestic6for6,
     GuardianWeeklyDomesticQuarterly,
     GuardianWeeklyDomesticAnnual,
+  )
+
+  val enabledGuardianWeeklyROWPlans = List(
     GuardianWeeklyROW6for6,
     GuardianWeeklyROWQuarterly,
     GuardianWeeklyROWAnnual
   )
 
-  val supportedPlans: List[PlanId] = enabledVoucherPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans ++ enabledDigipackPlans
-  def fromName(name: String): Option[PlanId] = (enabledGuardianWeeklyPlans ++ supportedPlans).find(_.name == name)
+  val supportedPlans: List[PlanId] =
+    enabledVoucherPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans ++ enabledDigipackPlans ++
+      enabledGuardianWeeklyDomesticPlans ++ enabledGuardianWeeklyROWPlans
+
+  def fromName(name: String): Option[PlanId] = supportedPlans.find(_.name == name)
 }
 
 case class Plan(id: PlanId, description: PlanDescription, startDateRules: StartDateRules = StartDateRules(), paymentPlans: Map[Currency, PaymentPlan] = Map.empty)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -94,8 +94,8 @@ object NewProductApi {
       StartDateRules(
         daysOfWeekRule = Some(DaysOfWeekRule(List(DayOfWeek.FRIDAY))),
         windowRule = Some(WindowRule(
-          maybeCutOffDay = Some(DayOfWeek.FRIDAY),
-          maybeStartDelay = Some(DelayDays(14)),
+          maybeCutOffDay = Some(DayOfWeek.THURSDAY),
+          maybeStartDelay = Some(DelayDays(7)),
           maybeSize = Some(WindowSizeDays(28))
         ))
       )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -94,7 +94,7 @@ object NewProductApi {
       StartDateRules(
         daysOfWeekRule = Some(DaysOfWeekRule(List(DayOfWeek.FRIDAY))),
         windowRule = Some(WindowRule(
-          maybeCutOffDay = Some(DayOfWeek.THURSDAY),
+          maybeCutOffDay = Some(DayOfWeek.WEDNESDAY),
           maybeStartDelay = Some(DelayDays(7)),
           maybeSize = Some(WindowSizeDays(28))
         ))

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -2,7 +2,7 @@ package com.gu.newproduct.api.productcatalog
 
 import java.time.DayOfWeek
 
-import com.gu.i18n.Currency
+import com.gu.i18n.{CountryGroup, Currency}
 import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.validation.guardianweekly.{GuardianWeeklyAddressValidator, GuardianWeeklyDomesticAddressValidator}
 import play.api.libs.json.{JsString, Json, Writes}
@@ -154,13 +154,13 @@ object WireModel {
       val guardianWeeklyDomestic = WireProduct(
         label = "Guardian Weekly - Domestic",
         plans = PlanId.enabledGuardianWeeklyDomesticPlans.map(wirePlanForPlanId),
-        enabledForDeliveryCountries = Some(GuardianWeeklyAddressValidator.domesticCountryCodes)
+        enabledForDeliveryCountries = Some(GuardianWeeklyAddressValidator.domesticCountries.map(_.name))
       )
 
       val guardianWeeklyROW = WireProduct(
         label = "Guardian Weekly - ROW",
         plans = PlanId.enabledGuardianWeeklyROWPlans.map(wirePlanForPlanId),
-        enabledForDeliveryCountries = Some(GuardianWeeklyAddressValidator.restOfWorldCountryCodes)
+        enabledForDeliveryCountries = Some(CountryGroup.RestOfTheWorld.countries.map(_.name))
       )
 
       val availableProductsAndPlans = List(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -50,7 +50,7 @@ object WireModel {
     selectableWindow: Option[WireSelectableWindow] = None
   )
 
-  case class WireProduct(label: String, plans: List[WirePlanInfo], enabledForBillingCountries: Option[List[String]])
+  case class WireProduct(label: String, plans: List[WirePlanInfo], enabledForDeliveryCountries: Option[List[String]])
 
   case class WireCatalog(products: List[WireProduct])
 
@@ -130,37 +130,37 @@ object WireModel {
       val voucherProduct = WireProduct(
         label = "Voucher",
         plans = PlanId.enabledVoucherPlans.map(wirePlanForPlanId),
-        enabledForBillingCountries = None
+        enabledForDeliveryCountries = None
       )
 
       val contributionProduct = WireProduct(
         label = "Contribution",
         plans = PlanId.enabledContributionPlans.map(wirePlanForPlanId),
-        enabledForBillingCountries = None
+        enabledForDeliveryCountries = None
       )
 
       val homeDeliveryProduct = WireProduct(
         label = "Home Delivery",
         plans = PlanId.enabledHomeDeliveryPlans.map(wirePlanForPlanId),
-        enabledForBillingCountries = None
+        enabledForDeliveryCountries = None
       )
 
       val digipackProduct = WireProduct(
         label = "Digital Pack",
         plans = PlanId.enabledDigipackPlans.map(wirePlanForPlanId),
-        enabledForBillingCountries = None
+        enabledForDeliveryCountries = None
       )
 
       val guardianWeeklyDomestic = WireProduct(
         label = "Guardian Weekly - Domestic",
         plans = PlanId.enabledGuardianWeeklyDomesticPlans.map(wirePlanForPlanId),
-        enabledForBillingCountries = Some(GuardianWeeklyAddressValidator.domesticCountryCodes)
+        enabledForDeliveryCountries = Some(GuardianWeeklyAddressValidator.domesticCountryCodes)
       )
 
       val guardianWeeklyROW = WireProduct(
         label = "Guardian Weekly - ROW",
         plans = PlanId.enabledGuardianWeeklyROWPlans.map(wirePlanForPlanId),
-        enabledForBillingCountries = Some(GuardianWeeklyAddressValidator.restOfWorldCountryCodes)
+        enabledForDeliveryCountries = Some(GuardianWeeklyAddressValidator.restOfWorldCountryCodes)
       )
 
       val availableProductsAndPlans = List(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -4,6 +4,7 @@ import java.time.DayOfWeek
 
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
+import com.gu.newproduct.api.addsubscription.validation.guardianweekly.{GuardianWeeklyAddressValidator, GuardianWeeklyDomesticAddressValidator}
 import play.api.libs.json.{JsString, Json, Writes}
 
 object WireModel {
@@ -49,7 +50,7 @@ object WireModel {
     selectableWindow: Option[WireSelectableWindow] = None
   )
 
-  case class WireProduct(label: String, plans: List[WirePlanInfo])
+  case class WireProduct(label: String, plans: List[WirePlanInfo], enabledForBillingCountries: Option[List[String]])
 
   case class WireCatalog(products: List[WireProduct])
 
@@ -128,25 +129,43 @@ object WireModel {
 
       val voucherProduct = WireProduct(
         label = "Voucher",
-        plans = PlanId.enabledVoucherPlans.map(wirePlanForPlanId)
+        plans = PlanId.enabledVoucherPlans.map(wirePlanForPlanId),
+        enabledForBillingCountries = None
       )
 
       val contributionProduct = WireProduct(
         label = "Contribution",
-        plans = PlanId.enabledContributionPlans.map(wirePlanForPlanId)
+        plans = PlanId.enabledContributionPlans.map(wirePlanForPlanId),
+        enabledForBillingCountries = None
       )
 
       val homeDeliveryProduct = WireProduct(
         label = "Home Delivery",
-        plans = PlanId.enabledHomeDeliveryPlans.map(wirePlanForPlanId)
+        plans = PlanId.enabledHomeDeliveryPlans.map(wirePlanForPlanId),
+        enabledForBillingCountries = None
       )
 
       val digipackProduct = WireProduct(
         label = "Digital Pack",
-        plans = PlanId.enabledDigipackPlans.map(wirePlanForPlanId)
+        plans = PlanId.enabledDigipackPlans.map(wirePlanForPlanId),
+        enabledForBillingCountries = None
       )
 
-      val availableProductsAndPlans = List(contributionProduct, voucherProduct, homeDeliveryProduct, digipackProduct).filterNot(_.plans.isEmpty)
+      val guardianWeeklyDomestic = WireProduct(
+        label = "Guardian Weekly - Domestic",
+        plans = PlanId.enabledGuardianWeeklyDomesticPlans.map(wirePlanForPlanId),
+        enabledForBillingCountries = Some(GuardianWeeklyAddressValidator.domesticCountryCodes)
+      )
+
+      val guardianWeeklyROW = WireProduct(
+        label = "Guardian Weekly - ROW",
+        plans = PlanId.enabledGuardianWeeklyROWPlans.map(wirePlanForPlanId),
+        enabledForBillingCountries = Some(GuardianWeeklyAddressValidator.restOfWorldCountryCodes)
+      )
+
+      val availableProductsAndPlans = List(
+        contributionProduct, voucherProduct, homeDeliveryProduct, digipackProduct, guardianWeeklyDomestic, guardianWeeklyROW
+      ).filterNot(_.plans.isEmpty)
 
       WireCatalog(availableProductsAndPlans)
     }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogTest.scala
@@ -15,7 +15,7 @@ import scala.util.Try
 class PricesFromZuoraCatalogTest extends FlatSpec with Matchers {
 
   val fakeGetStringFromS3: StringFromS3 = s3Location => {
-    s3Location shouldBe S3Location(bucket = "gu-zuora-catalog", key = "PROD/Zuora-DEV/catalog.json")
+    s3Location shouldBe S3Location(bucket = "gu-zuora-catalog", key = "CODE/Zuora-DEV/catalog.json")
     Try {
       """
         |{

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidatorTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidatorTest.scala
@@ -35,22 +35,17 @@ class GuardianWeeklyAddressValidatorTest extends FlatSpec with Matchers {
   )
 
   it should "succeed for Domestic if delivery address is domestic" in {
-    (CountryGroup.UK.countries ++
-      CountryGroup.US.countries ++
-      CountryGroup.Canada.countries ++
-      CountryGroup.Europe.countries ++
-      CountryGroup.Australia.countries ++
-      CountryGroup.NewZealand.countries).foreach { domesticCountry =>
-        val domesticAddress = testDomesticSoldToAddress.copy(country = domesticCountry)
-        GuardianWeeklyDomesticAddressValidator(
-          testBillingAddress,
-          domesticAddress
-        ) shouldBe Passed(())
-        GuardianWeeklyROWAddressValidator(
-          testBillingAddress,
-          domesticAddress
-        ) shouldBe Failed(s"Delivery address country ${domesticCountry.name} is not valid for a Guardian Weekly (ROW) subscription")
-      }
+    GuardianWeeklyAddressValidator.domesticCountries.foreach { domesticCountry =>
+      val domesticAddress = testDomesticSoldToAddress.copy(country = domesticCountry)
+      GuardianWeeklyDomesticAddressValidator(
+        testBillingAddress,
+        domesticAddress
+      ) shouldBe Passed(())
+      GuardianWeeklyROWAddressValidator(
+        testBillingAddress,
+        domesticAddress
+      ) shouldBe Failed(s"Delivery address country ${domesticCountry.name} is not valid for a Guardian Weekly (ROW) subscription")
+    }
   }
 
   it should "succeed for ROW if delivery address is domestic" in {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -575,8 +575,8 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Friday",
-        |              "startDaysAfterCutOff": 14,
+        |              "cutOffDayInclusive": "Thursday",
+        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -600,8 +600,8 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Friday",
-        |              "startDaysAfterCutOff": 14,
+        |              "cutOffDayInclusive": "Thursday",
+        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -625,8 +625,8 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Friday",
-        |              "startDaysAfterCutOff": 14,
+        |              "cutOffDayInclusive": "Thursday",
+        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -668,8 +668,8 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Friday",
-        |              "startDaysAfterCutOff": 14,
+        |              "cutOffDayInclusive": "Thursday",
+        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -693,8 +693,8 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Friday",
-        |              "startDaysAfterCutOff": 14,
+        |              "cutOffDayInclusive": "Thursday",
+        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -718,8 +718,8 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Friday",
-        |              "startDaysAfterCutOff": 14,
+        |              "cutOffDayInclusive": "Thursday",
+        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -644,10 +644,15 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |        }
         |      ],
         |      "enabledForDeliveryCountries": [
-        |        "GB", "FK", "GI", "GG", "IM", "JE", "SH", "US", "AU", "KI", "NR", "NF", "TV", "AD", "AL", "AT", "BA", "BE",
-        |        "BG", "BL", "CH", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FO", "FR", "GF", "GL", "GP", "GR", "HR", "HU",
-        |        "IE", "IT", "LI", "LT", "LU", "LV", "MC", "ME", "MF", "IS", "MQ", "MT", "NL", "NO", "PF", "PL", "PM", "PT",
-        |        "RE", "RO", "RS", "SE", "SI", "SJ", "SK", "SM", "TF", "TR", "WF", "YT", "VA", "AX"
+        |        "Australia", "Kiribati", "Nauru", "Norfolk Island", "Tuvalu", "Canada", "Andorra", "Albania",
+        |        "Austria", "Bosnia-Herzegovina", "Belgium", "Bulgaria", "Saint Barthélemy", "Switzerland", "Cyprus",
+        |        "Czech Republic", "Germany", "Denmark", "Estonia", "Spain", "Finland", "Faroe Islands", "France",
+        |        "French Guiana", "Greenland", "Guadeloupe", "Greece", "Croatia", "Hungary", "Ireland", "Italy",
+        |        "Liechtenstein", "Lithuania", "Luxembourg", "Latvia", "Monaco", "Montenegro", "Saint Martin",
+        |        "Iceland", "Martinique", "Malta", "Netherlands", "Norway", "French Polynesia", "Poland",
+        |        "Saint Pierre & Miquelon", "Portugal", "Réunion", "Romania", "Serbia", "Sweden", "Slovenia",
+        |        "Svalbard and Jan Mayen", "Slovakia", "San Marino", "French Southern Territories", "Turkey",
+        |        "Wallis & Futuna", "Mayotte", "Holy See", "Åland Islands", "New Zealand", "Cook Islands"
         |      ]
         |    },
         |    {
@@ -730,16 +735,34 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |        }
         |      ],
         |      "enabledForDeliveryCountries": [
-        |        "AE", "AF", "AG", "AI", "AM", "AO", "AQ", "AR", "AS", "AW", "AZ", "BB", "BD", "BF", "BH", "BI", "BJ", "BM",
-        |        "BN", "BO", "BQ", "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CC", "CD", "CF", "CG", "CI", "CL", "CM", "CN",
-        |        "CO", "CR", "CU", "CV", "CW", "CX", "DJ", "DM", "DO", "DZ", "EC", "EG", "EH", "ER", "ET", "FJ", "FM", "GA",
-        |        "GD", "GE", "GH", "GM", "GN", "GQ", "GS", "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HT", "ID", "IL", "IN",
-        |        "IO", "IQ", "IR", "JM", "JO", "JP", "KE", "KG", "KH", "KM", "KN", "KP", "KR", "KW", "KY", "KZ", "LA", "LB",
-        |        "LC", "LK", "LR", "LS", "LY", "MA", "MD", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MR", "MS", "MU",
-        |        "MV", "MW", "MX", "MY", "MZ", "NA", "NC", "NE", "NG", "NI", "NP", "NU", "OM", "PA", "PE", "PG", "PH", "PK",
-        |        "PN", "PR", "PS", "PW", "PY", "QA", "RU", "RW", "SA", "SB", "SC", "SD", "SG", "SL", "SN", "SO", "SR", "SS",
-        |        "ST", "SV", "SX", "SY", "SZ", "TC", "TD", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO", "TT", "TW", "TZ",
-        |        "UA", "UG", "UM", "UY", "UZ", "VC", "VE", "VG", "VI", "VN", "VU", "WS", "YE", "ZA", "ZM", "ZW"]
+        |        "United Arab Emirates", "Afghanistan", "Antigua & Barbuda", "Anguilla", "Armenia", "Angola",
+        |        "Antarctica", "Argentina", "American Samoa", "Aruba", "Azerbaijan", "Barbados", "Bangladesh",
+        |        "Burkina Faso", "Bahrain", "Burundi", "Benin", "Bermuda", "Brunei Darussalam", "Bolivia",
+        |        "Bonaire, Saint Eustatius and Saba", "Brazil", "Bahamas", "Bhutan", "Bouvet Island", "Botswana",
+        |        "Belarus", "Belize", "Cocos (Keeling) Islands", "Congo (Kinshasa)", "Central African Republic",
+        |        "Congo (Brazzaville)", "Ivory Coast", "Chile", "Cameroon", "China", "Colombia", "Costa Rica", "Cuba",
+        |        "Cape Verde Islands", "Curaçao", "Christmas Island", "Djibouti", "Dominica", "Dominican Republic",
+        |        "Algeria", "Ecuador", "Egypt", "Western Sahara", "Eritrea", "Ethiopia", "Fiji", "Micronesia", "Gabon",
+        |        "Grenada", "Georgia", "Ghana", "Gambia", "Guinea", "Equatorial Guinea",
+        |        "South Georgia & The South Sandwich Islands", "Guatemala", "Guam", "Guinea-Bissau", "Guyana",
+        |        "Hong Kong", "Heard Island and McDonald Islands", "Honduras", "Haiti", "Indonesia", "Israel",
+        |        "India", "British Indian Ocean Territory", "Iraq", "Iran", "Jamaica", "Jordan", "Japan", "Kenya",
+        |        "Kyrgyzstan", "Cambodia", "Comoros", "Saint Christopher & Nevis", "North Korea", "South Korea",
+        |        "Kuwait", "Cayman Islands", "Kazakhstan", "Laos", "Lebanon", "Saint Lucia", "Sri Lanka", "Liberia",
+        |        "Lesotho", "Libya", "Morocco", "Moldova", "Madagascar", "Marshall Islands", "Macedonia", "Mali",
+        |        "Myanmar", "Mongolia", "Macau", "Northern Mariana Islands", "Mauritania", "Montserrat", "Mauritius",
+        |        "Maldives", "Malawi", "Mexico", "Malaysia", "Mozambique", "Namibia", "New Caledonia", "Niger",
+        |        "Nigeria", "Nicaragua", "Nepal", "Niue", "Oman", "Panama", "Peru", "Papua New Guinea",
+        |        "Philippines", "Pakistan", "Pitcairn Islands", "Puerto Rico", "Palestinian Territories",
+        |        "Palau", "Paraguay", "Qatar", "Russia", "Rwanda", "Saudi Arabia", "Solomon Islands", "Seychelles",
+        |        "Sudan", "Singapore", "Sierra Leone", "Senegal", "Somalia", "Suriname", "South Sudan",
+        |        "Sao Tome & Principe", "El Salvador", "Sint Maarten", "Syria", "Swaziland", "Turks & Caicos Islands",
+        |        "Chad", "Togo", "Thailand", "Tajikistan", "Tokelau", "East Timor", "Turkmenistan", "Tunisia", "Tonga",
+        |        "Trinidad & Tobago", "Taiwan", "Tanzania", "Ukraine", "Uganda", "United States Minor Outlying Islands",
+        |        "Uruguay", "Uzbekistan", "Saint Vincent & The Grenadines", "Venezuela", "British Virgin Islands",
+        |        "United States Virgin Islands", "Vietnam", "Vanuatu", "Samoa", "Yemen", "South Africa", "Zambia",
+        |        "Zimbabwe"
+        |      ]
         |    }
         |  ]
         |}

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -575,7 +575,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Thursday",
+        |              "cutOffDayInclusive": "Wednesday",
         |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
@@ -600,7 +600,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Thursday",
+        |              "cutOffDayInclusive": "Wednesday",
         |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
@@ -625,7 +625,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Thursday",
+        |              "cutOffDayInclusive": "Wednesday",
         |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
@@ -668,7 +668,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Thursday",
+        |              "cutOffDayInclusive": "Wednesday",
         |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
@@ -693,7 +693,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Thursday",
+        |              "cutOffDayInclusive": "Wednesday",
         |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
@@ -718,7 +718,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "Friday"
         |            ],
         |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Thursday",
+        |              "cutOffDayInclusive": "Wednesday",
         |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -563,6 +563,183 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |          "paymentPlan": "GBP 55.55 every month"
         |        }
         |      ]
+        |    },
+        |    {
+        |      "label": "Guardian Weekly - Domestic",
+        |      "plans": [
+        |        {
+        |          "id": "guardian_weekly_domestic_6for6",
+        |          "label": "GW Oct 18 - Six for Six - Domestic",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Friday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Friday",
+        |              "startDaysAfterCutOff": 14,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 11111.11 for the first six weeks"
+        |            },
+        |            {
+        |              "currencyCode": "USD",
+        |              "description": "USD 111111.11 for the first six weeks"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 11111.11 for the first six weeks"
+        |        },
+        |        {
+        |          "id": "guardian_weekly_domestic_quarterly",
+        |          "label": "GW Oct 18 - Quarterly - Domestic",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Friday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Friday",
+        |              "startDaysAfterCutOff": 14,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 22222.22 every 3 months"
+        |            },
+        |            {
+        |              "currencyCode": "USD",
+        |              "description": "USD 222222.22 every 3 months"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 22222.22 every 3 months"
+        |        },
+        |        {
+        |          "id": "guardian_weekly_domestic_annual",
+        |          "label": "GW Oct 18 - Annual - Domestic",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Friday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Friday",
+        |              "startDaysAfterCutOff": 14,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 33333.33 every 12 months"
+        |            },
+        |            {
+        |              "currencyCode": "USD",
+        |              "description": "USD 333333.33 every 12 months"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 33333.33 every 12 months"
+        |        }
+        |      ],
+        |      "enabledForBillingCountries": [
+        |        "GB", "FK", "GI", "GG", "IM", "JE", "SH", "US", "AU", "KI", "NR", "NF", "TV", "AD", "AL", "AT", "BA", "BE",
+        |        "BG", "BL", "CH", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FO", "FR", "GF", "GL", "GP", "GR", "HR", "HU",
+        |        "IE", "IT", "LI", "LT", "LU", "LV", "MC", "ME", "MF", "IS", "MQ", "MT", "NL", "NO", "PF", "PL", "PM", "PT",
+        |        "RE", "RO", "RS", "SE", "SI", "SJ", "SK", "SM", "TF", "TR", "WF", "YT", "VA", "AX"
+        |      ]
+        |    },
+        |    {
+        |      "label": "Guardian Weekly - ROW",
+        |      "plans": [
+        |        {
+        |          "id": "guardian_weekly_row_6for6",
+        |          "label": "GW Oct 18 - Six for Six - ROW",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Friday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Friday",
+        |              "startDaysAfterCutOff": 14,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 44444.44 for the first six weeks"
+        |            },
+        |            {
+        |              "currencyCode": "USD",
+        |              "description": "USD 444444.44 for the first six weeks"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 44444.44 for the first six weeks"
+        |        },
+        |        {
+        |          "id": "guardian_weekly_row_quarterly",
+        |          "label": "GW Oct 18 - Quarterly - ROW",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Friday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Friday",
+        |              "startDaysAfterCutOff": 14,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 55555.55 every 3 months"
+        |            },
+        |            {
+        |              "currencyCode": "USD",
+        |              "description": "USD 555555.55 every 3 months"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 55555.55 every 3 months"
+        |        },
+        |        {
+        |          "id": "guardian_weekly_row_annual",
+        |          "label": "GW Oct 18 - Annual - ROW",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Friday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Friday",
+        |              "startDaysAfterCutOff": 14,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 66666.66 every 12 months"
+        |            },
+        |            {
+        |              "currencyCode": "USD",
+        |              "description": "USD 666666.66 every 12 months"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 66666.66 every 12 months"
+        |        }
+        |      ],
+        |      "enabledForBillingCountries": [
+        |        "AE", "AF", "AG", "AI", "AM", "AO", "AQ", "AR", "AS", "AW", "AZ", "BB", "BD", "BF", "BH", "BI", "BJ", "BM",
+        |        "BN", "BO", "BQ", "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CC", "CD", "CF", "CG", "CI", "CL", "CM", "CN",
+        |        "CO", "CR", "CU", "CV", "CW", "CX", "DJ", "DM", "DO", "DZ", "EC", "EG", "EH", "ER", "ET", "FJ", "FM", "GA",
+        |        "GD", "GE", "GH", "GM", "GN", "GQ", "GS", "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HT", "ID", "IL", "IN",
+        |        "IO", "IQ", "IR", "JM", "JO", "JP", "KE", "KG", "KH", "KM", "KN", "KP", "KR", "KW", "KY", "KZ", "LA", "LB",
+        |        "LC", "LK", "LR", "LS", "LY", "MA", "MD", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MR", "MS", "MU",
+        |        "MV", "MW", "MX", "MY", "MZ", "NA", "NC", "NE", "NG", "NI", "NP", "NU", "OM", "PA", "PE", "PG", "PH", "PK",
+        |        "PN", "PR", "PS", "PW", "PY", "QA", "RU", "RW", "SA", "SB", "SC", "SD", "SG", "SL", "SN", "SO", "SR", "SS",
+        |        "ST", "SV", "SX", "SY", "SZ", "TC", "TD", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO", "TT", "TW", "TZ",
+        |        "UA", "UG", "UM", "UY", "UZ", "VC", "VE", "VG", "VI", "VN", "VU", "WS", "YE", "ZA", "ZM", "ZW"]
         |    }
         |  ]
         |}

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -652,7 +652,9 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |        "Iceland", "Martinique", "Malta", "Netherlands", "Norway", "French Polynesia", "Poland",
         |        "Saint Pierre & Miquelon", "Portugal", "Réunion", "Romania", "Serbia", "Sweden", "Slovenia",
         |        "Svalbard and Jan Mayen", "Slovakia", "San Marino", "French Southern Territories", "Turkey",
-        |        "Wallis & Futuna", "Mayotte", "Holy See", "Åland Islands", "New Zealand", "Cook Islands"
+        |        "Wallis & Futuna", "Mayotte", "Holy See", "Åland Islands", "New Zealand", "Cook Islands",
+        |        "United Kingdom","Falkland Islands","Gibraltar","Guernsey","Isle of Man","Jersey","Saint Helena",
+        |        "United States"
         |      ]
         |    },
         |    {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -643,7 +643,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |          "paymentPlan": "GBP 33333.33 every 12 months"
         |        }
         |      ],
-        |      "enabledForBillingCountries": [
+        |      "enabledForDeliveryCountries": [
         |        "GB", "FK", "GI", "GG", "IM", "JE", "SH", "US", "AU", "KI", "NR", "NF", "TV", "AD", "AL", "AT", "BA", "BE",
         |        "BG", "BL", "CH", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FO", "FR", "GF", "GL", "GP", "GR", "HR", "HU",
         |        "IE", "IT", "LI", "LT", "LU", "LV", "MC", "ME", "MF", "IS", "MQ", "MT", "NL", "NO", "PF", "PL", "PM", "PT",
@@ -729,7 +729,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |          "paymentPlan": "GBP 66666.66 every 12 months"
         |        }
         |      ],
-        |      "enabledForBillingCountries": [
+        |      "enabledForDeliveryCountries": [
         |        "AE", "AF", "AG", "AI", "AM", "AO", "AQ", "AR", "AS", "AW", "AZ", "BB", "BD", "BF", "BH", "BI", "BJ", "BM",
         |        "BN", "BO", "BQ", "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CC", "CD", "CF", "CG", "CI", "CL", "CM", "CN",
         |        "CO", "CR", "CU", "CV", "CW", "CX", "DJ", "DM", "DO", "DZ", "EC", "EG", "EH", "ER", "ET", "FJ", "FM", "GA",


### PR DESCRIPTION
This PR adds Guardian Weekly Domestic and ROW product meta data to the new product api catalog endpoint.

Details:
- Start date rules for GW have a cutoff day of friday, 14 day delay before fulfilment can start and a window of 28 days. This gives the same start date selection behaviour as the subscriptions frontend.
- The GW products have an additional field 'enabledForDeliveryCountries' which will enable salesforce to select the Domestic or ROW product based on the customers delivery address. 
- Additional cloudformation config to support deploying the api in DEV, also pointing pre-prod envs at the output of the CODE zuora catalog export in s3