### PR TITLE
[zuora-datalake-export] add row count assertion (downloaded vs Zuora)

### DIFF
--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -385,7 +385,14 @@ object GetResultsFile {
       .asString
 
     response.code match {
-      case 200 => response.body
+      case 200 =>
+        val zuoraRowCount = batch.recordCount.get
+        val downloadedLineCount = response.body.lines.length
+        val downloadedRowCount = downloadedLineCount - 1 // for header row
+        if (downloadedRowCount != zuoraRowCount) {
+          throw new RuntimeException(s"HALTING at '${batch.name}' because the row count of downloaded file ($downloadedRowCount) did not match the Zuora row count (${zuoraRowCount})")
+        }
+        response.body
       case _ => throw new RuntimeException(s"Failed to execute request GetResultsFile: ${response}")
     }
   }


### PR DESCRIPTION
When working on the CLI entry-point for `zuora-datalake-export` (https://github.com/guardian/support-service-lambdas/pull/654) I introduced a row count assertion (to ensure the downloaded row count matches what's quoted in the Zuora job metadata) before uploading to S3 (💥 if they don't match).

This PR brings just those changes on their own, as the CLI one needs more work.