### PR TITLE
Fulfilment date calculator new subscription start date

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -108,7 +108,8 @@ object DeliveryCreditProcessor extends Logging {
       deliveryAddressChangeEffectiveDate = None,
       holidayStopFirstAvailableDate = tomorrow,
       holidayStopProcessorTargetDate = Some(tomorrow),
-      finalFulfilmentFileGenerationDate = None
+      finalFulfilmentFileGenerationDate = None,
+      newSubscriptionEarliestStartDate = None
     )
     Right(
       DayOfWeek

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala
@@ -29,7 +29,8 @@ object GuardianWeeklyFulfilmentDates extends FulfilmentConstants(
         deliveryAddressChangeEffectiveDate(today),
         holidayStopFirstAvailableDate(today),
         holidayStopProcessorTargetDate(today),
-        finalFulfilmentFileGenerationDate(today)
+        finalFulfilmentFileGenerationDate(today),
+        deliveryAddressChangeEffectiveDate(today)
       )
     )
 

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala
@@ -30,7 +30,7 @@ object GuardianWeeklyFulfilmentDates extends FulfilmentConstants(
         holidayStopFirstAvailableDate(today),
         holidayStopProcessorTargetDate(today),
         finalFulfilmentFileGenerationDate(today),
-        deliveryAddressChangeEffectiveDate(today)
+        newSubscriptionEarliestStartDate(today)
       )
     )
 
@@ -55,6 +55,9 @@ object GuardianWeeklyFulfilmentDates extends FulfilmentConstants(
 
   // Cover date of first issue sent to the new address.
   def deliveryAddressChangeEffectiveDate(today: LocalDate): LocalDate =
+    nextAffectablePublicationDateOnFrontCover(today)
+
+  def newSubscriptionEarliestStartDate(today: LocalDate): LocalDate =
     nextAffectablePublicationDateOnFrontCover(today)
 
   // TODO: Take into account bank holidays

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
@@ -1,7 +1,8 @@
 package com.gu.supporter.fulfilment
 
 import java.time.DayOfWeek._
-import java.time.temporal.TemporalAdjusters.next
+import java.time.temporal.TemporalAdjusters
+import java.time.temporal.TemporalAdjusters.{next, nextOrSame}
 import java.time.{DayOfWeek, LocalDate}
 
 import com.gu.fulfilmentdates.FulfilmentDates
@@ -21,7 +22,7 @@ object HomeDeliveryFulfilmentDates {
           holidayStopFirstAvailableDate(targetDayOfWeek, today),
           holidayStopProcessorTargetDate(targetDayOfWeek, today),
           finalFulfilmentFileGenerationDate(targetDayOfWeek, today),
-          deliveryAddressChangeEffectiveDate(targetDayOfWeek, today)
+          newSubscriptionEarliestStartDate(targetDayOfWeek, today)
         )): _*
     )
 
@@ -107,4 +108,37 @@ object HomeDeliveryFulfilmentDates {
     }
   }
 
+  /**
+   *  This is designed to implement the delay before fulfilment can be started defined by this grid:
+   *  -----------------------------------------------------------------------------------
+   *  |   Pack    |   Mon   |   Tue   |   Wed   |   Thu   |   Fri   |   Sat   |   Sun   |
+   *  -----------------------------------------------------------------------------------
+   *  | Everyday  |    3    |    3    |    3    |    6    |    5    |    4    |    3    |
+   *  | Sixday    |    3    |    3    |    3    |    6    |    5    |    4    |    3    |
+   *  | Weekend   |    5    |    4    |    3    |    9    |    8    |    7    |    3    |
+   *  | Saturday  |    5    |    4    |    3    |    9    |    8    |    7    |    6    |
+   *  | Sunday    |    6    |    5    |    4    |    10   |    9    |    8    |    7    |
+   *  -----------------------------------------------------------------------------------
+   *
+   *  This is designed to ensure all subscription make it into the fulfilment files for the first day of the
+   *  subscription, including easter bank holidays etc.
+   *
+   *  This grid is probably in most cases overly conservative however the fulfilment partners have a report
+   *  that they can use to track acquisitions in order to re-plan routes etc if its necessary.
+   *
+   *  So any change need to be agreed.
+   */
+  def newSubscriptionEarliestStartDate(
+    targetDayOfWeek: DayOfWeek,
+    today: LocalDate
+  ) = {
+    val startDateDelay = today.getDayOfWeek match {
+      case DayOfWeek.THURSDAY => 6
+      case DayOfWeek.FRIDAY => 5
+      case DayOfWeek.SATURDAY => 4
+      case _ => 3
+    }
+
+    today plusDays(startDateDelay) `with` nextOrSame(targetDayOfWeek)
+  }
 }

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
@@ -20,7 +20,8 @@ object HomeDeliveryFulfilmentDates {
           deliveryAddressChangeEffectiveDate(targetDayOfWeek, today),
           holidayStopFirstAvailableDate(targetDayOfWeek, today),
           holidayStopProcessorTargetDate(targetDayOfWeek, today),
-          finalFulfilmentFileGenerationDate(targetDayOfWeek, today)
+          finalFulfilmentFileGenerationDate(targetDayOfWeek, today),
+          deliveryAddressChangeEffectiveDate(targetDayOfWeek, today)
         )): _*
     )
 

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
@@ -139,6 +139,6 @@ object HomeDeliveryFulfilmentDates {
       case _ => 3
     }
 
