### PR TITLE
Add CorporateAccountId__c and RedemptionCode__c to Zuora Subscription export 

### DIFF
--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -188,7 +188,7 @@ object Query extends Enum[Query] {
   )
   case object Subscription extends Query(
     "Subscription",
-    "SELECT AutoRenew, CancellationReason__c, ContractAcceptanceDate, ContractEffectiveDate, IPCountry__c, CreatedDate, Name, InitialPromotionCode__c, PromotionCode__c, ReaderType__c, Status, TermEndDate, TermStartDate, Version, serviceActivationDate, ID, BillToContact.ID, SoldToContact.ID, SubscriptionVersionAmendment.ID, Account.ID, AcquisitionCase__c, AcquisitionSource__c, ActivationDate__c, CanadaHandDelivery__c, CancelledDate, CASSubscriberID__c, CreatedByCSR__c, CreatedByID, CreatedRequestId__c, CreatorAccountID, CreatorInvoiceOwnerID, CurrentTerm, CurrentTermPeriodType, Gift_Subscription__c, InitialTerm, InitialTermPeriodType, InvoiceOwnerID, IPAddress__c, IsInvoiceSeparate, LastPriceChangeDate__c, legacy_cat__c, LegacyContractStartDate__c FROM Subscription",
+    "SELECT AutoRenew, CancellationReason__c, ContractAcceptanceDate, ContractEffectiveDate, IPCountry__c, CreatedDate, Name, InitialPromotionCode__c, PromotionCode__c, ReaderType__c, Status, TermEndDate, TermStartDate, Version, serviceActivationDate, ID, BillToContact.ID, SoldToContact.ID, SubscriptionVersionAmendment.ID, Account.ID, AcquisitionCase__c, AcquisitionSource__c, ActivationDate__c, CanadaHandDelivery__c, CancelledDate, CASSubscriberID__c, CreatedByCSR__c, CreatedByID, CreatedRequestId__c, CreatorAccountID, CreatorInvoiceOwnerID, CurrentTerm, CurrentTermPeriodType, Gift_Subscription__c, InitialTerm, InitialTermPeriodType, InvoiceOwnerID, IPAddress__c, IsInvoiceSeparate, LastPriceChangeDate__c, legacy_cat__c, LegacyContractStartDate__c, CorporateAccountId__c, RedemptionCode__c FROM Subscription",
     "ophan-raw-zuora-increment-subscription",
     "Subscription.csv"
   )


### PR DESCRIPTION
This PR adds the new corporate subs fields to the DL export query.

https://trello.com/c/GfucWmsP/3068-get-redemption-code-corporate-code-into-dl-for-the-redemption-reporting-subs-table

We need these to report back to the corporate client the uptake of their subscriptions in aggregate, so they know if they are getting value for money from the deal.  They also might want to encourage their customers to sign up, if the uptake is not going well.

Once we have this data we can also link to engagement via the identity ids etc.

The code itself is not essential if we have the corporate ID, but it will be useful for diagnosing issues with particular codes without having to query zuora directly.

@mario-galic I gather you are the expert on zuora exports as this will presumably need a full export from subs table to be done - perhaps you can help there please!