### PR TITLE
Removing Http4sLambdaHandler dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,11 +347,10 @@ lazy val `metric-push-api` = all(project in file("handlers/metric-push-api"))
   .dependsOn()
 
 lazy val `sf-move-subscriptions-api` = all(project in file("handlers/sf-move-subscriptions-api"))
-  .dependsOn(`effects-s3`, `config-cats`, `zuora-core`)
+  .dependsOn(`effects-s3`, `config-cats`, `zuora-core`, `http4s-lambda-handler`)
   .settings(
     libraryDependencies ++=
       Seq(
-        http4sLambda,
         http4sDsl,
         http4sCirce,
         http4sServer,
@@ -369,10 +368,12 @@ lazy val `fulfilment-date-calculator` = all(project in file("handlers/fulfilment
   .dependsOn(testDep, `fulfilment-dates`)
 
 lazy val `delivery-records-api` = all(project in file("handlers/delivery-records-api"))
-  .dependsOn(`effects-s3`, `config-core`, `salesforce-sttp-client`, `salesforce-sttp-test-stub` % Test)
+  .dependsOn(
+    `effects-s3`, `config-core`, `salesforce-sttp-client`, `salesforce-sttp-test-stub` % Test, `http4s-lambda-handler`
+  )
   .settings(
     libraryDependencies ++=
-      Seq(http4sLambda, http4sDsl, http4sCirce, http4sServer, circe, sttpAsycHttpClientBackendCats, scalatest)
+      Seq(http4sDsl, http4sCirce, http4sServer, circe, sttpAsycHttpClientBackendCats, scalatest)
         ++ logging
   )
   .enablePlugins(RiffRaffArtifact)

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/Handler.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/Handler.scala
@@ -1,7 +1,7 @@
 package com.gu.delivery_records_api
 
-import io.github.howardjohn.lambda.http4s.Http4sLambdaHandler
 import cats.syntax.either._
+import com.gu.http4s.Http4sLambdaHandler
 
 object Handler extends Http4sLambdaHandler(
   DeliveryRecordsApiApp()

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Handler.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Handler.scala
@@ -1,9 +1,9 @@
 package com.gu.sf.move.subscriptions.api
 
 import com.gu.AppIdentity
-import io.github.howardjohn.lambda.http4s.Http4sLambdaHandler
 import cats.syntax.either._
 import com.softwaremill.sttp.HttpURLConnectionBackend
+import com.gu.http4s.Http4sLambdaHandler
 
 object Handler extends Http4sLambdaHandler(
   SFMoveSubscriptionsApiApp(AppIdentity.whoAmI(defaultAppName = "sf-move-subscriptions-api"), HttpURLConnectionBackend())

--- a/lib/http4s-lambda-handler/src/test/scala/com/gu/http4s/Http4sLambdaHandlerTest.scala
+++ b/lib/http4s-lambda-handler/src/test/scala/com/gu/http4s/Http4sLambdaHandlerTest.scala
@@ -174,7 +174,6 @@ class Http4sLambdaHandlerTest extends FlatSpec with Matchers {
       stream
     )
 
-
     val request = Inside.inside(requestReceived) {
       case Some(request) => request
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,6 @@ object Dependencies {
   val sttpAsycHttpClientBackendCats = "com.softwaremill.sttp" %% "async-http-client-backend-cats" % sttpVersion
   val mouse = "org.typelevel" %% "mouse" % "0.23" // can be removed once we move to Scala 2.13 (native 'tap')
   val enumeratum = "com.beachape" %% "enumeratum" % "1.5.13"
-  val http4sLambda = "io.github.howardjohn" %% "http4s-lambda" % "0.4.0"
   val http4sDsl = "org.http4s" %% "http4s-dsl" % http4sVersion
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   val http4sServer = "org.http4s" %% "http4s-server" % http4sVersion


### PR DESCRIPTION
This completely removes the dependency on https://github.com/howardjohn/scala-server-lambda which was a blocker for a 2.13 release

This involves migrating the following to the http4s-lamda-handler lib in this project:
- delivery-records-api
- sf-move-subscription-api


