### PR TITLE
Remove unrequired fields for date calc

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -215,7 +215,7 @@ case class StartDateRules(daysOfWeekRule: Option[DaysOfWeekRule] = None, windowR
 
 case class DaysOfWeekRule(allowedDays: List[DayOfWeek]) extends DateRule
 
-case class WindowRule(startDate: LocalDate, maybeCutOffDay: Option[DayOfWeek], maybeStartDelay: Option[DelayDays], maybeSize: Option[WindowSizeDays]) extends DateRule
+case class WindowRule(startDate: LocalDate, maybeSize: Option[WindowSizeDays]) extends DateRule
 
 case class AmountMinorUnits(value: Int) extends AnyVal
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -45,8 +45,6 @@ object NewProductApi {
     def voucherWindowRule(issueDays: List[DayOfWeek]) = {
       WindowRule(
         startDate = getStartDateFromFulfilmentFiles(ProductType.NewspaperVoucherBook, issueDays),
-        maybeCutOffDay = Some(DayOfWeek.TUESDAY),
-        maybeStartDelay = Some(DelayDays(20)),
         maybeSize = Some(VoucherSubscriptionStartDateWindowSize)
       )
     }
@@ -62,8 +60,6 @@ object NewProductApi {
 
     def homeDeliveryWindowRule(issueDays: List[DayOfWeek]) = WindowRule(
       startDate =  getStartDateFromFulfilmentFiles(ProductType.NewspaperHomeDelivery, issueDays),
-      maybeCutOffDay = None,
-      maybeStartDelay = Some(DelayDays(3)),
       maybeSize = Some(HomeDeliverySubscriptionStartDateWindowSize)
     )
 
@@ -92,15 +88,11 @@ object NewProductApi {
       windowRule = WindowRule(
         startDate = today,
         maybeSize = Some(ContributionStartDateWindowSize),
-        maybeCutOffDay = None,
-        maybeStartDelay = None
       )
     )
 
     val digiPackWindowRule =  WindowRule(
       startDate = today.plusDays(DigiPackFreeTrialPeriodDays),
-      maybeCutOffDay = None,
-      maybeStartDelay = Some(DelayDays(14)),
       maybeSize = Some(DigiPackStartDateWindowSize)
     )
 
@@ -121,8 +113,6 @@ object NewProductApi {
         daysOfWeekRule = Some(DaysOfWeekRule(guardianWeeklyIssueDays)),
         windowRule = WindowRule(
           startDate = getStartDateFromFulfilmentFiles(ProductType.GuardianWeekly, guardianWeeklyIssueDays),
-          maybeCutOffDay = Some(DayOfWeek.WEDNESDAY),
-          maybeStartDelay = Some(DelayDays(7)),
           maybeSize = Some(GuardianWeeklySubscriptionStartDateWindowSize)
         )
       )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -41,8 +41,6 @@ object WireModel {
 
   case class WireSelectableWindow(
     startDate: LocalDate,
-    cutOffDayInclusive: Option[WireDayOfWeek] = None,
-    startDaysAfterCutOff: Option[Int] = None,
     sizeInDays: Option[Int] = None
   )
 
@@ -77,8 +75,7 @@ object WireModel {
     implicit val writes = Json.writes[WireSelectableWindow]
 
     def fromWindowRule(rule: WindowRule) = {
-      val wireCutoffDay = rule.maybeCutOffDay.map(WireDayOfWeek.fromDayOfWeek)
-      WireSelectableWindow(rule.startDate, wireCutoffDay, rule.maybeStartDelay.map(_.value), rule.maybeSize.map(_.value))
+      WireSelectableWindow(rule.startDate, rule.maybeSize.map(_.value))
     }
   }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/InitSelectableWindowTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/InitSelectableWindowTest.scala
@@ -1,6 +1,5 @@
 package com.gu.newproduct.api.addsubscription.validation
 
-import java.time.DayOfWeek._
 import java.time.LocalDate
 
 import com.gu.newproduct.api.productcatalog.{WindowRule, WindowSizeDays}
@@ -17,8 +16,6 @@ class InitSelectableWindowTest extends FlatSpec with Matchers {
       now = getWedAugust8,
       WindowRule(
         startDate = wednesdayAugust8,
-        maybeCutOffDay = None,
-        maybeStartDelay = None,
         maybeSize = None
       )
     )
@@ -31,8 +28,6 @@ class InitSelectableWindowTest extends FlatSpec with Matchers {
       now = getWedAugust8,
       WindowRule(
         startDate = wednesdayAugust8,
-        maybeCutOffDay = Some(THURSDAY),
-        maybeStartDelay = None,
         maybeSize = Some(WindowSizeDays(10))
       )
     )

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -72,8 +72,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-01",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -94,8 +92,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-01",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -116,8 +112,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-02",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -138,8 +132,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-02",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -160,8 +152,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-01",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -182,8 +172,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-01",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -204,8 +192,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-03",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -226,8 +212,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-03",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -248,8 +232,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-02",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -270,8 +252,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-03-02",
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
         |              "sizeInDays": 35
         |            }
         |          },
@@ -303,7 +283,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-01",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -330,7 +309,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-01",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -351,7 +329,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-03",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -372,7 +349,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-03",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -398,7 +374,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-02",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -424,7 +399,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-02",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -445,7 +419,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-04",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -466,7 +439,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-04",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -488,7 +460,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-05",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -510,7 +481,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-02-05",
-        |              "startDaysAfterCutOff": 3,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -542,7 +512,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2019-12-15",
-        |              "startDaysAfterCutOff": 14,
         |              "sizeInDays": 90
         |            }
         |          },
@@ -573,7 +542,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2019-12-15",
-        |              "startDaysAfterCutOff": 14,
         |              "sizeInDays": 90
         |            }
         |          },
@@ -603,8 +571,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-01-01",
-        |              "cutOffDayInclusive": "Wednesday",
-        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -629,8 +595,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-01-01",
-        |              "cutOffDayInclusive": "Wednesday",
-        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -655,8 +619,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-01-01",
-        |              "cutOffDayInclusive": "Wednesday",
-        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -699,8 +661,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-01-01",
-        |              "cutOffDayInclusive": "Wednesday",
-        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -725,8 +685,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-01-01",
-        |              "cutOffDayInclusive": "Wednesday",
-        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },
@@ -751,8 +709,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            ],
         |            "selectableWindow": {
         |              "startDate": "2020-01-01",
-        |              "cutOffDayInclusive": "Wednesday",
-        |              "startDaysAfterCutOff": 7,
         |              "sizeInDays": 28
         |            }
         |          },

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/RuleFixtures.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/RuleFixtures.scala
@@ -5,6 +5,6 @@ import java.time.LocalDate
 object RuleFixtures {
   val testStartDateRules = StartDateRules(
     None,
-    WindowRule(LocalDate.of(2020, 1, 1), None, None, None)
+    WindowRule(LocalDate.of(2020, 1, 1), None)
   )
 }


### PR DESCRIPTION
This PR removes maybeCutOffDay and maybeStartDelay fields from the new product api catalog endpoint.

These fields were used by salesforce to calculate the dates when a new subscription can start being fulfilled.

This has been replace by a 'pre-baked' startdate field, which is calculated using the files from the fulfilment-date-calcluator. For details see:

https://github.com/guardian/support-service-lambdas/pull/650