### PR TITLE
better error message for dev env cleaner failures

### DIFF
--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -154,7 +154,7 @@ class Steps(log: String => Unit) {
       _ <- queryResults(subs_to_cancel).map { case id :: termEndDate :: Nil => cancelSub.run(id, dateToCancel(LocalDate.parse(termEndDate), today())) }.toList.sequence
       _ <- queryResults(accounts_to_cancel).map { case id :: Nil => cancelAccount.run(id) }.toList.sequence
     } yield ()
-    zRes.toDisjunction.leftMap(failure => new RuntimeException(failure.toString))
+    zRes.toDisjunction.leftMap(failure => new RuntimeException(s"one of the preceding requests has failed: ${failure.toString}"))
 
   }
 


### PR DESCRIPTION
The dev env cleaner tries to clean all the subscriptions one by one first, and stores the success/fail status in a list.
Then it checks the list for any failures, throwing an exception if there are any.

This means that if there is a failure, you might have to scroll up quite a bit to find it, and it was not clear from the message.

This PR makes the message a bit clearer so we are more likely to find the problem without having to debug.