### PR TITLE
Enable holiday-stop-processor in DEV stage (Schedule, fulfilment-date-calculator)

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -17,6 +17,9 @@ Conditions:
 
 Mappings:
   StageMap:
+    DEV:
+      FulfilmentDatesBucketUrn: "arn:aws:s3:::fulfilment-date-calculator-dev/*"
+      ScheduleName: holiday-stop-processor-schedule-dev
     CODE:
       FulfilmentDatesBucketUrn: "arn:aws:s3:::fulfilment-date-calculator-code/*"
       ScheduleName: holiday-stop-processor-schedule-code


### PR DESCRIPTION
Related PR: https://github.com/guardian/support-service-lambdas/pull/693

