### PR TITLE
retry the dev env cleaner

### DIFF
--- a/handlers/dev-env-cleaner/cfn.yaml
+++ b/handlers/dev-env-cleaner/cfn.yaml
@@ -47,7 +47,7 @@ Resources:
             Schedule: !FindInMap [ Stages, Schedule, !Ref Stage ]
             Description: clean zuora dev regularly so that space in SF is cleaned up
       EventInvokeConfig:
-        MaximumRetryAttempts: 0
+        MaximumRetryAttempts: 2
       Policies:
         - Statement:
             - Effect: Allow


### PR DESCRIPTION
The dev-env cleaner fails sometimes just due to timeout/etc, it's not a problem - so we run it every 12 hours but the maximum alarm period is 24 hours so if it fails once, we are likely to get an alarm depending whether it was faster or slower the time before.
We could change to be every 8 hours to give an extra chance to pass, but we could instead retry only when it fails for some reason.
This PR makes it retry twice (3 times in total).  We can see how the alarms go from that.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventinvokeconfig.html#cfn-lambda-eventinvokeconfig-maximumretryattempts:~:text=The%20maximum%20number%20of%20times%20to%20retry%20when%20the%20function%20returns%20an%20error.