### PR TITLE
Add redemption history endpoint

### DIFF
--- a/handlers/digital-voucher-api/README.md
+++ b/handlers/digital-voucher-api/README.md
@@ -19,8 +19,9 @@ All endpoints require...
 | DELETE | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> |  | | Deletes an Imovo digital subscription |
 | PUT | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> | {"ratePlanName":"\<subscription rate plan name\>"} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Creates an Imovo digital subscription or returns the details of the subscription if it already exists |
 | GET | /{STAGE}/digital-voucher/\<SALESFORCE_SUBSCRIPTION_ID\> |  | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} | Gets the details of the Imovo digital subscription |
-| POST | /{STAGE}/digital-voucher/replace | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>, \"replaceCard\": true\|false\, \"replaceLetter\": true\|false\} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} \| {"cardCode":"\<Imovo Card Code\>"} \|  {"letterCode":"\<Imovo Letter Code\>"} | Asks for a replacement card code, letter code or both from i-movo for a subscriptionId |
+| POST | /{STAGE}/digital-voucher/replace | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>, \"replaceCard\": true/false\, \"replaceLetter\": true/false\} | {"cardCode":"\<Imovo Card Code\>","letterCode":"\<Imovo Letter Code\>"} or {"cardCode":"\<Imovo Card Code\>"} or {"letterCode":"\<Imovo Letter Code\>"} | Asks for a replacement card code, letter code or both from i-movo for a subscriptionId |
 | POST | /{STAGE}/digital-voucher/cancel | {"subscriptionId":"\<SALESFORCE_SUBSCRIPTION_ID\>" ,"cancellationDate":"yyy-MM-dd"} | {} | Cancels an Imovo subscription either immediately or on the cancellationDate if one is supplied |
+| GET | /{STAGE}/digital-voucher/redemption-history/\<SALESFORCE_SUBSCRIPTION_ID\> |  | {redemptionAttempts: [{"voucherCode": "6027181854", "voucherType": "Card","actionDate": "2019-10-17T10:45:20.787","activityType": "Redemption", "address": "Russ's Test shop", "postCode": "CB2 1TN", "message": "Success", "value": 1.00}]} | Returns up to the last 20 redemption attempts |
 
 Config
 ======

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
@@ -130,7 +130,7 @@ object DigitalVoucherService {
     override def getRedemptionHistory(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, RedemptionHistory] = {
       imovoClient
         .getRedemptionHistory(SfSubscriptionId(subscriptionId))
-        .map(response => RedemptionHistory(response.subscriptionHistoryItems.map(item => RedemptionAttempt(item))))
+        .map(response => RedemptionHistory(response.voucherHistoryItem.map(item => RedemptionAttempt(item))))
         .leftMap(error => DigitalVoucherServiceFailure(error.message))
     }
 

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
@@ -12,6 +12,7 @@ trait DigitalVoucherService[F[_]] {
   def replaceVoucher(subscriptionId: SfSubscriptionId, typeOfReplacement: ImovoSubscriptionType): EitherT[F, DigitalVoucherServiceError, ReplacementSubscriptionVouchers]
   def getVoucher(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, SubscriptionVouchers]
   def cancelVouchers(subscriptionId: SfSubscriptionId, cancellationDate: LocalDate): EitherT[F, DigitalVoucherServiceError, Unit]
+  def getRedemptionHistory(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, RedemptionHistory]
 }
 
 object DigitalVoucherService {
@@ -100,6 +101,7 @@ object DigitalVoucherService {
       }
     }
 
+
     override def cancelVouchers(subscriptionId: SfSubscriptionId, cancellationDate: LocalDate): EitherT[F, DigitalVoucherServiceError, Unit] = {
       val lastActiveDate = cancellationDate.minusDays(1)
       imovoClient
@@ -124,5 +126,13 @@ object DigitalVoucherService {
         voucher <- toReplacementVoucher(voucherResponse).toEitherT[F]
       } yield voucher
     }
+
+    override def getRedemptionHistory(subscriptionId: String): EitherT[F, DigitalVoucherServiceError, RedemptionHistory] = {
+      imovoClient
+        .getRedemptionHistory(SfSubscriptionId(subscriptionId))
+        .map(response => RedemptionHistory(response.subscriptionHistoryItems.map(item => RedemptionAttempt(item))))
+        .leftMap(error => DigitalVoucherServiceFailure(error.message))
+    }
+
   }
 }

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Model.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Model.scala
@@ -1,5 +1,6 @@
 package com.gu.digital_voucher_api
 
+import com.gu.imovo.ImovoSubscriptionHistoryItem
 import io.circe.{Encoder, Json}
 
 case class RatePlanName(value: String) extends AnyVal