-    today plusDays(startDateDelay) `with` nextOrSame(targetDayOfWeek)
+    today plusDays (startDateDelay) `with` nextOrSame(targetDayOfWeek)
   }
 }

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
@@ -2,6 +2,8 @@ package com.gu.supporter.fulfilment
 
 import java.time.DayOfWeek._
 import java.time.format.TextStyle.FULL
+import java.time.temporal.TemporalAdjusters.{next, nextOrSame}
+import java.time.temporal.{TemporalAdjuster, TemporalAdjusters}
 import java.time.{DayOfWeek, LocalDate}
 import java.util.Locale.ENGLISH
 
@@ -12,14 +14,17 @@ import scala.collection.immutable.ListMap
 object VoucherBookletFulfilmentDates {
 
   lazy val VoucherHolidayStopNoticePeriodDays = 1
+  lazy val FulfilmentCutoffDay = DayOfWeek.WEDNESDAY
+  lazy val WeekStartDay = DayOfWeek.MONDAY
 
   def apply(today: LocalDate): ListMap[String, FulfilmentDates] =
     ListMap( // to preserve insertion order, so the file is easier to read
       List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(targetDayOfWeek =>
         targetDayOfWeek.getDisplayName(FULL, ENGLISH) -> FulfilmentDates(
-          today,
-          holidayStopFirstAvailableDate(today),
-          holidayStopProcessorTargetDate(targetDayOfWeek, today)
+          today = today,
+          holidayStopFirstAvailableDate = holidayStopFirstAvailableDate(today),
+          holidayStopProcessorTargetDate = holidayStopProcessorTargetDate(targetDayOfWeek, today),
+          newSubscriptionEarliestStartDate = newSubscriptionEarliestStartDate(targetDayOfWeek, today)
         )): _*
     )
 
@@ -33,4 +38,10 @@ object VoucherBookletFulfilmentDates {
     }
   }
 
+  def newSubscriptionEarliestStartDate(issueDay: DayOfWeek, today: LocalDate) = {
+    //Subscriptions made today can be included in the the voucher fulfilment file generated on the next wednesday
+    //morning the voucher book will be received in roughly two weeks after the fulfilment file is generated and
+    //will contain vouchers that are valid for the week (starting monday) after they are received
+    today `with` next(FulfilmentCutoffDay) plusWeeks(2) `with` next(WeekStartDay) `with` nextOrSame(issueDay)
+  }
 }

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
@@ -20,10 +20,10 @@ object VoucherBookletFulfilmentDates {
     ListMap( // to preserve insertion order, so the file is easier to read
       List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(targetDayOfWeek =>
         targetDayOfWeek.getDisplayName(FULL, ENGLISH) -> FulfilmentDates(
-          today = today,
-          holidayStopFirstAvailableDate = holidayStopFirstAvailableDate(today),
-          holidayStopProcessorTargetDate = holidayStopProcessorTargetDate(targetDayOfWeek, today),
-          newSubscriptionEarliestStartDate = newSubscriptionEarliestStartDate(targetDayOfWeek, today)
+          today,
+          holidayStopFirstAvailableDate(today),
+          holidayStopProcessorTargetDate(targetDayOfWeek, today),
+          newSubscriptionEarliestStartDate(targetDayOfWeek, today)
         )): _*
     )
 

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
@@ -39,8 +39,9 @@ object VoucherBookletFulfilmentDates {
 
   def newSubscriptionEarliestStartDate(issueDay: DayOfWeek, today: LocalDate) = {
     //Subscriptions made today can be included in the the voucher fulfilment file generated on the next wednesday
-    //morning the voucher book will be received in roughly two weeks after the fulfilment file is generated and
-    //will contain vouchers that are valid for the week (starting monday) after they are received
+    //morning the voucher book will be received in roughly two weeks after the fulfilment file is generated
+    //the customer is charged on the basis they will start redeeming the vouchers the week after they have
+    //received the vouchers
     today `with` next(FulfilmentCutoffDay) plusWeeks (2) `with` next(WeekStartDay) `with` nextOrSame(issueDay)
   }
 }

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
@@ -42,6 +42,6 @@ object VoucherBookletFulfilmentDates {
     //Subscriptions made today can be included in the the voucher fulfilment file generated on the next wednesday
     //morning the voucher book will be received in roughly two weeks after the fulfilment file is generated and
     //will contain vouchers that are valid for the week (starting monday) after they are received
-    today `with` next(FulfilmentCutoffDay) plusWeeks(2) `with` next(WeekStartDay) `with` nextOrSame(issueDay)
+    today `with` next(FulfilmentCutoffDay) plusWeeks (2) `with` next(WeekStartDay) `with` nextOrSame(issueDay)
   }
 }

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/VoucherBooklet.scala
@@ -3,7 +3,6 @@ package com.gu.supporter.fulfilment
 import java.time.DayOfWeek._
 import java.time.format.TextStyle.FULL
 import java.time.temporal.TemporalAdjusters.{next, nextOrSame}
