### PR TITLE
Enable credit products to vary with subscriptions

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -5,6 +5,7 @@ import java.time.{DayOfWeek, LocalDate, LocalDateTime}
 import cats.data.EitherT
 import cats.effect.IO
 import cats.implicits._
+import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.creditprocessor.{ProcessResult, Processor}
 import com.gu.effects.GetFromS3
 import com.gu.fulfilmentdates.{FulfilmentDates, FulfilmentDatesFetcher}
@@ -15,7 +16,7 @@ import com.gu.util.config.ConfigReads.ConfigFailure
 import com.gu.util.config.{ConfigLocation, LoadConfigModule, Stage}
 import com.gu.zuora.ZuoraProductTypes.{GuardianWeekly, NewspaperHomeDelivery, ZuoraProductType}
 import com.gu.zuora.subscription._
-import com.gu.zuora.{AccessToken, Zuora, HolidayStopProcessorZuoraConfig}
+import com.gu.zuora.{AccessToken, HolidayStopProcessorZuoraConfig, Zuora}
 import com.softwaremill.sttp.HttpURLConnectionBackend
 import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import io.circe.generic.auto._
@@ -120,13 +121,13 @@ object DeliveryCreditProcessor extends Logging {
   }
 
   def updateToApply(
-    creditProduct: CreditProduct,
-    subscription: Subscription,
-    account: ZuoraAccount,
-    request: DeliveryCreditRequest
+     creditProduct: CreditProductForSubscription,
+     subscription: Subscription,
+     account: ZuoraAccount,
+     request: DeliveryCreditRequest
   ): ZuoraApiResponse[SubscriptionUpdate] =
     SubscriptionUpdate(
-      creditProduct,
+      creditProduct(subscription),
       subscription,
       account,
       AffectedPublicationDate(request.Delivery_Date__c),

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProduct.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProduct.scala
@@ -1,5 +1,6 @@
 package com.gu.deliveryproblemcreditprocessor
 
+import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.util.config.Stage
 import com.gu.zuora.subscription.CreditProduct
 
@@ -25,9 +26,10 @@ object DeliveryCreditProduct {
     productRatePlanChargeName = ratePlanChargeName
   )
 
-  def forStage(stage: Stage): CreditProduct = stage match {
-    case Stage("PROD") => DeliveryCreditProduct.Prod
-    case Stage("CODE") => DeliveryCreditProduct.Code
-    case _ => DeliveryCreditProduct.Dev
-  }
+  def forStage(stage: Stage): CreditProductForSubscription =
+    stage match {
+      case Stage("PROD") => _ => DeliveryCreditProduct.Prod
+      case Stage("CODE") => _ => DeliveryCreditProduct.Code
+      case _ => _ => DeliveryCreditProduct.Dev
+    }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCreditProduct.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayCreditProduct.scala
@@ -1,5 +1,6 @@
 package com.gu.holidaystopprocessor
 
+import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.util.config.Stage
 import com.gu.zuora.subscription.CreditProduct
 
@@ -31,9 +32,9 @@ object HolidayCreditProduct {
     productRatePlanChargeName
   )
 
-  def forStage(stage: Stage): CreditProduct = stage match {
-    case Stage("PROD") => HolidayCreditProduct.Prod
-    case Stage("CODE") => HolidayCreditProduct.Code
-    case Stage("DEV") => HolidayCreditProduct.Dev
+  def forStage(stage: Stage): CreditProductForSubscription = stage match {
+    case Stage("PROD") => _ => HolidayCreditProduct.Prod
+    case Stage("CODE") => _ => HolidayCreditProduct.Code
+    case _ => _ => HolidayCreditProduct.Dev
   }
 }

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopCreditProcessor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopCreditProcessor.scala
@@ -2,6 +2,7 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
+import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.creditprocessor.{ProcessResult, Processor}
 import com.gu.effects.S3Location
 import com.gu.fulfilmentdates.FulfilmentDatesFetcher
@@ -10,7 +11,7 @@ import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.Holid
 import com.gu.util.config.Stage
 import com.gu.zuora.Zuora
 import com.gu.zuora.ZuoraProductTypes.{GuardianWeekly, NewspaperHomeDelivery, NewspaperVoucherBook}
-import com.gu.zuora.subscription.{CreditProduct, OverallFailure, Subscription, SubscriptionUpdate, ZuoraAccount}
+import com.gu.zuora.subscription.{OverallFailure, Subscription, SubscriptionUpdate, ZuoraAccount}
 import com.softwaremill.sttp.{Id, SttpBackend}
 
 import scala.util.Try
@@ -38,13 +39,13 @@ object HolidayStopCreditProcessor {
         .map { productType => {
 
           def updateToApply(
-            creditProduct: CreditProduct,
-            subscription: Subscription,
-            account: ZuoraAccount,
-            request: HolidayStopRequestsDetail
+             creditProduct: CreditProductForSubscription,
+             subscription: Subscription,
+             account: ZuoraAccount,
+             request: HolidayStopRequestsDetail
           ) =
-            SubscriptionUpdate(
-              creditProduct,
+             SubscriptionUpdate(
+              creditProduct(subscription),
               subscription,
               account,
               request.Stopped_Publication_Date__c,

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -5,6 +5,7 @@ import java.time.{DayOfWeek, LocalDate}
 
 import cats.implicits._
 import com.gu.creditprocessor.Processor
+import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.fulfilmentdates.{FulfilmentDates, FulfilmentDatesFetcher, FulfilmentDatesFetcherError}
 import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail._
@@ -65,16 +66,16 @@ class HolidayStopProcessTest extends AnyFlatSpec with Matchers with EitherValues
     }
   }
 
-  private val creditProduct = HolidayCreditProduct.Dev
+  private val creditProduct: CreditProductForSubscription = _ => HolidayCreditProduct.Dev
 
   private def updateToApply(
-    creditProduct: CreditProduct,
+    creditProduct: CreditProductForSubscription,
     subscription: Subscription,
     account: ZuoraAccount,
     request: HolidayStopRequestsDetail
   ) =
     SubscriptionUpdate(
-      creditProduct,
+      creditProduct(subscription),
       subscription,
       account,
       request.Stopped_Publication_Date__c,

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ProcessorErrorHandlingSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ProcessorErrorHandlingSpec.scala
@@ -5,6 +5,7 @@ import java.time.{DayOfWeek, LocalDate}
 
 import cats.implicits._
 import com.gu.creditprocessor.Processor
+import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.fulfilmentdates.{FulfilmentDates, FulfilmentDatesFetcher, FulfilmentDatesFetcherError}
 import com.gu.holiday_stops.Fixtures
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.HolidayStopRequestsDetail
@@ -51,16 +52,16 @@ class ProcessorErrorHandlingSpec extends AnyFlatSpec with Matchers with OptionVa
     }
   }
 
-  private val creditProduct = HolidayCreditProduct.Dev
+  private val creditProduct: CreditProductForSubscription = _ => HolidayCreditProduct.Dev
 
   private def updateToApply(
-    creditProduct: CreditProduct,
+    creditProduct: CreditProductForSubscription,
     subscription: Subscription,
     account: ZuoraAccount,
     request: HolidayStopRequestsDetail
   ) =
     SubscriptionUpdate(
-      creditProduct,
+      creditProduct(subscription),
       subscription,
       account,
       request.Stopped_Publication_Date__c,

--- a/lib/credit-processor/src/main/scala/com/gu/creditprocessor/Processor.scala
+++ b/lib/credit-processor/src/main/scala/com/gu/creditprocessor/Processor.scala
@@ -11,18 +11,21 @@ import com.softwaremill.sttp.{Id, SttpBackend}
 import org.slf4j.LoggerFactory
 
 object Processor {
+
+  type CreditProductForSubscription = Subscription => CreditProduct
+
   private val logger = LoggerFactory.getLogger(getClass)
 
   def processLiveProduct[Request <: CreditRequest, Result <: ZuoraCreditAddResult](
     config: HolidayStopProcessorZuoraConfig,
     zuoraAccessToken: AccessToken,
     sttpBackend: SttpBackend[Id, Nothing],
-    creditProduct: CreditProduct,
+    creditProduct: CreditProductForSubscription,
     getCreditRequestsFromSalesforce: (ZuoraProductType, List[LocalDate]) => SalesforceApiResponse[List[Request]],
     fulfilmentDatesFetcher: FulfilmentDatesFetcher,
     processOverrideDate: Option[LocalDate],
     productType: ZuoraProductType,
-    updateToApply: (CreditProduct, Subscription, ZuoraAccount, Request) => ZuoraApiResponse[SubscriptionUpdate],
+    updateToApply: (CreditProductForSubscription, Subscription, ZuoraAccount, Request) => ZuoraApiResponse[SubscriptionUpdate],
     resultOfZuoraCreditAdd: (Request, RatePlanCharge) => Result,
     writeCreditResultsToSalesforce: List[Result] => SalesforceApiResponse[_],
     getAccount: String => ZuoraApiResponse[ZuoraAccount]
@@ -40,14 +43,14 @@ object Processor {
       Zuora.subscriptionUpdateResponse(config, zuoraAccessToken, sttpBackend)(subscription, update)
 
     processProduct(
-      creditProduct: CreditProduct,
+      creditProduct: CreditProductForSubscription,
       getCreditRequestsFromSalesforce: (ZuoraProductType, List[LocalDate]) => SalesforceApiResponse[List[Request]],
       fulfilmentDatesFetcher: FulfilmentDatesFetcher,
       processOverrideDate: Option[LocalDate],
       productType: ZuoraProductType,
       getSubscription: SubscriptionName => ZuoraApiResponse[Subscription],
       getAccount: String => ZuoraApiResponse[ZuoraAccount],
-      updateToApply: (CreditProduct, Subscription, ZuoraAccount, Request) => ZuoraApiResponse[SubscriptionUpdate],
+      updateToApply: (CreditProductForSubscription, Subscription, ZuoraAccount, Request) => ZuoraApiResponse[SubscriptionUpdate],
       updateSubscription: (Subscription, SubscriptionUpdate) => ZuoraApiResponse[Unit],
       resultOfZuoraCreditAdd: (Request, RatePlanCharge) => Result,
       writeCreditResultsToSalesforce: List[Result] => SalesforceApiResponse[_]
@@ -55,21 +58,21 @@ object Processor {
   }
 
   def processProduct[Request <: CreditRequest, Result <: ZuoraCreditAddResult](
-    creditProduct: CreditProduct,
+    creditProduct: CreditProductForSubscription,
     getCreditRequestsFromSalesforce: (ZuoraProductType, List[LocalDate]) => SalesforceApiResponse[List[Request]],
     fulfilmentDatesFetcher: FulfilmentDatesFetcher,
     processOverrideDate: Option[LocalDate],
     productType: ZuoraProductType,
     getSubscription: SubscriptionName => ZuoraApiResponse[Subscription],
     getAccount: String => ZuoraApiResponse[ZuoraAccount],
-    updateToApply: (CreditProduct, Subscription, ZuoraAccount, Request) => ZuoraApiResponse[SubscriptionUpdate],
+    updateToApply: (CreditProductForSubscription, Subscription, ZuoraAccount, Request) => ZuoraApiResponse[SubscriptionUpdate],
     updateSubscription: (Subscription, SubscriptionUpdate) => ZuoraApiResponse[Unit],
     resultOfZuoraCreditAdd: (Request, RatePlanCharge) => Result,
     writeCreditResultsToSalesforce: List[Result] => SalesforceApiResponse[_]
   ): ProcessResult[Result] = {
     val creditRequestsFromSalesforce = for {
       datesToProcess <- getDatesToProcess(fulfilmentDatesFetcher, productType, processOverrideDate, LocalDate.now())
-      _ = logger.info(s"Processing ${creditProduct.productRatePlanChargeName}s for ${productType.name} for issue dates ${datesToProcess.mkString(", ")}")
+      _ = logger.info(s"Processing credits for ${productType.name} for issue dates ${datesToProcess.mkString(", ")}")
       salesforceCreditRequests <- if (datesToProcess.isEmpty) Nil.asRight else getCreditRequestsFromSalesforce(productType, datesToProcess)
     } yield salesforceCreditRequests
 
@@ -107,10 +110,10 @@ object Processor {
    * This is the main business logic for adding a credit amendment to a subscription in Zuora
    */
   def addCreditToSubscription[Request <: CreditRequest, Result <: ZuoraCreditAddResult](
-    creditProduct: CreditProduct,
+    creditProduct: CreditProductForSubscription,
     getSubscription: SubscriptionName => ZuoraApiResponse[Subscription],
     getAccount: String => ZuoraApiResponse[ZuoraAccount],
-    updateToApply: (CreditProduct, Subscription, ZuoraAccount, Request) => ZuoraApiResponse[SubscriptionUpdate],
+    updateToApply: (CreditProductForSubscription, Subscription, ZuoraAccount, Request) => ZuoraApiResponse[SubscriptionUpdate],
     updateSubscription: (Subscription, SubscriptionUpdate) => ZuoraApiResponse[Unit],
     result: (Request, RatePlanCharge) => Result
   )(request: Request): ZuoraApiResponse[Result] =


### PR DESCRIPTION
## What does this change?
This refactor enables us to have a range of credit products (rate plans) that are specific to particular product rate plans.
Eg. a credit product for taxable vouchers and another one for non-taxable home delivery.

After this, the only changes to support different credit products will be in `HolidayCreditProduct` and `DeliveryCreditProduct`.

## How can we measure success?
Nothing will change.  The holiday and delivery-credit processors will continue to work.
