### PR TITLE
[holiday-stop-api] fix MutabilityFlags

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -465,7 +465,8 @@ object Handler extends Logging {
       contact <- extractContactFromHeaders(req.headers)
       pathParams <- req.pathParamsAsCaseClass[SpecificHolidayStopRequestPathParams]()
       existingForUser <- lookupOp(contact, None, None).toDisjunction.toApiGatewayOp(s"lookup Holiday Stop Requests for contact $contact")
-      _ = existingForUser.exists(_.Id == pathParams.holidayStopRequestId).toApiGatewayContinueProcessing(ApiGatewayResponse.forbidden("not your holiday stop"))
+      hsr <- existingForUser.find(_.Id == pathParams.holidayStopRequestId).toApiGatewayContinueProcessing(ApiGatewayResponse.forbidden("not your holiday stop"))
+      _ = hsr.Holiday_Stop_Request_Detail__r.exists(_.records.exists(_.Is_Actioned__c)).toApiGatewayContinueProcessing(ApiGatewayResponse.forbidden("can't withdraw holiday stop with any actioned items"))
       _ <- withdrawOp(pathParams.holidayStopRequestId).toDisjunction.toApiGatewayOp(
         exposeSfErrorMessageIn500ApiResponse(s"withdraw Holiday Stop Request for subscription ${pathParams.subscriptionName.value} of contact $contact")
       )

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -388,7 +388,7 @@ class HandlerTest extends AnyFlatSpec with Matchers {
         inside(parsedResponseBody) {
           case JsSuccess(response, _) =>
             response.publicationsToRefund should contain only(
-              HolidayStopRequestsDetail(stopDate, Some(price), Some(price), Some(invoiceDate))
+              HolidayStopRequestsDetail(stopDate, Some(price), Some(price), Some(invoiceDate), isActioned = false)
             )
         }
     }
@@ -399,7 +399,8 @@ class HandlerTest extends AnyFlatSpec with Matchers {
       holidayStop.Stopped_Publication_Date__c.value,
       holidayStop.Estimated_Price__c.map(_.value),
       holidayStop.Actual_Price__c.map(_.value),
-      holidayStop.Expected_Invoice_Date__c.map(_.value)
+      holidayStop.Expected_Invoice_Date__c.map(_.value),
+      holidayStop.Is_Actioned__c
     )
   }
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -29,14 +29,15 @@ class HolidayStopProcessTest extends AnyFlatSpec with Matchers with EitherValues
   )
 
   private val request = HolidayStopRequestsDetail(
-    HolidayStopRequestsDetailId("HSR1"),
-    SubscriptionName("S1"),
-    ProductName("Gu Weekly"),
-    AffectedPublicationDate(LocalDate.of(2019, 8, 9)),
-    None,
-    None,
-    None,
-    None
+    Id = HolidayStopRequestsDetailId("HSR1"),
+    Subscription_Name__c = SubscriptionName("S1"),
+    Product_Name__c = ProductName("Gu Weekly"),
+    Stopped_Publication_Date__c = AffectedPublicationDate(LocalDate.of(2019, 8, 9)),
+    Estimated_Price__c = None,
+    Charge_Code__c = None,
+    Is_Actioned__c = false,
+    Actual_Price__c = None,
+    Expected_Invoice_Date__c = None
   )
 
   private def updateSubscription(

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -296,12 +296,17 @@ object SalesforceHolidayStopRequest extends Logging {
         .filterNot(holidayStopRequestDetail =>
           issuesData.map(_.issueDate).contains(holidayStopRequestDetail.Stopped_Publication_Date__c.value)
         )
-        .map( holidayStopRequestDetail => CompositePart(
-          method = "DELETE",
-          url = s"$sfObjectsBaseUrl$holidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
-          referenceId = "DELETE DETAIL : " + UUID.randomUUID().toString,
-          body = JsNull
-        ))
+        .map( holidayStopRequestDetail => {
+          if(holidayStopRequestDetail.Is_Actioned__c){
+            throw new RuntimeException("actioned publications cannot be deleted")
+          }
+          CompositePart(
+            method = "DELETE",
+            url = s"$sfObjectsBaseUrl$holidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
+            referenceId = "DELETE DETAIL : " + UUID.randomUUID().toString,
+            body = JsNull
+          )
+        })
 
       CompositeRequest(
         allOrNone = true,

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
@@ -56,6 +56,7 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
     Stopped_Publication_Date__c: AffectedPublicationDate,
     Estimated_Price__c: Option[Price],
     Charge_Code__c: Option[RatePlanChargeCode],
+    Is_Actioned__c: Boolean,
     Actual_Price__c: Option[Price],
     Expected_Invoice_Date__c: Option[HolidayStopRequestsDetailExpectedInvoiceDate]
   ) extends CreditRequest {
@@ -71,7 +72,7 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
 
   val SOQL_SELECT_CLAUSE = """
       | SELECT Id, Subscription_Name__c, Product_Name__c, Stopped_Publication_Date__c,
-      | Estimated_Price__c, Charge_Code__c, Actual_Price__c, Expected_Invoice_Date__c
+      | Estimated_Price__c, Charge_Code__c, Is_Actioned__c, Actual_Price__c, Expected_Invoice_Date__c
       |""".stripMargin
 
   private def soqlFilterClause(stoppedPublicationDates: List[LocalDate]) =

--- a/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/holiday_stops/Fixtures.scala
@@ -254,6 +254,7 @@ object Fixtures extends Assertions {
     Stopped_Publication_Date__c = AffectedPublicationDate(request.Start_Date__c.value),
     Estimated_Price__c = None,
     Charge_Code__c = Some(RatePlanChargeCode(chargeCode)),
+    Is_Actioned__c = true,
     Actual_Price__c = None,
     Expected_Invoice_Date__c = None
   )
@@ -275,6 +276,7 @@ object Fixtures extends Assertions {
       Stopped_Publication_Date__c = AffectedPublicationDate(stopDate),
       Estimated_Price__c = estimatedPrice.map(Price.apply),
       Charge_Code__c = chargeCode.map(RatePlanChargeCode(_)),
+      Is_Actioned__c = chargeCode.isDefined,
       Actual_Price__c = actualPrice.map(Price.apply),
       Expected_Invoice_Date__c = expectedInvoiceDate.map(HolidayStopRequestsDetailExpectedInvoiceDate.apply)
     )
@@ -287,6 +289,7 @@ object Fixtures extends Assertions {
     Stopped_Publication_Date__c = AffectedPublicationDate(date),
     Estimated_Price__c = None,
     Charge_Code__c = None,
+    Is_Actioned__c = false,
     Actual_Price__c = None,
     Expected_Invoice_Date__c = None
   )

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetailTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetailTest.scala
@@ -14,7 +14,7 @@ class SalesforceHolidayStopRequestsDetailTest extends FlatSpec {
       ZuoraProductTypes.GuardianWeekly
     ).trim should ===(
         """SELECT Id, Subscription_Name__c, Product_Name__c, Stopped_Publication_Date__c,
-        | Estimated_Price__c, Charge_Code__c, Actual_Price__c, Expected_Invoice_Date__c
+        | Estimated_Price__c, Charge_Code__c, Is_Actioned__c, Actual_Price__c, Expected_Invoice_Date__c
         |
         | FROM Holiday_Stop_Requests_Detail__c
         | WHERE Holiday_Stop_Request__r.SF_Subscription__r.Product_Type__c = 'Guardian Weekly'


### PR DESCRIPTION
Whether a customer can amend their holiday stop (either self-serve or via CSR) is determined by the `mutabilityFlags` returned from the API...
- `isFullyMutable` - for when both the start and end date can be changed
- `isEndDateEditable` - for when only the end date can be changed (UIs ensure this end date can't be moved before the `firstAvailableDate`

However there was a bug in the `isEndDateEditable` calculation, because it didn't consider _actioned_ publications (i.e. already locked into Zuora). So in the case of backfilled holiday stops where they're all already _actioned_ (because they were extracted from Zuora - as the old system wrote straight to Zuora, unlike our new just-in-time model). 

This bug meant customers could change the end date on future holiday stops that they had originally booked in the old system. Performing these amends  only updated the data in SF rather than Zuora (which is where it matters for fulfilment/credit purposes). 

This affected 15 holidays stops, which are being addressed separately.

### PLUS
Added additional server-side validation on the endpoints which actually perform the mutation...

- block on withdrawing holiday stops which have actioned publications (this is actually already blocked by SF trigger, but this doesn't hurt)
- on the amend call, fails before deleting any holiday stops publications which are actioned 