-import java.time.temporal.{TemporalAdjuster, TemporalAdjusters}
 import java.time.{DayOfWeek, LocalDate}
 import java.util.Locale.ENGLISH
 

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/GuardianWeeklyFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/GuardianWeeklyFulfilmentDatesSpec.scala
@@ -66,4 +66,19 @@ class GuardianWeeklyFulfilmentDatesSpec extends FlatSpec with Matchers with Date
     GuardianWeeklyFulfilmentDates("2019-12-13")("Friday").finalFulfilmentFileGenerationDate.get should equalDate("2019-12-19")
   }
 
+  it should "calculate newSubscriptionEarliestStartDate" in {
+    GuardianWeeklyFulfilmentDates("2019-12-02")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    GuardianWeeklyFulfilmentDates("2019-12-03")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    GuardianWeeklyFulfilmentDates("2019-12-04")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    GuardianWeeklyFulfilmentDates("2019-12-05")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+    GuardianWeeklyFulfilmentDates("2019-12-06")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+    GuardianWeeklyFulfilmentDates("2019-12-07")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+    GuardianWeeklyFulfilmentDates("2019-12-08")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+    GuardianWeeklyFulfilmentDates("2019-12-09")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+    GuardianWeeklyFulfilmentDates("2019-12-10")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+    GuardianWeeklyFulfilmentDates("2019-12-11")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+    GuardianWeeklyFulfilmentDates("2019-12-12")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-27")
+    GuardianWeeklyFulfilmentDates("2019-12-13")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-27")
+  }
+
 }

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
@@ -6,8 +6,6 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class HomeDeliveryFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
 
-
-
   def apply(today: LocalDate) = HomeDeliveryFulfilmentDates.apply(today)(
     BankHolidays(Nil) // TODO reuse sampleBankHolidays from LocalDateHelpersSpec with some test cases below
   )

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
@@ -6,6 +6,8 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class HomeDeliveryFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
 
+
+
   def apply(today: LocalDate) = HomeDeliveryFulfilmentDates.apply(today)(
     BankHolidays(Nil) // TODO reuse sampleBankHolidays from LocalDateHelpersSpec with some test cases below
   )
@@ -225,98 +227,98 @@ class HomeDeliveryFulfilmentDatesSpec extends FlatSpec with Matchers with DateSu
 
   "MONDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
     apply( /* Wednesday */ "2019-12-04")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-09")
-    apply( /* Thursday  */ "2019-12-05")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-09")
+    apply( /* Thursday  */ "2019-12-05")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
     apply( /* Friday    */ "2019-12-06")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
     apply( /* Saturday  */ "2019-12-07")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
     apply( /* Sunday    */ "2019-12-08")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
     apply( /* Monday    */ "2019-12-09")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
     apply( /* Tuesday   */ "2019-12-10")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
     apply( /* Wednesday */ "2019-12-11")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
-    apply( /* Thursday  */ "2019-12-12")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
+    apply( /* Thursday  */ "2019-12-12")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-23")
     apply( /* Friday    */ "2019-12-13")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-23")
     apply( /* Saturday  */ "2019-12-14")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-23")
   }
 
   "TUESDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
-    apply( /* Saturday  */ "2019-12-07")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-10")
-    apply( /* Sunday    */ "2019-12-08")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-10")
+    apply( /* Saturday  */ "2019-12-07")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Sunday    */ "2019-12-08")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
     apply( /* Monday    */ "2019-12-09")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
     apply( /* Tuesday   */ "2019-12-10")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
     apply( /* Wednesday */ "2019-12-11")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
-    apply( /* Thursday  */ "2019-12-12")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
-    apply( /* Friday    */ "2019-12-13")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
-    apply( /* Saturday  */ "2019-12-14")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
-    apply( /* Sunday    */ "2019-12-15")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Thursday  */ "2019-12-12")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-24")
+    apply( /* Friday    */ "2019-12-13")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-24")
+    apply( /* Saturday  */ "2019-12-14")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-24")
+    apply( /* Sunday    */ "2019-12-15")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-24")
     apply( /* Monday    */ "2019-12-16")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-24")
     apply( /* Tuesday   */ "2019-12-17")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-24")
   }
 
   "WEDNESDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
     apply( /* Sunday    */ "2019-12-01")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-04")
-    apply( /* Monday    */ "2019-12-02")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-04")
+    apply( /* Monday    */ "2019-12-02")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
     apply( /* Tuesday   */ "2019-12-03")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
     apply( /* Wednesday */ "2019-12-04")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
     apply( /* Thursday  */ "2019-12-05")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
     apply( /* Friday    */ "2019-12-06")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
     apply( /* Saturday  */ "2019-12-07")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
     apply( /* Sunday    */ "2019-12-08")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
