### PR TITLE
Add digital vouchers to fulfilment date calculator

### DIFF
--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDates.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDates.scala
@@ -6,6 +6,7 @@ import java.time.temporal.TemporalAdjusters.{next, nextOrSame}
 import java.time.{DayOfWeek, LocalDate}
 import java.util.Locale.ENGLISH
 
+import cats.data.NonEmptyList
 import com.gu.fulfilmentdates.FulfilmentDates
 
 import scala.collection.immutable.ListMap
@@ -13,7 +14,7 @@ import scala.collection.immutable.ListMap
 object DigitalVoucherFulfilmentDates {
 
   lazy val VoucherHolidayStopNoticePeriodDays = 1
-  lazy val FulfilmentCutoffDays = List(DayOfWeek.MONDAY, DayOfWeek.THURSDAY)
+  lazy val FulfilmentCutoffDays = NonEmptyList.of(DayOfWeek.MONDAY, DayOfWeek.THURSDAY)
   lazy val WeekStartDay = DayOfWeek.MONDAY
 
   def apply(today: LocalDate): ListMap[String, FulfilmentDates] =
@@ -47,5 +48,5 @@ object DigitalVoucherFulfilmentDates {
     soonestFulfilmentFileDate plusDays (7) `with` nextOrSame(issueDay)
   }
 
-  def soonest(dates: List[LocalDate]) = dates.min[LocalDate](_ compareTo _)
+  def soonest(dates: NonEmptyList[LocalDate]): LocalDate = dates.toList.min[LocalDate](_ compareTo _)
 }

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDates.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDates.scala
@@ -1,0 +1,51 @@
+package com.gu.supporter.fulfilment
+
+import java.time.DayOfWeek._
+import java.time.format.TextStyle.FULL
+import java.time.temporal.TemporalAdjusters.{next, nextOrSame}
+import java.time.{DayOfWeek, LocalDate}
+import java.util.Locale.ENGLISH
+
+import com.gu.fulfilmentdates.FulfilmentDates
+
+import scala.collection.immutable.ListMap
+
+object DigitalVoucherFulfilmentDates {
+
+  lazy val VoucherHolidayStopNoticePeriodDays = 1
+  lazy val FulfilmentCutoffDays = List(DayOfWeek.MONDAY, DayOfWeek.THURSDAY)
+  lazy val WeekStartDay = DayOfWeek.MONDAY
+
+  def apply(today: LocalDate): ListMap[String, FulfilmentDates] =
+    ListMap( // to preserve insertion order, so the file is easier to read
+      List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(targetDayOfWeek =>
+        targetDayOfWeek.getDisplayName(FULL, ENGLISH) -> FulfilmentDates(
+          today,
+          holidayStopFirstAvailableDate(today),
+          holidayStopProcessorTargetDate(targetDayOfWeek, today),
+          newSubscriptionEarliestStartDate(targetDayOfWeek, today)
+        )): _*
+    )
+
+  def holidayStopFirstAvailableDate(today: LocalDate): LocalDate = today plusDays VoucherHolidayStopNoticePeriodDays
+
+  def holidayStopProcessorTargetDate(targetDayOfWeek: DayOfWeek, today: LocalDate): Option[LocalDate] = {
+    if (today.getDayOfWeek == targetDayOfWeek) {
+      Some(today) // we process voucher holiday stops on the day they're scheduled for
+    } else {
+      None
+    }
+  }
+
+  def newSubscriptionEarliestStartDate(issueDay: DayOfWeek, today: LocalDate) = {
+    //Fulfilment files are generated on Mondays and Thursdays
+    //There is a delay of up to 7 days for the voucher cards to be printed and sent to the customer
+    //The earliest start date will be the issue day on or after that date
+    val soonestFulfilmentFileDate =
+      soonest(FulfilmentCutoffDays.map(fulfilmentCutoffDay => today `with` next(fulfilmentCutoffDay)))
+
+    soonestFulfilmentFileDate plusDays (7) `with` nextOrSame(issueDay)
+  }
+
+  def soonest(dates: List[LocalDate]) = dates.min[LocalDate](_ compareTo _)
+}

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/FulfilmentDateCalculator.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/FulfilmentDateCalculator.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.s3.model.PutObjectResult
 import com.gu.fulfilmentdates.FulfilmentDatesLocation.fulfilmentDatesFileLocation
 import com.gu.util.config.Stage