@@ -7,6 +8,34 @@ case class RatePlanName(value: String) extends AnyVal
 case class SubscriptionVouchers(cardCode: String, letterCode: String)
 
 case class ReplacementSubscriptionVouchers(cardCode: Option[String], letterCode: Option[String])
+
+case class RedemptionAttempt(
+  voucherCode: String,
+  voucherType: String,
+  actionDate: String,
+  activityType: String,
+  address: String,
+  postCode: String,
+  message: String,
+  amount: Double
+)
+
+object RedemptionAttempt {
+  def apply(historyItem: ImovoSubscriptionHistoryItem): RedemptionAttempt = {
+    RedemptionAttempt(
+      historyItem.voucherCode,
+      historyItem.voucherType,
+      historyItem.date,
+      historyItem.activityType,
+      historyItem.address,
+      historyItem.postCode,
+      historyItem.reason,
+      historyItem.value
+    )
+  }
+}
+
+case class RedemptionHistory(redemptionAttempts: List[RedemptionAttempt])
 
 object ReplacementSubscriptionVouchers {
   implicit val encodeReplacementSubscriptionVouchers: Encoder[ReplacementSubscriptionVouchers] =
@@ -24,3 +53,4 @@ object ReplacementSubscriptionVouchers {
       }
     }
 }
+

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import cats.effect.IO
 import com.gu.DevIdentity
 import com.gu.imovo.ImovoStub._
-import com.gu.imovo.{ImovoConfig, ImovoErrorResponse, ImovoSubscriptionResponse, ImovoSubscriptionType, ImovoSuccessResponse, ImovoVoucherResponse, SfSubscriptionId}
+import com.gu.imovo.{ImovoConfig, ImovoErrorResponse, ImovoRedemptionHistoryResponse, ImovoSubscriptionHistoryItem, ImovoSubscriptionResponse, ImovoSubscriptionType, ImovoSuccessResponse, ImovoVoucherResponse, SfSubscriptionId}
 import com.softwaremill.diffx.scalatest.DiffMatcher
 import com.softwaremill.sttp.impl.cats.CatsMonadError
 import com.softwaremill.sttp.testing.SttpBackendStub
@@ -307,6 +307,108 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
     ).value.unsafeRunSync().get
 
     getBody[Unit](response) should equal(())
+
+    response.status.code should equal(200)
+  }
+
+  it should "return 200 response for redemption history request with no redemption history" in {
+
+    val imovoBackendStub: SttpBackendStub[IO, Nothing] = SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
+      .stubRedemptionHistorySubscription(
+        imovoConfig,
+        subscriptionId = subscriptionId.value,
+        response = ImovoRedemptionHistoryResponse(
+          subscriptionId.value,
+          0,
+          List.empty[ImovoSubscriptionHistoryItem],
+          true
+        )
+      )
+
+    val app = createApp(imovoBackendStub)
+    val response = app.run(
+      Request(
+        method = Method.GET,
+        Uri(path = s"/digital-voucher/redemption-history/${subscriptionId.value}")
+      )
+    ).value.unsafeRunSync().get
+
+    getBody[RedemptionHistory](response) should equal(RedemptionHistory(List.empty[RedemptionAttempt]))
+
+    response.status.code should equal(200)
+  }
+
+  it should "return 200 response for redemption history request" in {
+
+    val redemptionHistoryResponse = List(
+      ImovoSubscriptionHistoryItem(
+        "abc123",
+        "card",
+        "2020-06-29T19:19:21.816Z",
+        "redemption",
+        "221B Baker Street, London, U.K.",
+        "NW1 6XE",
+        "Success",
+        2.22
+      ),
+      ImovoSubscriptionHistoryItem(
+        "abc123",
+        "card",
+        "2020-07-29T19:19:21.816Z",
+        "redemption",
+        "221B Baker Street, London, U.K.",
+        "NW1 6XE",
+        "Redemption rejected - this voucher has been used the maximum number of times this period. Please check terms and conditions",
+        0.0
+      )
+    )
+
+    val redemptionHistory = RedemptionHistory(
+      List(
+        RedemptionAttempt(
+          "abc123",
+          "card",
+          "2020-06-29T19:19:21.816Z",
+          "redemption",
+          "221B Baker Street, London, U.K.",
+          "NW1 6XE",
+          "Success",
+          2.22
+        ),
+        RedemptionAttempt(
+          "abc123",
+          "card",
+          "2020-07-29T19:19:21.816Z",
+          "redemption",
+          "221B Baker Street, London, U.K.",
+          "NW1 6XE",
+          "Redemption rejected - this voucher has been used the maximum number of times this period. Please check terms and conditions",
+          0.0
+        )
+      )
+    )
+
+    val imovoBackendStub: SttpBackendStub[IO, Nothing] = SttpBackendStub[IO, Nothing](new CatsMonadError[IO])
+      .stubRedemptionHistorySubscription(
+        imovoConfig,
+        subscriptionId = subscriptionId.value,
+        response = ImovoRedemptionHistoryResponse(
+          subscriptionId.value,
+          0,
+          redemptionHistoryResponse,
+          true
+        )
+      )
+
+    val app = createApp(imovoBackendStub)
+    val response = app.run(
+      Request(
+        method = Method.GET,
+        Uri(path = s"/digital-voucher/redemption-history/${subscriptionId.value}")
+      )
+    ).value.unsafeRunSync().get
+
+    getBody[RedemptionHistory](response) should equal(redemptionHistory)
 
     response.status.code should equal(200)
   }

