### PR TITLE
Upgrade to Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -429,7 +429,7 @@ deployAwsLambda := {
   import scala.sys.process._
   import complete.DefaultParsers._
   val Seq(name, stage) = spaceDelimited("<arg>").parsed
-  s"aws lambda update-function-code --function-name $name-$stage --zip-file fileb://handlers/$name/target/scala-2.12/$name.jar --profile membership --region eu-west-1".!
+  s"aws lambda update-function-code --function-name $name-$stage --zip-file fileb://handlers/$name/target/scala-2.13/$name.jar --profile membership --region eu-west-1".!
 }
 
 // run from root project: deploy holiday-stop-processor CODE

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 val scalaSettings = Seq(
-  scalaVersion := "2.12.10",
+  scalaVersion := "2.13.3",
   version      := "0.0.1",
   organization := "com.gu",
   scalacOptions ++= Seq(
@@ -14,7 +14,6 @@ val scalaSettings = Seq(
     "-language:implicitConversions",
     "-unchecked",
     "-Xlint",
-    "-Yno-adapted-args",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard"

--- a/handlers/batch-email-sender/build.sbt
+++ b/handlers/batch-email-sender/build.sbt
@@ -1,5 +1,3 @@
-// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
-// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
 import Dependencies._
 
 name := "batch-email-sender"

--- a/handlers/batch-email-sender/build.sbt
+++ b/handlers/batch-email-sender/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "batch-email-sender"
 description:= "Receive batches of emails to be sent, munge them into an appropriate format and put them on the email sending queue."
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "batch-email-sender.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/braze-to-salesforce-file-upload/build.sbt
+++ b/handlers/braze-to-salesforce-file-upload/build.sbt
@@ -2,7 +2,6 @@ import Dependencies._
 
 name := "braze-to-salesforce-file-upload"
 description:= "Braze to Salesforce file upload"
-scalacOptions += "-Ypartial-unification"
 assemblyJarName := s"${name.value}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
@@ -10,12 +9,12 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"MemSub::Membership Admin::${name.value}"
 riffRaffArtifactResources += (file(s"handlers/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
 libraryDependencies ++= Seq(
-  "io.github.mkotsur" %% "aws-lambda-scala" % "0.1.1",
-  "org.scalaj" %% "scalaj-http" % "2.4.1",
+  "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0",
+  "org.scalaj" %% "scalaj-http" % "2.4.2",
   Dependencies.awsS3,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-  "com.github.pathikrit" %% "better-files" % "3.7.1"
+  "com.github.pathikrit" %% "better-files" % "3.9.1"
 )
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/braze-to-salesforce-file-upload/build.sbt
+++ b/handlers/braze-to-salesforce-file-upload/build.sbt
@@ -9,12 +9,10 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"MemSub::Membership Admin::${name.value}"
 riffRaffArtifactResources += (file(s"handlers/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
 libraryDependencies ++= Seq(
-  "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0",
-  "org.scalaj" %% "scalaj-http" % "2.4.2",
+  scalaLambda,
+  scalajHttp,
   Dependencies.awsS3,
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "com.github.pathikrit" %% "better-files" % "3.9.1"
-)
+) ++ logging
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/cancellation-sf-cases-api/build.sbt
+++ b/handlers/cancellation-sf-cases-api/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "cancellation-sf-cases-api"
 description:= "Create/update SalesForce cases for self service cancellation tracking"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "cancellation-sf-cases-api.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/catalog-service/build.sbt
+++ b/handlers/catalog-service/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "catalog-service"
 description:= "Download the Zuora Catalog and store the JSON in S3"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "catalog-service.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/delivery-problem-credit-processor/build.sbt
+++ b/handlers/delivery-problem-credit-processor/build.sbt
@@ -4,9 +4,6 @@ name := "delivery-problem-credit-processor"
 description := "Applies a credit amendment to a subscription for a delivery problem."
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.12.10"
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := s"${name.value}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/delivery-records-api/build.sbt
+++ b/handlers/delivery-records-api/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "delivery-records-api"
 description:= "API for accessing delivery records in Salesforce"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "delivery-records-api.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/digital-subscription-expiry/build.sbt
+++ b/handlers/digital-subscription-expiry/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "digital-subscription-expiry"
 description:= "check digital subscription expiration for authorisation purposes"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "digital-subscription-expiry.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
@@ -15,7 +13,7 @@ riffRaffManifestProjectName := "MemSub::Subscriptions::Lambdas::Digital Subscrip
 riffRaffArtifactResources += (file("handlers/digital-subscription-expiry/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-authorisation-common" % "0.4"
+  "com.gu" %% "content-authorisation-common" % "0.5"
 )
 
 resolvers ++= Seq(

--- a/handlers/digital-subscription-expiry/build.sbt
+++ b/handlers/digital-subscription-expiry/build.sbt
@@ -13,7 +13,7 @@ riffRaffManifestProjectName := "MemSub::Subscriptions::Lambdas::Digital Subscrip
 riffRaffArtifactResources += (file("handlers/digital-subscription-expiry/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-authorisation-common" % "0.5"
+  contentAuthCommon
 )
 
 resolvers ++= Seq(

--- a/handlers/digital-voucher-api/build.sbt
+++ b/handlers/digital-voucher-api/build.sbt
@@ -3,8 +3,6 @@ import Dependencies._
 name := "digital-voucher-api"
 description:= "API for integrating Imovos digital voucher services"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "digital-voucher-api.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/fulfilment-date-calculator/build.sbt
+++ b/handlers/fulfilment-date-calculator/build.sbt
@@ -12,11 +12,9 @@ riffRaffManifestProjectName := s"MemSub::Membership Admin::${name.value}"
 riffRaffArtifactResources += (file(s"handlers/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0",
-  "org.scalaj" %% "scalaj-http" % "2.4.2",
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-  "com.beachape" %% "enumeratum" % "1.5.13"
-)
+  scalaLambda,
+  scalajHttp,
+  enumeratum,
+) ++ logging
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/fulfilment-date-calculator/build.sbt
+++ b/handlers/fulfilment-date-calculator/build.sbt
@@ -4,9 +4,6 @@ name := "fulfilment-date-calculator"
 description:= "Generate files in S3 bucket containing relevant fulfilment-related dates, for example, acquisitionsStartDate, holidayStopFirstAvailableDate, etc."
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.12.10"
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := s"${name.value}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
@@ -15,8 +12,8 @@ riffRaffManifestProjectName := s"MemSub::Membership Admin::${name.value}"
 riffRaffArtifactResources += (file(s"handlers/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "io.github.mkotsur" %% "aws-lambda-scala" % "0.1.1",
-  "org.scalaj" %% "scalaj-http" % "2.4.1",
+  "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0",
+  "org.scalaj" %% "scalaj-http" % "2.4.2",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "com.beachape" %% "enumeratum" % "1.5.13"

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/HomeDelivery.scala
@@ -32,8 +32,8 @@ object HomeDeliveryFulfilmentDates {
     implicit
     bankHolidays: BankHolidays
   ): LocalDate = {
-    val distributorPickupDay: LocalDate = (nextTargetDayOfWeek findPreviousWorkingDay)
-    distributorPickupDay minusDays 0 // distributor picks up files generated early-AM that SAME morning
+    val distributorPickupDay: LocalDate = (nextTargetDayOfWeek.findPreviousWorkingDay)
+    distributorPickupDay.minusDays(0) // distributor picks up files generated early-AM that SAME morning
   }
 
   private def getFulfilmentFileGenerationDateForNextTargetDayOfWeek(

--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/LocalDateHelpers.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/LocalDateHelpers.scala
@@ -20,10 +20,10 @@ object LocalDateHelpers {
 
     def findPreviousWorkingDay: LocalDate = {
       val previousDay = date.minusDays(1)
-      if (previousDay isWorkingDay) {
+      if (previousDay.isWorkingDay) {
         previousDay
       } else {
-        previousDay findPreviousWorkingDay
+        previousDay.findPreviousWorkingDay
       }
     }
 

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/LocalDateHelpersSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/LocalDateHelpersSpec.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.gu.supporter.fulfilment.LocalDateHelpers.LocalDateWithWorkingDaySupport
 import org.scalatest.{FlatSpec, Matchers}
+import scala.language.postfixOps
 
 class LocalDateHelpersSpec extends FlatSpec with Matchers with DateSupport {
 

--- a/handlers/holiday-stop-api/build.sbt
+++ b/handlers/holiday-stop-api/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "holiday-stop-api"
 description:= "CRUD API for Holiday Stop Requests stored in SalesForce"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "holiday-stop-api.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/ConfigTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/ConfigTest.scala
@@ -2,14 +2,17 @@ package com.gu.holiday_stops
 
 import com.gu.effects.FakeFetchString
 import com.gu.zuora.subscription.OverallFailure
-import zio.Task
+import zio.{Task, ZIO}
 
 trait ConfigTest extends Configuration {
   val configuration: Configuration.Service[Any] = new Configuration.Service[Any] {
-    val config: Task[Config] =
-      Task.effect(Config.fromS3(FakeFetchString.fetchString)).absolve.mapError {
-        case e: OverallFailure => new RuntimeException(e.reason)
-        case t: Throwable => t
-      }
+    val config: Task[Config] = {
+      ZIO.absolve(
+        Task.effect(Config.fromS3(FakeFetchString.fetchString))
+      ).mapError {
+          case e: OverallFailure => new RuntimeException(e.reason)
+          case t: Throwable => t
+        }
+    }
   }
 }

--- a/handlers/holiday-stop-processor/build.sbt
+++ b/handlers/holiday-stop-processor/build.sbt
@@ -4,9 +4,6 @@ name := "holiday-stop-processor"
 description := "Add a holiday credit amendment to a subscription."
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.12.10"
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := s"${name.value}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
@@ -15,7 +12,7 @@ riffRaffManifestProjectName := s"MemSub::Membership Admin::${name.value}"
 riffRaffArtifactResources += (file(s"handlers/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "io.github.mkotsur" %% "aws-lambda-scala" % "0.1.1",
+  "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.566",
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "ch.qos.logback" % "logback-classic" % "1.2.3",

--- a/handlers/holiday-stop-processor/build.sbt
+++ b/handlers/holiday-stop-processor/build.sbt
@@ -12,11 +12,8 @@ riffRaffManifestProjectName := s"MemSub::Membership Admin::${name.value}"
 riffRaffArtifactResources += (file(s"handlers/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.566",
-  "org.slf4j" % "slf4j-api" % "1.7.25",
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
-)
+  scalaLambda,
+  awsS3,
+) ++ logging
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/identity-backfill/build.sbt
+++ b/handlers/identity-backfill/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "identity-backfill"
 description:= "links subscriptions with identity accounts"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "identity-backfill.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
@@ -15,7 +13,7 @@ riffRaffManifestProjectName := "MemSub::Membership Admin::Identity Backfill"
 riffRaffArtifactResources += (file("handlers/identity-backfill/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "support-internationalisation" % "0.9"
+  supportInternationalisation
 )
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/identity-retention/build.sbt
+++ b/handlers/identity-retention/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "identity-retention"
 description:= "Confirms whether an identity account can be deleted, from a reader revenue perspective"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "identity-retention.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/new-product-api/build.sbt
+++ b/handlers/new-product-api/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "new-product-api"
 description:= "Add subscription to account"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "new-product-api.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFiles.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFiles.scala
@@ -81,10 +81,11 @@ object StartDateFromFulfilmentFiles extends LazyLogging {
             .leftMap(ex => s"Failed to parse fulfilment file for $productType: $ex")
           wireCatalog <- Either
             .catchNonFatal(parseFulfillmentFile.as[Map[DayOfWeek, FulfilmentDates]])
-            .leftMap(ex => s"Failed to decode fulfilment file $productType: $ex")
+            .left.map(ex => s"Failed to decode fulfilment file $productType: $ex")
           soonestDate = wireCatalog
-            .mapValues(_.newSubscriptionEarliestStartDate)
+            .view.mapValues(_.newSubscriptionEarliestStartDate)
             .collect { case (key, Some(value)) => key -> value }
+            .toMap
         } yield (productType -> soonestDate)
     }.map(_.toMap)
   }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -171,13 +171,13 @@ object ZuoraIds {
     digitalVoucher: DigitalVoucherZuoraIds
   ) {
     def apiIdToRateplanId: Map[PlanId, ProductRatePlanId] =
-      contributionsZuoraIds.planAndChargeByApiPlanId.mapValues(_.productRatePlanId) ++
+      (contributionsZuoraIds.planAndChargeByApiPlanId.view.mapValues(_.productRatePlanId) ++
       voucherZuoraIds.byApiPlanId ++
       homeDeliveryZuoraIds.byApiPlanId ++
       digitalPackIds.byApiPlanId ++
       guardianWeeklyDomestic.zuoraRatePlanIdByApiPlanId ++
       guardianWeeklyROW.zuoraRatePlanIdByApiPlanId ++
-      digitalVoucher.byApiPlanId
+      digitalVoucher.byApiPlanId).toMap
 
     val rateplanIdToApiId: Map[ProductRatePlanId, PlanId] = apiIdToRateplanId.map(_.swap)
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -643,7 +643,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |        "Liechtenstein", "Lithuania", "Luxembourg", "Latvia", "Monaco", "Montenegro", "Saint Martin",
         |        "Iceland", "Martinique", "Malta", "Netherlands", "Norway", "French Polynesia", "Poland",
         |        "Saint Pierre & Miquelon", "Portugal", "Réunion", "Romania", "Serbia", "Sweden", "Slovenia",
-        |        "Svalbard and Jan Mayen", "Slovakia", "San Marino", "French Southern Territories", "Turkey",
+        |        "Svalbard and Jan Mayen", "Slovakia", "San Marino", "French Southern Territories",
         |        "Wallis & Futuna", "Mayotte", "Holy See", "Åland Islands", "New Zealand", "Cook Islands",
         |        "United Kingdom","Falkland Islands","Gibraltar","Guernsey","Isle of Man","Jersey","Saint Helena",
         |        "United States"
@@ -748,7 +748,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |        "Palau", "Paraguay", "Qatar", "Russia", "Rwanda", "Saudi Arabia", "Solomon Islands", "Seychelles",
         |        "Sudan", "Singapore", "Sierra Leone", "Senegal", "Somalia", "Suriname", "South Sudan",
         |        "Sao Tome & Principe", "El Salvador", "Sint Maarten", "Syria", "Swaziland", "Turks & Caicos Islands",
-        |        "Chad", "Togo", "Thailand", "Tajikistan", "Tokelau", "East Timor", "Turkmenistan", "Tunisia", "Tonga",
+        |        "Chad", "Togo", "Thailand", "Tajikistan", "Tokelau", "East Timor", "Turkmenistan", "Tunisia", "Tonga", "Turkey",
         |        "Trinidad & Tobago", "Taiwan", "Tanzania", "Ukraine", "Uganda", "United States Minor Outlying Islands",
         |        "Uruguay", "Uzbekistan", "Saint Vincent & The Grenadines", "Venezuela", "British Virgin Islands",
         |        "United States Virgin Islands", "Vietnam", "Vanuatu", "Samoa", "Yemen", "South Africa", "Zambia",

--- a/handlers/sf-contact-merge/build.sbt
+++ b/handlers/sf-contact-merge/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "sf-contact-merge"
 description:= "Merges together the salesforce account referenced by a set of zuora accounts"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "sf-contact-merge.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/sf-contact-merge/build.sbt
+++ b/handlers/sf-contact-merge/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies._
 
-// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
-// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
 name := "sf-contact-merge"
 description:= "Merges together the salesforce account referenced by a set of zuora accounts"
 
@@ -11,7 +9,5 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::SF Contact Merge"
 riffRaffArtifactResources += (file("handlers/sf-contact-merge/cfn.yaml"), "cfn/cfn.yaml")
-
-libraryDependencies ++= Seq()
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/sf-datalake-export/build.sbt
+++ b/handlers/sf-datalake-export/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "sf-datalake-export"
 description:= "Export salesforce data to the data lake"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "sf-datalake-export.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
@@ -14,6 +12,6 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::SF Data Lake Export"
 riffRaffArtifactResources += (file("handlers/sf-datalake-export/cfn.yaml"), "cfn/cfn.yaml")
 
-libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.1.0"
+libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.3.0"
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/sf-datalake-export/build.sbt
+++ b/handlers/sf-datalake-export/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies._
 
-// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
-// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
 name := "sf-datalake-export"
 description:= "Export salesforce data to the data lake"
 
@@ -12,6 +10,6 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::SF Data Lake Export"
 riffRaffArtifactResources += (file("handlers/sf-datalake-export/cfn.yaml"), "cfn/cfn.yaml")
 
-libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.3.0"
+libraryDependencies += scalaXml
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/sf-gocardless-sync/build.sbt
+++ b/handlers/sf-gocardless-sync/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "sf-gocardless-sync"
 description:= "Polls GoCardless for direct debit mandate events and pushes into SalesForce"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "sf-gocardless-sync.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/sf-gocardless-sync/build.sbt
+++ b/handlers/sf-gocardless-sync/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies._
 
-// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
-// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
 name := "sf-gocardless-sync"
 description:= "Polls GoCardless for direct debit mandate events and pushes into SalesForce"
 

--- a/handlers/sf-move-subscriptions-api/build.sbt
+++ b/handlers/sf-move-subscriptions-api/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies._
 
-// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
-// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
 name := "sf-move-subscriptions-api"
 description:= "API for for moving subscriptions in ZUORA from SalesForce"
 

--- a/handlers/sf-move-subscriptions-api/build.sbt
+++ b/handlers/sf-move-subscriptions-api/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "sf-move-subscriptions-api"
 description:= "API for for moving subscriptions in ZUORA from SalesForce"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := s"${name.value}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/zuora-callout-apis/build.sbt
+++ b/handlers/zuora-callout-apis/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "org.scalatest" %% "scalatest" % "3.1.1" % "test",
   "com.stripe" % "stripe-java" % "5.28.0",
   jacksonDatabind
 )

--- a/handlers/zuora-callout-apis/build.sbt
+++ b/handlers/zuora-callout-apis/build.sbt
@@ -1,4 +1,3 @@
-// this is stuff for the root handlers, which will be moved to handlers/root at some point
 import Dependencies._
 
 name := "support-service-lambdas"
@@ -13,13 +12,11 @@ riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Auto Cancel"
 addCommandAlias("dist", ";riffRaffArtifact")
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-  "org.scalatest" %% "scalatest" % "3.1.1" % "test",
-  "com.stripe" % "stripe-java" % "5.28.0",
+  awsLambda,
+  okhttp3,
+  scalatest,
+  stripe,
   jacksonDatabind
-)
+) ++ logging
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/zuora-datalake-export/build.sbt
+++ b/handlers/zuora-datalake-export/build.sbt
@@ -2,7 +2,6 @@ import Dependencies._
 
 name := "zuora-datalake-export"
 description:= "Zuora to Datalake export using Stateful AQuA API which exports incremental changes"
-scalacOptions += "-Ypartial-unification"
 assemblyJarName := "zuora-datalake-export.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
@@ -10,8 +9,8 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Data Lake Export"
 riffRaffArtifactResources += (file("handlers/zuora-datalake-export/cfn.yaml"), "cfn/cfn.yaml")
 libraryDependencies ++= Seq(
-  "io.github.mkotsur" %% "aws-lambda-scala" % "0.1.1",
-  "org.scalaj" %% "scalaj-http" % "2.4.1",
+  "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0",
+  "org.scalaj" %% "scalaj-http" % "2.4.2",
   Dependencies.awsS3,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",

--- a/handlers/zuora-datalake-export/build.sbt
+++ b/handlers/zuora-datalake-export/build.sbt
@@ -9,12 +9,10 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Data Lake Export"
 riffRaffArtifactResources += (file("handlers/zuora-datalake-export/cfn.yaml"), "cfn/cfn.yaml")
 libraryDependencies ++= Seq(
-  "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0",
-  "org.scalaj" %% "scalaj-http" % "2.4.2",
-  Dependencies.awsS3,
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-  "com.beachape" %% "enumeratum" % "1.5.13"
-)
+  scalaLambda,
+  scalajHttp,
+  awsS3,
+  enumeratum,
+) ++ logging
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/zuora-retention/build.sbt
+++ b/handlers/zuora-retention/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies._
 
-// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
-// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
 name := "zuora-retention"
 description:= "find and mark accounts that are out of the retention period"
 
@@ -11,9 +9,6 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Retention"
 riffRaffArtifactResources += (file("handlers/zuora-retention/cfn.yaml"), "cfn/cfn.yaml")
-
-libraryDependencies ++= Seq(
-)
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases")

--- a/handlers/zuora-retention/build.sbt
+++ b/handlers/zuora-retention/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "zuora-retention"
 description:= "find and mark accounts that are out of the retention period"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "zuora-retention.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/zuora-sar/build.sbt
+++ b/handlers/zuora-sar/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies._
 
-// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
-// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
 name := "zuora-sar"
 description:= "Performs a Subject Access Requests against Zuora"
 
@@ -11,7 +9,5 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Sar"
 riffRaffArtifactResources += (file("handlers/zuora-sar/cfn.yaml"), "cfn/cfn.yaml")
-
-libraryDependencies ++= Seq()
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/handlers/zuora-sar/build.sbt
+++ b/handlers/zuora-sar/build.sbt
@@ -5,8 +5,6 @@ import Dependencies._
 name := "zuora-sar"
 description:= "Performs a Subject Access Requests against Zuora"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "zuora-sar.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ConfigLive.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/ConfigLive.scala
@@ -1,15 +1,19 @@
 package com.gu.holiday_stops
 
 import com.gu.effects.GetFromS3
+import com.gu.zuora.subscription
 import com.gu.zuora.subscription.OverallFailure
-import zio.Task
+import zio.{Task, ZIO}
 
 trait ConfigLive extends Configuration {
   val configuration: Configuration.Service[Any] = new Configuration.Service[Any] {
-    val config: Task[Config] =
-      Task.effect(Config.fromS3(GetFromS3.fetchString)).absolve.mapError {
-        case e: OverallFailure => new RuntimeException(e.reason)
-        case t: Throwable => t
-      }
+    val config: Task[Config] = {
+      ZIO.absolve(
+        Task.effect(Config.fromS3(GetFromS3.fetchString))
+      ).mapError {
+          case e: OverallFailure => new RuntimeException(e.reason)
+          case t: Throwable => t
+        }
+    }
   }
 }

--- a/lib/test/src/test/scala/com/gu/test/JsonMatchersTest.scala
+++ b/lib/test/src/test/scala/com/gu/test/JsonMatchersTest.scala
@@ -13,7 +13,7 @@ class JSComparisonTest extends FlatSpec with Matchers {
   it should "handle missed fields as normal" in {
     val testData = """{}"""
     val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
-    val expectedError = "List((/key,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"
+    val expectedError = "List((/key,List(JsonValidationError(List(error.path.missing),ArraySeq()))))"
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
@@ -26,7 +26,7 @@ class JSComparisonTest extends FlatSpec with Matchers {
   it should "fail for extra fields" in {
     val testData = """{"key":"test", "extra": "bad"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
-    val expectedError = """List((,List(JsonValidationError(List(extra fields, {"key":"test"} == {"key":"test","extra":"bad"}),WrappedArray()))))"""
+    val expectedError = """List((,List(JsonValidationError(List(extra fields, {"key":"test"} == {"key":"test","extra":"bad"}),ArraySeq()))))"""
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
@@ -44,14 +44,14 @@ class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
   it should "handle missed fields as normal" in {
     val testData = """{}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    val expectedError = "List((/embed,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"
+    val expectedError = "List((/embed,List(JsonValidationError(List(error.path.missing),ArraySeq()))))"
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
   it should "handle missed fields in the nested class" in {
     val testData = """{"embed":"{}"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    val expectedError = "List((/embed/key,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"
+    val expectedError = "List((/embed/key,List(JsonValidationError(List(error.path.missing),ArraySeq()))))"
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
@@ -64,7 +64,7 @@ class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
   it should "fail for extra fields in the nested class" in {
     val testData = """{"embed":"{\"key\":\"test\",  \"extra\":\"bad\"}"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    val expectedError = "List((/embed,List(JsonValidationError(List(extra fields, {\"key\":\"test\"} == {\"key\":\"test\",\"extra\":\"bad\"}),WrappedArray()))))"
+    val expectedError = "List((/embed,List(JsonValidationError(List(extra fields, {\"key\":\"test\"} == {\"key\":\"test\",\"extra\":\"bad\"}),ArraySeq()))))"
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,27 +4,17 @@ import sbtassembly.AssemblyPlugin.autoImport.{MergeStrategy, assemblyMergeStrate
 import sbtassembly.PathList
 
 object Dependencies {
-  
   val awsVersion = "1.11.574"
-
   val circeVersion = "0.12.3"
   val sttpVersion = "1.7.0"
   val http4sVersion = "0.21.0"
   val catsVersion = "2.1.1"
   val catsEffectVersion = "2.1.1"
 
-  val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.9.1"
-
   val logging = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   )
-
-  // play-json
-  val playJson = "com.typesafe.play" %% "play-json" % "2.8.0"
-  val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.40.1"
-
-  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.0" // FIXME: Why is this necessery?
 
   // AWS
   val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
@@ -40,18 +30,21 @@ object Dependencies {
   val catsEffect = "org.typelevel" %% "cats-effect" % catsEffectVersion
   val mouse = "org.typelevel" %% "mouse" % "0.23" // can be removed once we move to Scala 2.13 (native 'tap')
 
-  val enumeratum = "com.beachape" %% "enumeratum" % "1.5.13"
-
-  // Circe
+  // JSON libraries
   val circe = "io.circe" %% "circe-generic" % circeVersion
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val circeConfig =  "io.circe" %% "circe-config" % "0.7.0"
+  val playJson = "com.typesafe.play" %% "play-json" % "2.8.0"
+  val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.40.1"
+  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.0" // FIXME: Why is this necessery?
 
-  // STTP
+  // HTTP clients
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion
   val sttpCats = "com.softwaremill.sttp" %% "cats" % sttpVersion
   val sttpAsycHttpClientBackendCats = "com.softwaremill.sttp" %% "async-http-client-backend-cats" % sttpVersion
+  val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.9.1"
+  val scalajHttp = "org.scalaj" %% "scalaj-http" % "2.4.2"
 
   // HTTP4S
   val http4sDsl = "org.http4s" %% "http4s-dsl" % http4sVersion
@@ -59,11 +52,16 @@ object Dependencies {
   val http4sServer = "org.http4s" %% "http4s-server" % http4sVersion
   val http4sCore = "org.http4s" %% "http4s-core" % http4sVersion
 
-  val zio = "dev.zio" %% "zio" % "1.0.0-RC17"
-
   // Guardian
   val simpleConfig = "com.gu" %% "simple-configuration-ssm" % "1.5.2"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"
+  val contentAuthCommon = "com.gu" %% "content-authorisation-common" % "0.5"
+
+  // Other
+  val zio = "dev.zio" %% "zio" % "1.0.0-RC17"
+  val enumeratum = "com.beachape" %% "enumeratum" % "1.5.13"
+  val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.3.0"
+  val stripe = "com.stripe" % "stripe-java" % "5.28.0"
 
   // Testing
   val diffx = "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,48 +7,68 @@ object Dependencies {
   
   val awsVersion = "1.11.574"
 
-  val circeVersion = "0.11.1"
-  val sttpVersion = "1.5.17"
-  val http4sVersion = "0.20.3"
-  val catsVersion = "1.6.1"
-  val catsEffectVersion = "1.3.1"
+  val circeVersion = "0.12.3"
+  val sttpVersion = "1.7.0"
+  val http4sVersion = "0.21.0"
+  val catsVersion = "2.1.1"
+  val catsEffectVersion = "2.1.1"
 
   val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.9.1"
+
   val logging = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   )
+
+  // play-json
   val playJson = "com.typesafe.play" %% "play-json" % "2.8.0"
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.40.1"
-  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
-  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.0" % Test
-  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.0"
+
+  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.0" // FIXME: Why is this necessery?
+
+  // AWS
   val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion
   val awsSES = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion
   val awsStepFunction = "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsVersion
   val awsSdkLambda = "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
-  val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
+  val scalaLambda = "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0"
+
+  // Cats
+  val catsCore = "org.typelevel" %% "cats-core" % catsVersion
+  val catsEffect = "org.typelevel" %% "cats-effect" % catsEffectVersion
+  val mouse = "org.typelevel" %% "mouse" % "0.23" // can be removed once we move to Scala 2.13 (native 'tap')
+
+  val enumeratum = "com.beachape" %% "enumeratum" % "1.5.13"
+
+  // Circe
   val circe = "io.circe" %% "circe-generic" % circeVersion
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
-  val circeConfig =  "io.circe" %% "circe-config" % "0.6.1"
+  val circeConfig =  "io.circe" %% "circe-config" % "0.7.0"
+
+  // STTP
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion
   val sttpCats = "com.softwaremill.sttp" %% "cats" % sttpVersion
   val sttpAsycHttpClientBackendCats = "com.softwaremill.sttp" %% "async-http-client-backend-cats" % sttpVersion
-  val mouse = "org.typelevel" %% "mouse" % "0.23" // can be removed once we move to Scala 2.13 (native 'tap')
-  val enumeratum = "com.beachape" %% "enumeratum" % "1.5.13"
+
+  // HTTP4S
   val http4sDsl = "org.http4s" %% "http4s-dsl" % http4sVersion
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   val http4sServer = "org.http4s" %% "http4s-server" % http4sVersion
   val http4sCore = "org.http4s" %% "http4s-core" % http4sVersion
-  val catsCore = "org.typelevel" %% "cats-core" % catsVersion
-  val catsEffect = "org.typelevel" %% "cats-effect" % catsEffectVersion
-  val scalaLambda = "io.github.mkotsur" %% "aws-lambda-scala" % "0.1.1"
+
   val zio = "dev.zio" %% "zio" % "1.0.0-RC17"
-  val diffx = "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.17" % Test
-  val simpleConfig = "com.gu" %% "simple-configuration-ssm" % "1.4.1"
+
+  // Guardian
+  val simpleConfig = "com.gu" %% "simple-configuration-ssm" % "1.5.2"
+  val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"
+
+  // Testing
+  val diffx = "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test
+  val scalatest = "org.scalatest" %% "scalatest" % "3.1.1" % Test
+  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.0" % Test
 
   // to resolve merge clash of 'module-info.class'
   // see https://stackoverflow.com/questions/54834125/sbt-assembly-deduplicate-module-info-class

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
-
 resolvers += Resolver.typesafeRepo("releases")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?

- Migrate to Scala 2.13
- The following guardian libraries had to be released for 2.13
  - content-authorisation-common https://github.com/guardian/content-authorisation-common/pull/6
  - support-internationalisation https://github.com/guardian/support-frontend/pull/2676

## Have we considered potential risks?

- Moving from support-internationalisation 0.9 to 0.13 means Turkey is classified as ROW instead of Domestic as per https://github.com/guardian/support-libraries/pull/13
- Upgrade is made riskier by the fact that there are many libraries (some performing duplicated functionality) in `Dependencies.scala`.


