### PR TITLE
Add replacement options for card, letter and both

### DIFF
--- a/handlers/digital-voucher-api/README.md
+++ b/handlers/digital-voucher-api/README.md
@@ -19,7 +19,7 @@ All endpoints require...
 | DELETE | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> |  | | Deletes an Imovo digital subscription |
 | PUT | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> | {"ratePlanName":"\<subscription rate plan name\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Creates an Imovo digital subscription or returns the details of the subscription if it already exists |
 | GET | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> |  | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Gets the details of the Imovo digital subscription |
-| POST | /{STAGE}/digital-voucher/replace | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>, \"typeOfReplacement\": \"Both\|ActiveLetter\|ActiveCard\""} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} \| {"cardCode":"\<Imovo Card Code\>"} \|  {"letterCode":"\<Imovo Letter Code\>"} | Asks for a replacement card code, letter code or both from i-movo for a subscriptionId |
+| POST | /{STAGE}/digital-voucher/replace | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>, \"replaceCard\": true\|false\, \"replaceLetter\": true\|false\} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} \| {"cardCode":"\<Imovo Card Code\>"} \|  {"letterCode":"\<Imovo Letter Code\>"} | Asks for a replacement card code, letter code or both from i-movo for a subscriptionId |
 | POST | /{STAGE}/digital-voucher/cancel | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>" ,"cancellationDate":"yyy-MM-dd"} | {} | Cancels an Imovo subscription either immediately or on the cancellationDate if one is supplied |
 
 Config

--- a/handlers/digital-voucher-api/README.md
+++ b/handlers/digital-voucher-api/README.md
@@ -19,7 +19,7 @@ All endpoints require...
 | DELETE | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> |  | | Deletes an Imovo digital subscription |
 | PUT | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> | {"ratePlanName":"\<subscription rate plan name\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Creates an Imovo digital subscription or returns the details of the subscription if it already exists |
 | GET | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> |  | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Gets the details of the Imovo digital subscription |
-| POST | /{STAGE}/digital-voucher/replace | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Forces an Imovo to create a new digital subscription invalidating the existing vouchers associated with the salesforce subscription id |
+| POST | /{STAGE}/digital-voucher/replace | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>, \"typeOfReplacement\": \"Both\|ActiveLetter\|ActiveCard\""} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} \| {"cardCode":"\<Imovo Card Code\>"} \|  {"letterCode":"\<Imovo Letter Code\>"} | Asks for a replacement card code, letter code or both from i-movo for a subscriptionId |
 | POST | /{STAGE}/digital-voucher/cancel | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>" ,"cancellationDate":"yyy-MM-dd"} | {} | Cancels an Imovo subscription either immediately or on the cancellationDate if one is supplied |
 
 Config

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
@@ -12,7 +12,8 @@ import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{DecodeFailure, HttpRoutes, InvalidMessageBodyFailure, MalformedMessageBodyFailure, Request, Response}
-import com.gu.imovo.SfSubscriptionId
+import com.gu.imovo.{ImovoSubscriptionType, SfSubscriptionId}
+import com.gu.digital_voucher_api.ReplacementSubscriptionVouchers._
 
 case class DigitalVoucherApiRoutesError(message: String)
 
@@ -20,7 +21,7 @@ case class CreateVoucherRequestBody(ratePlanName: String)
 
 case class CancelSubscriptionVoucherRequestBody(subscriptionId: String, cancellationDate: LocalDate)
 
