### PR TITLE
[sf-gocardless-sync] update metric filter that find errors to be more generic to catch all errors

### DIFF
--- a/handlers/sf-gocardless-sync/README.md
+++ b/handlers/sf-gocardless-sync/README.md
@@ -41,7 +41,7 @@ back-fill from the beginning of time, however if SalesForce has some events this
 
 #### Errors
 There are a few log filters & alarms configured in [cfn.yml](cfn.yaml) 
-- "GenericError Count" filer & alarm, is fired if "HTTP request was unsuccessful" is found in the logs. **Fairly important
+- "GenericError Count" filer & alarm, is fired if `"ERROR -"` is found in the logs. **Fairly important
  given this lambda is designed to stop processing events upon any error (to avoid missing data)**
 - TODO add metric events processed filter and mandate records created filter (with alarm if this drops below certain threshold per 12 hours)
 - TODO add 'StoppedRunning' alarm based on existing Invocations metric

--- a/handlers/sf-gocardless-sync/cfn.yaml
+++ b/handlers/sf-gocardless-sync/cfn.yaml
@@ -113,7 +113,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     DependsOn: GoCardlessSalesForceSyncLogGroup
     Properties:
-      FilterPattern: "HTTP request was unsuccessful"
+      FilterPattern: "\"ERROR -\""
       LogGroupName: !Sub "${LogGroupNamePrefix}-${Stage}"
       MetricTransformations:
       -


### PR DESCRIPTION
_SEE [handlers/sf-gocardless-sync/README.md](https://github.com/guardian/support-service-lambdas/blob/master/handlers/sf-gocardless-sync/README.md)_

Previously we were just alarming on repeated `"HTTP request was unsuccessful"` in the logs, but now its on `"ERROR -"` to ensure we catch a broader variety of issues.