### PR TITLE
Fix wrong confirmation email for Subscription Card (Digital Voucher)

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/SendConfirmationEmail.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/SendConfirmationEmail.scala
@@ -41,6 +41,7 @@ object SendConfirmationEmail extends Logging {
 
   def dataExtensionFor(plan: Plan) = DataExtensionName(
     plan.id match {
+      case _: DigitalVoucherPlanId => "paper-subscription-card" // SV_SC_WelcomeDay0
       case _: VoucherPlanId => "paper-voucher"
       case _: DigipackPlanId => "digipack"
       case _: ContributionPlanId => "regular-contribution-thank-you"

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -161,25 +161,25 @@ object PlanId {
 
   case object GuardianWeeklyROWAnnual extends PlanId("guardian_weekly_row_annual") with GuardianWeeklyRow
 
-  case object DigitalVoucherWeekend extends PlanId("digital_voucher_weekend") with VoucherPlanId
+  case object DigitalVoucherWeekend extends PlanId("digital_voucher_weekend") with DigitalVoucherPlanId
 
-  case object DigitalVoucherWeekendPlus extends PlanId("digital_voucher_weekend_plus") with VoucherPlanId
+  case object DigitalVoucherWeekendPlus extends PlanId("digital_voucher_weekend_plus") with DigitalVoucherPlanId
 
-  case object DigitalVoucherEveryday extends PlanId("digital_voucher_everyday") with VoucherPlanId
+  case object DigitalVoucherEveryday extends PlanId("digital_voucher_everyday") with DigitalVoucherPlanId
 
-  case object DigitalVoucherEverydayPlus extends PlanId("digital_voucher_everyday_plus") with VoucherPlanId
+  case object DigitalVoucherEverydayPlus extends PlanId("digital_voucher_everyday_plus") with DigitalVoucherPlanId
 
-  case object DigitalVoucherSunday extends PlanId("digital_voucher_sunday") with VoucherPlanId
+  case object DigitalVoucherSunday extends PlanId("digital_voucher_sunday") with DigitalVoucherPlanId
 
-  case object DigitalVoucherSundayPlus extends PlanId("digital_voucher_sunday_plus") with VoucherPlanId
+  case object DigitalVoucherSundayPlus extends PlanId("digital_voucher_sunday_plus") with DigitalVoucherPlanId
 
-  case object DigitalVoucherSaturday extends PlanId("digital_voucher_saturday") with VoucherPlanId
+  case object DigitalVoucherSaturday extends PlanId("digital_voucher_saturday") with DigitalVoucherPlanId
 
-  case object DigitalVoucherSaturdayPlus extends PlanId("digital_voucher_saturday_plus") with VoucherPlanId
+  case object DigitalVoucherSaturdayPlus extends PlanId("digital_voucher_saturday_plus") with DigitalVoucherPlanId
 
-  case object DigitalVoucherSixday extends PlanId("digital_voucher_sixday") with VoucherPlanId
+  case object DigitalVoucherSixday extends PlanId("digital_voucher_sixday") with DigitalVoucherPlanId
 
-  case object DigitalVoucherSixdayPlus extends PlanId("digital_voucher_sixday_plus") with VoucherPlanId
+  case object DigitalVoucherSixdayPlus extends PlanId("digital_voucher_sixday_plus") with DigitalVoucherPlanId
 
   val enabledVoucherPlans = List(
     VoucherEveryDay,


### PR DESCRIPTION
## What does this change?

Fix error introduced by https://github.com/guardian/support-service-lambdas/pull/679 which caused sending paper voucher confirmation email instead of Subscription Card one.

## How to test

Try CSR acquisition of Subscription Card in UAT and see if correct confirmation email is sent.

## How can we measure success?

SV_SC_WelcomeDay0 campaign should pick up.

## Have we considered potential risks?

No major risk apparent given correct campaign mapping.

