### PR TITLE
Adding support for digital vouchers to the new product api 

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -97,6 +97,7 @@ sealed trait HomeDeliveryPlanId
 sealed trait DigipackPlanId
 sealed trait GuardianWeeklyDomestic
 sealed trait GuardianWeeklyRow
+sealed trait DigitalVoucherPlanId
 sealed abstract class PlanId(val name: String)
 
 object PlanId {
@@ -160,6 +161,26 @@ object PlanId {
 
   case object GuardianWeeklyROWAnnual extends PlanId("guardian_weekly_row_annual") with GuardianWeeklyRow
 
+  case object DigitalVoucherWeekend extends PlanId("digital_voucher_weekend") with VoucherPlanId
+
+  case object DigitalVoucherWeekendPlus extends PlanId("digital_voucher_weekend_plus") with VoucherPlanId
+
+  case object DigitalVoucherEveryday extends PlanId("digital_voucher_everyday") with VoucherPlanId
+
+  case object DigitalVoucherEverydayPlus extends PlanId("digital_voucher_everyday_plus") with VoucherPlanId
+
+  case object DigitalVoucherSunday extends PlanId("digital_voucher_sunday") with VoucherPlanId
+
+  case object DigitalVoucherSundayPlus extends PlanId("digital_voucher_sunday_plus") with VoucherPlanId
+
+  case object DigitalVoucherSaturday extends PlanId("digital_voucher_saturday") with VoucherPlanId
+
+  case object DigitalVoucherSaturdayPlus extends PlanId("digital_voucher_saturday_plus") with VoucherPlanId
+
+  case object DigitalVoucherSixday extends PlanId("digital_voucher_sixday") with VoucherPlanId
+
+  case object DigitalVoucherSixdayPlus extends PlanId("digital_voucher_sixday_plus") with VoucherPlanId
+
   val enabledVoucherPlans = List(
     VoucherEveryDay,
     VoucherEveryDayPlus,
@@ -206,9 +227,22 @@ object PlanId {
     GuardianWeeklyROWAnnual
   )
 
+  val enabledDigitalVoucherPlans = List(
+    DigitalVoucherWeekend,
+    DigitalVoucherWeekendPlus,
+    DigitalVoucherEveryday,
+    DigitalVoucherEverydayPlus,
+    DigitalVoucherSunday,
+    DigitalVoucherSundayPlus,
+    DigitalVoucherSaturday,
+    DigitalVoucherSaturdayPlus,
+    DigitalVoucherSixday,
+    DigitalVoucherSixdayPlus
+  )
+
   val supportedPlans: List[PlanId] =
     enabledVoucherPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans ++ enabledDigipackPlans ++
-      enabledGuardianWeeklyDomesticPlans ++ enabledGuardianWeeklyROWPlans
+      enabledGuardianWeeklyDomesticPlans ++ enabledGuardianWeeklyROWPlans ++ enabledDigitalVoucherPlans
 
   def fromName(name: String): Option[PlanId] = supportedPlans.find(_.name == name)
 }
@@ -247,7 +281,7 @@ case class ProductType(value: String)
 object ProductType {
   val GuardianWeekly = ProductType("Guardian Weekly")
   val NewspaperVoucherBook = ProductType("Newspaper - Voucher Book")
-  val NewspaperDigitalVoucherBook = ProductType("Newspaper - Digital Voucher Book")
+  val NewspaperDigitalVoucher = ProductType("Newspaper - Digital Voucher")
   val NewspaperHomeDelivery = ProductType("Newspaper - Home Delivery")
   val DigitalPack = ProductType("Digital Pack")
   val Contribution = ProductType("Contribution")

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -35,6 +35,16 @@ case class Catalog(
   guardianWeeklyROWSixForSix: Plan,
   guardianWeeklyROWQuarterly: Plan,
   guardianWeeklyROWAnnual: Plan,
+  digitalVoucherWeekend: Plan,
+  digitalVoucherWeekendPlus: Plan,
+  digitalVoucherEveryday: Plan,
+  digitalVoucherEverydayPlus: Plan,
+  digitalVoucherSunday: Plan,
+  digitalVoucherSundayPlus: Plan,
+  digitalVoucherSaturday: Plan,
+  digitalVoucherSaturdayPlus: Plan,
+  digitalVoucherSixday: Plan,
+  digitalVoucherSixdayPlus: Plan
 ) {
   val allPlans = List(
     voucherWeekend,
@@ -66,7 +76,17 @@ case class Catalog(
     guardianWeeklyDomesticAnnual,
     guardianWeeklyROWSixForSix,
     guardianWeeklyROWQuarterly,
-    guardianWeeklyROWAnnual
+    guardianWeeklyROWAnnual,
+    digitalVoucherWeekend,
+    digitalVoucherWeekendPlus,
+    digitalVoucherEveryday,
+    digitalVoucherEverydayPlus,
+    digitalVoucherSunday,
+    digitalVoucherSundayPlus,
+    digitalVoucherSaturday,
+    digitalVoucherSaturdayPlus,
+    digitalVoucherSixday,
+    digitalVoucherSixdayPlus,
   )
 
   val planForId: Map[PlanId, Plan] = allPlans.map(x => x.id -> x).toMap

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -16,6 +16,7 @@ object NewProductApi {
   val VoucherSubscriptionStartDateWindowSize = WindowSizeDays(35)
   val ContributionStartDateWindowSize = WindowSizeDays(1)
   val DigiPackStartDateWindowSize = WindowSizeDays(90)
+  val DigitalVoucherStartDateWindowSize = WindowSizeDays(1)
 
   def catalog(
     pricingFor: PlanId => Map[Currency, AmountMinorUnits],
@@ -54,9 +55,21 @@ object NewProductApi {
       voucherWindowRule(allowedDays)
     )
 
+    val saturdayDays = List(SATURDAY)
+    val sundayDays = List(SUNDAY)
+    val weekendDays = List(SATURDAY, SUNDAY)
+    val weekDays = List(
+      MONDAY,
+      TUESDAY,
+      WEDNESDAY,
+      THURSDAY,
+      FRIDAY
+    )
+    val sixDayDays = weekDays ++ saturdayDays
+    val everyDayDays = List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
     val voucherMondayRules = voucherDateRules(List(MONDAY))
-    val voucherSundayDateRules = voucherDateRules(List(SUNDAY))
-    val voucherSaturdayDateRules = voucherDateRules(List(SATURDAY))
+    val voucherSundayDateRules = voucherDateRules(sundayDays)
+    val voucherSaturdayDateRules = voucherDateRules(saturdayDays)
 
     def homeDeliveryWindowRule(issueDays: List[DayOfWeek]) = WindowRule(
       startDate =  getStartDateFromFulfilmentFiles(ProductType.NewspaperHomeDelivery, issueDays),
@@ -69,20 +82,13 @@ object NewProductApi {
     )
 
     val homeDeliveryEveryDayRules = homeDeliveryDateRules(
-      List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
-    )
-    val weekDays = List(
-      MONDAY,
-      TUESDAY,
-      WEDNESDAY,
-      THURSDAY,
-      FRIDAY
+      everyDayDays
     )
 
-    val homeDeliverySixDayRules = homeDeliveryDateRules(weekDays ++ List(SATURDAY))
-    val homeDeliverySundayDateRules = homeDeliveryDateRules(List(SUNDAY))
-    val homeDeliverySaturdayDateRules = homeDeliveryDateRules(List(SATURDAY))
-    val homeDeliveryWeekendRules = homeDeliveryDateRules(List(SATURDAY, SUNDAY))
+    val homeDeliverySixDayRules = homeDeliveryDateRules(sixDayDays)
+    val homeDeliverySundayDateRules = homeDeliveryDateRules(sundayDays)
+    val homeDeliverySaturdayDateRules = homeDeliveryDateRules(saturdayDays)
+    val homeDeliveryWeekendRules = homeDeliveryDateRules(weekendDays)
 
     val contributionsRule = StartDateRules(
       windowRule = WindowRule(
@@ -117,6 +123,14 @@ object NewProductApi {
         )
       )
 
+    def digitalVoucherStartDateRule(daysOfWeek: List[DayOfWeek]) =
+      StartDateRules(
+        daysOfWeekRule = Some(DaysOfWeekRule(daysOfWeek)),
+        windowRule = WindowRule(
+          startDate = getStartDateFromFulfilmentFiles(ProductType.NewspaperDigitalVoucher, daysOfWeek),
+          maybeSize = Some(DigitalVoucherStartDateWindowSize)
+        )
+      )
 
     Catalog(
       voucherWeekendPlus = planWithPayment(VoucherWeekendPlus, PlanDescription("Weekend+"), voucherSaturdayDateRules, Monthly),
@@ -149,6 +163,16 @@ object NewProductApi {
       guardianWeeklyROWSixForSix = planWithPayment(GuardianWeeklyROW6for6, PlanDescription("GW Oct 18 - Six for Six - ROW"), guardianWeeklyStartDateRules, SixWeeks),
       guardianWeeklyROWQuarterly = planWithPayment(GuardianWeeklyROWQuarterly, PlanDescription("GW Oct 18 - Quarterly - ROW"), guardianWeeklyStartDateRules, Quarterly),
       guardianWeeklyROWAnnual = planWithPayment(GuardianWeeklyROWAnnual, PlanDescription("GW Oct 18 - Annual - ROW"), guardianWeeklyStartDateRules, Annual),
+      digitalVoucherWeekend = planWithPayment(DigitalVoucherWeekend, PlanDescription("Weekend"), digitalVoucherStartDateRule(weekendDays), Monthly),
+      digitalVoucherWeekendPlus = planWithPayment(DigitalVoucherWeekendPlus, PlanDescription("Weekend+"), digitalVoucherStartDateRule(weekendDays), Monthly),
+      digitalVoucherEveryday = planWithPayment(DigitalVoucherEveryday, PlanDescription("Everyday"), digitalVoucherStartDateRule(everyDayDays), Monthly),
+      digitalVoucherEverydayPlus = planWithPayment(DigitalVoucherEverydayPlus, PlanDescription("Everyday+"), digitalVoucherStartDateRule(everyDayDays), Monthly),
+      digitalVoucherSunday = planWithPayment(DigitalVoucherSunday, PlanDescription("Sunday"), digitalVoucherStartDateRule(sundayDays), Monthly),
+      digitalVoucherSundayPlus = planWithPayment(DigitalVoucherSundayPlus, PlanDescription("Sunday+"), digitalVoucherStartDateRule(sundayDays), Monthly),
+      digitalVoucherSaturday = planWithPayment(DigitalVoucherSaturday, PlanDescription("Saturday"), digitalVoucherStartDateRule(saturdayDays), Monthly),
+      digitalVoucherSaturdayPlus = planWithPayment(DigitalVoucherSaturdayPlus, PlanDescription("Saturday+"), digitalVoucherStartDateRule(saturdayDays), Monthly),
+      digitalVoucherSixday = planWithPayment(DigitalVoucherSixday, PlanDescription("Sixday"), digitalVoucherStartDateRule(sixDayDays), Monthly),
+      digitalVoucherSixdayPlus = planWithPayment(DigitalVoucherSixdayPlus, PlanDescription("Sixday+"), digitalVoucherStartDateRule(sixDayDays), Monthly),
     )
   }
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFiles.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFiles.scala
@@ -26,7 +26,8 @@ object StartDateFromFulfilmentFiles extends LazyLogging {
   private val productTypesWithFulfilmentDateFiles: List[ProductType] = List(
     ProductType.GuardianWeekly,
     ProductType.NewspaperHomeDelivery,
-    ProductType.NewspaperVoucherBook
+    ProductType.NewspaperVoucherBook,
+    ProductType.NewspaperDigitalVoucher
   )
 
   def apply(stage: Stage, fetchString: StringFromS3, today: LocalDate): Either[String, (ProductType, List[DayOfWeek]) => LocalDate] = {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -166,7 +166,7 @@ object WireModel {
       )
 
       val digitalVoucher = WireProduct(
-        label = "Digital Voucher",
+        label = "Subscription Card",
         plans = PlanId.enabledDigitalVoucherPlans.map(wirePlanForPlanId),
         enabledForDeliveryCountries = Some(List(Country.UK.name))
       )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -2,7 +2,7 @@ package com.gu.newproduct.api.productcatalog
 
 import java.time.{DayOfWeek, LocalDate}
 
-import com.gu.i18n.{CountryGroup, Currency}
+import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.validation.guardianweekly.GuardianWeeklyAddressValidator
 import play.api.libs.json.{JsString, Json, Writes}
@@ -165,8 +165,15 @@ object WireModel {
         enabledForDeliveryCountries = Some(CountryGroup.RestOfTheWorld.countries.map(_.name))
       )
 
+      val digitalVoucher = WireProduct(
+        label = "Digital Voucher",
+        plans = PlanId.enabledDigitalVoucherPlans.map(wirePlanForPlanId),
+        enabledForDeliveryCountries = Some(List(Country.UK.name))
+      )
+
       val availableProductsAndPlans = List(
-        contributionProduct, voucherProduct, homeDeliveryProduct, digipackProduct, guardianWeeklyDomestic, guardianWeeklyROW
+        contributionProduct, voucherProduct, homeDeliveryProduct, digipackProduct, guardianWeeklyDomestic,
+        guardianWeeklyROW, digitalVoucher
       ).filterNot(_.plans.isEmpty)
 
       WireCatalog(availableProductsAndPlans)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -128,13 +128,47 @@ object ZuoraIds {
     )
   }
 
+  case class DigitalVoucherZuoraIds(
+    everyday: ProductRatePlanId,
+    saturday: ProductRatePlanId,
+    sunday: ProductRatePlanId,
+    weekend: ProductRatePlanId,
+    sixDay: ProductRatePlanId,
+    everydayPlus: ProductRatePlanId,
+    saturdayPlus: ProductRatePlanId,
+    sundayPlus: ProductRatePlanId,
+    weekendPlus: ProductRatePlanId,
+    sixDayPlus: ProductRatePlanId
+  ) {
+    val byApiPlanId: Map[PlanId, ProductRatePlanId] = Map(
+      DigitalVoucherEveryday -> everyday,
+      DigitalVoucherWeekend -> weekend,
+      DigitalVoucherSixday -> sixDay,
+      DigitalVoucherSunday -> sunday,
+      DigitalVoucherSaturday -> saturday,
+      DigitalVoucherEverydayPlus -> everydayPlus,
+      DigitalVoucherWeekendPlus -> weekendPlus,
+      DigitalVoucherSixdayPlus -> sixDayPlus,
+      DigitalVoucherSundayPlus -> sundayPlus,
+      DigitalVoucherSaturdayPlus -> saturdayPlus
+    )
+
+    val plansWithDigipack = List(
+      everydayPlus, weekendPlus, sixDayPlus, sundayPlus, saturdayPlus
+    )
+
+    val zuoraIdToPlanid = byApiPlanId.map(_.swap)
+  }
+
+
   case class ZuoraIds(
     contributionsZuoraIds: ContributionsZuoraIds,
     voucherZuoraIds: VoucherZuoraIds,
     homeDeliveryZuoraIds: HomeDeliveryZuoraIds,
     digitalPackIds: DigipackZuoraIds,
     guardianWeeklyDomestic: GuardianWeeklyDomesticIds,
-    guardianWeeklyROW: GuardianWeeklyROWIds
+    guardianWeeklyROW: GuardianWeeklyROWIds,
+    digitalVoucher: DigitalVoucherZuoraIds
   ) {
     def apiIdToRateplanId: Map[PlanId, ProductRatePlanId] =
       contributionsZuoraIds.planAndChargeByApiPlanId.mapValues(_.productRatePlanId) ++
@@ -142,7 +176,8 @@ object ZuoraIds {
       homeDeliveryZuoraIds.byApiPlanId ++
       digitalPackIds.byApiPlanId ++
       guardianWeeklyDomestic.zuoraRatePlanIdByApiPlanId ++
-      guardianWeeklyROW.zuoraRatePlanIdByApiPlanId
+      guardianWeeklyROW.zuoraRatePlanIdByApiPlanId ++
+      digitalVoucher.byApiPlanId
 
     val rateplanIdToApiId: Map[ProductRatePlanId, PlanId] = apiIdToRateplanId.map(_.swap)
 
@@ -210,6 +245,18 @@ object ZuoraIds {
           ),
           quarterly = ProductRatePlanId("2c92a0086619bf8901661ab02752722f"),
           annual = ProductRatePlanId("2c92a0fe6619b4b601661ab300222651")
+        ),
+        DigitalVoucherZuoraIds(
+          everyday = ProductRatePlanId("2c92a00870ec598001710740c78d2f13"),
+          sunday = ProductRatePlanId("2c92a00870ec598001710740d0d83017"),
+          saturday = ProductRatePlanId("2c92a00870ec598001710740cdd02fbd"),
+          weekend = ProductRatePlanId("2c92a00870ec598001710740d24b3022"),
+          sixDay = ProductRatePlanId("2c92a00870ec598001710740ca532f69"),
+          everydayPlus = ProductRatePlanId("2c92a00870ec598001710740d3d03035"),
+          sundayPlus = ProductRatePlanId("2c92a00870ec598001710740cf9e3004"),
+          saturdayPlus = ProductRatePlanId("2c92a00870ec598001710740ce702ff0"),
+          weekendPlus = ProductRatePlanId("2c92a00870ec598001710740c6672ee7"),
+          sixDayPlus = ProductRatePlanId("2c92a00870ec598001710740c4582ead")
         )
       ),
       Stage("CODE") -> ZuoraIds(
@@ -266,6 +313,18 @@ object ZuoraIds {
           ),
           quarterly = ProductRatePlanId("2c92c0f9660fc4d70166109c01465f10"),
           annual = ProductRatePlanId("2c92c0f9660fc4d70166109a2eb0607c")
+        ),
+        DigitalVoucherZuoraIds(
+          everyday = ProductRatePlanId("2c92c0f870f682820171070474ee419d"),
+          sunday = ProductRatePlanId("2c92c0f870f682820171070487f142c4"),
+          saturday = ProductRatePlanId("2c92c0f870f682820171070488df42ce"),
+          weekend = ProductRatePlanId("2c92c0f870f682820171070477d841e2"),
+          sixDay = ProductRatePlanId("2c92c0f870f68282017107047d054230"),
+          everydayPlus = ProductRatePlanId("2c92c0f870f682820171070481bf4264"),
+          sundayPlus = ProductRatePlanId("2c92c0f870f68282017107047b214214"),
+          saturdayPlus = ProductRatePlanId("2c92c0f870f682820171070489d542da"),
+          weekendPlus = ProductRatePlanId("2c92c0f870f682820171070478d441f5"),
+          sixDayPlus = ProductRatePlanId("2c92c0f870f682820171070470ad4120")
         )
       ),
       Stage("DEV") -> ZuoraIds(
@@ -322,6 +381,18 @@ object ZuoraIds {
           ),
           quarterly = ProductRatePlanId("2c92c0f965f2122101660fb81b745a06"),
           annual = ProductRatePlanId("2c92c0f965f2122101660fb33ed24a45")
+        ),
+        DigitalVoucherZuoraIds(
+          everyday = ProductRatePlanId("2c92c0f86fa49142016fa49ea56a2938"),
+          sunday = ProductRatePlanId("2c92c0f86fa49142016fa49eb0a42a01"),
+          saturday = ProductRatePlanId("2c92c0f86fa49142016fa49ea442291b"),
+          weekend = ProductRatePlanId("2c92c0f86fa49142016fa49ea0d028b6"),
+          sixDay = ProductRatePlanId("2c92c0f86fa49142016fa49e9b9a286f"),
+          everydayPlus = ProductRatePlanId("2c92c0f86fa49142016fa49eaa492988"),
+          sundayPlus = ProductRatePlanId("2c92c0f86fa49142016fa49ea90e2976"),
+          saturdayPlus = ProductRatePlanId("2c92c0f86fa49142016fa49eb1732a39"),
+          weekendPlus = ProductRatePlanId("2c92c0f86fa49142016fa49eaecb29dd"),
+          sixDayPlus = ProductRatePlanId("2c92c0f86fa49142016fa49ea1af28c8")
         )
       )
     )

--- a/handlers/new-product-api/src/test/resources/fulfilmentdatefiles/2020-04-27_Newspaper - Digital Voucher.json
+++ b/handlers/new-product-api/src/test/resources/fulfilmentdatefiles/2020-04-27_Newspaper - Digital Voucher.json
@@ -5,7 +5,7 @@
     "holidayStopFirstAvailableDate" : "2020-04-28",
     "holidayStopProcessorTargetDate" : "2020-04-27",
     "finalFulfilmentFileGenerationDate" : null,
-    "newSubscriptionEarliestStartDate" : "2020-05-18"
+    "newSubscriptionEarliestStartDate" : "2020-06-18"
   },
   "Tuesday" : {
     "today" : "2020-04-27",
@@ -13,7 +13,7 @@
     "holidayStopFirstAvailableDate" : "2020-04-28",
     "holidayStopProcessorTargetDate" : null,
     "finalFulfilmentFileGenerationDate" : null,
-    "newSubscriptionEarliestStartDate" : "2020-05-19"
+    "newSubscriptionEarliestStartDate" : "2020-06-19"
   },
   "Wednesday" : {
     "today" : "2020-04-27",
@@ -21,7 +21,7 @@
     "holidayStopFirstAvailableDate" : "2020-04-28",
     "holidayStopProcessorTargetDate" : null,
     "finalFulfilmentFileGenerationDate" : null,
-    "newSubscriptionEarliestStartDate" : "2020-05-20"
+    "newSubscriptionEarliestStartDate" : "2020-06-20"
   },
   "Thursday" : {
     "today" : "2020-04-27",
@@ -29,7 +29,7 @@
     "holidayStopFirstAvailableDate" : "2020-04-28",
     "holidayStopProcessorTargetDate" : null,
     "finalFulfilmentFileGenerationDate" : null,
-    "newSubscriptionEarliestStartDate" : "2020-05-21"
+    "newSubscriptionEarliestStartDate" : "2020-06-21"
   },
   "Friday" : {
     "today" : "2020-04-27",
@@ -37,7 +37,7 @@
     "holidayStopFirstAvailableDate" : "2020-04-28",
     "holidayStopProcessorTargetDate" : null,
     "finalFulfilmentFileGenerationDate" : null,
-    "newSubscriptionEarliestStartDate" : "2020-05-22"
+    "newSubscriptionEarliestStartDate" : "2020-06-22"
   },
   "Saturday" : {
     "today" : "2020-04-27",
@@ -45,7 +45,7 @@
     "holidayStopFirstAvailableDate" : "2020-04-28",
     "holidayStopProcessorTargetDate" : null,
     "finalFulfilmentFileGenerationDate" : null,
-    "newSubscriptionEarliestStartDate" : "2020-05-23"
+    "newSubscriptionEarliestStartDate" : "2020-06-23"
   },
   "Sunday" : {
     "today" : "2020-04-27",
@@ -53,6 +53,6 @@
     "holidayStopFirstAvailableDate" : "2020-04-28",
     "holidayStopProcessorTargetDate" : null,
     "finalFulfilmentFileGenerationDate" : null,
-    "newSubscriptionEarliestStartDate" : "2020-05-24"
+    "newSubscriptionEarliestStartDate" : "2020-06-24"
   }
 }

--- a/handlers/new-product-api/src/test/resources/fulfilmentdatefiles/2020-04-27_Newspaper - Digital Voucher.json
+++ b/handlers/new-product-api/src/test/resources/fulfilmentdatefiles/2020-04-27_Newspaper - Digital Voucher.json
@@ -1,0 +1,58 @@
+{
+  "Monday" : {
+    "today" : "2020-04-27",
+    "deliveryAddressChangeEffectiveDate" : null,
+    "holidayStopFirstAvailableDate" : "2020-04-28",
+    "holidayStopProcessorTargetDate" : "2020-04-27",
+    "finalFulfilmentFileGenerationDate" : null,
+    "newSubscriptionEarliestStartDate" : "2020-05-18"
+  },
+  "Tuesday" : {
+    "today" : "2020-04-27",
+    "deliveryAddressChangeEffectiveDate" : null,
+    "holidayStopFirstAvailableDate" : "2020-04-28",
+    "holidayStopProcessorTargetDate" : null,
+    "finalFulfilmentFileGenerationDate" : null,
+    "newSubscriptionEarliestStartDate" : "2020-05-19"
+  },
+  "Wednesday" : {
+    "today" : "2020-04-27",
+    "deliveryAddressChangeEffectiveDate" : null,
+    "holidayStopFirstAvailableDate" : "2020-04-28",
+    "holidayStopProcessorTargetDate" : null,
+    "finalFulfilmentFileGenerationDate" : null,
+    "newSubscriptionEarliestStartDate" : "2020-05-20"
+  },
+  "Thursday" : {
+    "today" : "2020-04-27",
+    "deliveryAddressChangeEffectiveDate" : null,
+    "holidayStopFirstAvailableDate" : "2020-04-28",
+    "holidayStopProcessorTargetDate" : null,
+    "finalFulfilmentFileGenerationDate" : null,
+    "newSubscriptionEarliestStartDate" : "2020-05-21"
+  },
+  "Friday" : {
+    "today" : "2020-04-27",
+    "deliveryAddressChangeEffectiveDate" : null,
+    "holidayStopFirstAvailableDate" : "2020-04-28",
+    "holidayStopProcessorTargetDate" : null,
+    "finalFulfilmentFileGenerationDate" : null,
+    "newSubscriptionEarliestStartDate" : "2020-05-22"
+  },
+  "Saturday" : {
+    "today" : "2020-04-27",
+    "deliveryAddressChangeEffectiveDate" : null,
+    "holidayStopFirstAvailableDate" : "2020-04-28",
+    "holidayStopProcessorTargetDate" : null,
+    "finalFulfilmentFileGenerationDate" : null,
+    "newSubscriptionEarliestStartDate" : "2020-05-23"
+  },
+  "Sunday" : {
+    "today" : "2020-04-27",
+    "deliveryAddressChangeEffectiveDate" : null,
+    "holidayStopFirstAvailableDate" : "2020-04-28",
+    "holidayStopProcessorTargetDate" : null,
+    "finalFulfilmentFileGenerationDate" : null,
+    "newSubscriptionEarliestStartDate" : "2020-05-24"
+  }
+}

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -817,6 +817,16 @@ class CatalogWireTest extends FlatSpec with Matchers {
         Currency.GBP -> AmountMinorUnits(6666666),
         Currency.USD -> AmountMinorUnits(66666666),
       )
+      case DigitalVoucherEveryday => gbpPrice(7001)
+      case DigitalVoucherEverydayPlus => gbpPrice(7002)
+      case DigitalVoucherSixday => gbpPrice(7003)
+      case DigitalVoucherSixdayPlus => gbpPrice(7004)
+      case DigitalVoucherWeekend => gbpPrice(7005)
+      case DigitalVoucherWeekendPlus => gbpPrice(7006)
+      case DigitalVoucherSaturday => gbpPrice(7008)
+      case DigitalVoucherSaturdayPlus => gbpPrice(7008)
+      case DigitalVoucherSunday => gbpPrice(7009)
+      case DigitalVoucherSundayPlus => gbpPrice(7010)
     }
 
     def stubGetFirstAvailableStartDate(productType: ProductType, daysOfWeek: List[DayOfWeek]) = {
@@ -839,6 +849,16 @@ class CatalogWireTest extends FlatSpec with Matchers {
           LocalDate.of(2020, 3, 2)
         case (ProductType.NewspaperVoucherBook, List(SUNDAY) ) =>
           LocalDate.of(2020, 3, 3)
+        case (ProductType.NewspaperDigitalVoucher, List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY) ) =>
+          LocalDate.of(2020, 4, 1)
+        case (ProductType.NewspaperDigitalVoucher, List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY) ) =>
+          LocalDate.of(2020, 4, 2)
+        case (ProductType.NewspaperDigitalVoucher, List(SATURDAY, SUNDAY) ) =>
+          LocalDate.of(2020, 4, 3)
+        case (ProductType.NewspaperDigitalVoucher, List(SATURDAY) ) =>
+          LocalDate.of(2020, 4, 4)
+        case (ProductType.NewspaperDigitalVoucher, List(SUNDAY) ) =>
+          LocalDate.of(2020, 4, 5)
       }
     }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -754,6 +754,238 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |        "United States Virgin Islands", "Vietnam", "Vanuatu", "Samoa", "Yemen", "South Africa", "Zambia",
         |        "Zimbabwe"
         |      ]
+        |    },
+        |    {
+        |      "label": "Digital Voucher",
+        |      "plans": [
+        |        {
+        |          "id": "digital_voucher_weekend",
+        |          "label": "Weekend",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday",
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-03",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.05 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.05 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_weekend_plus",
+        |          "label": "Weekend+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday",
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-03",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.06 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.06 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_everyday",
+        |          "label": "Everyday",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Monday",
+        |              "Tuesday",
+        |              "Wednesday",
+        |              "Thursday",
+        |              "Friday",
+        |              "Saturday",
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-01",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.01 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.01 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_everyday_plus",
+        |          "label": "Everyday+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Monday",
+        |              "Tuesday",
+        |              "Wednesday",
+        |              "Thursday",
+        |              "Friday",
+        |              "Saturday",
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-01",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.02 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.02 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_sunday",
+        |          "label": "Sunday",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-05",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.09 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.09 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_sunday_plus",
+        |          "label": "Sunday+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-05",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.10 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.10 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_saturday",
+        |          "label": "Saturday",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-04",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.08 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.08 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_saturday_plus",
+        |          "label": "Saturday+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-04",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.08 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.08 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_sixday",
+        |          "label": "Sixday",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Monday",
+        |              "Tuesday",
+        |              "Wednesday",
+        |              "Thursday",
+        |              "Friday",
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-02",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.03 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.03 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_sixday_plus",
+        |          "label": "Sixday+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Monday",
+        |              "Tuesday",
+        |              "Wednesday",
+        |              "Thursday",
+        |              "Friday",
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-02",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.04 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.04 every month"
+        |        }
+        |      ],
+        |      "enabledForDeliveryCountries": [
+        |        "United Kingdom"
+        |      ]
         |    }
         |  ]
         |}

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -756,7 +756,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |      ]
         |    },
         |    {
-        |      "label": "Digital Voucher",
+        |      "label": "Subscription Card",
         |      "plans": [
         |        {
         |          "id": "digital_voucher_weekend",

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFilesTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFilesTest.scala
@@ -18,6 +18,8 @@ class StartDateFromFulfilmentFilesTest extends FlatSpec with Matchers {
       Try(Source.fromResource("fulfilmentdatefiles/2020-04-27_Newspaper - Home Delivery.json").getLines().mkString("\n"))
     case S3Location("fulfilment-date-calculator-dev", "Newspaper - Voucher Book/2020-04-27_Newspaper - Voucher Book.json") =>
       Try(Source.fromResource("fulfilmentdatefiles/2020-04-27_Newspaper - Voucher Book.json").getLines().mkString("\n"))
+    case S3Location("fulfilment-date-calculator-dev", "Newspaper - Digital Voucher/2020-04-27_Newspaper - Digital Voucher.json") =>
+      Try(Source.fromResource("fulfilmentdatefiles/2020-04-27_Newspaper - Voucher Book.json").getLines().mkString("\n"))
   }
 
   "StartDateFromFulfilmentFiles" should "get start dates for guardian weekly" in {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFilesTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFilesTest.scala
@@ -19,7 +19,7 @@ class StartDateFromFulfilmentFilesTest extends FlatSpec with Matchers {
     case S3Location("fulfilment-date-calculator-dev", "Newspaper - Voucher Book/2020-04-27_Newspaper - Voucher Book.json") =>
       Try(Source.fromResource("fulfilmentdatefiles/2020-04-27_Newspaper - Voucher Book.json").getLines().mkString("\n"))
     case S3Location("fulfilment-date-calculator-dev", "Newspaper - Digital Voucher/2020-04-27_Newspaper - Digital Voucher.json") =>
-      Try(Source.fromResource("fulfilmentdatefiles/2020-04-27_Newspaper - Voucher Book.json").getLines().mkString("\n"))
+      Try(Source.fromResource("fulfilmentdatefiles/2020-04-27_Newspaper - Digital Voucher.json").getLines().mkString("\n"))
   }
 
   "StartDateFromFulfilmentFiles" should "get start dates for guardian weekly" in {
@@ -49,7 +49,7 @@ class StartDateFromFulfilmentFilesTest extends FlatSpec with Matchers {
     )
   }
 
-  "StartDateFromFulfilmentFiles" should "get start dates for vouchers " in {
+  it should "get start dates for vouchers " in {
     testStartDate(
       ProductType.NewspaperVoucherBook,
       List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY),
@@ -69,6 +69,28 @@ class StartDateFromFulfilmentFilesTest extends FlatSpec with Matchers {
       ProductType.NewspaperVoucherBook,
       List(SUNDAY),
       LocalDate.of(2020, 5, 24)
+    )
+  }
+  it should "get start dates for digital vouchers " in {
+    testStartDate(
+      ProductType.NewspaperDigitalVoucher,
+      List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY),
+      LocalDate.of(2020, 6, 18)
+    )
+    testStartDate(
+      ProductType.NewspaperDigitalVoucher,
+      List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY),
+      LocalDate.of(2020, 6, 18)
+    )
+    testStartDate(
+      ProductType.NewspaperDigitalVoucher,
+      List(SATURDAY, SUNDAY),
+      LocalDate.of(2020, 6, 23)
+    )
+    testStartDate(
+      ProductType.NewspaperDigitalVoucher,
+      List(SUNDAY),
+      LocalDate.of(2020, 6, 24)
     )
   }
 

--- a/handlers/new-product-api/src/test/scala/manualTest/SendConfirmationEmailsManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/SendConfirmationEmailsManualTest.scala
@@ -10,7 +10,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.NonDirectDeb
 import com.gu.newproduct.api.addsubscription.zuora.{PaymentMethodStatus, PaymentMethodType}
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
-import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, NewProductApi, Plan, PlanDescription, RuleFixtures}
+import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, Plan, PlanDescription}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
 import com.gu.util.config.Stage
 import com.gu.newproduct.api.EmailQueueNames.emailQueuesFor

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -93,7 +93,7 @@ object SupportedProduct {
         SupportedRatePlan("Fiveday", fiveDayCharges),
         SupportedRatePlan("Multi-day", everyDayCharges),
         SupportedRatePlan("Saturday ", saturdayCharges),
-        SupportedRatePlan("Saturday", saturdayCharges),  // Some do not have whitespace
+        SupportedRatePlan("Saturday", saturdayCharges), // Some do not have whitespace
         SupportedRatePlan("Saturday+", saturdayCharges),
         SupportedRatePlan("Sixday", sixDayCharges),
         SupportedRatePlan("Sixday+", sixDayCharges),


### PR DESCRIPTION
## What does this change?
This adds support for creating digital voucher subscriptions using salesforce via the new-product-api. 

This includes the following:
- modifying the product-catalog endpoint
  - Creating entries for the digital voucher product including enabledForDeliveryCountries = Uk to support salesforce filtering the product dropdown. Only displaying digital vouchers for customers in the UK
  - Creating entries for digital voucher rate plans. Start dates are calculated using the fulfilment date calculator files. The selectableWindow.sizeInDays set to 1, so the start date cannot be set far in the future. This is because customers will get free papers using their email barcode until they get their card in the post. This limits the amount of free products they get.
- Modifying the add-subscription endpoint
  - Adding rate plan ids mappings for the digital-voucher products
  - The validation and creation logic for other paper products ie Home-Delivery and Voucher Books is used for creating digital voucher subs.

## How to test
You should be able to create a digital voucher subscription for an existing customer using salesforce:

- Navigate to an existing customers billing account page
- Click on the 'Create Subscription' link in the top right.
- Select the 'Subscription Card' option from the product drop down
- Select the required rateplan from the drop down
- Youll need to create a case and add select it in the case text box
- Check 'Delivery address confirmed', Payment Authorisation and T&C checkboxes
- Click Ok
- Once the subscription gets synced over from zuora it will appear on the billing account page

## Images

<img width="546" alt="Screenshot 2020-08-13 at 14 25 38" src="https://user-images.githubusercontent.com/289928/90142902-db18c580-dd74-11ea-80c6-7c332faed844.png">
