### PR TITLE
Remove the Subscription Card Saturday rateplan

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -41,8 +41,6 @@ case class Catalog(
   digitalVoucherEverydayPlus: Plan,
   digitalVoucherSunday: Plan,
   digitalVoucherSundayPlus: Plan,
-  digitalVoucherSaturday: Plan,
-  digitalVoucherSaturdayPlus: Plan,
   digitalVoucherSixday: Plan,
   digitalVoucherSixdayPlus: Plan
 ) {
@@ -83,8 +81,6 @@ case class Catalog(
     digitalVoucherEverydayPlus,
     digitalVoucherSunday,
     digitalVoucherSundayPlus,
-    digitalVoucherSaturday,
-    digitalVoucherSaturdayPlus,
     digitalVoucherSixday,
     digitalVoucherSixdayPlus,
   )
@@ -173,10 +169,6 @@ object PlanId {
 
   case object DigitalVoucherSundayPlus extends PlanId("digital_voucher_sunday_plus") with DigitalVoucherPlanId
 
-  case object DigitalVoucherSaturday extends PlanId("digital_voucher_saturday") with DigitalVoucherPlanId
-
-  case object DigitalVoucherSaturdayPlus extends PlanId("digital_voucher_saturday_plus") with DigitalVoucherPlanId
-
   case object DigitalVoucherSixday extends PlanId("digital_voucher_sixday") with DigitalVoucherPlanId
 
   case object DigitalVoucherSixdayPlus extends PlanId("digital_voucher_sixday_plus") with DigitalVoucherPlanId
@@ -234,8 +226,6 @@ object PlanId {
     DigitalVoucherEverydayPlus,
     DigitalVoucherSunday,
     DigitalVoucherSundayPlus,
-    DigitalVoucherSaturday,
-    DigitalVoucherSaturdayPlus,
     DigitalVoucherSixday,
     DigitalVoucherSixdayPlus
   )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -169,8 +169,6 @@ object NewProductApi {
       digitalVoucherEverydayPlus = planWithPayment(DigitalVoucherEverydayPlus, PlanDescription("Everyday+"), digitalVoucherStartDateRule(everyDayDays), Monthly),
       digitalVoucherSunday = planWithPayment(DigitalVoucherSunday, PlanDescription("Sunday"), digitalVoucherStartDateRule(sundayDays), Monthly),
       digitalVoucherSundayPlus = planWithPayment(DigitalVoucherSundayPlus, PlanDescription("Sunday+"), digitalVoucherStartDateRule(sundayDays), Monthly),
-      digitalVoucherSaturday = planWithPayment(DigitalVoucherSaturday, PlanDescription("Saturday"), digitalVoucherStartDateRule(saturdayDays), Monthly),
-      digitalVoucherSaturdayPlus = planWithPayment(DigitalVoucherSaturdayPlus, PlanDescription("Saturday+"), digitalVoucherStartDateRule(saturdayDays), Monthly),
       digitalVoucherSixday = planWithPayment(DigitalVoucherSixday, PlanDescription("Sixday"), digitalVoucherStartDateRule(sixDayDays), Monthly),
       digitalVoucherSixdayPlus = planWithPayment(DigitalVoucherSixdayPlus, PlanDescription("Sixday+"), digitalVoucherStartDateRule(sixDayDays), Monthly),
     )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -145,12 +145,10 @@ object ZuoraIds {
       DigitalVoucherWeekend -> weekend,
       DigitalVoucherSixday -> sixDay,
       DigitalVoucherSunday -> sunday,
-      DigitalVoucherSaturday -> saturday,
       DigitalVoucherEverydayPlus -> everydayPlus,
       DigitalVoucherWeekendPlus -> weekendPlus,
       DigitalVoucherSixdayPlus -> sixDayPlus,
       DigitalVoucherSundayPlus -> sundayPlus,
-      DigitalVoucherSaturdayPlus -> saturdayPlus
     )
 
     val plansWithDigipack = List(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -893,46 +893,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |          "paymentPlan": "GBP 70.10 every month"
         |        },
         |        {
-        |          "id": "digital_voucher_saturday",
-        |          "label": "Saturday",
-        |          "startDateRules": {
-        |            "daysOfWeek": [
-        |              "Saturday"
-        |            ],
-        |            "selectableWindow": {
-        |              "startDate": "2020-04-04",
-        |              "sizeInDays": 1
-        |            }
-        |          },
-        |          "paymentPlans": [
-        |            {
-        |              "currencyCode": "GBP",
-        |              "description": "GBP 70.08 every month"
-        |            }
-        |          ],
-        |          "paymentPlan": "GBP 70.08 every month"
-        |        },
-        |        {
-        |          "id": "digital_voucher_saturday_plus",
-        |          "label": "Saturday+",
-        |          "startDateRules": {
-        |            "daysOfWeek": [
-        |              "Saturday"
-        |            ],
-        |            "selectableWindow": {
-        |              "startDate": "2020-04-04",
-        |              "sizeInDays": 1
-        |            }
-        |          },
-        |          "paymentPlans": [
-        |            {
-        |              "currencyCode": "GBP",
-        |              "description": "GBP 70.08 every month"
-        |            }
-        |          ],
-        |          "paymentPlan": "GBP 70.08 every month"
-        |        },
-        |        {
         |          "id": "digital_voucher_sixday",
         |          "label": "Sixday",
         |          "startDateRules": {
@@ -1055,8 +1015,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
       case DigitalVoucherSixdayPlus => gbpPrice(7004)
       case DigitalVoucherWeekend => gbpPrice(7005)
       case DigitalVoucherWeekendPlus => gbpPrice(7006)
-      case DigitalVoucherSaturday => gbpPrice(7008)
-      case DigitalVoucherSaturdayPlus => gbpPrice(7008)
       case DigitalVoucherSunday => gbpPrice(7009)
       case DigitalVoucherSundayPlus => gbpPrice(7010)
     }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The decision was made early on to not have a Saturday rate plan for the Subscription Card, unfortunately we have included this in the new product api. This PR removes this unsupported rate plan. 
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Check the Saturday & Saturday+ options are not included in the CSR new subscription screen.
## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
No more errors around people creating Saturday only subs.
## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
