### PR TITLE
Implement digital voucher suspension

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -418,13 +418,20 @@ lazy val `digital-voucher-cancellation-processor` = all(project in file("handler
   )
   .enablePlugins(RiffRaffArtifact)
 
-lazy val `digital-voucher-suspension-processor` = all(project in file("handlers/digital-voucher-suspension-processor"))
-  .dependsOn(`salesforce-sttp-client`)
+lazy val `digital-voucher-suspension-processor` =
+  all(project in file("handlers/digital-voucher-suspension-processor"))
+  .dependsOn(
+    `salesforce-sttp-client`,
+    `imovo-sttp-client`
+  )
   .settings(
     libraryDependencies ++=
       Seq(
         awsLambda,
-        sttpAsyncHttpClientBackendCats
+        sttpAsyncHttpClientBackendCats,
+        sttpOkhttpBackend,
+        scalatest,
+        scalaMock
       )
         ++ logging
   )

--- a/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorService.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorService.scala
@@ -120,7 +120,7 @@ object DigitalVoucherCancellationProcessorService extends LazyLogging {
             .cancelSubscriptionVoucher(SfSubscriptionId(voucherToCancel.SF_Subscription__r.Id), None)
             .fold(
               {
-                case ImovoClientException(message) if message.contains(ImovoSubscriptionDoesNotExistMessage) =>
+                case ImovoClientException(message, _) if message.contains(ImovoSubscriptionDoesNotExistMessage) =>
                   ImovoCancellationResults(alreadyCancelled = List(voucherToCancel))
                 case error: ImovoClientException =>
                   ImovoCancellationResults(cancellationFailures = List(error))

--- a/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
@@ -224,12 +224,20 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
           successfullyCancelled = List(voucherToCancelQueryResult("valid-sub")),
           cancellationFailures = List(
             ImovoClientException(
-              """Request GET https://unit-test.imovo.com/Subscription/CancelSubscriptionVoucher?SubscriptionId=sf-subscription-id-imovo-failure failed with response ({
+              message = """Request GET https://unit-test.imovo.com/Subscription/CancelSubscriptionVoucher?SubscriptionId=sf-subscription-id-imovo-failure failed with response ({
                 |  "errorMessages" : [
                 |    "Unexpected error"
                 |  ],
                 |  "successfulRequest" : false
-                |})""".stripMargin
+                |})""".stripMargin,
+              responseBody = Some(
+                """{
+                |  "errorMessages" : [
+                |    "Unexpected error"
+                |  ],
+                |  "successfulRequest" : false
+                |}""".stripMargin
+              )
             )
           )
         )

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Config.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Config.scala
@@ -1,31 +1,37 @@
 package com.gu.digitalvouchersuspensionprocessor
 
+import com.gu.imovo.ImovoConfig
 import com.gu.salesforce.SFAuthConfig
 
-case class Config(salesforce: SFAuthConfig)
+case class Config(salesforce: SFAuthConfig, imovo: ImovoConfig)
 
 object Config {
 
-  def fromEnv(): Either[ConfigFailure, Config] = {
-    def envVal(name: String): Either[ConfigFailure, String] =
-      sys.env.get(name).toRight(ConfigFailure(s"No value in environment for '$name'"))
+  def envVal(name: String): Either[ConfigFailure, String] =
+    sys.env.get(name).toRight(ConfigFailure(s"No value in environment for '$name'"))
 
+  def fromEnv(): Either[ConfigFailure, Config] =
     for {
-      url <- envVal("salesforceUrl")
-      clientId <- envVal("salesforceClientId")
-      clientSecret <- envVal("salesforceClientSecret")
-      userName <- envVal("salesforceUserName")
-      password <- envVal("salesforcePassword")
-      token <- envVal("salesforceToken")
+      sfUrl <- envVal("salesforceUrl")
+      sfClientId <- envVal("salesforceClientId")
+      sfClientSecret <- envVal("salesforceClientSecret")
+      sfUserName <- envVal("salesforceUserName")
+      sfPassword <- envVal("salesforcePassword")
+      sfToken <- envVal("salesforceToken")
+      imovoUrl <- envVal("imovoUrl")
+      imovoApiKey <- envVal("imovoApiKey")
     } yield Config(
       salesforce = SFAuthConfig(
-        url = url,
-        client_id = clientId,
-        client_secret = clientSecret,
-        username = userName,
-        password = password,
-        token = token
+        url = sfUrl,
+        client_id = sfClientId,
+        client_secret = sfClientSecret,
+        username = sfUserName,
+        password = sfPassword,
+        token = sfToken
+      ),
+      imovo = ImovoConfig(
+        imovoBaseUrl = imovoUrl,
+        imovoApiKey = imovoApiKey
       )
     )
-  }
 }

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucher.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucher.scala
@@ -10,23 +10,21 @@ import io.circe.parser.decode
 object DigitalVoucher {
 
   def suspend[F[_]: Sync](imovo: ImovoClient[F], suspension: Suspension): EitherT[F, DigitalVoucherSuspendFailure, Unit] =
-    for {
-      _ <- imovo.suspendSubscriptionVoucher(
-        subscriptionId = SfSubscriptionId(suspension.Holiday_Stop_Request__r.SF_Subscription__c),
-        startDate = suspension.Stopped_Publication_Date__c,
-        endDateExclusive = suspension.Stopped_Publication_Date__c.plusDays(1)
-      )
-        .leftFlatMap {
-          case e @ ImovoClientException(_, _) if isExistingSuspension(e) =>
-            EitherT.fromEither(
-              Right[DigitalVoucherSuspendFailure, Unit](())
-            )
-          case e =>
-            EitherT.fromEither(
-              Left[DigitalVoucherSuspendFailure, Unit](DigitalVoucherSuspendFailure(e.toString))
-            )
-        }
-    } yield ()
+    imovo.suspendSubscriptionVoucher(
+      subscriptionId = SfSubscriptionId(suspension.Holiday_Stop_Request__r.SF_Subscription__c),
+      startDate = suspension.Stopped_Publication_Date__c,
+      endDateExclusive = suspension.Stopped_Publication_Date__c.plusDays(1)
+    )
+      .leftFlatMap {
+        case e @ ImovoClientException(_, _) if isExistingSuspension(e) =>
+          EitherT.fromEither(
+            Right[DigitalVoucherSuspendFailure, Unit](())
+          )
+        case e =>
+          EitherT.fromEither(
+            Left[DigitalVoucherSuspendFailure, Unit](DigitalVoucherSuspendFailure(e.toString))
+          )
+      }
 
   private def isExistingSuspension(e: ImovoClientException): Boolean =
     (for {

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucher.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucher.scala
@@ -1,0 +1,38 @@
+package com.gu.digitalvouchersuspensionprocessor
+
+import cats.data.EitherT
+import cats.effect.Sync
+import com.gu.digitalvouchersuspensionprocessor.Salesforce.Suspension
+import com.gu.imovo.{ImovoClient, ImovoClientException, ImovoErrorResponse, SfSubscriptionId}
+import io.circe.generic.auto._
+import io.circe.parser.decode
+
+object DigitalVoucher {
+
+  def suspend[F[_]: Sync](imovo: ImovoClient[F], suspension: Suspension): EitherT[F, DigitalVoucherSuspendFailure, Unit] =
+    for {
+      _ <- imovo.suspendSubscriptionVoucher(
+        subscriptionId = SfSubscriptionId(suspension.Holiday_Stop_Request__r.SF_Subscription__c),
+        startDate = suspension.Stopped_Publication_Date__c,
+        endDateExclusive = suspension.Stopped_Publication_Date__c.plusDays(1)
+      )
+        .leftFlatMap {
+          case e @ ImovoClientException(_, _) if isExistingSuspension(e) =>
+            EitherT.fromEither(
+              Right[DigitalVoucherSuspendFailure, Unit](())
+            )
+          case e =>
+            EitherT.fromEither(
+              Left[DigitalVoucherSuspendFailure, Unit](DigitalVoucherSuspendFailure(e.toString))
+            )
+        }
+    } yield ()
+
+  private def isExistingSuspension(e: ImovoClientException): Boolean =
+    (for {
+      responseBody <- e.responseBody.toRight(false)
+      response <- decode[ImovoErrorResponse](responseBody).left.map(_ => false)
+    } yield response.errorMessages ==
+      Seq("Unable to create holiday, conflicting holiday found between entered dates"))
+      .fold(_ => false, _ => true)
+}

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucher.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucher.scala
@@ -32,5 +32,5 @@ object DigitalVoucher {
       response <- decode[ImovoErrorResponse](responseBody).left.map(_ => false)
     } yield response.errorMessages ==
       Seq("Unable to create holiday, conflicting holiday found between entered dates"))
-      .fold(_ => false, _ => true)
+      .fold(_ => false, identity)
 }

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Failure.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Failure.scala
@@ -7,3 +7,7 @@ sealed trait Failure {
 case class ConfigFailure(reason: String) extends Failure
 
 case class SalesforceFetchFailure(reason: String) extends Failure
+
+case class SalesforceWriteFailure(reason: String) extends Failure
+
+case class DigitalVoucherSuspendFailure(reason: String) extends Failure

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Handler.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Handler.scala
@@ -1,37 +1,72 @@
 package com.gu.digitalvouchersuspensionprocessor
 
+import java.time.LocalDateTime
+
 import cats.arrow.FunctionK
 import cats.data.EitherT
-import cats.effect.IO
+import cats.effect.{IO, Sync}
 import cats.implicits._
+import com.gu.digitalvouchersuspensionprocessor.Salesforce.Suspension
+import com.gu.imovo.ImovoClient
+import com.gu.salesforce.sttp.SalesforceClient
 import com.softwaremill.sttp.impl.cats.implicits._
-import com.softwaremill.sttp.{HttpURLConnectionBackend, Id, SttpBackend}
+import com.softwaremill.sttp.okhttp.OkHttpSyncBackend
+import com.softwaremill.sttp.{Id, SttpBackend}
 import com.typesafe.scalalogging.LazyLogging
 
 object Handler extends LazyLogging {
 
   // lambda entry point
-  def handleRequest(): String =
-    fetchSuspensionsToBeProcessed()
+  def handleRequest(): Unit = processSuspensions()
 
-  def main(args: Array[String]): Unit = println(fetchSuspensionsToBeProcessed())
+  def main(args: Array[String]): Unit = processSuspensions()
 
-  def fetchSuspensionsToBeProcessed(): String = {
-    val fetch = for {
-      config <- EitherT.fromEither[IO](Config.fromEnv())
-      suspensions <- Salesforce.fetchSuspensions(config.salesforce, sttpBackend).leftWiden[Failure].map(_.records)
-    } yield suspensions
-    val suspensions = fetch.value.unsafeRunSync().valueOr { e =>
-      logger.error(s"Fetching suspensions from Salesforce failed: $e")
+  def processSuspensions(): Unit = {
+    val sttpBackend = buildSttpBackend()
+    val processed = for {
+      config <- EitherT.fromEither[IO](Config.fromEnv()).leftWiden[Failure]
+      salesforce <- SalesforceClient(sttpBackend, config.salesforce)
+        .leftMap(e => SalesforceFetchFailure(s"Failed to create Salesforce client: $e"))
+      imovo <- ImovoClient(sttpBackend, config.imovo)
+        .leftMap(e => DigitalVoucherSuspendFailure(s"Failed to create Imovo client: $e"))
+      suspensions <- fetchSuspensionsToBeProcessed(salesforce).leftWiden[Failure]
+      _ <- suspensions.map { suspension =>
+        val result =
+          sendSuspensionToDigitalVoucherApi(salesforce, imovo, suspension, LocalDateTime.now)
+        loggedResult(suspension, result)
+      }.toList.sequence.map(_ => ())
+    } yield ()
+    processed.value.unsafeRunSync().valueOr { e =>
+      logger.error(s"Processing failed: $e")
       throw new RuntimeException(e.toString)
     }
-    suspensions.foreach(suspension =>
-      logger.info(s"Suspension to be processed: ${suspension.toString}"))
-    suspensions.toString
   }
 
+  def fetchSuspensionsToBeProcessed[F[_]: Sync](salesforce: SalesforceClient[F]): EitherT[F, SalesforceFetchFailure, Seq[Suspension]] =
+    Salesforce.fetchSuspensions(salesforce).map(_.records).map { suspensions =>
+      logger.info(s"${suspensions.length} suspensions to be processed")
+      suspensions.foreach(suspension =>
+        logger.info(s"To be processed: $suspension"))
+      suspensions
+    }
+
+  def sendSuspensionToDigitalVoucherApi[F[_]: Sync](salesforce: SalesforceClient[F], imovo: ImovoClient[F], suspension: Suspension, now: LocalDateTime): EitherT[F, Failure, Unit] =
+    for {
+      _ <- DigitalVoucher.suspend(imovo, suspension).leftWiden[Failure]
+      _ <- Salesforce.writeSuccess(salesforce, suspension, now).leftWiden[Failure]
+    } yield ()
+
+  def loggedResult[F[_]: Sync](suspension: Suspension, result: EitherT[F, Failure, Unit]): EitherT[F, Failure, Unit] =
+    result.bimap({ e =>
+      logger.error(s"Failed to process $suspension: $e")
+      e
+    }, { _ =>
+      logger.info(s"Successfully processed $suspension")
+      ()
+    })
+
   // This is stolen from the digital-voucher-cancellation-processor - can be improved when STTP upgraded to v2
-  val sttpBackend: SttpBackend[IO, Nothing] =
-    sttpBackendToCatsMappableSttpBackend[Id, Nothing](HttpURLConnectionBackend())
+  def buildSttpBackend(): SttpBackend[IO, Nothing] =
+    sttpBackendToCatsMappableSttpBackend[Id, Nothing](OkHttpSyncBackend())
       .mapK(FunctionK.lift[Id, IO](IO.delay))
 }

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala
@@ -44,6 +44,9 @@ object Salesforce {
          |SELECT Id, Holiday_Stop_Request__r.SF_Subscription__c, Stopped_Publication_Date__c, Holiday_Stop_Request__r.Subscription_Name__c
          |FROM Holiday_Stop_Requests_Detail__c
          |WHERE Holiday_Stop_Request__r.SF_Subscription__r.Product__c = 'Newspaper Digital Voucher'
+         |AND Stopped_Publication_Date__c >= TODAY
+         |AND Is_Withdrawn__c = false
+         |AND Is_Actioned__c = true
          |AND Sent_To_Digital_Voucher_Service__c = null
          |""".stripMargin
   }

--- a/handlers/digital-voucher-suspension-processor/src/test/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucherTest.scala
+++ b/handlers/digital-voucher-suspension-processor/src/test/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucherTest.scala
@@ -1,0 +1,81 @@
+package com.gu.digitalvouchersuspensionprocessor
+
+import java.time.LocalDate
+
+import cats.Id
+import cats.data.EitherT
+import com.gu.digitalvouchersuspensionprocessor.Salesforce.{HolidayStopRequest, Suspension}
+import com.gu.digitalvouchersuspensionprocessor.Syncs.idSync
+import com.gu.imovo.{ImovoClient, ImovoClientException, SfSubscriptionId}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.OneInstancePerTest
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DigitalVoucherTest extends AnyFlatSpec with Matchers with MockFactory with OneInstancePerTest {
+
+  private val subscriptionNumber = "subNum"
+  private val sfSubscriptionId = "sfId"
+  private val suspendedDate = LocalDate.parse("2020-10-01")
+  private val suspension = Suspension(
+    Id = "id",
+    Stopped_Publication_Date__c = suspendedDate,
+    Holiday_Stop_Request__r = HolidayStopRequest(
+      SF_Subscription__c = sfSubscriptionId,
+      Subscription_Name__c = subscriptionNumber
+    )
+  )
+
+  private val imovo = mock[ImovoClient[Id]]
+
+  "suspend" should "return unit after successfully suspending a subscription" in {
+    (imovo.suspendSubscriptionVoucher _)
+      .expects(
+        SfSubscriptionId(sfSubscriptionId),
+        suspendedDate,
+        suspendedDate.plusDays(1)
+      )
+      .returns(EitherT[Id, ImovoClientException, Unit](Right(())))
+
+    DigitalVoucher.suspend(imovo, suspension).value shouldBe Right(())
+  }
+
+  it should "return a failure after failing to suspend a subscription" in {
+    (imovo.suspendSubscriptionVoucher _)
+      .expects(
+        SfSubscriptionId(sfSubscriptionId),
+        suspendedDate,
+        suspendedDate.plusDays(1)
+      )
+      .returns(EitherT[Id, ImovoClientException, Unit](Left(ImovoClientException("failed"))))
+
+    DigitalVoucher.suspend(imovo, suspension).value shouldBe Left(
+      DigitalVoucherSuspendFailure("ImovoClientException(failed,None)")
+    )
+  }
+
+  it should "return a unit if subscription has already been suspended on given date" in {
+    (imovo.suspendSubscriptionVoucher _)
+      .expects(
+        SfSubscriptionId(sfSubscriptionId),
+        suspendedDate,
+        suspendedDate.plusDays(1)
+      )
+      .returns(EitherT[Id, ImovoClientException, Unit](Left(ImovoClientException(
+        message = s"""
+          |Request GET\n
+          |https://domain/Subscription/SetHoliday?
+          |SubscriptionId=$sfSubscriptionId&StartDate=$suspendedDate&
+          |ReactivationDate=${suspendedDate.plusDays(1)}\n
+          |failed with response ({"errorMessages":
+          |["Unable to create holiday, conflicting holiday found between entered dates"],\n
+          |"successfulRequest":false})"))))
+          |""".stripMargin,
+        responseBody = Some(
+          """{"errorMessages":["Unable to create holiday, conflicting holiday found between entered dates"],"successfulRequest":false}"""
+        )
+      ))))
+
+    DigitalVoucher.suspend(imovo, suspension).value shouldBe Right(())
+  }
+}

--- a/handlers/digital-voucher-suspension-processor/src/test/scala/com/gu/digitalvouchersuspensionprocessor/Syncs.scala
+++ b/handlers/digital-voucher-suspension-processor/src/test/scala/com/gu/digitalvouchersuspensionprocessor/Syncs.scala
@@ -1,0 +1,17 @@
+package com.gu.digitalvouchersuspensionprocessor
+
+import cats.effect.{ExitCase, Sync}
+import com.softwaremill.sttp.Id
+
+object Syncs {
+
+  implicit val idSync: Sync[Id] = new Sync[Id] {
+    def suspend[A](thunk: => Id[A]): Id[A] = thunk
+    def bracketCase[A, B](acquire: Id[A])(use: A => Id[B])(release: (A, ExitCase[Throwable]) => Id[Unit]): Id[B] = use(acquire)
+    def flatMap[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = f(fa)
+    def tailRecM[A, B](a: A)(f: A => Id[Either[A, B]]): Id[B] = ???
+    def raiseError[A](e: Throwable): Id[A] = ???
+    def handleErrorWith[A](fa: Id[A])(f: Throwable => Id[A]): Id[A] = fa
+    def pure[A](x: A): Id[A] = x
+  }
+}

--- a/handlers/digital-voucher-suspension-processor/src/test/scala/com/gu/digitalvouchersuspensionprocessor/Syncs.scala
+++ b/handlers/digital-voucher-suspension-processor/src/test/scala/com/gu/digitalvouchersuspensionprocessor/Syncs.scala
@@ -1,8 +1,11 @@
 package com.gu.digitalvouchersuspensionprocessor
 
 import cats.effect.{ExitCase, Sync}
-import com.softwaremill.sttp.Id
+import cats.Id
 
+/**
+ * The tests use the cats
+ */
 object Syncs {
 
   implicit val idSync: Sync[Id] = new Sync[Id] {

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala
@@ -17,7 +17,7 @@ import play.api.libs.json.{JsValue, Json}
 
 object SalesforceHolidayStopRequestsDetail extends Logging {
 
-  final val HolidayStopRequestsDetailSfObjectRef = "Holiday_Stop_Requests_Detail__c"
+  final val HolidayStopRequestsDetailSfObjectRef: String = "Holiday_Stop_Requests_Detail__c"
   val holidayStopRequestsDetailSfObjectsBaseUrl = sfObjectsBaseUrl + HolidayStopRequestsDetailSfObjectRef
 
   case class HolidayStopRequestsDetailId(value: String) extends AnyVal

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,6 +44,7 @@ object Dependencies {
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion
   val sttpCats = "com.softwaremill.sttp" %% "cats" % sttpVersion
   val sttpAsyncHttpClientBackendCats = "com.softwaremill.sttp" %% "async-http-client-backend-cats" % sttpVersion
+  val sttpOkhttpBackend = "com.softwaremill.sttp" %% "okhttp-backend" % sttpVersion
   val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.9.1"
   val scalajHttp = "org.scalaj" %% "scalaj-http" % "2.4.2"
 


### PR DESCRIPTION
This finishes the digital voucher suspension processor, begun in #713.
It connects Salesforce to Imovo to suspend voucher subscriptions that have already been marked as suspended internally.

The main logic is [here](https://github.com/guardian/support-service-lambdas/compare/kc-voucher-suspend?expand=1#diff-b39ec5741ba13514c290cdffd645d5f4R32-R37).
We:
1. read all the subscriptions that are eligible for suspension
1. for each one:
    1. we send it to Imovo and then, if successful, 
    1. write a timestamp back to Salesforce.
