### PR TITLE
clean more dev test data, also increase frequency

### DIFF
--- a/handlers/dev-env-cleaner/cfn.yaml
+++ b/handlers/dev-env-cleaner/cfn.yaml
@@ -15,7 +15,7 @@ Mappings:
   Stages:
     Schedule:
       CODE: 'rate(365 days)'
-      PROD: 'rate(1 day)'
+      PROD: 'rate(12 hours)'
   Constants:
     Alarm:
       Process: See the wiki at https://github.com/guardian/support-frontend/wiki/Automated-IT-Tests

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -124,7 +124,7 @@ class Steps(log: String => Unit) {
       subs_to_cancel,
       """select Id, TermEndDate
         |from Subscription
-        |where billtocontact.WorkEmail = 'integration-test@gu.com' and Status = 'Active' and account.Status = 'Active'
+        |where (billtocontact.WorkEmail = 'integration-test@gu.com' OR billtocontact.WorkEmail = 'test@gu.com') and Status = 'Active' and account.Status = 'Active'
         |""".stripMargin
     )
     val accounts_to_cancel = "accounts_to_cancel"


### PR DESCRIPTION
From inspecting the subs created in DEV zuora after an IT test run, I found there are also test@gu.com being created.

This PR adds that address to the cleaner, so it will clean more thoroughly.

I have also upped it from once a day to twice.  This is becasue the alarm period is 1 day, and we want it to at least have two goes, to avoid false alarms.