-    apply( /* Monday    */ "2019-12-09")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
+    apply( /* Monday    */ "2019-12-09")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-18")
     apply( /* Tuesday   */ "2019-12-10")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-18")
     apply( /* Wednesday */ "2019-12-11")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-18")
   }
 
   "THURSDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
     apply( /* Monday    */ "2019-12-02")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-05")
-    apply( /* Tuesday   */ "2019-12-03")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-05")
+    apply( /* Tuesday   */ "2019-12-03")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
     apply( /* Wednesday */ "2019-12-04")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
     apply( /* Thursday  */ "2019-12-05")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
     apply( /* Friday    */ "2019-12-06")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
     apply( /* Saturday  */ "2019-12-07")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
     apply( /* Sunday    */ "2019-12-08")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
     apply( /* Monday    */ "2019-12-09")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
-    apply( /* Tuesday   */ "2019-12-10")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
+    apply( /* Tuesday   */ "2019-12-10")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-19")
     apply( /* Wednesday */ "2019-12-11")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-19")
     apply( /* Thursday  */ "2019-12-12")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-19")
   }
 
   "FRIDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
     apply( /* Tuesday   */ "2019-12-03")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-06")
-    apply( /* Wednesday */ "2019-12-04")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-06")
+    apply( /* Wednesday */ "2019-12-04")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
     apply( /* Thursday  */ "2019-12-05")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
     apply( /* Friday    */ "2019-12-06")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
     apply( /* Saturday  */ "2019-12-07")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
     apply( /* Sunday    */ "2019-12-08")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
     apply( /* Monday    */ "2019-12-09")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
     apply( /* Tuesday   */ "2019-12-10")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
-    apply( /* Wednesday */ "2019-12-11")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    apply( /* Wednesday */ "2019-12-11")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
     apply( /* Thursday  */ "2019-12-12")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
     apply( /* Friday    */ "2019-12-13")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
   }
 
   "SATURDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
     apply( /* Wednesday */ "2019-12-04")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-07")
-    apply( /* Thursday  */ "2019-12-05")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-07")
+    apply( /* Thursday  */ "2019-12-05")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
     apply( /* Friday    */ "2019-12-06")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
     apply( /* Saturday  */ "2019-12-07")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
     apply( /* Sunday    */ "2019-12-08")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
     apply( /* Monday    */ "2019-12-09")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
     apply( /* Tuesday   */ "2019-12-10")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
     apply( /* Wednesday */ "2019-12-11")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
-    apply( /* Thursday  */ "2019-12-12")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
+    apply( /* Thursday  */ "2019-12-12")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-21")
     apply( /* Friday    */ "2019-12-13")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-21")
     apply( /* Saturday  */ "2019-12-14")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-21")
   }
 
   "SUNDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
     apply( /* Wednesday */ "2019-12-04")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-08")
-    apply( /* Thursday  */ "2019-12-05")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-08")
+    apply( /* Thursday  */ "2019-12-05")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
     apply( /* Friday    */ "2019-12-06")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
     apply( /* Saturday  */ "2019-12-07")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
     apply( /* Sunday    */ "2019-12-08")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
     apply( /* Monday    */ "2019-12-09")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
     apply( /* Tuesday   */ "2019-12-10")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
     apply( /* Wednesday */ "2019-12-11")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
-    apply( /* Thursday  */ "2019-12-12")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
+    apply( /* Thursday  */ "2019-12-12")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-22")
     apply( /* Friday    */ "2019-12-13")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-22")
     apply( /* Saturday  */ "2019-12-14")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-22")
   }

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
@@ -222,5 +222,103 @@ class HomeDeliveryFulfilmentDatesSpec extends FlatSpec with Matchers with DateSu
     apply( /* Friday    */ "2019-12-13")("Sunday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-22")
     apply( /* Saturday  */ "2019-12-14")("Sunday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-22")
   }
