### PR TITLE
[delivery-records-api] expose `bulkSuspensionReason: Option[String]`

### DIFF
--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsService.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsService.scala
@@ -30,6 +30,7 @@ final case class DeliveryRecord(
   addressCountry: Option[String],
   addressPostcode: Option[String],
   hasHolidayStop: Option[Boolean],
+  bulkSuspensionReason: Option[String],
   problemCaseId: Option[String],
   isChangedAddress: Option[Boolean],
   isChangedDeliveryInstruction: Option[Boolean],
@@ -127,6 +128,7 @@ object DeliveryRecordsService {
       addressPostcode = sfRecord.Address_Postcode__c,
       deliveryInstruction = sfRecord.Delivery_Instructions__c,
       hasHolidayStop = sfRecord.Has_Holiday_Stop__c,
+      bulkSuspensionReason = sfRecord.Holiday_Stop_Request_Detail__r.flatMap(_.Holiday_Stop_Request__r.Bulk_Suspension_Reason__c),
       problemCaseId = sfRecord.Case__r.map(_.Id),
       isChangedAddress = sfRecord.Delivery_Address__c.map(detectChangeSkippingNoneAtHead(accumulator, _.deliveryAddress)),
       isChangedDeliveryInstruction = sfRecord.Delivery_Instructions__c.map(detectChangeSkippingNoneAtHead(accumulator, _.deliveryInstruction)),
@@ -228,6 +230,7 @@ object DeliveryRecordsService {
   ) =
     s"""SELECT Buyer__r.Id, Buyer__r.Phone, Buyer__r.HomePhone, Buyer__r.MobilePhone, Buyer__r.OtherPhone, (
        |    SELECT Id, Delivery_Date__c, Delivery_Address__c, Delivery_Instructions__c, Has_Holiday_Stop__c,
+       |           Holiday_Stop_Request_Detail__r.Holiday_Stop_Request__r.Bulk_Suspension_Reason__c,
        |           Address_Line_1__c,Address_Line_2__c, Address_Line_3__c, Address_Town__c, Address_Country__c, Address_Postcode__c,
        |           Case__c, Case__r.Id, Case__r.CaseNumber, Case__r.Subject, Case__r.Description, Case__r.Case_Closure_Reason__c,
        |           Credit_Amount__c, Is_Actioned__c, Invoice_Date__c

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryRecord.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryRecord.scala
@@ -2,6 +2,9 @@ package com.gu.delivery_records_api
 
 import java.time.LocalDate
 
+case class HolidayStopRequest(Bulk_Suspension_Reason__c: Option[String])
+case class HolidayStopRequestDetail(Holiday_Stop_Request__r: HolidayStopRequest)
+
 case class SFApiDeliveryRecord(
   Id: String,
   Delivery_Date__c: Option[LocalDate],
@@ -14,6 +17,7 @@ case class SFApiDeliveryRecord(
   Address_Postcode__c: Option[String],
   Delivery_Instructions__c: Option[String],
   Has_Holiday_Stop__c: Option[Boolean],
+  Holiday_Stop_Request_Detail__r: Option[HolidayStopRequestDetail],
   Case__r: Option[SFApiDeliveryProblemCase],
   Credit_Amount__c: Option[Double],
   Is_Actioned__c: Boolean,

--- a/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiTest.scala
+++ b/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiTest.scala
@@ -36,7 +36,8 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
   val deliveryInstruction1 = "leave by the gnome"
   val deliveryInstruction2 = "leave by the red gnome"
   val hasHolidayStop = true
-  val doesntHaveHolidayStop = true
+  val doesntHaveHolidayStop = false
+  val bulkSuspensionReason = "Covid-19"
   val sfProblemCase = SFApiDeliveryProblemCase(
     Id = "case_id",
     CaseNumber = "123456",
@@ -67,6 +68,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
     Address_Postcode__c = Some(addressPostcode),
     Delivery_Instructions__c = Some(deliveryInstruction1),
     Has_Holiday_Stop__c = Some(doesntHaveHolidayStop),
+    Holiday_Stop_Request_Detail__r = None,
     Case__r = Some(sfProblemCase),
     Credit_Amount__c = Some(creditAmount),
     Invoice_Date__c = Some(invoiceDate),
@@ -75,6 +77,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
 
   val sfDeliveryRecordWithHolidayStop: SFApiDeliveryRecord = sfDeliveryRecordA.copy(
     Has_Holiday_Stop__c = Some(hasHolidayStop),
+    Holiday_Stop_Request_Detail__r = Some(HolidayStopRequestDetail(HolidayStopRequest(Some(bulkSuspensionReason)))),
     Delivery_Address__c = None,
     Delivery_Instructions__c = None
   )
@@ -115,6 +118,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
     addressCountry = Some(addressCountry),
     addressPostcode = Some(addressPostcode),
     hasHolidayStop = Some(doesntHaveHolidayStop),
+    bulkSuspensionReason = None,
     problemCaseId = Some(sfProblemCase.Id),
     isChangedAddress = Some(false),
     isChangedDeliveryInstruction = Some(false),
@@ -129,6 +133,7 @@ class DeliveryRecordsApiTest extends FlatSpec with Matchers with EitherValues {
     deliveryInstruction = None,
     deliveryAddress = None,
     hasHolidayStop = Some(true),
+    bulkSuspensionReason = Some(bulkSuspensionReason),
     isChangedAddress = None,
     isChangedDeliveryInstruction = None
   )


### PR DESCRIPTION
…for each delivery record.