### PR TITLE
Add deployment configuration for digital-voucher suspension lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -435,6 +435,7 @@ lazy val `digital-voucher-suspension-processor` =
       )
         ++ logging
   )
+  .enablePlugins(RiffRaffArtifact)
 
 lazy val `contact-us-api` = all(project in file("handlers/contact-us-api"))
   .dependsOn(handler)

--- a/handlers/digital-voucher-suspension-processor/build.sbt
+++ b/handlers/digital-voucher-suspension-processor/build.sbt
@@ -1,2 +1,13 @@
+import Dependencies.assemblyMergeStrategyDiscardModuleInfo
+
 name := "digital-voucher-suspension-processor"
 description := "Processor that suspends digital vouchers via the digital voucher API."
+
+assemblyJarName := s"${name.value}.jar"
+assemblyMergeStrategyDiscardModuleInfo
+
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffManifestProjectName := s"MemSub::Membership Admin::${name.value}"
+riffRaffArtifactResources += (file(s"handlers/${name.value}/cfn.yaml"), "cfn/cfn.yaml")

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -16,6 +16,9 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub digital-voucher-suspension-processor-${Stage}
+      Description: >
+        Suspends fulfilment of digital voucher subscriptions.
+        Source: https://github.com/guardian/support-service-lambdas/tree/main/handlers/digital-voucher-suspension-processor
       Runtime: java8
       MemorySize: 1536
       Timeout: 900

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -1,0 +1,35 @@
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - PROD
+      - CODE
+    Default: CODE
+
+Resources:
+
+  SuspensionLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub digital-voucher-suspension-processor-${Stage}
+      Runtime: java8
+      MemorySize: 1536
+      Timeout: 900
+      CodeUri:
+        Bucket: support-service-lambdas-dist
+        Key: !Sub membership/${Stage}/digital-voucher-suspension-processor/digital-voucher-suspension-processor.jar
+      Handler: com.gu.digitalvouchersuspensionprocessor.Handler::handleRequest
+      Environment:
+        Variables:
+          salesforceUrl: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:salesforceUrl}}'
+          salesforceClientId: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:salesforceClientId}}'
+          salesforceClientSecret: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:salesforceClientSecret}}'
+          salesforceUserName: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:salesforceUserName}}'
+          salesforcePassword: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:salesforcePassword}}'
+          salesforceToken: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:salesforceToken}}'
+          imovoUrl: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:imovoUrl}}'
+          imovoApiKey: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:imovoApiKey}}'

--- a/handlers/digital-voucher-suspension-processor/riff-raff.yaml
+++ b/handlers/digital-voucher-suspension-processor/riff-raff.yaml
@@ -1,0 +1,21 @@
+stacks:
+  - membership
+regions:
+  - eu-west-1
+deployments:
+
+  cfn:
+    type: cloud-formation
+    app: digital-voucher-suspension-processor
+    parameters:
+      templatePath: cfn.yaml
+
+  digital-voucher-suspension-processor:
+    type: aws-lambda
+    parameters:
+      bucket: support-service-lambdas-dist
+      fileName: digital-voucher-suspension-processor.jar
+      functionNames:
+        - digital-voucher-suspension-processor-
+      prefixStack: false
+    dependencies: [ cfn ]


### PR DESCRIPTION
This adds Cloudformation and Riffraff configuration to the project.

Riffraff has successfully [deployed](https://riffraff.gutools.co.uk/deployment/view/9c93355f-c2fe-4c3a-944c-68f66123d60e) the lambda to Code.