+  
+  "MONDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-09")
+    apply( /* Thursday  */ "2019-12-05")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-09")
+    apply( /* Friday    */ "2019-12-06")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
+    apply( /* Saturday  */ "2019-12-07")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
+    apply( /* Sunday    */ "2019-12-08")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
+    apply( /* Monday    */ "2019-12-09")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
+    apply( /* Tuesday   */ "2019-12-10")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
+    apply( /* Wednesday */ "2019-12-11")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
+    apply( /* Thursday  */ "2019-12-12")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-16")
+    apply( /* Friday    */ "2019-12-13")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-23")
+    apply( /* Saturday  */ "2019-12-14")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-23")
+  }
+
+  "TUESDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Saturday  */ "2019-12-07")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-10")
+    apply( /* Sunday    */ "2019-12-08")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-10")
+    apply( /* Monday    */ "2019-12-09")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Tuesday   */ "2019-12-10")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Wednesday */ "2019-12-11")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Thursday  */ "2019-12-12")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Friday    */ "2019-12-13")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Saturday  */ "2019-12-14")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Sunday    */ "2019-12-15")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-17")
+    apply( /* Monday    */ "2019-12-16")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-24")
+    apply( /* Tuesday   */ "2019-12-17")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-24")
+  }
+
+  "WEDNESDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Sunday    */ "2019-12-01")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-04")
+    apply( /* Monday    */ "2019-12-02")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-04")
+    apply( /* Tuesday   */ "2019-12-03")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
+    apply( /* Wednesday */ "2019-12-04")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
+    apply( /* Thursday  */ "2019-12-05")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
+    apply( /* Friday    */ "2019-12-06")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
+    apply( /* Saturday  */ "2019-12-07")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
+    apply( /* Sunday    */ "2019-12-08")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
+    apply( /* Monday    */ "2019-12-09")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-11")
+    apply( /* Tuesday   */ "2019-12-10")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-18")
+    apply( /* Wednesday */ "2019-12-11")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-18")
+  }
+
+  "THURSDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Monday    */ "2019-12-02")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-05")
+    apply( /* Tuesday   */ "2019-12-03")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-05")
+    apply( /* Wednesday */ "2019-12-04")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
+    apply( /* Thursday  */ "2019-12-05")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
+    apply( /* Friday    */ "2019-12-06")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
+    apply( /* Saturday  */ "2019-12-07")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
+    apply( /* Sunday    */ "2019-12-08")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
+    apply( /* Monday    */ "2019-12-09")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
+    apply( /* Tuesday   */ "2019-12-10")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-12")
+    apply( /* Wednesday */ "2019-12-11")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-19")
+    apply( /* Thursday  */ "2019-12-12")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-19")
+  }
+
+  "FRIDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Tuesday   */ "2019-12-03")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-06")
+    apply( /* Wednesday */ "2019-12-04")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-06")
+    apply( /* Thursday  */ "2019-12-05")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    apply( /* Friday    */ "2019-12-06")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    apply( /* Saturday  */ "2019-12-07")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    apply( /* Sunday    */ "2019-12-08")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    apply( /* Monday    */ "2019-12-09")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    apply( /* Tuesday   */ "2019-12-10")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    apply( /* Wednesday */ "2019-12-11")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-13")
+    apply( /* Thursday  */ "2019-12-12")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+    apply( /* Friday    */ "2019-12-13")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-20")
+  }
+
+  "SATURDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-07")
+    apply( /* Thursday  */ "2019-12-05")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-07")
+    apply( /* Friday    */ "2019-12-06")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
+    apply( /* Saturday  */ "2019-12-07")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
+    apply( /* Sunday    */ "2019-12-08")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
+    apply( /* Monday    */ "2019-12-09")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
+    apply( /* Tuesday   */ "2019-12-10")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
+    apply( /* Wednesday */ "2019-12-11")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
+    apply( /* Thursday  */ "2019-12-12")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-14")
+    apply( /* Friday    */ "2019-12-13")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-21")
+    apply( /* Saturday  */ "2019-12-14")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-21")
+  }
+
+  "SUNDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-08")
+    apply( /* Thursday  */ "2019-12-05")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-08")
+    apply( /* Friday    */ "2019-12-06")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
+    apply( /* Saturday  */ "2019-12-07")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
+    apply( /* Sunday    */ "2019-12-08")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
+    apply( /* Monday    */ "2019-12-09")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
+    apply( /* Tuesday   */ "2019-12-10")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
+    apply( /* Wednesday */ "2019-12-11")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
+    apply( /* Thursday  */ "2019-12-12")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-15")
+    apply( /* Friday    */ "2019-12-13")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-22")
+    apply( /* Saturday  */ "2019-12-14")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-22")
+  }
 
 }

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/HomeDeliveryFulfilmentDatesSpec.scala
@@ -222,7 +222,7 @@ class HomeDeliveryFulfilmentDatesSpec extends FlatSpec with Matchers with DateSu
     apply( /* Friday    */ "2019-12-13")("Sunday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-22")
     apply( /* Saturday  */ "2019-12-14")("Sunday").deliveryAddressChangeEffectiveDate.get should equalDate("2019-12-22")
   }
-  
+
   "MONDAY HomeDeliveryFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
     apply( /* Wednesday */ "2019-12-04")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-09")
     apply( /* Thursday  */ "2019-12-05")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-09")

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/VoucherBookletFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/VoucherBookletFulfilmentDatesSpec.scala
@@ -16,7 +16,7 @@ class VoucherBookletFulfilmentDatesSpec extends FlatSpec with Matchers with Date
     result.values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List(expectedDate)
     result(expectedDayOfWeek).holidayStopProcessorTargetDate.get should equalDate(expectedDate)
   }
