### PR TITLE
Revert 500 email response on partial success and parsing errors 

### DIFF
--- a/handlers/batch-email-sender/build.sbt
+++ b/handlers/batch-email-sender/build.sbt
@@ -20,3 +20,10 @@ libraryDependencies ++= Seq(
 )
 
 assemblyMergeStrategyDiscardModuleInfo
+
+lazy val deployAwsLambda = taskKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
+deployAwsLambda := {
+  import scala.sys.process._
+  assembly.value
+  "aws lambda update-function-code --function-name batch-email-sender-CODE --zip-file fileb://handlers/batch-email-sender/target/scala-2.12/batch-email-sender.jar --profile membership --region eu-west-1" !
+}


### PR DESCRIPTION
Fixes regression introduced at https://github.com/guardian/support-service-lambdas/commit/7bbddd89af7ade2225c3669f66dcea457d8f3006?diff=split#diff-3552780353f082a1e387abaf81274d57R32 which changed the response from 502 

```
{
  "message": "There were items that were not added to the queue.",
  "code": 502,
  "failed_item_ids": [
    "12345"
  ]
}
```

to 500 

```
{
  "message": "Internal server error"
}
```

Note this also reverts handling of parsing errors to previous behaviour where invalid batch items  were just silently dropped, so the question remains

```
FIXME: What should be the behaviour with some/all items having parsing errors?
```

Here are examples of what salesforce expects

- https://github.com/guardian/salesforce/blob/215073420ece6b8cc83d5310f9860b6130748696/src/classes/batch_sendHolidayStopsToServiceLayer.cls#L72
- https://github.com/guardian/salesforce/blob/215073420ece6b8cc83d5310f9860b6130748696/src/classes/batch_PaymentFailuresToServiceLayer.cls#L88

