### PR TITLE
also clean test accounts as well as subs

### DIFF
--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -132,7 +132,7 @@ class Steps(log: String => Unit) {
       accounts_to_cancel,
       """select Id
         |from Account
-        |where billtocontact.WorkEmail = 'integration-test@gu.com' and Status = 'Active'
+        |where (billtocontact.WorkEmail = 'integration-test@gu.com' OR billtocontact.WorkEmail = 'test@gu.com') and Status = 'Active'
         |""".stripMargin
     )
     val request = AquaQueryRequest(


### PR DESCRIPTION
In the previous PR https://github.com/guardian/support-service-lambdas/pull/711 I added some code to clean test subscriptions, but I forgot to clean the accounts as well.  This actually meant there was more subscriptions data in salesforce as it stored the cancellation as well as the original sub.
Cancelling the account as well will wipe the lot.

I am running it locally and the space usage in SF is decreasing, so this should work on the daily cleaner as well.

cc @david-pepper @rupertbates @ripecosta 