-  
+
   it should "calculate holidayStopProcessorTargetDate" in {
     shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-02", "Monday", "2019-12-02")
     shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-03", "Tuesday", "2019-12-03")

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/VoucherBookletFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/VoucherBookletFulfilmentDatesSpec.scala
@@ -3,6 +3,7 @@ package com.gu.supporter.fulfilment
 import java.time.LocalDate
 
 import org.scalatest.{FlatSpec, Matchers}
+import VoucherBookletFulfilmentDates.apply
 
 class VoucherBookletFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
 
@@ -15,9 +16,8 @@ class VoucherBookletFulfilmentDatesSpec extends FlatSpec with Matchers with Date
     result.values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List(expectedDate)
     result(expectedDayOfWeek).holidayStopProcessorTargetDate.get should equalDate(expectedDate)
   }
-
+  
   it should "calculate holidayStopProcessorTargetDate" in {
-
     shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-02", "Monday", "2019-12-02")
     shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-03", "Tuesday", "2019-12-03")
     shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-04", "Wednesday", "2019-12-04")
@@ -30,7 +30,103 @@ class VoucherBookletFulfilmentDatesSpec extends FlatSpec with Matchers with Date
     shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-11", "Wednesday", "2019-12-11")
     shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-12", "Thursday", "2019-12-12")
     shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-13", "Friday", "2019-12-13")
-
   }
 