--- a/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
+++ b/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
@@ -50,7 +50,7 @@ object ImovoSubscriptionType {
 case class ImovoRedemptionHistoryResponse(
   subscriptionId: String,
   lines: Int,
-  subscriptionHistoryItems: List[ImovoSubscriptionHistoryItem],
+  voucherHistoryItem: List[ImovoSubscriptionHistoryItem],
   successfulRequest: Boolean
 )
 

--- a/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
+++ b/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
@@ -198,6 +198,28 @@ object ImovoClient extends LazyLogging {
         )
       }
 
+      /**
+       * Method to return `redemptionHistoryMaxLines` of redemption attempts - this call returns successful redemptions,
+       * failed redemptions with a reason and any top up credits applied to the subscription
+       *
+       * The call to imovo has some additional parameters that can be used to paginate the request
+       * /Subscription/SubscriptionRedemptionHistory?EndDate=2019-11-23&StartDate=2008-11-23&SubscriptionId=A-S0039247&MaxLines=20
+       *
+       *   REQUIRED
+       *
+       *    CustomerReference - string
+       *
+       *  OPTIONAL
+       *
+       *    StartDate - string (yyyy-MM-dd)
+       *
+       *    EndDate - string (yyyy-MM-dd)
+       *
+       *    MaxLines - integer
+       *
+       * @param subscriptionId
+       * @return Either[F, ImovoClientException, ImovoRedemptionHistoryResponse]
+       */
       override def getRedemptionHistory(subscriptionId: SfSubscriptionId): EitherT[F, ImovoClientException, ImovoRedemptionHistoryResponse] = {
         val uri = Uri(new URI(s"${config.imovoBaseUrl}/Subscription/SubscriptionRedemptionHistory"))
           .param("SubscriptionId", subscriptionId.value)

--- a/lib/imovo/imovo-sttp-test-stub/src/main/scala/com/gu/imovo/ImovoStub.scala
+++ b/lib/imovo/imovo-sttp-test-stub/src/main/scala/com/gu/imovo/ImovoStub.scala
@@ -39,6 +39,14 @@ object ImovoStub {
           Response.ok(response.asJson.spaces2)
       }
     }
+
+    def stubRedemptionHistorySubscription[A: Encoder](config: ImovoConfig, subscriptionId: String, response: A): SttpBackendStub[F, S] = {
+      sttpStub.whenRequestMatchesPartial {
+        case request: Request[_, _] if matchesRedemptionHistoryRequest(config, subscriptionId, request) =>
+          Response.ok(response.asJson.spaces2)
+      }
+    }
+
   }
 
   private def matchesQueryCreateSubscription[S, F[_]](config: ImovoConfig, subscriptionId: String, schemeName: String, startDate: String, request: Request[_, _]) = {
@@ -75,6 +83,14 @@ object ImovoStub {
 
   private def matchesGetRequest[S, F[_]](config: ImovoConfig, subscriptionId: String, request: Request[_, _]) = {
     val urlMatches = urlNoQueryString(request) === s"${config.imovoBaseUrl}/Subscription/GetSubscriptionVoucherDetails"
+    val methodMatches = request.method == Method.GET
+    val queryParamMatches = request.uri.paramsMap.get("SubscriptionId") === Some(subscriptionId)
+    val apiKeyMatches = request.headers.toMap.get("X-API-KEY") === Some({ config.imovoApiKey })
+    urlMatches && methodMatches && queryParamMatches && apiKeyMatches
+  }
+
+  private def matchesRedemptionHistoryRequest[S, F[_]](config: ImovoConfig, subscriptionId: String, request: Request[_, _]) = {
+    val urlMatches = urlNoQueryString(request) === s"${config.imovoBaseUrl}/Subscription/SubscriptionRedemptionHistory"
     val methodMatches = request.method == Method.GET
     val queryParamMatches = request.uri.paramsMap.get("SubscriptionId") === Some(subscriptionId)
     val apiKeyMatches = request.headers.toMap.get("X-API-KEY") === Some({ config.imovoApiKey })


### PR DESCRIPTION
## What does this change?
This PR has a first pass at returning 20 redemption attempts for a Digital Voucher.

We will look to expand this out to have pagination on the next go round.

## How can we measure success?

The API returns a successful response when hit.