-case class SubscriptionActionRequestBody(subscriptionId: Option[String], cardCode: Option[String], letterCode: Option[String])
+case class SubscriptionActionRequestBody(subscriptionId: Option[String], cardCode: Option[String], letterCode: Option[String], typeOfReplacement: Option[String])
 
 object DigitalVoucherApiRoutes {
 
@@ -66,8 +67,12 @@ object DigitalVoucherApiRoutes {
         subscriptionId <- requestBody.subscriptionId
           .toRight(UnprocessableEntity(DigitalVoucherApiRoutesError(s"subscriptionId is required")))
           .toEitherT[F]
+        typeOfReplacement <- requestBody.typeOfReplacement
+          .flatMap(replace => ImovoSubscriptionType.fromString(replace))
+          .toRight(UnprocessableEntity(DigitalVoucherApiRoutesError(s"type of replacement is required")))
+          .toEitherT[F]
         replacementVoucher <- digitalVoucherService
-          .replaceVoucher(SfSubscriptionId(subscriptionId))
+          .replaceVoucher(SfSubscriptionId(subscriptionId), typeOfReplacement)
           .leftMap(error => InternalServerError(DigitalVoucherApiRoutesError(s"Failed replace voucher: $error")))
       } yield Ok(replacementVoucher)).merge.flatten
     }

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
@@ -9,7 +9,7 @@ import com.gu.imovo.{ImovoClient, ImovoSubscriptionResponse, ImovoSubscriptionTy
 
 trait DigitalVoucherService[F[_]] {
   def createVoucher(subscriptionId: SfSubscriptionId, ratePlanName: RatePlanName): EitherT[F, DigitalVoucherServiceError, SubscriptionVouchers]
-  def replaceVoucher(subscriptionId: SfSubscriptionId): EitherT[F, DigitalVoucherServiceError, SubscriptionVouchers]
+  def replaceVoucher(subscriptionId: SfSubscriptionId, typeOfReplacement: ImovoSubscriptionType): EitherT[F, DigitalVoucherServiceError, ReplacementSubscriptionVouchers]
   def getVoucher(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, SubscriptionVouchers]
   def cancelVouchers(subscriptionId: SfSubscriptionId, cancellationDate: LocalDate): EitherT[F, DigitalVoucherServiceError, Unit]
 }
@@ -85,6 +85,21 @@ object DigitalVoucherService {
       }
     }
 
+    def toReplacementVoucher(voucherResponse: ImovoSubscriptionResponse): Either[DigitalVoucherServiceError, ReplacementSubscriptionVouchers] = {
+      val cardCode = voucherResponse.subscriptionVouchers.find(_.subscriptionType === ImovoSubscriptionType.ActiveCard.value)
+      val letterCode = voucherResponse.subscriptionVouchers.find(_.subscriptionType === ImovoSubscriptionType.ActiveLetter.value)
+
+      (cardCode, letterCode) match {
+        case (Some(card), Some(letter)) => Right(ReplacementSubscriptionVouchers(Some(card.voucherCode), Some(letter.voucherCode)))
+        case (Some(card), None) => Right(ReplacementSubscriptionVouchers(Some(card.voucherCode), None))
+        case (None, Some(letter)) => Right(ReplacementSubscriptionVouchers(None, Some(letter.voucherCode)))
+        case _ => {
+          Left(DigitalVoucherServiceFailure(List("Imovo response did not contain an subscription voucher where subscriptionType==\"ActiveLetter\" ",
+            "Imovo response did not contain an subscription voucher where subscriptionType==\"ActiveCard\" ").mkString(",")))
+        }
+      }
+    }
+
     override def cancelVouchers(subscriptionId: SfSubscriptionId, cancellationDate: LocalDate): EitherT[F, DigitalVoucherServiceError, Unit] = {
       val lastActiveDate = cancellationDate.minusDays(1)
       imovoClient
@@ -101,12 +116,12 @@ object DigitalVoucherService {
         voucher <- toVoucher(voucherResponse).toEitherT[F]
       } yield voucher
 
-    override def replaceVoucher(subscriptionId: SfSubscriptionId): EitherT[F, DigitalVoucherServiceError, SubscriptionVouchers] = {
+    override def replaceVoucher(subscriptionId: SfSubscriptionId, typeOfReplacement: ImovoSubscriptionType): EitherT[F, DigitalVoucherServiceError, ReplacementSubscriptionVouchers] = {
       for {
         voucherResponse <- imovoClient
-          .replaceSubscriptionVoucher(subscriptionId, ImovoSubscriptionType.Both)
+          .replaceSubscriptionVoucher(subscriptionId, typeOfReplacement)
           .leftMap(error => DigitalVoucherServiceFailure(error.message))
-        voucher <- toVoucher(voucherResponse).toEitherT[F]
+        voucher <- toReplacementVoucher(voucherResponse).toEitherT[F]
       } yield voucher
     }
   }

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Model.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Model.scala
@@ -1,5 +1,26 @@
 package com.gu.digital_voucher_api
 
+import io.circe.{Encoder, Json}
+
 case class RatePlanName(value: String) extends AnyVal
 
 case class SubscriptionVouchers(cardCode: String, letterCode: String)
+
+case class ReplacementSubscriptionVouchers(cardCode: Option[String], letterCode: Option[String])
+
+object ReplacementSubscriptionVouchers {
+  implicit val encodeReplacementSubscriptionVouchers: Encoder[ReplacementSubscriptionVouchers] =
+    (replacementVoucher: ReplacementSubscriptionVouchers) => {
+      val tupledCardAndLetter = (
+        replacementVoucher.cardCode.map(card => ("cardCode", Json.fromString(card))),
+        replacementVoucher.letterCode.map(letter => ("letterCode", Json.fromString(letter)))
+      )
+
+      tupledCardAndLetter match {
+        case (Some(card), Some(letter)) => Json.obj(card, letter)
+        case (Some(card), _) => Json.obj(card)
+        case (_, Some(letter)) => Json.obj(letter)
+        case _ => Json.obj()
+      }
+    }
+}

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -170,7 +170,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.POST,
         Uri(path = "/digital-voucher/replace")
-      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some("Both")).asJson.spaces2)
+      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some(true), Some(true)).asJson.spaces2)
     ).value.unsafeRunSync().get
 
     getBody[ReplacementSubscriptionVouchers](response) should matchTo(
@@ -200,7 +200,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.POST,
         Uri(path = "/digital-voucher/replace")
-      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some("ActiveLetter")).asJson.spaces2)
+      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some(false), Some(true)).asJson.spaces2)
     ).value.unsafeRunSync().get
 
     getBody[ReplacementSubscriptionVouchers](response) should matchTo(
@@ -214,7 +214,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .stubReplaceSubscription(
         imovoConfig,
         subscriptionId = subscriptionId.value,
-        imovoSubscriptionType = ImovoSubscriptionType.ActiveLetter,
+        imovoSubscriptionType = ImovoSubscriptionType.ActiveCard,
         response = ImovoSubscriptionResponse(
           schemeName = "Guardian7Day",
           subscriptionId = subscriptionId.value,
@@ -230,7 +230,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.POST,
         Uri(path = "/digital-voucher/replace")
-      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some("ActiveLetter")).asJson.spaces2)
+      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some(true), Some(false)).asJson.spaces2)
     ).value.unsafeRunSync().get
 
     getBody[ReplacementSubscriptionVouchers](response) should matchTo(
@@ -253,7 +253,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.POST,
         Uri(path = "/digital-voucher/replace")
-      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some("Both")).asJson.spaces2)
+      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some(true), Some(true)).asJson.spaces2)
     ).value.unsafeRunSync().get
 
     response.status.code should matchTo(500)

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -170,11 +170,71 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.POST,
         Uri(path = "/digital-voucher/replace")
