### PR TITLE
Try to process 400 delivery-problem credits every 20 mins

### DIFF
--- a/handlers/delivery-problem-credit-processor/cfn.yaml
+++ b/handlers/delivery-problem-credit-processor/cfn.yaml
@@ -115,7 +115,7 @@ Resources:
     Properties:
       Description: Trigger processing of delivery-problem credits every hour (to give 24 attempts a day)
       Name: !FindInMap [StageMap, !Ref Stage, ScheduleName]
-      ScheduleExpression: "cron(0 * ? * * *)"
+      ScheduleExpression: "cron(0/20 * ? * * *)"
       State: ENABLED
       Targets:
         - Arn: !GetAtt DeliveryProblemCreditProcessor.Arn

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -161,6 +161,7 @@ object DeliveryCreditProcessor extends Logging {
         }
     }
 
+    // limited to 400 because each record takes ~ 2s to process and lambda has 15 min to run
     def deliveryRecordsQuery(productType: ZuoraProductType) =
       s"""
          |SELECT Id, SF_Subscription__r.Name, Delivery_Date__c, Charge_Code__c, Invoice_Date__c
@@ -169,6 +170,7 @@ object DeliveryCreditProcessor extends Logging {
          |AND Credit_Requested__c = true
          |AND Is_Actioned__c = false
          |ORDER BY SF_Subscription__r.Name, Delivery_Date__c
+         |LIMIT 400
          |""".stripMargin
 
     val results = for {


### PR DESCRIPTION
## What does this change?
The credit processor is an all-or-nothing process so if it can't process all the records available in the time that the lambda can run it won't do anything.  It will make the change in Zuora but it won't write anything back to Salesforce until all the records have been processed in Zuora.  This means that as soon as a large backlog builds up it can never be cleared.

This change limits the number of delivery-problem credits the processor handles to 400.  And it increases the rate of running to 3 times per hour.  This should progressively reduce the backlog and make the process scalable.

## How to test
Deploy it and run the lambda.

## How can we measure success?
The number of credits to process slowly falls to 0.

## Have we considered potential risks?
Yes

## Images
N/A
