### PR TITLE
Make invoice date for delivery credit requests optional

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -77,9 +77,9 @@ object DeliveryCreditProcessor extends Logging {
     } yield results
 
   def processProduct(
-                      sfAuthConfig: SFAuthConfig,
-                      zuoraConfig: HolidayStopProcessorZuoraConfig,
-                      zuoraAccessToken: AccessToken
+    sfAuthConfig: SFAuthConfig,
+    zuoraConfig: HolidayStopProcessorZuoraConfig,
+    zuoraAccessToken: AccessToken
   )(productType: ZuoraProductType): Task[ProcessResult[DeliveryCreditResult]] =
     for {
       processResult <- Task.effect(
@@ -121,17 +121,17 @@ object DeliveryCreditProcessor extends Logging {
   }
 
   def updateToApply(
-     creditProduct: CreditProductForSubscription,
-     subscription: Subscription,
-     account: ZuoraAccount,
-     request: DeliveryCreditRequest
+    creditProduct: CreditProductForSubscription,
+    subscription: Subscription,
+    account: ZuoraAccount,
+    request: DeliveryCreditRequest
   ): ZuoraApiResponse[SubscriptionUpdate] =
     SubscriptionUpdate(
       creditProduct(subscription),
       subscription,
       account,
       AffectedPublicationDate(request.Delivery_Date__c),
-      Some(InvoiceDate(request.Invoice_Date__c))
+      request.Invoice_Date__c.map(InvoiceDate)
     )
 
   def resultOfZuoraCreditAdd(
@@ -141,6 +141,7 @@ object DeliveryCreditProcessor extends Logging {
     deliveryId = request.Id,
     chargeCode = RatePlanChargeCode(addedCharge.number),
     amountCredited = Price(addedCharge.price),
+    invoiceDate = InvoiceDate(addedCharge.effectiveStartDate)
   )
 
   def getCreditRequestsFromSalesforce(sfAuthConfig: SFAuthConfig)(
@@ -191,6 +192,7 @@ object DeliveryCreditProcessor extends Logging {
     Charge_Code__c: String,
     Credit_Amount__c: Double,
     Actioned_On__c: LocalDateTime,
+    Invoice_Date__c: LocalDate
   )
 
   def writeCreditResultsToSalesforce(sfAuthConfig: SFAuthConfig)(
@@ -207,6 +209,7 @@ object DeliveryCreditProcessor extends Logging {
           Charge_Code__c = result.chargeCode.value,
           Credit_Amount__c = result.amountCredited.value,
           Actioned_On__c = LocalDateTime.now,
+          Invoice_Date__c = result.invoiceDate.value
         )
         salesforceClient.patch(
           deliveryObject,

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequest.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequest.scala
@@ -9,7 +9,7 @@ case class DeliveryCreditRequest(
   SF_Subscription__r: DeliveryCreditSubscription,
   Delivery_Date__c: LocalDate,
   Charge_Code__c: Option[String],
-  Invoice_Date__c: LocalDate
+  Invoice_Date__c: Option[LocalDate]
 ) extends CreditRequest {
   val subscriptionName: SubscriptionName = SubscriptionName(SF_Subscription__r.Name)
   val publicationDate: AffectedPublicationDate = AffectedPublicationDate(Delivery_Date__c)

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditResult.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditResult.scala
@@ -1,10 +1,11 @@
 package com.gu.deliveryproblemcreditprocessor
 
 import com.gu.creditprocessor.ZuoraCreditAddResult
-import com.gu.zuora.subscription.{Price, RatePlanChargeCode}
+import com.gu.zuora.subscription.{InvoiceDate, Price, RatePlanChargeCode}
 
 case class DeliveryCreditResult(
   deliveryId: String,
   chargeCode: RatePlanChargeCode,
   amountCredited: Price,
+  invoiceDate: InvoiceDate
 ) extends ZuoraCreditAddResult

--- a/handlers/delivery-problem-credit-processor/src/test/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequestTest.scala
+++ b/handlers/delivery-problem-credit-processor/src/test/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequestTest.scala
@@ -27,14 +27,14 @@ class DeliveryCreditRequestTest
           SF_Subscription__r = DeliveryCreditSubscription(Name = "A-S00001"),
           Delivery_Date__c = LocalDate.of(2019, 12, 6),
           Charge_Code__c = None,
-          Invoice_Date__c = LocalDate.of(2020, 2, 10)
+          Invoice_Date__c = Some(LocalDate.of(2020, 2, 10))
         ),
         DeliveryCreditRequest(
           Id = "r2",
           SF_Subscription__r = DeliveryCreditSubscription(Name = "A-S00002"),
           Delivery_Date__c = LocalDate.of(2019, 12, 13),
           Charge_Code__c = Some("C12345"),
-          Invoice_Date__c = LocalDate.of(2020, 3, 1)
+          Invoice_Date__c = Some(LocalDate.of(2020, 3, 1))
         )
       ))
     )


### PR DESCRIPTION
## What does this change?
The delivery credit processor used to rely on credit requests having their next invoice date pre-populated by a call to the holiday-stop API.  With this change it becomes possible for the credit processor to determine and return the invoice date if it hasn't already been filled in.  This makes it easier to do bulk requests if necessary.

## How to test
It's been tested it in the Code environment.

## How can we measure success?
A delivery-credit request with no invoice date populated results in a successful credit applied and the invoice date is written back to Salesforce.

## Have we considered potential risks?
Yes.

## Images
N/A