-      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None).asJson.spaces2)
+      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some("Both")).asJson.spaces2)
     ).value.unsafeRunSync().get
 
-    getBody[SubscriptionVouchers](response) should matchTo(
-      SubscriptionVouchers("replaced-card-test-voucher-code", "replaced-letter-test-voucher-code")
+    getBody[ReplacementSubscriptionVouchers](response) should matchTo(
+      ReplacementSubscriptionVouchers(Some("replaced-card-test-voucher-code"), Some("replaced-letter-test-voucher-code"))
+    )
+    response.status.code should matchTo(200)
+  }
+
+  it should "return replaced letter details for replace only letter request with subscriptionId" in {
+    val imovoBackendStub: SttpBackendStub[IO, Nothing] = SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
+      .stubReplaceSubscription(
+        imovoConfig,
+        subscriptionId = subscriptionId.value,
+        imovoSubscriptionType = ImovoSubscriptionType.ActiveLetter,
+        response = ImovoSubscriptionResponse(
+          schemeName = "Guardian7Day",
+          subscriptionId = subscriptionId.value,
+          successfulRequest = true,
+          subscriptionVouchers = List(
+            ImovoVoucherResponse("ActiveLetter", "replaced-letter-test-voucher-code")
+          )
+        )
+      )
+
+    val app = createApp(imovoBackendStub)
+    val response = app.run(
+      Request(
+        method = Method.POST,
+        Uri(path = "/digital-voucher/replace")
+      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some("ActiveLetter")).asJson.spaces2)
+    ).value.unsafeRunSync().get
+
+    getBody[ReplacementSubscriptionVouchers](response) should matchTo(
+      ReplacementSubscriptionVouchers(None, Some("replaced-letter-test-voucher-code"))
+    )
+    response.status.code should matchTo(200)
+  }
+
+  it should "return replaced card details for replace only card request with subscriptionId" in {
+    val imovoBackendStub: SttpBackendStub[IO, Nothing] = SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
+      .stubReplaceSubscription(
+        imovoConfig,
+        subscriptionId = subscriptionId.value,
+        imovoSubscriptionType = ImovoSubscriptionType.ActiveLetter,
+        response = ImovoSubscriptionResponse(
+          schemeName = "Guardian7Day",
+          subscriptionId = subscriptionId.value,
+          successfulRequest = true,
+          subscriptionVouchers = List(
+            ImovoVoucherResponse("ActiveCard", "replaced-card-test-voucher-code")
+          )
+        )
+      )
+
+    val app = createApp(imovoBackendStub)
+    val response = app.run(
+      Request(
+        method = Method.POST,
+        Uri(path = "/digital-voucher/replace")
+      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some("ActiveLetter")).asJson.spaces2)
+    ).value.unsafeRunSync().get
+
+    getBody[ReplacementSubscriptionVouchers](response) should matchTo(
+      ReplacementSubscriptionVouchers(Some("replaced-card-test-voucher-code"), None)
     )
     response.status.code should matchTo(200)
   }
