### PR TITLE
Add digital voucher export query

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -549,10 +549,19 @@ Resources:
       ScheduleExpression: "cron(0 1 ? * * *)"
       State: "ENABLED"
       Targets:
-        - Arn: !Ref StateMachine
+        -
+          Arn: !Ref StateMachine
           Id: !Sub trigger_sf_export-ImovoContract-${Stage}
           Input: |
             {
              "objectName": "ImovoContract"
+            }
+          RoleArn: !GetAtt [ TriggerRole, Arn ]
+        -
+          Arn: !Ref StateMachine
+          Id: !Sub trigger_sf_export-DigitalVoucher-${Stage}
+          Input: |
+            {
+             "objectName": "DigitalVoucher"
             }
           RoleArn: !GetAtt [ TriggerRole, Arn ]

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -31,6 +31,7 @@ object BulkApiParams {
   val directDebitMandateFailure = SfQueryInfo(Soql(SfQueries.directDebitMandateFailure), ObjectName("DirectDebitMandateFailure"), SfObjectName("DD_Mandate_Failure__c"))
   val directDebitMandate = SfQueryInfo(Soql(SfQueries.directDebitMandate), ObjectName("DirectDebitMandate"), SfObjectName("DD_Mandate__c"))
   val directDebitMandateEvent = SfQueryInfo(Soql(SfQueries.directDebitMandateEvent), ObjectName("DirectDebitMandateEvent"), SfObjectName("DD_Mandate_Event__c"))
+  val digitalVoucher = SfQueryInfo(Soql(SfQueries.digitalVoucher), ObjectName("DigitalVoucher"), SfObjectName("Digital_Voucher__c"))
 
   val all = List(
     contact,
@@ -48,7 +49,8 @@ object BulkApiParams {
     paymentFailure,
     directDebitMandateFailure,
     directDebitMandate,
-    directDebitMandateEvent
+    directDebitMandateEvent,
+    digitalVoucher
   )
 
   val byName = all.map(obj => obj.objectName -> obj).toMap
@@ -595,4 +597,21 @@ object SfQueries {
       |WHERE
       |DD_Mandate__r.Billing_Account__r.Contact__r.Account.GDPR_Deletion_Pending__c = false
     """.stripMargin
+
+  val digitalVoucher =
+    """
+      |SELECT
+      |Id,
+      |Card_Code__c,
+      |Letter_Code__c,
+      |Last_Replaced_On__c,
+      |SF_Subscription__r.Id,
+      |SF_Subscription__r.Name
+      |
+      |FROM
+      |Digital_Voucher__c
+      |
+      |WHERE
+      |SF_Subscription__r.Buyer__r.Account.GDPR_Deletion_Pending__c = false
+      |""".stripMargin
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
We need to export the card and letter values to the lake. This PR contains the query to make that happen. 

## How to test
You can use the test class `StartJobManualTest.scala` to trigger a run of it in DEV. Alternatively you can trigger the lambda via the AWS console.

## How can we measure success?
The appearance of a file in s3 containing current Digital Voucher data.

## Have we considered potential risks?
We need to ensure that we have enabled object access in Salesforce otherwise the job will fail.

