### PR TITLE
Enable holiday stops for Newspaper - Digital Voucher

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopCreditProcessor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopCreditProcessor.scala
@@ -10,7 +10,7 @@ import com.gu.holiday_stops.Config
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.HolidayStopRequestsDetail
 import com.gu.util.config.Stage
 import com.gu.zuora.Zuora
-import com.gu.zuora.ZuoraProductTypes.{GuardianWeekly, NewspaperHomeDelivery, NewspaperVoucherBook}
+import com.gu.zuora.ZuoraProductTypes._
 import com.gu.zuora.subscription.{OverallFailure, Subscription, SubscriptionUpdate, ZuoraAccount}
 import com.softwaremill.sttp.{Id, SttpBackend}
 
@@ -34,6 +34,7 @@ object HolidayStopCreditProcessor {
         List(
           NewspaperHomeDelivery,
           NewspaperVoucherBook,
+          NewspaperDigitalVoucher,
           GuardianWeekly,
         )
         .map { productType => {

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -129,7 +129,7 @@ object SalesforceHolidayStopRequest extends Logging {
     Estimated_Price__c: Price,
     Expected_Invoice_Date__c: HolidayStopRequestsDetailExpectedInvoiceDate,
     attributes: CompositeAttributes = CompositeAttributes(
-      holidayStopRequestsDetailSfObjectRef,
+      HolidayStopRequestsDetailSfObjectRef,
       UUID.randomUUID().toString
     )
   )
@@ -282,7 +282,7 @@ object SalesforceHolidayStopRequest extends Logging {
         .map{ issueData =>
           CompositePart(
             method = "POST",
-            url = s"$sfObjectsBaseUrl$holidayStopRequestsDetailSfObjectRef",
+            url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef",
             referenceId = "CREATE DETAIL : " + UUID.randomUUID().toString,
             body = Json.toJson(AddHolidayStopRequestDetailBody(
               Holiday_Stop_Request__c = holidayStopRequestId,
@@ -302,7 +302,7 @@ object SalesforceHolidayStopRequest extends Logging {
           }
           CompositePart(
             method = "DELETE",
-            url = s"$sfObjectsBaseUrl$holidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
+            url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
             referenceId = "DELETE DETAIL : " + UUID.randomUUID().toString,
             body = JsNull
           )

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
@@ -17,8 +17,8 @@ import play.api.libs.json.{JsValue, Json}
 
 object SalesforceHolidayStopRequestsDetail extends Logging {
 
-  val holidayStopRequestsDetailSfObjectRef = "Holiday_Stop_Requests_Detail__c"
-  val holidayStopRequestsDetailSfObjectsBaseUrl = sfObjectsBaseUrl + holidayStopRequestsDetailSfObjectRef
+  final val HolidayStopRequestsDetailSfObjectRef = "Holiday_Stop_Requests_Detail__c"
+  val holidayStopRequestsDetailSfObjectsBaseUrl = sfObjectsBaseUrl + HolidayStopRequestsDetailSfObjectRef
 
   case class HolidayStopRequestsDetailId(value: String) extends AnyVal
   implicit val formatHolidayStopRequestsDetailId = Jsonx.formatInline[HolidayStopRequestsDetailId]
@@ -44,7 +44,7 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
 
     def apply(sfPatch: HttpOp[RestRequestMaker.PatchRequest, Unit])(detailSfId: HolidayStopRequestsDetailId): HolidayStopRequestsDetailActioned => ClientFailableOp[Unit] =
       sfPatch.setupRequest[HolidayStopRequestsDetailActioned] { actionedInfo =>
-        PatchRequest(actionedInfo, RelativePath(s"$sfObjectsBaseUrl$holidayStopRequestsDetailSfObjectRef/${detailSfId.value}"))
+        PatchRequest(actionedInfo, RelativePath(s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef/${detailSfId.value}"))
       }.runRequest
 
   }
@@ -102,7 +102,7 @@ object SalesforceHolidayStopRequestsDetail extends Logging {
     def createSoql(dates: List[LocalDate], productType: ZuoraProductType) = {
       s"""
          | $SOQL_SELECT_CLAUSE
-         | FROM $holidayStopRequestsDetailSfObjectRef
+         | FROM $HolidayStopRequestsDetailSfObjectRef
          | WHERE Holiday_Stop_Request__r.SF_Subscription__r.Product_Type__c = '${productType.name}'
          | AND ${soqlFilterClause(dates)}
          | $SOQL_ORDER_BY_CLAUSE

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -2,7 +2,7 @@ package com.gu.zuora.subscription
 
 import java.time.DayOfWeek
 
-import com.gu.zuora.ZuoraProductTypes.{GuardianWeekly, NewspaperHomeDelivery, NewspaperVoucherBook, ZuoraProductType}
+import com.gu.zuora.ZuoraProductTypes._
 
 case class SupportedRatePlan(name: String, ratePlanCharges: List[SupportedRatePlanCharge])
 
@@ -106,6 +106,23 @@ object SupportedProduct {
     SupportedProduct(
       name = "Newspaper Voucher",
       productType = NewspaperVoucherBook,
+      annualIssueLimitPerEdition = 10,
+      ratePlans = List(
+        SupportedRatePlan("Everyday", everyDayCharges),
+        SupportedRatePlan("Everyday+", everyDayCharges),
+        SupportedRatePlan("Saturday", saturdayCharges),
+        SupportedRatePlan("Saturday+", saturdayCharges),
+        SupportedRatePlan("Sixday", sixDayCharges),
+        SupportedRatePlan("Sixday+", sixDayCharges),
+        SupportedRatePlan("Sunday", sundayCharges),
+        SupportedRatePlan("Sunday+", sundayCharges),
+        SupportedRatePlan("Weekend", weekendCharges),
+        SupportedRatePlan("Weekend+", weekendCharges)
+      )
+    ),
+    SupportedProduct(
+      name = "Newspaper Digital Voucher",
+      productType = NewspaperDigitalVoucher,
       annualIssueLimitPerEdition = 10,
       ratePlans = List(
         SupportedRatePlan("Everyday", everyDayCharges),


### PR DESCRIPTION
## What does this change?
https://trello.com/c/PORsbOiR/1533-goal-customers-capability-to-request-a-holiday-suspensions-for-subscription-card-s

* Enable `Newspaper - Digital Voucher`, also known as Subscription Card, in holiday-stop-api and holiday-stop-processor. 
* The code changes follow the pattern of `Newspaper - Voucher Book`.
* Digital Voucher has already been added to fulfilment-date-calculator by https://github.com/guardian/support-service-lambdas/pull/677
* This PR should be merged after correct `CreditProduct` is added in PROD. For example @kelvin-chappell has PR for CODE reeady https://github.com/guardian/support-service-lambdas/pull/688

## How to test

1. Acquire Subscription Card
1. Find subscription in Salesforce
1. Create holiday stop request in Salesforce
1. Run holiday-stop-processor lambda with date override
1. Verify correct credit product was applied in Zuora on correct dates

## How can we measure success?

User is able to book Subscription Card holidays via CSR and MMA.

## Have we considered potential risks?

No major risks apparent.