+  "MONDAY VoucherBookletFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-30")
+    apply( /* Thursday  */ "2019-12-05")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-30")
+    apply( /* Friday    */ "2019-12-06")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-30")
+    apply( /* Saturday  */ "2019-12-07")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-30")
+    apply( /* Sunday    */ "2019-12-08")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-30")
+    apply( /* Monday    */ "2019-12-09")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-30")
+    apply( /* Tuesday   */ "2019-12-10")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-30")
+    apply( /* Wednesday */ "2019-12-11")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-06")
+    apply( /* Thursday  */ "2019-12-12")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-06")
+    apply( /* Friday    */ "2019-12-13")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-06")
+    apply( /* Saturday  */ "2019-12-14")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-06")
+  }
+
+  "TUESDAY VoucherBookletFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-31")
+    apply( /* Thursday  */ "2019-12-05")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-31")
+    apply( /* Friday    */ "2019-12-06")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-31")
+    apply( /* Saturday  */ "2019-12-07")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-31")
+    apply( /* Sunday    */ "2019-12-08")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-31")
+    apply( /* Monday    */ "2019-12-09")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-31")
+    apply( /* Tuesday   */ "2019-12-10")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2019-12-31")
+    apply( /* Wednesday */ "2019-12-11")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-07")
+    apply( /* Thursday  */ "2019-12-12")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-07")
+    apply( /* Friday    */ "2019-12-13")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-07")
+    apply( /* Saturday  */ "2019-12-14")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-07")
+  }
+
+  "WEDNESDAY VoucherBookletFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-01")
+    apply( /* Thursday  */ "2019-12-05")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-01")
+    apply( /* Friday    */ "2019-12-06")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-01")
+    apply( /* Saturday  */ "2019-12-07")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-01")
+    apply( /* Sunday    */ "2019-12-08")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-01")
+    apply( /* Monday    */ "2019-12-09")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-01")
+    apply( /* Tuesday   */ "2019-12-10")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-01")
+    apply( /* Wednesday */ "2019-12-11")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-08")
+    apply( /* Thursday  */ "2019-12-12")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-08")
+    apply( /* Friday    */ "2019-12-13")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-08")
+    apply( /* Saturday  */ "2019-12-14")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-08")
+  }
+
+  "THURSDAY VoucherBookletFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-02")
+    apply( /* Thursday  */ "2019-12-05")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-02")
+    apply( /* Friday    */ "2019-12-06")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-02")
+    apply( /* Saturday  */ "2019-12-07")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-02")
+    apply( /* Sunday    */ "2019-12-08")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-02")
+    apply( /* Monday    */ "2019-12-09")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-02")
+    apply( /* Tuesday   */ "2019-12-10")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-02")
+    apply( /* Wednesday */ "2019-12-11")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-09")
+    apply( /* Thursday  */ "2019-12-12")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-09")
+    apply( /* Friday    */ "2019-12-13")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-09")
+    apply( /* Saturday  */ "2019-12-14")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-09")
+  }
+
+  "FRIDAY VoucherBookletFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-03")
+    apply( /* Thursday  */ "2019-12-05")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-03")
+    apply( /* Friday    */ "2019-12-06")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-03")
+    apply( /* Saturday  */ "2019-12-07")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-03")
+    apply( /* Sunday    */ "2019-12-08")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-03")
+    apply( /* Monday    */ "2019-12-09")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-03")
+    apply( /* Tuesday   */ "2019-12-10")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-03")
+    apply( /* Wednesday */ "2019-12-11")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-10")
+    apply( /* Thursday  */ "2019-12-12")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-10")
+    apply( /* Friday    */ "2019-12-13")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-10")
+    apply( /* Saturday  */ "2019-12-14")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-10")
+  }
+
+  "SATURDAY VoucherBookletFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-04")
+    apply( /* Thursday  */ "2019-12-05")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-04")
+    apply( /* Friday    */ "2019-12-06")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-04")
+    apply( /* Saturday  */ "2019-12-07")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-04")
+    apply( /* Sunday    */ "2019-12-08")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-04")
+    apply( /* Monday    */ "2019-12-09")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-04")
+    apply( /* Tuesday   */ "2019-12-10")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-04")
+    apply( /* Wednesday */ "2019-12-11")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-11")
+    apply( /* Thursday  */ "2019-12-12")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-11")
+    apply( /* Friday    */ "2019-12-13")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-11")
+    apply( /* Saturday  */ "2019-12-14")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-11")
+  }
+
+  "SUNDAY VoucherBookletFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Wednesday */ "2019-12-04")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-05")
+    apply( /* Thursday  */ "2019-12-05")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-05")
+    apply( /* Friday    */ "2019-12-06")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-05")
+    apply( /* Saturday  */ "2019-12-07")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-05")
+    apply( /* Sunday    */ "2019-12-08")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-05")
+    apply( /* Monday    */ "2019-12-09")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-05")
+    apply( /* Tuesday   */ "2019-12-10")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-05")
+    apply( /* Wednesday */ "2019-12-11")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-12")
+    apply( /* Thursday  */ "2019-12-12")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-12")
+    apply( /* Friday    */ "2019-12-13")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-12")
+    apply( /* Saturday  */ "2019-12-14")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-01-12")
+  }
 }

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/GetHolidayStopRequestsTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/GetHolidayStopRequestsTest.scala
@@ -34,8 +34,11 @@ class GetHolidayStopRequestsTest extends FlatSpec {
   val fulfilmentDates: Map[DayOfWeek, FulfilmentDates] = Map(
     FRIDAY -> FulfilmentDates(
       today = today,
+      deliveryAddressChangeEffectiveDate = None,
       holidayStopFirstAvailableDate = fulfilmentDatesFirstAvailableDate,
-      holidayStopProcessorTargetDate = None
+      holidayStopProcessorTargetDate = None,
+      finalFulfilmentFileGenerationDate = None,
+      newSubscriptionEarliestStartDate = None
     )
   )
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -60,7 +60,7 @@ class HolidayStopProcessTest extends AnyFlatSpec with Matchers with EitherValues
 
   private val fulfilmentDatesFetcher = new FulfilmentDatesFetcher {
     override def getFulfilmentDates(zuoraProductType: ZuoraProductType, date: LocalDate): Either[FulfilmentDatesFetcherError, Map[DayOfWeek, FulfilmentDates]] = {
-      Map(DayOfWeek.FRIDAY -> FulfilmentDates(today, today, Some(targetProcessingDate))).asRight
+      Map(DayOfWeek.FRIDAY -> FulfilmentDates(today, today, Some(targetProcessingDate), today)).asRight
     }
   }
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ProcessorErrorHandlingSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ProcessorErrorHandlingSpec.scala
@@ -47,7 +47,7 @@ class ProcessorErrorHandlingSpec extends AnyFlatSpec with Matchers with OptionVa
 
   private val fulfilmentDatesFetcher = new FulfilmentDatesFetcher {
     override def getFulfilmentDates(zuoraProductType: ZuoraProductType, date: LocalDate): Either[FulfilmentDatesFetcherError, Map[DayOfWeek, FulfilmentDates]] = {
-      Map(DayOfWeek.FRIDAY -> FulfilmentDates(today, today, Some(processingDate))).asRight
+      Map(DayOfWeek.FRIDAY -> FulfilmentDates(today, today, Some(processingDate), today)).asRight
     }
   }
 

--- a/lib/fulfilment-dates/src/main/scala/com/gu/fulfilmentdates/FulfilmentDates.scala
+++ b/lib/fulfilment-dates/src/main/scala/com/gu/fulfilmentdates/FulfilmentDates.scala
@@ -15,7 +15,8 @@ case class FulfilmentDates(
 )
 
 object FulfilmentDates {
-  def apply(today: LocalDate,
+  def apply(
+    today: LocalDate,
     holidayStopFirstAvailableDate: LocalDate,
     holidayStopProcessorTargetDate: Option[LocalDate],
     newSubscriptionEarliestStartDate: LocalDate

--- a/lib/fulfilment-dates/src/main/scala/com/gu/fulfilmentdates/FulfilmentDates.scala
+++ b/lib/fulfilment-dates/src/main/scala/com/gu/fulfilmentdates/FulfilmentDates.scala
@@ -10,26 +10,41 @@ case class FulfilmentDates(
   deliveryAddressChangeEffectiveDate: Option[LocalDate],
   holidayStopFirstAvailableDate: LocalDate,
   holidayStopProcessorTargetDate: Option[LocalDate],
-  finalFulfilmentFileGenerationDate: Option[LocalDate]
+  finalFulfilmentFileGenerationDate: Option[LocalDate],
+  newSubscriptionEarliestStartDate: Option[LocalDate]
 )
 
 object FulfilmentDates {
-  def apply(today: LocalDate, holidayStopFirstAvailableDate: LocalDate, holidayStopProcessorTargetDate: Option[LocalDate]): FulfilmentDates =
+  def apply(today: LocalDate,
+    holidayStopFirstAvailableDate: LocalDate,
+    holidayStopProcessorTargetDate: Option[LocalDate],
+    newSubscriptionEarliestStartDate: LocalDate
+  ): FulfilmentDates =
     FulfilmentDates(
       today,
       deliveryAddressChangeEffectiveDate = None,
       holidayStopFirstAvailableDate,
       holidayStopProcessorTargetDate,
-      finalFulfilmentFileGenerationDate = None
+      finalFulfilmentFileGenerationDate = None,
+      newSubscriptionEarliestStartDate = Some(newSubscriptionEarliestStartDate)
     )
 
-  def apply(today: LocalDate, deliveryAddressChangeEffectiveDate: LocalDate, holidayStopFirstAvailableDate: LocalDate, holidayStopProcessorTargetDate: Option[LocalDate], finalFulfilmentFileGenerationDate: LocalDate): FulfilmentDates =
+  def apply(
+    today: LocalDate,
+    deliveryAddressChangeEffectiveDate: LocalDate,
+    holidayStopFirstAvailableDate: LocalDate,
+    holidayStopProcessorTargetDate: Option[LocalDate],
+    finalFulfilmentFileGenerationDate: LocalDate,
+    newSubscriptionEarliestStartDate: LocalDate
+
+  ): FulfilmentDates =
     FulfilmentDates(
-      today,
-      Some(deliveryAddressChangeEffectiveDate),
-      holidayStopFirstAvailableDate,
-      holidayStopProcessorTargetDate,
-      Some(finalFulfilmentFileGenerationDate)
+      today = today,
+      deliveryAddressChangeEffectiveDate = Some(deliveryAddressChangeEffectiveDate),
+      holidayStopFirstAvailableDate = holidayStopFirstAvailableDate,
+      holidayStopProcessorTargetDate = holidayStopProcessorTargetDate,
+      finalFulfilmentFileGenerationDate = Some(finalFulfilmentFileGenerationDate),
+      newSubscriptionEarliestStartDate = Some(newSubscriptionEarliestStartDate)
     )
 
   val dayOfWeekFormat =

--- a/lib/fulfilment-dates/src/test/resources/Newspaper - Home Delivery.json
+++ b/lib/fulfilment-dates/src/test/resources/Newspaper - Home Delivery.json
@@ -3,6 +3,7 @@
     "today" : "2019-12-11",
     "deliveryAddressChangeEffectiveDate" : "2019-12-16",
     "holidayStopFirstAvailableDate" : "2019-12-16",
-    "finalFulfilmentFileGenerationDate" : "2019-12-12"
+    "finalFulfilmentFileGenerationDate" : "2019-12-12",
+    "newSubscriptionEarliestStartDate" : "2019-12-16"
   }
 }

--- a/lib/fulfilment-dates/src/test/scala/com/gu/fulfilmentdates/FulfilmentDatesFetcherTest.scala
+++ b/lib/fulfilment-dates/src/test/scala/com/gu/fulfilmentdates/FulfilmentDatesFetcherTest.scala
@@ -42,6 +42,7 @@ class FulfilmentDatesFetcherTest extends FlatSpec {
                 holidayStopFirstAvailableDate = LocalDate.parse("2019-12-16"),
                 holidayStopProcessorTargetDate = None,
                 finalFulfilmentFileGenerationDate = LocalDate.parse("2019-12-12"),
+                newSubscriptionEarliestStartDate = LocalDate.parse("2019-12-16")
               )
             )
           )


### PR DESCRIPTION
This change is to support centralising the logic for calculating the earliest start date for a particular type of subscription in the fulfilment date calculator.

The fulfilment date files will contain a new field "newSubscriptionEarliestStartDate" eg:

```json
{
  "Monday" : {
   ...
    "newSubscriptionEarliestStartDate" : "2020-05-25"
  },
...
```

This field defines the first date a customer can receive a particular issue of a particular product type.

The client would typically filter the list of these dates based on which issues the subscription they were creating had. Then use the lowest date as the start date for the subscription.

This field has been implemented for the following ProductTypes:
- Guardian Weekly - Same implementation as deliveryAddressChangeEffectiveDate
- Newspaper - Home Delivery - This replicates the logic used to derive the subscription start date used in support frontend, see the comments for details.
- Newpaper - Voucher Book - A new implementation based on the existing behaviour of support frontend and the Salesforce billing account create subscription page. Ie 
  - Subscriptions made today can be included in the the voucher fulfilment file generated on the next wednesday morning the 
  - voucher book will be received in roughly two weeks after the fulfilment file is generated  
  - the customer is charged on the basis they will start redeeming the vouchers the week after they have received the vouchers