@@ -193,7 +253,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       Request(
         method = Method.POST,
         Uri(path = "/digital-voucher/replace")
-      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None).asJson.spaces2)
+      ).withEntity[String](SubscriptionActionRequestBody(Some(subscriptionId.value), None, None, Some("Both")).asJson.spaces2)
     ).value.unsafeRunSync().get
 
     response.status.code should matchTo(500)

--- a/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
+++ b/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
@@ -36,14 +36,15 @@ object ImovoSubscriptionType {
   case object ActiveLetter extends ImovoSubscriptionType { override val value: String = "ActiveLetter" }
   case object Both extends ImovoSubscriptionType { override val value: String = "Both" }
 
-  def fromString(subscriptionType: String): Option[ImovoSubscriptionType] = {
-    subscriptionType match {
-      case ImovoSubscriptionType.ActiveCard.value => Some(ActiveCard)
-      case ImovoSubscriptionType.ActiveLetter.value => Some(ActiveLetter)
-      case ImovoSubscriptionType.Both.value => Some(Both)
+  def fromBooleans(replaceCard: Boolean, replaceLetter: Boolean): Option[ImovoSubscriptionType] = {
+    (replaceCard, replaceLetter) match {
+      case (true, true) => Some(Both)
+      case (true, false) => Some(ActiveCard)
+      case (false, true) => Some(ActiveLetter)
       case _ => None
     }
   }
+
 }
 
 trait ImovoClient[F[_]] {

--- a/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
+++ b/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
@@ -29,12 +29,21 @@ case class ImovoSuccessResponse(message: String, successfulRequest: Boolean)
 
 case class ImovoClientException(message: String)
 sealed trait ImovoSubscriptionType {
-  def value: String
+  val value: String
 }
 object ImovoSubscriptionType {
-  case object ActiveCard extends ImovoSubscriptionType { override def value: String = "ActiveCard" }
-  case object ActiveLetter extends ImovoSubscriptionType { override def value: String = "ActiveLetter" }
-  case object Both extends ImovoSubscriptionType { override def value: String = "Both" }
+  case object ActiveCard extends ImovoSubscriptionType { override val value: String = "ActiveCard" }
+  case object ActiveLetter extends ImovoSubscriptionType { override val value: String = "ActiveLetter" }
+  case object Both extends ImovoSubscriptionType { override val value: String = "Both" }
+
+  def fromString(subscriptionType: String): Option[ImovoSubscriptionType] = {
+    subscriptionType match {
+      case ImovoSubscriptionType.ActiveCard.value => Some(ActiveCard)
+      case ImovoSubscriptionType.ActiveLetter.value => Some(ActiveLetter)
+      case ImovoSubscriptionType.Both.value => Some(Both)
+      case _ => None
+    }
+  }
 }
 
 trait ImovoClient[F[_]] {


### PR DESCRIPTION
## What does this change?
This change allows us to replace the card code, letter code or both rather than just both.

This then allows us to preserve a supporter's letter and replace their card reducing the impact on the retailer.

