### PR TITLE
Salesforce gdpr billing account removal

### DIFF
--- a/handlers/sf-billing-account-remover/.gitignore
+++ b/handlers/sf-billing-account-remover/.gitignore
@@ -1,0 +1,2 @@
+target/
+.idea

--- a/handlers/sf-billing-account-remover/build.sbt
+++ b/handlers/sf-billing-account-remover/build.sbt
@@ -1,0 +1,13 @@
+version := "0.1"
+
+scalaVersion := "2.13.3"
+
+libraryDependencies += "org.scalaj" %% "scalaj-http" % "2.4.2"
+libraryDependencies += "com.lihaoyi" %% "upickle" % "0.9.5" // SBT
+val circeVersion = "0.12.3"
+
+libraryDependencies ++= Seq(
+  "io.circe" %% "circe-core",
+  "io.circe" %% "circe-generic",
+  "io.circe" %% "circe-parser"
+).map(_ % circeVersion)

--- a/handlers/sf-billing-account-remover/build.sbt
+++ b/handlers/sf-billing-account-remover/build.sbt
@@ -3,7 +3,6 @@ version := "0.1"
 scalaVersion := "2.13.3"
 
 libraryDependencies += "org.scalaj" %% "scalaj-http" % "2.4.2"
-libraryDependencies += "com.lihaoyi" %% "upickle" % "0.9.5" // SBT
 val circeVersion = "0.12.3"
 
 libraryDependencies ++= Seq(

--- a/handlers/sf-billing-account-remover/project/build.properties
+++ b/handlers/sf-billing-account-remover/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.13

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -7,14 +7,15 @@ import io.circe.syntax._
 import scalaj.http._
 
 object BillingAccountRemover extends App {
+  //Salesforce
   case class SfAuthDetails(access_token: String, instance_url: String)
 
-  //Salesforce
   case class SfGetBillingAccsResponse(
     done: Boolean,
     records: Seq[BillingAccountsRecords.Records],
     nextRecordsUrl: Option[String] = None
   )
+
   case class SfGetCustomSettingResponse(
     done: Boolean,
     records: Seq[CustomSettingRecords.Records]
@@ -27,6 +28,7 @@ object BillingAccountRemover extends App {
                                       attributes: Attributes = Attributes(
                                         `type` = "Zuora__CustomerAccount__c"
                                       ))
+
   case class SfBillingAccountsToUpdate(allOrNone: Boolean,
                                        records: Seq[SfBillingAccountToUpdate])
 
@@ -36,6 +38,7 @@ object BillingAccountRemover extends App {
                                    attributes: Attributes = Attributes(
                                      `type` = "Apex_Error__c"
                                    ))
+
   case class SfErrorRecordsToCreate(allOrNone: Boolean,
                                     records: Seq[SfErrorRecordToCreate])
 
@@ -73,12 +76,13 @@ object BillingAccountRemover extends App {
     )
 
   var counter: Int = 0;
-  processPage()
 
-  def processPage(): Unit = {
+  processBillingAccounts()
+
+  def processBillingAccounts(): Unit = {
     val t1 = System.nanoTime
 
-    val iteration = for {
+    for {
       config <- optConfig map (c => Right(c)) getOrElse Left(
         new RuntimeException("Missing config value")
       )
@@ -95,7 +99,6 @@ object BillingAccountRemover extends App {
 
     val duration = (System.nanoTime - t1) / 1e9d
     println("Elapsed time: " + duration + "s")
-    println("maxAttempts: " + iteration)
 
   }
 

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -84,7 +84,7 @@ object BillingAccountRemover extends App {
       config <- optConfig map (c => Right(c)) getOrElse Left(
         new RuntimeException("Missing config value")
       )
-      sfAuthDetails <- SfLogin(config.salesforceConfig)
+      sfAuthDetails <- decode[SfAuthDetails](auth(config.salesforceConfig))
       getCustomSettingResponse <- getSfCustomSetting(sfAuthDetails)
       maxAttempts = getCustomSettingResponse.records(0).Property_Value__c
       getBillingAccountsResponse <- getSfBillingAccounts(
@@ -124,7 +124,7 @@ object BillingAccountRemover extends App {
 
     val customSettingFromSf =
       getMaxAttemptsCustomSetting(sfAuthentication)
-
+    println("customSettingFromSf:" + customSettingFromSf)
     val decodedCustomSetting = decode[SfGetCustomSettingResponse](
       customSettingFromSf
     ) map { customSettingObject =>
@@ -300,12 +300,6 @@ object BillingAccountRemover extends App {
       .body
 
   }
-
-  def SfLogin(salesforceConfig: SalesforceConfig) =
-    decode[SfAuthDetails](auth(salesforceConfig)) match {
-      case Right(responseObject) => Right(responseObject)
-      case Left(ex)              => Left(ex)
-    }
 
   object SfUpdateBillingAccounts {
     def apply(

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -113,15 +113,10 @@ object BillingAccountRemover extends App {
     sfAuthentication: SfAuthDetails
   ): Either[Error, SfGetBillingAccsResponse] = {
 
-    val billingAccountListFromSf =
-      getBillingAccountsFromSf(maxAttempts: Int, sfAuthentication)
-    val decodedBillingAccounts = decode[SfGetBillingAccsResponse](
-      billingAccountListFromSf
-    ) map { billingAccountsObject =>
-      billingAccountsObject
-    }
-
-    decodedBillingAccounts
+    //can we bring this into a one liner and remove the method?
+    decode[SfGetBillingAccsResponse](
+      getBillingAccountsFromSf(maxAttempts, sfAuthentication)
+    )
   }
   def getSfCustomSetting(
     sfAuthentication: SfAuthDetails

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -60,6 +60,7 @@ object BillingAccountRemover extends App {
 
     zuoraApiAccessKeyId <- Option(System.getenv("apiAccessKeyId"))
     zuoraApiSecretAccessKey <- Option(System.getenv("apiSecretAccessKey"))
+    zuoraInstanceUrl <- Option(System.getenv("zuoraInstanceUrl"))
 
   } yield
     Config(
@@ -73,7 +74,8 @@ object BillingAccountRemover extends App {
       ),
       ZuoraConfig(
         apiAccessKeyId = zuoraApiAccessKeyId,
-        apiSecretAccessKey = zuoraApiSecretAccessKey
+        apiSecretAccessKey = zuoraApiSecretAccessKey,
+        zuoraInstanceUrl = zuoraInstanceUrl
       )
     )
 
@@ -242,7 +244,7 @@ object BillingAccountRemover extends App {
                             billingAccountForRemovalAsJson: String,
                             zuoraBillingAccountId: String) = {
     Http(
-      s"https://rest.apisandbox.zuora.com/v1/object/account/$zuoraBillingAccountId"
+      s"${zuoraConfig.zuoraInstanceUrl}/v1/object/account/$zuoraBillingAccountId"
     ).header("apiAccessKeyId", zuoraConfig.apiAccessKeyId)
       .header("apiSecretAccessKey", zuoraConfig.apiSecretAccessKey)
       .header("Content-Type", "application/json")

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -1,0 +1,305 @@
+package com.gu.sf_billing_account_remover
+
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.parser._
+import io.circe.syntax._
+import scalaj.http._
+
+object BillingAccountRemover extends App {
+  case class SfAuthDetails(access_token: String, instance_url: String)
+
+  //Salesforce
+  case class SfGetBillingAccsResponse(done: Boolean,
+                                      records: Seq[Records],
+                                      nextRecordsUrl: Option[String] = None)
+  case class Records(Id: String,
+                     Zuora__Account__c: String,
+                     Zuora__External_Id__c: String,
+                     GDPR_Removal_Attempts__c: Int,
+                     ErrorMessage: Option[String] = None,
+                     ErrorCode: Option[String] = None)
+  case class Attributes(`type`: String)
+
+  case class SfBillingAccountToUpdate(id: String,
+                                      GDPR_Removal_Attempts__c: Int,
+                                      attributes: Attributes = Attributes(
+                                        `type` = "Zuora__CustomerAccount__c"
+                                      ))
+  case class SfBillingAccountsToUpdate(allOrNone: Boolean,
+                                       records: Seq[SfBillingAccountToUpdate])
+
+  case class SfErrorRecordToCreate(Type__c: String,
+                                   Info__c: String,
+                                   Message__c: String,
+                                   attributes: Attributes = Attributes(
+                                     `type` = "Apex_Error__c"
+                                   ))
+  case class SfErrorRecordsToCreate(allOrNone: Boolean,
+                                    records: Seq[SfErrorRecordToCreate])
+
+  //Zuora
+  case class BillingAccountsForRemoval(CrmId: String = "",
+                                       Status: String = "Canceled")
+  case class Errors(Code: String, Message: String)
+  case class ZuoraResponse(Success: Boolean, Errors: Seq[Errors])
+
+  val optConfig = for {
+    sfUserName <- Option(System.getenv("username"))
+    sfClientId <- Option(System.getenv("client_id"))
+    sfClientSecret <- Option(System.getenv("client_secret"))
+    sfPassword <- Option(System.getenv("password"))
+    sfToken <- Option(System.getenv("token"))
+    sfAuthUrl <- Option(System.getenv("authUrl"))
+
+    zuoraApiAccessKeyId <- Option(System.getenv("apiAccessKeyId"))
+    zuoraApiSecretAccessKey <- Option(System.getenv("apiSecretAccessKey"))
+
+  } yield
+    Config(
+      SalesforceConfig(
+        userName = sfUserName,
+        clientId = sfClientId,
+        clientSecret = sfClientSecret,
+        password = sfPassword,
+        token = sfToken,
+        authUrl = sfAuthUrl
+      ),
+      ZuoraConfig(
+        apiAccessKeyId = zuoraApiAccessKeyId,
+        apiSecretAccessKey = zuoraApiSecretAccessKey
+      )
+    )
+
+  val limit = 200;
+  val query =
+    s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Active_Subs__c > 0 and Zuora__External_Id__c != null limit $limit"
+  var counter: Int = 0;
+  processPage(query)
+
+  def processPage(query: String): Unit = {
+    val t1 = System.nanoTime
+
+    println("process records with query:" + query)
+
+    val iteration = for {
+      config <- optConfig map (c => Right(c)) getOrElse Left(
+        new RuntimeException("Missing config value")
+      )
+      token <- authToken(config.salesforceConfig)
+      getBillingAccountsResponse <- getSfBillingAccounts(query, token)
+      sfRecords = getBillingAccountsResponse.records
+
+      failedUpdates = updateRecordsInZuora(sfRecords)
+      _ <- updateBillingAccountsInSf(token, failedUpdates)
+      _ <- insertErrorRecordsInSf(token, failedUpdates)
+    } yield getBillingAccountsResponse
+
+    val duration = (System.nanoTime - t1) / 1e9d
+    println("Elapsed time: " + duration + "s")
+
+  }
+
+  def getSfBillingAccounts(
+    query: String,
+    bearerToken: String
+  ): Either[Error, SfGetBillingAccsResponse] = {
+
+    val billingAccountListFromSf = getBillingAccountsFromSf(query, bearerToken)
+    println("billingAccountListFromSf: " + billingAccountListFromSf)
+    val decodedBillingAccounts = decode[SfGetBillingAccsResponse](
+      billingAccountListFromSf
+    ) map { billingAccountsObject =>
+      billingAccountsObject
+    }
+
+    decodedBillingAccounts
+  }
+
+  def updateRecordsInZuora(recordsForUpdate: Seq[Records]): Seq[Records] = {
+
+    for {
+      billingAccount <- recordsForUpdate
+      zuoraCancellationResponses <- updateBillingAccountInZuora(billingAccount)
+    } yield zuoraCancellationResponses
+
+  }
+
+  def updateBillingAccountsInSf(
+    bearerToken: String,
+    recordsToUpdate: Seq[Records]
+  ): Either[Throwable, String] = {
+
+    val sfBillingAccUpdateJson = SfUpdateBillingAccounts(recordsToUpdate).asJson.spaces2
+    updateSfBillingAccs(bearerToken, sfBillingAccUpdateJson)
+
+  }
+
+  def insertErrorRecordsInSf(
+    bearerToken: String,
+    recordsToUpdate: Seq[Records]
+  ): Either[Throwable, String] = {
+
+    val sfErrorRecordInsertJson = SfCreateErrorRecords(recordsToUpdate).asJson.spaces2
+    insertSfErrorRecs(bearerToken, sfErrorRecordInsertJson)
+
+  }
+
+  def updateBillingAccountInZuora(accountToDelete: Records): Option[Records] = {
+    counter = counter + 1
+    val response =
+      updateZuoraBillingAcc(
+        BillingAccountsForRemoval().asJson.spaces2,
+        accountToDelete.Zuora__External_Id__c
+      )
+    println(counter + " | response:" + response)
+    val parsedResponse = decode[ZuoraResponse](response)
+
+    parsedResponse match {
+      case Right(dr) =>
+        if (dr.Success) {
+          None
+        } else {
+          Some(
+            accountToDelete.copy(
+              ErrorCode = Some(dr.Errors(0).Code),
+              ErrorMessage = Some(dr.Errors(0).Message)
+            )
+          )
+        }
+      case Left(ex) => {
+        Some(accountToDelete.copy(ErrorMessage = Some(ex.toString)))
+      }
+    }
+
+  }
+
+  def insertSfErrorRecs(bearerToken: String,
+                        jsonBody: String): Either[Throwable, String] = {
+
+    val response =
+      try {
+        Right(
+          Http(
+            "https://gnmtouchpoint--dev.my.salesforce.com/services/data/v45.0/composite/sobjects"
+          ).header("Authorization", s"Bearer $bearerToken")
+            .header("Content-Type", "application/json")
+            .put(jsonBody)
+            .method("POST")
+            .asString
+            .body
+        )
+      } catch {
+        case ex: Throwable => Left(ex)
+      }
+    response
+  }
+
+  def updateSfBillingAccs(bearerToken: String,
+                          jsonBody: String): Either[Throwable, String] = {
+
+    val response =
+      try {
+        Right(
+          Http(
+            "https://gnmtouchpoint--dev.my.salesforce.com/services/data/v45.0/composite/sobjects"
+          ).header("Authorization", s"Bearer $bearerToken")
+            .header("Content-Type", "application/json")
+            .put(jsonBody)
+            .method("PATCH")
+            .asString
+            .body
+        )
+      } catch {
+        case ex: Throwable => Left(ex)
+      }
+    response
+  }
+
+  def updateZuoraBillingAcc(billingAccountForRemovalAsJson: String,
+                            zuoraBillingAccountId: String) = {
+    Http(
+      s"https://rest.apisandbox.zuora.com/v1/object/account/$zuoraBillingAccountId"
+    ).header("apiAccessKeyId", System.getenv("apiAccessKeyId"))
+      .header("apiSecretAccessKey", System.getenv("apiSecretAccessKey"))
+      .header("Content-Type", "application/json")
+      .put(billingAccountForRemovalAsJson)
+      .asString
+      .body
+  }
+
+  def parseBillingAccountsFromSf(
+    billingAccountList: String
+  ): Either[Exception, Seq[Records]] =
+    decode[SfGetBillingAccsResponse](billingAccountList) map {
+      billingAccountsObject =>
+        billingAccountsObject.records
+    }
+
+  def getBillingAccountsFromSf(query: String, bearerToken: String): String = {
+    Http(
+      s"https://gnmtouchpoint--dev.my.salesforce.com/services/data/v20.0/query/"
+    ).param("q", query)
+      .option(HttpOptions.readTimeout(30000))
+      .header("Authorization", s"Bearer $bearerToken")
+      .method("GET")
+      .asString
+      .body
+  }
+
+  def auth(salesforceConfig: SalesforceConfig): String = {
+    Http(s"${System.getenv("authUrl")}/services/oauth2/token")
+      .postForm(
+        Seq(
+          "grant_type" -> "password",
+          "client_id" -> salesforceConfig.clientId,
+          "client_secret" -> salesforceConfig.clientSecret,
+          "username" -> salesforceConfig.userName,
+          "password" -> s"${salesforceConfig.password}${salesforceConfig.token}"
+        )
+      )
+      .asString
+      .body
+
+  }
+
+  def authToken(salesforceConfig: SalesforceConfig) =
+    decode[SfAuthDetails](auth(salesforceConfig)) match {
+      case Right(responseObject) => Right(responseObject.access_token)
+      case Left(ex)              => Left(ex)
+    }
+
+  object SfUpdateBillingAccounts {
+    def apply(recordList: Seq[Records]): SfBillingAccountsToUpdate = {
+
+      val recordListWithincrementedGDPRAttempts =
+        recordList.map(
+          a => a.copy(GDPR_Removal_Attempts__c = a.GDPR_Removal_Attempts__c + 1)
+        )
+
+      val sfBillingAccounts = recordListWithincrementedGDPRAttempts
+        .map(a => SfBillingAccountToUpdate(a.Id, a.GDPR_Removal_Attempts__c))
+        .toSeq
+
+      SfBillingAccountsToUpdate(false, sfBillingAccounts)
+    }
+  }
+
+  object SfCreateErrorRecords {
+    def apply(recordList: Seq[Records]): SfErrorRecordsToCreate = {
+
+      val sfErrorRecords = recordList
+        .map(
+          a =>
+            SfErrorRecordToCreate(
+              Type__c = a.ErrorCode.get,
+              Info__c = "Billing Account Id:" + a.Id,
+              Message__c = a.ErrorMessage.get
+          )
+        )
+        .toSeq
+
+      SfErrorRecordsToCreate(false, sfErrorRecords)
+    }
+  }
+}

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -75,8 +75,6 @@ object BillingAccountRemover extends App {
       )
     )
 
-  var counter: Int = 0;
-
   processBillingAccounts()
 
   def processBillingAccounts(): Unit = {
@@ -100,7 +98,7 @@ object BillingAccountRemover extends App {
         updateBillingAccountsInSf(sfAuthDetails, failedUpdates)
         insertErrorRecordsInSf(sfAuthDetails, failedUpdates)
       }
-    } yield allUpdates
+    } yield ()
   }
 
   def getSfBillingAccounts(
@@ -168,13 +166,12 @@ object BillingAccountRemover extends App {
   def updateBillingAccountInZuora(
     accountToDelete: BillingAccountsRecords.Records
   ): Option[BillingAccountsRecords.Records] = {
-    counter = counter + 1
+
     val response =
       updateZuoraBillingAcc(
         BillingAccountsForRemoval().asJson.spaces2,
         accountToDelete.Zuora__External_Id__c
       )
-    println(counter + " | response:" + response)
 
     val parsedResponse = decode[ZuoraResponse](response)
 

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -82,7 +82,7 @@ object BillingAccountRemover extends App {
   processBillingAccounts()
 
   def processBillingAccounts(): Unit = {
-    for {
+    (for {
       config <- optConfig.toRight(new RuntimeException("Missing config value"))
       sfAuthDetails <- decode[SfAuthDetails](auth(config.salesforceConfig))
       getCustomSettingResponse <- getSfCustomSetting(sfAuthDetails)
@@ -97,7 +97,7 @@ object BillingAccountRemover extends App {
         maxAttempts,
         sfAuthDetails
       )
-    } {
+    } yield {
       val sfRecords = getBillingAccountsResponse.records
 
       val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
@@ -106,7 +106,7 @@ object BillingAccountRemover extends App {
       if (failedUpdates.nonEmpty) {
         writeErrorsBackToSf(sfAuthDetails, failedUpdates)
       }
-    }
+    }).left.foreach(e => throw e)
   }
 
   def auth(salesforceConfig: SalesforceConfig): String = {

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -140,15 +140,11 @@ object BillingAccountRemover extends App {
     maxAttempts: Int,
     sfAuthentication: SfAuthDetails
   ): Either[Error, SfGetBillingAccsResponse] = {
-    val limit = 5;
-    val devQuery =
-      s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Name like '%Bill-Acc-Remover-ctc%' and createddate>=2020-09-17T09:17:45.000+0000 order by Name limit $limit"
+    val limit = 200;
 
-    //val prodQuery =
-    s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Account.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts limit $limit"
+    val query =
+      s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Account.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts limit $limit"
 
-    val query = devQuery
-    //can we bring this into a one liner and remove the method?
     decode[SfGetBillingAccsResponse](doSfGetWithQuery(sfAuthentication, query))
   }
 

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -122,16 +122,9 @@ object BillingAccountRemover extends App {
     sfAuthentication: SfAuthDetails
   ): Either[Error, SfGetCustomSettingResponse] = {
 
-    val customSettingFromSf =
+    decode[SfGetCustomSettingResponse](
       getMaxAttemptsCustomSetting(sfAuthentication)
-    println("customSettingFromSf:" + customSettingFromSf)
-    val decodedCustomSetting = decode[SfGetCustomSettingResponse](
-      customSettingFromSf
-    ) map { customSettingObject =>
-      customSettingObject
-    }
-
-    decodedCustomSetting
+    )
   }
 
   def updateRecordsInZuora(

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -249,8 +249,10 @@ object BillingAccountRemover extends App {
     failedUpdates: Seq[BillingAccountsRecords.Records]
   ): Unit = {
 
-    updateBillingAccountsInSf(sfAuthDetails, failedUpdates)
-    insertErrorRecordsInSf(sfAuthDetails, failedUpdates)
+    (for {
+      _ <- updateBillingAccountsInSf(sfAuthDetails, failedUpdates)
+      _ <- insertErrorRecordsInSf(sfAuthDetails, failedUpdates)
+    } yield ()).left.foreach(e => throw e)
 
   }
 

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -95,16 +95,17 @@ object BillingAccountRemover extends App {
         maxAttempts,
         sfAuthDetails
       )
-      sfRecords = getBillingAccountsResponse.records
+    } {
+      val sfRecords = getBillingAccountsResponse.records
 
-      allUpdates = updateRecordsInZuora(sfRecords)
-      failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
+      val allUpdates = updateRecordsInZuora(sfRecords)
+      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
 
-      _ = if (failedUpdates.nonEmpty) {
+      if (failedUpdates.nonEmpty) {
         updateBillingAccountsInSf(sfAuthDetails, failedUpdates)
         insertErrorRecordsInSf(sfAuthDetails, failedUpdates)
       }
-    } yield ()
+    }
   }
 
   def getSfBillingAccounts(

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountsRecords.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountsRecords.scala
@@ -1,0 +1,10 @@
+package com.gu.sf_billing_account_remover
+
+object BillingAccountsRecords {
+  case class Records(Id: String,
+                     Zuora__Account__c: String,
+                     Zuora__External_Id__c: String,
+                     GDPR_Removal_Attempts__c: Int,
+                     ErrorMessage: Option[String] = None,
+                     ErrorCode: Option[String] = None)
+}

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/Config.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/Config.scala
@@ -1,0 +1,12 @@
+package com.gu.sf_billing_account_remover
+
+case class Config(salesforceConfig: SalesforceConfig, zuoraConfig: ZuoraConfig)
+
+case class ZuoraConfig(apiAccessKeyId: String, apiSecretAccessKey: String)
+
+case class SalesforceConfig(authUrl: String,
+                            clientId: String,
+                            clientSecret: String,
+                            userName: String,
+                            password: String,
+                            token: String)

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/Config.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/Config.scala
@@ -2,7 +2,9 @@ package com.gu.sf_billing_account_remover
 
 case class Config(salesforceConfig: SalesforceConfig, zuoraConfig: ZuoraConfig)
 
-case class ZuoraConfig(apiAccessKeyId: String, apiSecretAccessKey: String)
+case class ZuoraConfig(apiAccessKeyId: String,
+                       apiSecretAccessKey: String,
+                       zuoraInstanceUrl: String)
 
 case class SalesforceConfig(authUrl: String,
                             clientId: String,

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/CustomSettingRecords.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/CustomSettingRecords.scala
@@ -1,0 +1,5 @@
+package com.gu.sf_billing_account_remover
+
+object CustomSettingRecords {
+  case class Records(Id: String, Property_Value__c: Int)
+}


### PR DESCRIPTION
# Description
This feature enables the automated removal of Zuora records in Salesforce for GDPR Retention, by removing the crmId in Zuora of Billing Accounts marked for removal in Salesforce. 

When the crmId is removed from a Billing Account in Zuora, z360 will delete the Billing Account, and all of its related Zuora records (Zuora__Subscription__c, zqu__ProductRatePlan__c, Zuora__PaymentMethod__c, Zuora__Refund__c etc) in Salesforce.

This lambda works alongside logic in Salesforce to surface Billing Accounts for removal, as shown in the image below:

![image](https://user-images.githubusercontent.com/36296660/93484015-53852000-f8f9-11ea-8510-5d8d2c593213.png)

## Lambda Actions
The lambda performs the following actions:

1. Performs a GET HttpRequest to Salesforce, to obtain a list of all Billing Accounts where the parent Account record is marked as ‘GDPR_Billing_Accounts_Ready_for_Removal__c’ 

2. For each Billing Account retrieved, perform an individual callout to Zuora to remove the CrmId and set status=’Canceled’

3. Any failures that occur (for example if the Billing Account is already canceled, or where there are active subscriptions, or something else), will be collected and two subsequent PATCH HttpRequests will be made to Salesforce:

- Update Billing Account field GDPR_Removal_Attempts__c by incrementing by 1
- Insert Apex_Error__c record that contains the details of the error


### Identifying Billing Accounts for removal
Billing Accounts will be marked for removal when the parent Account, and its related records fall outside the currently agreed time window for retaining the records, which is currently set to be 30 months since the last 'touchpoint'

The last **touchpoint** is defined as the most recent interaction with the customer, which could be the creation date or last modified of a case, the cancellation date of a subscription, or the date of a response to a customer survey, amongst others. 

The specific logic for the last touchpoint for a given set of customer records is contained within the AccountRetentionBatch job in Salesforce, and is not the focus of this PR.



## Handling Limits

### Lamdba maximum runtime is 15 minutes
During testing, it was observed that processing a set of 200 records in a response from Salesforce, from the executing initial query, to writing back to Salesforce any errors that occurred, took approximately 2.5 minutes, which is well within the 15 minute time window for operations to take place. 


### Salesforce API limits
Salesforce API callouts are minimised to 2 or 4 depending on whether there are any failures when calling out to Zuora:

 - When querying for records from Salesforce, one query is used to get a maximum of 200 records in one call

- The lambda then splits this record list and performs individual callouts to Zuora to do the necessary update.

- Any failures are then collated into a list and parsed into a json object that uses the Salesforce REST API Composite request to update all relevant Billing Accounts, and another json object that performs another composite request to insert the relevant Apex Error records.


## Scheduling
When the process is activated for the first time, there will be a much higher number of records (>40,000)  to process than there would be for the usual daily run (estimated to be less than 200 per day). 

In order to process higher numbers of records, using recursion was briefly implemented and tested, but it was subsequently decided that the added complexity of using recursion could be eliminated by simply scheduling the lambda to execute with a higher frequency (once every 20 minutes between 10:00 and 15:00 each day) to clear the backlog of records, and once complete, to reschedule the lambda to run daily to process the daily cohort of records which have fallen outside the retention window.


## Potential Risks

### Risk
An attempt to remove the crmId in Zuora for a Billing Account fails 

### How it is handled
This will result in an update to GDPR_Removal_Attempts__c field on Salesforce Billing Account record, as well as the creation of corresponding Apex Error records where the error message and error code from the failure response from Zuora are logged. 

Each time the lambda runs, it will extract Billing Accounts where GDPR_Removal_Attempts__c <= 5, therefore for each Billing Account that encounters an error when updating in Zuora, there will be 4 subsequent retries before it is omitted from the resultset returned to the Lambda for processing.


### Risk
5 or more consecutive attempts to remove the crmId in Zuora for a Billing Account fail

### How it is handled
It is intended that a report will be scheduled in Salesforce, that will identify any Billing Accounts where GDPR_Removal_Attempts__c >=5. This report will be run weekly, and the contents of which will be emailed to the relevant team to investigate the errors.

### Risk
Calling back to Salesforce to increment Removal Attempts on Billing Account or creating Error records fails

### How it is handled
In this scenario, the data stored in Salesforce will not accurately represent the state of the Billing Account’s journey for removal, in that its value for  GDPR_Removal_Attempts__c will remain as 0, and/or there will be no Apex Errors to provide further context to the issue. 

This is handled by the addition of a new datetime field on the Salesforce Account object (parent to Billing Account). The field will contain the date time that the Account and its related records (which include Billing Account) were initially marked as ‘ready for gdpr removal’. This field will let us know if any records have been ready for removal for an unintended amount of time, for example 1 week or more. A report should be scheduled to identify any Accounts where the date they are marked for removal is more than one week in the past at the time the report is run.

## Testing
A Runner collection was executed in Postman to generate the following test data sets:

1. 200 Billing Accounts that should successfully be removed by the execution of the lambda

2. 200 Billing Accounts that should fail when execution of the lambda takes place. This was achieved by ensuring that each of the Billing Accounts had 1 active subscription

3. A combination of 100 Billing Accounts that should be successfully removed and 100 Billing Accounts that should fail (as in 2 above)

Each of the test scenarios yielded the expected results, namely that successes resulted in the Billing Accounts being removed from Salesforce, and failures resulted in the incrementing of GDPR_Removal_Attempts__c by 1, and an Apex Error records being generated for each failure.

See [BillingAccountRemover Test Data](https://docs.google.com/spreadsheets/d/1QX_uP9Yxmm8xQHh2BZePOPXtNq4u-ZH8w2qYFXYnC78/edit?usp=sharing)

**BillingAccounts.GDPR_Removal_Attempts__c**
![image](https://user-images.githubusercontent.com/36296660/93485322-dce92200-f8fa-11ea-9cda-800b806cb6b4.png)



**New Apex Error on failure**
![image](https://user-images.githubusercontent.com/36296660/93484310-aced4f00-f8f9-11ea-8e9b-5376de6b34b3.png)

## Release
It is intended to deploy this solution to production but not to schedule it to run until a future date. There are still some decisions to be made as to whether the scope of the actions that the lambda performs should be expanded, for example to delete the billing account entirely in Zuora, or to set values in some other fields.

