### PR TITLE
Retry Zuora lock contention on subscription update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -424,3 +424,17 @@ initialize := {
   assert(sys.props("java.specification.version") == "1.8",
     "Java 8 is required for this project.")
 }
+
+lazy val deployAwsLambda = inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
+deployAwsLambda := {
+  import scala.sys.process._
+  import complete.DefaultParsers._
+  val Seq(name, stage) = spaceDelimited("<arg>").parsed
+  s"aws lambda update-function-code --function-name $name-$stage --zip-file fileb://handlers/$name/target/scala-2.12/$name.jar --profile membership --region eu-west-1".!
+}
+
+// run from root project: deploy holiday-stop-processor CODE
+commands += Command.args("deploy", "<name stage>") { (state, args) =>
+  val Seq(name, stage) = args
+  s"""$name/assembly""":: s"deployAwsLambda $name $stage" :: state
+}

--- a/handlers/batch-email-sender/build.sbt
+++ b/handlers/batch-email-sender/build.sbt
@@ -20,10 +20,3 @@ libraryDependencies ++= Seq(
 )
 
 assemblyMergeStrategyDiscardModuleInfo
-
-lazy val deployAwsLambda = taskKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
-deployAwsLambda := {
-  import scala.sys.process._
-  assembly.value
-  "aws lambda update-function-code --function-name batch-email-sender-CODE --zip-file fileb://handlers/batch-email-sender/target/scala-2.12/batch-email-sender.jar --profile membership --region eu-west-1" !
-}

--- a/handlers/holiday-stop-api/build.sbt
+++ b/handlers/holiday-stop-api/build.sbt
@@ -19,10 +19,3 @@ libraryDependencies ++= Seq(
 )
 
 assemblyMergeStrategyDiscardModuleInfo
-
-lazy val deployAwsLambda = taskKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
-deployAwsLambda := {
-  import scala.sys.process._
-  assembly.value
-  "aws lambda update-function-code --function-name holiday-stop-api-DEV --zip-file fileb://handlers/holiday-stop-api/target/scala-2.12/holiday-stop-api.jar --profile membership --region eu-west-1" !
-}

--- a/handlers/zuora-datalake-export/build.sbt
+++ b/handlers/zuora-datalake-export/build.sbt
@@ -19,10 +19,3 @@ libraryDependencies ++= Seq(
 )
 
 assemblyMergeStrategyDiscardModuleInfo
-
-lazy val deployAwsLambda = taskKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
-deployAwsLambda := {
-  import scala.sys.process._
-  assembly.value
-  "aws lambda update-function-code --function-name zuora-datalake-export-CODE --zip-file fileb://handlers/zuora-datalake-export/target/scala-2.12/zuora-datalake-export.jar --profile membership --region eu-west-1" !
-}


### PR DESCRIPTION
## What does this change?

- https://trello.com/c/9cvEbVoa/1543-fix-zuora-locking-contention-alarm-staleobjectstateexception-s
- Attempt to address `StaleObjectStateException` with retry as per Zuora recommendation.
- Retry is implemented using vanilla Scala and attempted right away. If it does not help, we can look into more sophisticated implementation with backoff or library. @kelvin-chappell implemented one using ZIO backend in https://github.com/guardian/price-migration-engine/pull/126
- This should work for holiday and delivery credits

----

As a side note, I have improved a bit `deployAwsLambda` so now from root project

```
 deploy holiday-stop-processor CODE
```

however this is still just a quick fix. I can make it better via sbt plugin later.

## How to test

Look out for log message

```
WARN - Retrying A-S00080884 due to locking contention 53500050... Follow up if all is OK.
```

and make sure to check PROD for double writes.

## How can we measure success?

No more related alarm in our inbox.

## Have we considered potential risks?

This is a retry on a write (PUT) to Zuora which carries risk of double-crediting. However retry was already effectively happening on subsequent run of processor and so far no one reported over-crediting.
