### PR TITLE
Configure HolidayCreditProduct for Code stage

### DIFF
--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditProductTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayCreditProductTest.scala
@@ -7,36 +7,30 @@ import org.scalatest.matchers.should.Matchers
 
 class HolidayCreditProductTest extends AnyFlatSpec with Matchers {
 
-  private val dev = Stage("DEV")
+  private val Dev = Stage("DEV")
+  private val Code = Stage("CODE")
 
-  "forStage" should "give correct credit product for a GW subscription in Dev stage" in {
+  "forStage" should "give correct credit product for a GW subscription" in {
     val subscription = Fixtures.subscriptionFromJson("GuardianWeeklyWith6For6.json")
-    HolidayCreditProduct.forStage(dev)(subscription) shouldBe HolidayCreditProduct.Dev.GuardianWeekly
+    HolidayCreditProduct.forStage(Dev)(subscription) shouldBe HolidayCreditProduct.Dev.GuardianWeekly
+    HolidayCreditProduct.forStage(Code)(subscription) shouldBe HolidayCreditProduct.Code.GuardianWeekly
   }
 
-  it should "give correct credit product for a Home Delivery subscription in Dev stage" in {
+  it should "give correct credit product for a Home Delivery subscription" in {
     val subscription = Fixtures.subscriptionFromJson("EchoLegacySubscription.json")
-    HolidayCreditProduct.forStage(dev)(subscription) shouldBe HolidayCreditProduct.Dev.HomeDelivery
+    HolidayCreditProduct.forStage(Dev)(subscription) shouldBe HolidayCreditProduct.Dev.HomeDelivery
+    HolidayCreditProduct.forStage(Code)(subscription) shouldBe HolidayCreditProduct.Code.HomeDelivery
   }
 
-  it should "give correct credit product for a Home Delivery Plus subscription in Dev stage" in {
-    val subscription = Fixtures.subscriptionFromJson("DeliveryEveryDatePlusSubscription.json")
-    HolidayCreditProduct.forStage(dev)(subscription) shouldBe HolidayCreditProduct.Dev.HomeDeliveryPlus
-  }
-
-  it should "give correct credit product for a Voucher subscription in Dev stage" in {
+  it should "give correct credit product for a Voucher subscription" in {
     val subscription = Fixtures.subscriptionFromJson("SundayVoucherSubscription.json")
-    HolidayCreditProduct.forStage(dev)(subscription) shouldBe HolidayCreditProduct.Dev.Voucher
-  }
-
-  it should "give correct credit product for a Voucher Plus subscription in Dev stage" in {
-    val subscription = Fixtures.subscriptionFromJson("VoucherWeekendPlusSubscription.json")
-    HolidayCreditProduct.forStage(dev)(subscription) shouldBe HolidayCreditProduct.Dev.VoucherPlus
+    HolidayCreditProduct.forStage(Dev)(subscription) shouldBe HolidayCreditProduct.Dev.Voucher
+    HolidayCreditProduct.forStage(Code)(subscription) shouldBe HolidayCreditProduct.Code.Voucher
   }
 
   it should "throw an exception when subscription has no applicable rate plan" in {
     val subscription = Fixtures.subscriptionFromJson("AlternativeSubscription.json")
-    val thrown = the[IllegalArgumentException] thrownBy HolidayCreditProduct.forStage(dev)(subscription)
-    thrown should have message "No holiday credit product available for subscription A-S00051570"
+    the[IllegalArgumentException] thrownBy HolidayCreditProduct.forStage(Dev)(subscription) should have message "No holiday credit product available for subscription A-S00051570"
+    the[IllegalArgumentException] thrownBy HolidayCreditProduct.forStage(Code)(subscription) should have message "No holiday credit product available for subscription A-S00051570"
   }
 }


### PR DESCRIPTION
This is the same as #686 but for the Code stage rather than the Dev stage.

We believe that tax arrangements can be adequately covered by credit products for GW, HD and Voucher.  There might be no need for separate 'Plus' products so I haven't created them in the Zuora UAT environment and they're not catered for in the codebase.