### PR TITLE
Replace dead dependency with out-of-the-box functionality to unblock migration to Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val `salesforce-sttp-client` = all(project in file("lib/salesforce/sttp-cli
   )
   .settings(
     libraryDependencies ++=
-      Seq(sttp, sttpCirce, sttpCats % Test, scalatest, catsCore, catsEffect, circe, circeJava8) ++ logging
+      Seq(sttp, sttpCirce, sttpCats % Test, scalatest, catsCore, catsEffect, circe) ++ logging
   )
 
 lazy val `salesforce-sttp-test-stub` = all(project in file("lib/salesforce/sttp-test-stub"))
@@ -234,7 +234,7 @@ lazy val `credit-processor` = all(project in file("lib/credit-processor"))
 lazy val `imovo-sttp-client` = all(project in file("lib/imovo/imovo-sttp-client"))
   .settings(
     libraryDependencies ++=
-      Seq(sttp, sttpCirce, sttpCats % Test, scalatest, catsCore, catsEffect, circe, circeJava8) ++ logging
+      Seq(sttp, sttpCirce, sttpCats % Test, scalatest, catsCore, catsEffect, circe) ++ logging
   )
 
 lazy val `imovo-sttp-test-stub` = all(project in file("lib/imovo/imovo-sttp-test-stub"))

--- a/lib/salesforce/sttp-client/src/main/scala/com/gu/salesforce/sttp/SalesforceCirceImplicits.scala
+++ b/lib/salesforce/sttp-client/src/main/scala/com/gu/salesforce/sttp/SalesforceCirceImplicits.scala
@@ -2,11 +2,12 @@ package com.gu.salesforce.sttp
 
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-import io.circe.java8.time._
 import io.circe.Decoder
+import scala.util.Try
 
+// FIXME: Why is this necessary? This seems to be used only by SalesforceClientTest
+// FIXME: Custom codec might not be necessary after migration to circe 0.12.0-M3 https://github.com/circe/circe/issues/1171
 object SalesforceCirceImplicits {
   implicit val salesforceInstantDecoder: Decoder[Instant] =
-    decodeOffsetDateTimeWithFormatter(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
-      .map(_.toInstant)
+    Decoder.decodeString.emapTry { str => Try(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parse(str, Instant.from(_))) }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,6 @@ object Dependencies {
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val circe = "io.circe" %% "circe-generic" % circeVersion
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
-  val circeJava8 = "io.circe" %% "circe-java8" % circeVersion
   val circeConfig =  "io.circe" %% "circe-config" % "0.6.1"
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion


### PR DESCRIPTION
## What does this change?

https://github.com/guardian/support-service-lambdas/pull/505 has pulled into our codebase 9 new dependencies out of which at least couple are dead.

circe-java8 is dead since circe 0.12.0-M3 and there is no Scala 2.13 build so we are blocked from migrating. We cannot just upgrade circe because it contains breaking changes https://github.com/circe/circe/releases/tag/v0.12.0-M3, so replace with regular circe-core codec.

## How can we measure success?

Eventually being able to migrate to Scala 2.13.

## Have we considered potential risks?

No idea why this snippet is necessary. Seems to be used only by test named `SalesforceClientTest`.

