### PR TITLE
Add suspension reason to holiday credit model

### DIFF
--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/BrazeSqsMessage.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/BrazeSqsMessage.scala
@@ -28,6 +28,7 @@ case class BrazeApiTriggerProperties(
   currency_symbol: Option[String],
   stopped_issue_count: Option[String],
   stopped_credit_summaries: Option[List[StoppedCreditSummary]],
+  bulk_suspension_reason: Option[String],
 
   /**
    * SV_VO_NewCard, SV_VO_ReplacementCard
@@ -105,6 +106,7 @@ object BrazeSqsMessage {
             summaryList <- stop.stopped_credit_summaries
             stoppedCreditSummaries = summaryList.map(detail => StoppedCreditSummary(detail.credit_amount, fromSfDateToDisplayDate(detail.credit_date)))
           } yield stoppedCreditSummaries,
+          salesforcePayload.holiday_stop_request.flatMap(_.bulk_suspension_reason),
 
           // Digital voucher
           digital_voucher = salesforceBatchItem

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/SalesforceMessage.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/SalesforceMessage.scala
@@ -40,7 +40,8 @@ object SalesforceMessage {
     stopped_credit_sum: String,
     currency_symbol: String,
     stopped_issue_count: String,
-    stopped_credit_summaries: Option[List[WireHolidayStopCreditSummary]]
+    stopped_credit_summaries: Option[List[WireHolidayStopCreditSummary]],
+    bulk_suspension_reason: Option[String]
   )
 
   case class WireHolidayStopCreditSummary(credit_amount: Double, credit_date: String)


### PR DESCRIPTION
This will allow us to show different email copy for holiday stops that have been imposed for some reason.

See guardian/salesforce#214