-import com.gu.zuora.ZuoraProductTypes.{GuardianWeekly, NewspaperHomeDelivery, NewspaperVoucherBook, ZuoraProductType}
+import com.gu.zuora.ZuoraProductTypes.{GuardianWeekly, NewspaperDigitalVoucher, NewspaperHomeDelivery, NewspaperVoucherBook, ZuoraProductType}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -31,6 +31,7 @@ class FulfilmentDateCalculator extends Lambda[Option[String], String] with LazyL
 
       writeToBucket(NewspaperVoucherBook, date, VoucherBookletFulfilmentDates(date).asJson.spaces2)
 
+      writeToBucket(NewspaperDigitalVoucher, date, DigitalVoucherFulfilmentDates(date).asJson.spaces2)
     }
 
     Right(s"Generated Guardian Weekly, Home Delivery and Voucher dates for $datesForYesterdayThroughToAFortnight")

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDatesSpec.scala
@@ -1,0 +1,118 @@
+package com.gu.supporter.fulfilment
+
+import java.time.LocalDate
+
+import com.gu.supporter.fulfilment.DigitalVoucherFulfilmentDates.apply
+import org.scalatest.{FlatSpec, Matchers}
+
+class DigitalVoucherFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
+
+  def shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek(
+    today: LocalDate,
+    expectedDayOfWeek: String,
+    expectedDate: LocalDate
+  ) = {
+    val result = apply(today)
+    result.values.flatMap(_.holidayStopProcessorTargetDate) shouldBe List(expectedDate)
+    result(expectedDayOfWeek).holidayStopProcessorTargetDate.get should equalDate(expectedDate)
+  }
+
+  it should "calculate holidayStopProcessorTargetDate" in {
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-02", "Monday", "2019-12-02")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-03", "Tuesday", "2019-12-03")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-04", "Wednesday", "2019-12-04")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-05", "Thursday", "2019-12-05")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-06", "Friday", "2019-12-06")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-07", "Saturday", "2019-12-07")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-08", "Sunday", "2019-12-08")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-09", "Monday", "2019-12-09")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-10", "Tuesday", "2019-12-10")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-11", "Wednesday", "2019-12-11")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-12", "Thursday", "2019-12-12")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-13", "Friday", "2019-12-13")
+  }
+
+  "MONDAY DigitalVoucherFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Sunday */ "2020-07-26")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-03")
+    apply( /* Monday */ "2020-07-27")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-10")
+    apply( /* Tuesday */ "2020-07-28")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-10")
+    apply( /* Wednesday */ "2020-07-29")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-10")
+    apply( /* Thursday */ "2020-07-30")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-10")
+    apply( /* Friday */ "2020-07-31")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-10")
+    apply( /* Saturday */ "2020-08-01")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-10")
+    apply( /* Sunday */ "2020-08-02")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-10")
+    apply( /* Monday */ "2020-08-03")("Monday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-17")
+  }
+
+  "TUESDAY DigitalVoucherFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Sunday */ "2020-07-26")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-04")
+    apply( /* Monday */ "2020-07-27")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-11")
+    apply( /* Tuesday */ "2020-07-28")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-11")
+    apply( /* Wednesday */ "2020-07-29")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-11")
+    apply( /* Thursday */ "2020-07-30")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-11")
+    apply( /* Friday */ "2020-07-31")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-11")
+    apply( /* Saturday */ "2020-08-01")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-11")
+    apply( /* Sunday */ "2020-08-02")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-11")
+    apply( /* Monday */ "2020-08-03")("Tuesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-18")
+  }
+
+  "WEDNESDAY DigitalVoucherFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Sunday */ "2020-07-26")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-05")
+    apply( /* Monday */ "2020-07-27")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-12")
+    apply( /* Tuesday */ "2020-07-28")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-12")
+    apply( /* Wednesday */ "2020-07-29")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-12")
+    apply( /* Thursday */ "2020-07-30")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-12")
+    apply( /* Friday */ "2020-07-31")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-12")
+    apply( /* Saturday */ "2020-08-01")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-12")
+    apply( /* Sunday */ "2020-08-02")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-12")
+    apply( /* Monday */ "2020-08-03")("Wednesday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-19")
+  }
+
+  "THURSDAY DigitalVoucherFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Sunday */ "2020-07-26")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-06")
+    apply( /* Monday */ "2020-07-27")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-06")
+    apply( /* Tuesday */ "2020-07-28")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-06")
+    apply( /* Wednesday */ "2020-07-29")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-06")
+    apply( /* Thursday */ "2020-07-30")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-13")
+    apply( /* Friday */ "2020-07-31")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-13")
+    apply( /* Saturday */ "2020-08-01")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-13")
+    apply( /* Sunday */ "2020-08-02")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-13")
+    apply( /* Monday */ "2020-08-03")("Thursday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-13")
+  }
+
+  "FRIDAY DigitalVoucherFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Sunday */ "2020-07-26")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-07")
+    apply( /* Monday */ "2020-07-27")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-07")
+    apply( /* Tuesday */ "2020-07-28")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-07")
+    apply( /* Wednesday */ "2020-07-29")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-07")
+    apply( /* Thursday */ "2020-07-30")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-14")
+    apply( /* Friday */ "2020-07-31")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-14")
+    apply( /* Saturday */ "2020-08-01")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-14")
+    apply( /* Sunday */ "2020-08-02")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-14")
+    apply( /* Monday */ "2020-08-03")("Friday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-14")
+  }
+
+  "SATURDAY DigitalVoucherFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Sunday */ "2020-07-26")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-08")
+    apply( /* Monday */ "2020-07-27")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-08")
+    apply( /* Tuesday */ "2020-07-28")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-08")
+    apply( /* Wednesday */ "2020-07-29")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-08")
+    apply( /* Thursday */ "2020-07-30")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-15")
+    apply( /* Friday */ "2020-07-31")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-15")
+    apply( /* Saturday */ "2020-08-01")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-15")
+    apply( /* Sunday */ "2020-08-02")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-15")
+    apply( /* Monday */ "2020-08-03")("Saturday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-15")
+  }
+
+  "SUNDAY DigitalVoucherFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {
+    apply( /* Sunday */ "2020-07-26")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-09")
+    apply( /* Monday */ "2020-07-27")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-09")
+    apply( /* Tuesday */ "2020-07-28")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-09")
+    apply( /* Wednesday */ "2020-07-29")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-09")
+    apply( /* Thursday */ "2020-07-30")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-16")
+    apply( /* Friday */ "2020-07-31")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-16")
+    apply( /* Saturday */ "2020-08-01")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-16")
+    apply( /* Sunday */ "2020-08-02")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-16")
+    apply( /* Monday */ "2020-08-03")("Sunday").newSubscriptionEarliestStartDate.get should equalDate("2020-08-16")
+  }
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -77,7 +77,6 @@ sealed trait HomeDeliveryPlanId
 sealed trait DigipackPlanId
 sealed trait GuardianWeeklyDomestic
 sealed trait GuardianWeeklyRow
