### PR TITLE
Revert "Save metadata file with record count in Datalake raw bucket"

### DIFF
--- a/handlers/zuora-datalake-export/README.md
+++ b/handlers/zuora-datalake-export/README.md
@@ -94,19 +94,7 @@ If extracting via postman make sure to use the **exact same** `partner` and `pro
 
 ## How to perform full export?
 
-1. There is a separate app designed just for full export. Follow the readme of https://github.com/guardian/zuora-full-export
-2. Manually upload big CSVs via [AWS CLI](https://github.com/guardian/zuora-full-export#upload-large-csv-files-to-raw-datalake-buckets)
-3. Make sure to also upload corresponding metadata file with corresponding recordCount otherwise Datalake job pre-conditions validation might fail
-    ```scala
-    {
-        "jobId": "2c92c0f9725046a2017255f7d84e5a48",
-        "fileId": "2c92c09472503749017255fc3c9379c8",
-        "batchId": "2c92c0f9725046a2017255f7d8925a55",
-        "status": "completed",
-        "name": "InvoiceItem",
-        "recordCount": 48650
-    }
-    ```
+There is a separate app designed just for full export. Follow the readme of https://github.com/guardian/zuora-full-export
 
 WARNINGS:
 * **Zuora is not capable of doing a full export of large objects due to 8 hours limitation on jobs: 

--- a/handlers/zuora-datalake-export/build.sbt
+++ b/handlers/zuora-datalake-export/build.sbt
@@ -19,10 +19,3 @@ libraryDependencies ++= Seq(
 )
 
 assemblyMergeStrategyDiscardModuleInfo
-
-lazy val deployAwsLambda = taskKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
-deployAwsLambda := {
-  import scala.sys.process._
-  assembly.value
-  "aws lambda update-function-code --function-name zuora-datalake-export-CODE --zip-file fileb://handlers/zuora-datalake-export/target/scala-2.12/zuora-datalake-export.jar --profile membership --region eu-west-1" !
-}

--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -4,10 +4,8 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.parser._
-import io.circe.syntax._
 import io.github.mkotsur.aws.handler.Lambda._
 import io.github.mkotsur.aws.handler.Lambda
 import com.amazonaws.services.lambda.runtime.Context
@@ -61,13 +59,6 @@ case class AccessToken(access_token: String)
 case class QueryResponse(id: String)
 case class Batch(fileId: Option[String], batchId: String, status: String, name: String, message: Option[String], recordCount: Option[Int])
 case class JobResults(status: String, id: String, batches: List[Batch], incrementalTime: Option[String])
-case class Metadata(jobId: String, fileId: String, batchId: String, status: String, name: String, recordCount: Int)
-object Metadata {
-  def apply(job: JobResults, batch: Batch): Metadata = {
-    assert(batch.fileId.isDefined && batch.recordCount.isDefined, s"Batch $batch from job ${job.id} should have file and record count available.")
-    Metadata(job.id, batch.fileId.get, batch.batchId, batch.status, batch.name, batch.recordCount.get)
-  }
-}
 
 /**
  * Exports incremental changeset from Zuora to Datalake S3 raw buckets in CSV format via
@@ -127,7 +118,7 @@ object Program extends (String => JobResults) {
     val jobResult = GetJobResult(jobId)
     jobResult.batches.foreach { batch =>
       val csvFile = GetResultsFile(batch)
-      SaveCsvToBucket(csvFile, jobResult, batch)
+      SaveCsvToBucket(csvFile, batch)
     }
     jobResult
   }
@@ -426,20 +417,15 @@ object GetResultsFile {
   }
 }
 
-object SaveCsvToBucket extends LazyLogging {
-  def apply(csvContent: String, job: JobResults, batch: Batch) = {
+object SaveCsvToBucket {
+  def apply(csvContent: String, batch: Batch) = {
     val s3Client = AmazonS3Client.builder.build()
     System.getenv("Stage") match {
       case "CODE" => // do nothing
 
       case "PROD" =>
-        val bucket = Query.withName(batch.name).s3Bucket
-        val metadata: String = Printer.spaces2.pretty(Metadata(job, batch).asJson)
-        val csvRequestWithAcl = putRequestWithAcl(bucket, key = Query.withName(batch.name).s3Key, csvContent)
-        val metadataRequestWithAcl = putRequestWithAcl(bucket, key = s"${batch.name}.metadata", metadata)
-        s3Client.putObject(csvRequestWithAcl)
-        logger.info(s"Saving ${batch.name}.metadata to $bucket with content: $metadata")
-        s3Client.putObject(metadataRequestWithAcl)
+        val requestWithAcl = putRequestWithAcl(Query.withName(batch.name).s3Bucket, Query.withName(batch.name).s3Key, csvContent)
+        s3Client.putObject(requestWithAcl)
     }
   }
 


### PR DESCRIPTION
Reverts guardian/support-service-lambdas#663

Ophan job failed as it just tries to read everything in the raw bucket as csv.