### PR TITLE
Convert billing account remover standalone app to lambda

### DIFF
--- a/handlers/sf-billing-account-remover/project/plugins.sbt
+++ b/handlers/sf-billing-account-remover/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -7,7 +7,6 @@ import io.circe.syntax._
 import scalaj.http._
 
 import scala.util.Try
-
 object BillingAccountRemover extends App {
   //Salesforce
   case class SfAuthDetails(access_token: String, instance_url: String)
@@ -310,5 +309,9 @@ object BillingAccountRemover extends App {
 
       SfErrorRecordsToCreate(false, sfErrorRecords)
     }
+  }
+
+  def lambda(): Unit = {
+    processBillingAccounts()
   }
 }


### PR DESCRIPTION
### Change Description
Enhance standalone app created in PR [Salesforce gdpr billing account removal #699](https://github.com/guardian/support-service-lambdas/pull/699) by adding lambda handler method to main logic