### PR TITLE
Adding a salesforce export of ZuoraSubscriptionProductFeature

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -565,3 +565,11 @@ Resources:
              "objectName": "DigitalVoucher"
             }
           RoleArn: !GetAtt [ TriggerRole, Arn ]
+        -
+          Arn: !Ref StateMachine
+          Id: !Sub trigger_sf_export-ZuoraSubscriptionProductFeature-${Stage}
+          Input: |
+            {
+             "objectName": "ZuoraSubscriptionProductFeature"
+            }
+          RoleArn: !GetAtt [ TriggerRole, Arn ]

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -32,6 +32,7 @@ object BulkApiParams {
   val directDebitMandate = SfQueryInfo(Soql(SfQueries.directDebitMandate), ObjectName("DirectDebitMandate"), SfObjectName("DD_Mandate__c"))
   val directDebitMandateEvent = SfQueryInfo(Soql(SfQueries.directDebitMandateEvent), ObjectName("DirectDebitMandateEvent"), SfObjectName("DD_Mandate_Event__c"))
   val digitalVoucher = SfQueryInfo(Soql(SfQueries.digitalVoucher), ObjectName("DigitalVoucher"), SfObjectName("Digital_Voucher__c"))
+  val subscriptionProductFeature = SfQueryInfo(Soql(SfQueries.subscriptionProductFeature), ObjectName("ZuoraSubscriptionProductFeature"), SfObjectName("Zuora__SubscriptionProductFeature__c"))
 
   val all = List(
     contact,
@@ -50,7 +51,8 @@ object BulkApiParams {
     directDebitMandateFailure,
     directDebitMandate,
     directDebitMandateEvent,
-    digitalVoucher
+    digitalVoucher,
+    subscriptionProductFeature
   )
 
   val byName = all.map(obj => obj.objectName -> obj).toMap
@@ -614,4 +616,14 @@ object SfQueries {
       |WHERE
       |SF_Subscription__r.Buyer__r.Account.GDPR_Deletion_Pending__c = false
       |""".stripMargin
+
+  val subscriptionProductFeature =
+    """
+      |SELECT
+      | Id,
+      | Zuora__FeatureName__c,
+      | Zuora__Subscription__r.Name
+      |
+      |FROM Zuora__SubscriptionProductFeature__c
+    """.stripMargin
 }

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -623,7 +623,6 @@ object SfQueries {
       |Id,
       |Zuora__FeatureName__c,
       |Zuora__Subscription__r.Name
-      |
       |FROM Zuora__SubscriptionProductFeature__c
     """.stripMargin
 }

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -620,9 +620,9 @@ object SfQueries {
   val subscriptionProductFeature =
     """
       |SELECT
-      | Id,
-      | Zuora__FeatureName__c,
-      | Zuora__Subscription__r.Name
+      |Id,
+      |Zuora__FeatureName__c,
+      |Zuora__Subscription__r.Name
       |
       |FROM Zuora__SubscriptionProductFeature__c
     """.stripMargin


### PR DESCRIPTION
## What does this change?
This PR adds an export of a data from Salesforce. In SF data lives in a materialised view so it's not ideal for exporting but this is the only place we know on how to get it. This is needed to get information on which Guardian users have opted to redeem a book for a marketing campaign. 

## How to test
Have no idea, looking for guidance from reviewers.

## How can we measure success?
Data is available in AWS S3

## Have we considered potential risks?
The level of risks is the same or lower as for other Salesforce exports as it doesn't contain any sensitive data.

## Images
```
  __
<(o )___
 ( ._> /
  `---'  
```
