### PR TITLE
Reduce number of delivery-problem credits to process to 300

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -164,7 +164,7 @@ object DeliveryCreditProcessor extends Logging {
         }
     }
 
-    // limited to 400 because each record takes ~ 2s to process and lambda has 15 min to run
+    // limited to 300 because each record takes ~ 2s to process and lambda has 15 min to run
     def deliveryRecordsQuery(productType: ZuoraProductType) =
       s"""
          |SELECT Id, SF_Subscription__r.Name, Delivery_Date__c, Charge_Code__c, Invoice_Date__c
@@ -173,7 +173,7 @@ object DeliveryCreditProcessor extends Logging {
          |AND Credit_Requested__c = true
          |AND Is_Actioned__c = false
          |ORDER BY SF_Subscription__r.Name, Delivery_Date__c
-         |LIMIT 400
+         |LIMIT 300
          |""".stripMargin
 
     val results = for {


### PR DESCRIPTION
Reduced from 400 to 300 every 20 minutes because still getting a lot of timeouts.  Some must be taking longer than 2s.