### PR TITLE
Saturday has no whitespace in ratePlanName

### DIFF
--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -93,6 +93,7 @@ object SupportedProduct {
         SupportedRatePlan("Fiveday", fiveDayCharges),
         SupportedRatePlan("Multi-day", everyDayCharges),
         SupportedRatePlan("Saturday ", saturdayCharges),
+        SupportedRatePlan("Saturday", saturdayCharges),  // Some do not have whitespace
         SupportedRatePlan("Saturday+", saturdayCharges),
         SupportedRatePlan("Sixday", sixDayCharges),
         SupportedRatePlan("Sixday+", sixDayCharges),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13835317/83406465-997bae00-a406-11ea-9710-2f855f29c058.png)

Attempt to fix

> unable to book delivery issues at all.

which throws

```
ZuoraApiFailure(Could not derive product type as there are no supported rateplan charges)
/aws/lambda/holiday-stop-api-PROD 
```




@frj I am unable to figure out how to test this using your abstracted unit tests, so this PR is a guess. Tests should be readable scripts, understandable as a unit. Also why did you change the codebase to rely on user inputted text fields? The code used to work on precise IDs, which computers prefer. There is no need for human "understandable" abstractions on config level.

