### PR TITLE
allow 15 minutes for dev env cleaner to run

### DIFF
--- a/handlers/dev-env-cleaner/cfn.yaml
+++ b/handlers/dev-env-cleaner/cfn.yaml
@@ -36,7 +36,7 @@ Resources:
         Key: !Sub membership/${Stage}/dev-env-cleaner/lambda.jar
       MemorySize: 2048
       Runtime: java8
-      Timeout: 300
+      Timeout: 900
       Environment:
         Variables:
           Stage: !Ref Stage


### PR DESCRIPTION
following #700 it turns out that now we have changed the it tests to run hourly, it takes more than 5 minutes for the dev env cleaner to clean all the subscriptions.

`2020-09-20T16:26:05.189Z 7543b93e-3d93-4752-97b4-ad47d96d67ea Task timed out after 300.10 seconds`

We could modify it to do some of them in parallel, but thatmight overload zuora, so I decided to try extending the timeout for now.