-sealed trait DigitalVoucherPlanId
 sealed abstract class PlanId(val name: String)
 
 object PlanId {
@@ -141,26 +140,6 @@ object PlanId {
 
   case object GuardianWeeklyROWAnnual extends PlanId("guardian_weekly_row_annual") with GuardianWeeklyRow
 
-  case object DigitalVoucherWeekend extends PlanId("digital_voucher_weekend") with VoucherPlanId
-
-  case object DigitalVoucherWeekendPlus extends PlanId("digital_voucher_weekend_plus") with VoucherPlanId
-
-  case object DigitalVoucherEveryday extends PlanId("digital_voucher_everyday") with VoucherPlanId
-
-  case object DigitalVoucherEverydayPlus extends PlanId("digital_voucher_everyday_plus") with VoucherPlanId
-
-  case object DigitalVoucherSunday extends PlanId("digital_voucher_sunday") with VoucherPlanId
-
-  case object DigitalVoucherSundayPlus extends PlanId("digital_voucher_sunday_plus") with VoucherPlanId
-
-  case object DigitalVoucherSaturday extends PlanId("digital_voucher_saturday") with VoucherPlanId
-
-  case object DigitalVoucherSaturdayPlus extends PlanId("digital_voucher_saturday_plus") with VoucherPlanId
-
-  case object DigitalVoucherSixday extends PlanId("digital_voucher_sixday") with VoucherPlanId
-
-  case object DigitalVoucherSixdayPlus extends PlanId("digital_voucher_sixday_plus") with VoucherPlanId
-
   val enabledVoucherPlans = List(
     VoucherEveryDay,
     VoucherEveryDayPlus,
@@ -207,22 +186,9 @@ object PlanId {
     GuardianWeeklyROWAnnual
   )
 
-  val enabledDigitalVoucherPlans = List(
-    DigitalVoucherWeekend,
-    DigitalVoucherWeekendPlus,
-    DigitalVoucherEveryday,
-    DigitalVoucherEverydayPlus,
-    DigitalVoucherSunday,
-    DigitalVoucherSundayPlus,
-    DigitalVoucherSaturday,
-    DigitalVoucherSaturdayPlus,
-    DigitalVoucherSixday,
-    DigitalVoucherSixdayPlus
-  )
-
   val supportedPlans: List[PlanId] =
     enabledVoucherPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans ++ enabledDigipackPlans ++
-      enabledGuardianWeeklyDomesticPlans ++ enabledGuardianWeeklyROWPlans ++ enabledDigitalVoucherPlans
+      enabledGuardianWeeklyDomesticPlans ++ enabledGuardianWeeklyROWPlans
 
   def fromName(name: String): Option[PlanId] = supportedPlans.find(_.name == name)
 }
@@ -261,7 +227,7 @@ case class ProductType(value: String)
 object ProductType {
   val GuardianWeekly = ProductType("Guardian Weekly")
   val NewspaperVoucherBook = ProductType("Newspaper - Voucher Book")
-  val NewspaperDigitalVoucher = ProductType("Newspaper - Digital Voucher")
+  val NewspaperDigitalVoucherBook = ProductType("Newspaper - Digital Voucher Book")
   val NewspaperHomeDelivery = ProductType("Newspaper - Home Delivery")
   val DigitalPack = ProductType("Digital Pack")
   val Contribution = ProductType("Contribution")

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -77,6 +77,7 @@ sealed trait HomeDeliveryPlanId
 sealed trait DigipackPlanId
 sealed trait GuardianWeeklyDomestic
 sealed trait GuardianWeeklyRow
+sealed trait DigitalVoucherPlanId
 sealed abstract class PlanId(val name: String)
 
 object PlanId {
@@ -140,6 +141,26 @@ object PlanId {
 
   case object GuardianWeeklyROWAnnual extends PlanId("guardian_weekly_row_annual") with GuardianWeeklyRow
 
+  case object DigitalVoucherWeekend extends PlanId("digital_voucher_weekend") with VoucherPlanId
+
+  case object DigitalVoucherWeekendPlus extends PlanId("digital_voucher_weekend_plus") with VoucherPlanId
+
+  case object DigitalVoucherEveryday extends PlanId("digital_voucher_everyday") with VoucherPlanId
+
+  case object DigitalVoucherEverydayPlus extends PlanId("digital_voucher_everyday_plus") with VoucherPlanId
+
+  case object DigitalVoucherSunday extends PlanId("digital_voucher_sunday") with VoucherPlanId
+
+  case object DigitalVoucherSundayPlus extends PlanId("digital_voucher_sunday_plus") with VoucherPlanId
+
+  case object DigitalVoucherSaturday extends PlanId("digital_voucher_saturday") with VoucherPlanId
+
+  case object DigitalVoucherSaturdayPlus extends PlanId("digital_voucher_saturday_plus") with VoucherPlanId
+
+  case object DigitalVoucherSixday extends PlanId("digital_voucher_sixday") with VoucherPlanId
+
+  case object DigitalVoucherSixdayPlus extends PlanId("digital_voucher_sixday_plus") with VoucherPlanId
+
   val enabledVoucherPlans = List(
     VoucherEveryDay,
     VoucherEveryDayPlus,
@@ -186,9 +207,22 @@ object PlanId {
     GuardianWeeklyROWAnnual
   )
 
+  val enabledDigitalVoucherPlans = List(
+    DigitalVoucherWeekend,
+    DigitalVoucherWeekendPlus,
+    DigitalVoucherEveryday,
+    DigitalVoucherEverydayPlus,
+    DigitalVoucherSunday,
+    DigitalVoucherSundayPlus,
+    DigitalVoucherSaturday,
+    DigitalVoucherSaturdayPlus,
+    DigitalVoucherSixday,
+    DigitalVoucherSixdayPlus
+  )
+
   val supportedPlans: List[PlanId] =
     enabledVoucherPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans ++ enabledDigipackPlans ++
-      enabledGuardianWeeklyDomesticPlans ++ enabledGuardianWeeklyROWPlans
+      enabledGuardianWeeklyDomesticPlans ++ enabledGuardianWeeklyROWPlans ++ enabledDigitalVoucherPlans
 
   def fromName(name: String): Option[PlanId] = supportedPlans.find(_.name == name)
 }
@@ -227,7 +261,7 @@ case class ProductType(value: String)
 object ProductType {
   val GuardianWeekly = ProductType("Guardian Weekly")
   val NewspaperVoucherBook = ProductType("Newspaper - Voucher Book")
-  val NewspaperDigitalVoucherBook = ProductType("Newspaper - Digital Voucher Book")
+  val NewspaperDigitalVoucher = ProductType("Newspaper - Digital Voucher")
   val NewspaperHomeDelivery = ProductType("Newspaper - Home Delivery")
   val DigitalPack = ProductType("Digital Pack")
   val Contribution = ProductType("Contribution")

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/ZuoraProductTypes.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/ZuoraProductTypes.scala
@@ -5,5 +5,6 @@ object ZuoraProductTypes {
 
   object NewspaperHomeDelivery extends ZuoraProductType("Newspaper - Home Delivery")
   object NewspaperVoucherBook extends ZuoraProductType("Newspaper - Voucher Book")
+  object NewspaperDigitalVoucher extends ZuoraProductType("Newspaper - Digital Voucher")
   object GuardianWeekly extends ZuoraProductType("Guardian Weekly")
 }

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -93,7 +93,7 @@ object SupportedProduct {
         SupportedRatePlan("Fiveday", fiveDayCharges),
         SupportedRatePlan("Multi-day", everyDayCharges),
         SupportedRatePlan("Saturday ", saturdayCharges),
-        SupportedRatePlan("Saturday", saturdayCharges),  // Some do not have whitespace
+        SupportedRatePlan("Saturday", saturdayCharges), // Some do not have whitespace
         SupportedRatePlan("Saturday+", saturdayCharges),
         SupportedRatePlan("Sixday", sixDayCharges),
         SupportedRatePlan("Sixday+", sixDayCharges),


### PR DESCRIPTION
## What does this change?
This PR adds support for products with a product type of 'Newspaper - Digital Voucher' to the fulfilment date calculator.

The following dates will be calculated:

- newSubscriptionEarliestStartDate
  - Used by the Billing account -> Create subscription feature in Salesforce and provides the earliest date a subscription can start 
  - Its calculated using the following process
    - Find the next day a fulfilment file is generated ie the next Monday/Thursday (not 'today')
    - Add 7 days to allow the Voucher card to be produced and sent to the customer
- holidayStopFirstAvailableDate 
  - Used by salesforce and mange frontend to find the earliest date a holiday stop can be created for a sub. 
  - This is just 'tomorrow' voucher fulfilment can be stopped 'immediately' using the imovo api
- holidayStopProcessorTargetDate
  - This is the date that holiday stops are processed on.
  - This is today voucher fulfilment can be stopped 'immediately' using the imovo api


## How to test
The results generated by the fulfilment-date-calculator should match the spread sheet set out by the business:

https://docs.google.com/spreadsheets/d/13NwOplT2SwO8c3-cCtjWIPYawixrBpY2SS-R2AJVCiQ/edit#gid=0
