### PR TITLE
Add reason for bulk suspension to holiday stops

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -20,6 +20,7 @@ object WireHolidayStopRequest {
       .Holiday_Stop_Request_Detail__r
       .map(_.records.map(toHolidayStopRequestDetail)).getOrElse(List()),
     withdrawnTime = sfHolidayStopRequest.Withdrawn_Time__c.map(_.value),
+    bulkSuspensionReason = sfHolidayStopRequest.Bulk_Suspension_Reason__c,
     mutabilityFlags = calculateMutabilityFlags(
       isWithdrawn = sfHolidayStopRequest.Is_Withdrawn__c.value,
       firstAvailableDate = firstAvailableDate,
@@ -117,6 +118,7 @@ case class HolidayStopRequestFull(
   subscriptionName: SubscriptionName,
   publicationsImpacted: List[HolidayStopRequestsDetail],
   withdrawnTime: Option[ZonedDateTime],
+  bulkSuspensionReason: Option[BulkSuspensionReason],
   mutabilityFlags: MutabilityFlags
 )
 

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -258,6 +258,7 @@ class HandlerTest extends AnyFlatSpec with Matchers {
                     holidayStopRequest.Subscription_Name__c,
                     List(toHolidayStopRequestDetail(holidayStopRequestsDetail)),
                     withdrawnTime = None,
+                    bulkSuspensionReason = None,
                     MutabilityFlags(isFullyMutable = false, isEndDateEditable = false)
                   )
                 ),

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -64,7 +64,7 @@ object SalesforceHolidayStopRequest extends Logging {
   def getHolidayStopRequestPrefixSOQL(productNamePrefixOption: Option[ProductName] = None) = s"""
       | SELECT Id, Start_Date__c, End_Date__c, Subscription_Name__c, Product_Name__c,
       | Actioned_Count__c, Pending_Count__c, Total_Issues_Publications_Impacted_Count__c,
-      | Withdrawn_Time__c, Is_Withdrawn__c, (
+      | Withdrawn_Time__c, Is_Withdrawn__c, Bulk_Suspension_Reason__c, (
       |   ${SalesforceHolidayStopRequestsDetail.SOQL_SELECT_CLAUSE}
       |   FROM Holiday_Stop_Request_Detail__r
       |   ${SalesforceHolidayStopRequestsDetail.SOQL_ORDER_BY_CLAUSE}
@@ -84,7 +84,8 @@ object SalesforceHolidayStopRequest extends Logging {
     Product_Name__c: ProductName,
     Holiday_Stop_Request_Detail__r: Option[RecordsWrapperCaseClass[HolidayStopRequestsDetail]],
     Withdrawn_Time__c: Option[HolidayStopRequestWithdrawnTime],
-    Is_Withdrawn__c: HolidayStopRequestIsWithdrawn
+    Is_Withdrawn__c: HolidayStopRequestIsWithdrawn,
+    Bulk_Suspension_Reason__c: Option[BulkSuspensionReason]
   )
   implicit val format = Json.format[HolidayStopRequest]
 

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -243,7 +243,8 @@ object Fixtures extends Assertions {
     Product_Name__c = ProductName("Gu Weekly"),
     Holiday_Stop_Request_Detail__r = Some(RecordsWrapperCaseClass(requestDetail)),
     Withdrawn_Time__c = None,
-    Is_Withdrawn__c = HolidayStopRequestIsWithdrawn(false)
+    Is_Withdrawn__c = HolidayStopRequestIsWithdrawn(false),
+    Bulk_Suspension_Reason__c = None
   )
 
   def mkHolidayStopRequestDetailsFromHolidayStopRequest(request: HolidayStopRequest, chargeCode: String) = HolidayStopRequestsDetail(


### PR DESCRIPTION
This change adds an optional field called `bulkSuspensionReason` to the response of calls to fetch holiday stops from the holiday-stop API.

A holiday stop that was imposed for some reason looks like this:
```
{
      "id": "a2k3E000000qMgsQAE",
      "startDate": "2020-04-24",
      "endDate": "2020-04-24",
      "subscriptionName": "A-S00063156",
      "publicationsImpacted": [
        {
          "publicationDate": "2020-04-24",
          "estimatedPrice": -2.89,
          "invoiceDate": "2020-07-10"
        }
      ],
      "bulkSuspensionReason": "Covid-19",
      "mutabilityFlags": {
        "isFullyMutable": false,
        "isEndDateEditable": false
      }
    }
```
