### PR TITLE
Update Salesforce query for finding subscriptions to suspend so that it works in every stage

### DIFF
--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucher.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucher.scala
@@ -22,7 +22,7 @@ object DigitalVoucher {
           )
         case e =>
           EitherT.fromEither(
-            Left[DigitalVoucherSuspendFailure, Unit](DigitalVoucherSuspendFailure(e.toString))
+            Left[DigitalVoucherSuspendFailure, Unit](DigitalVoucherSuspendFailure(e.message))
           )
       }
 

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala
@@ -43,7 +43,7 @@ object Salesforce {
       s"""
          |SELECT Id, Holiday_Stop_Request__r.SF_Subscription__c, Stopped_Publication_Date__c, Holiday_Stop_Request__r.Subscription_Name__c
          |FROM Holiday_Stop_Requests_Detail__c
-         |WHERE Holiday_Stop_Request__r.SF_Subscription__r.Product__c = 'Newspaper Digital Voucher'
+         |WHERE Holiday_Stop_Request__r.SF_Subscription__r.Product_Name__c = 'Newspaper Digital Voucher'
          |AND Stopped_Publication_Date__c >= TODAY
          |AND Is_Withdrawn__c = false
          |AND Is_Actioned__c = true

--- a/handlers/digital-voucher-suspension-processor/src/test/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucherTest.scala
+++ b/handlers/digital-voucher-suspension-processor/src/test/scala/com/gu/digitalvouchersuspensionprocessor/DigitalVoucherTest.scala
@@ -50,7 +50,7 @@ class DigitalVoucherTest extends AnyFlatSpec with Matchers with MockFactory with
       .returns(EitherT[Id, ImovoClientException, Unit](Left(ImovoClientException("failed"))))
 
     DigitalVoucher.suspend(imovo, suspension).value shouldBe Left(
-      DigitalVoucherSuspendFailure("ImovoClientException(failed,None)")
+      DigitalVoucherSuspendFailure("failed")
     )
   }
 
@@ -71,9 +71,7 @@ class DigitalVoucherTest extends AnyFlatSpec with Matchers with MockFactory with
       )))
 
     DigitalVoucher.suspend(imovo, suspension).value shouldBe Left(
-      DigitalVoucherSuspendFailure(
-        """ImovoClientException(failed,Some({"errorMessages":["Invalid Request: Please enter a reactivation date in the future"],"successfulRequest":false}))"""
-      )
+      DigitalVoucherSuspendFailure("failed")
     )
   }
 


### PR DESCRIPTION
The product type is different in every deployment stage but the product name appears to be the same everywhere.
So this change uses the product name to find subscriptions to suspend instead.

It's been tested in the Code lambda.
