### PR TITLE
Alarm on failure to send email due to 5xx response to Salesforce

### DIFF
--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -56,12 +56,35 @@ Resources:
                   - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${QueueName}"
                   - { QueueName: !FindInMap [ StageMap, !Ref Stage, EmailSendingQueueName ]}
 
-  FailedEmailAlarm:
+  FailedEmailApiAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
     Properties:
-      AlarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce"
-      AlarmDescription: Email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/master/handlers/batch-email-sender/
+      AlarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError"
+      AlarmDescription: API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/master/handlers/batch-email-sender/
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+      MetricName: 5XXError
+      Namespace: AWS/ApiGateway
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub BatchEmailSender-${Stage}
+        - Name: Stage
+          Value: !Sub ${Stage}
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 60
+      EvaluationPeriods: 1
+      Statistic: Sum
+      TreatMissingData: notBreaching
+    DependsOn: BatchEmailSenderApi
+
+  FailedEmailLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash"
+      AlarmDescription: Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/master/handlers/batch-email-sender/
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
       ComparisonOperator: GreaterThanOrEqualToThreshold


### PR DESCRIPTION
Alarms on API 5XX response whilst #657 alarms on lambda crashes.