### PR TITLE
Add alarm to digital voucher suspension processor

### DIFF
--- a/handlers/digital-voucher-suspension-processor/README.md
+++ b/handlers/digital-voucher-suspension-processor/README.md
@@ -1,0 +1,17 @@
+# Digital Voucher (Subscription Card) suspension processor
+
+:warning: **For troubleshooting tips because an alarm has gone off, see the
+[Subscription Card Recovery Runbook](https://docs.google.com/document/d/1YK-PcIvNcETacJs4VlTZtle5vdTtYoVN8h1fmzNYblw).**
+
+This processor temporarily suspends the fulfilment of a Subscription Card.
+A Subscription Card consists of a card and a letter.
+While it's suspended, the card will be disabled and the letter will stop accruing value.
+
+The processor works by:
+1. Fetching Subscription Card subscriptions from Salesforce that have future suspensions on them
+which have already been processed in Zuora.
+1. Sending these subscriptions to Imovo to apply the suspension there, to disable the card and
+letter.
+1. If successful, the `Sent_To_Digital_Voucher_Service__c` field of the associated
+`Holiday_Stop_Requests_Detail__c` is updated in Salesforce with the time that the successful
+response came back from Imovo.

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -1,5 +1,9 @@
 Transform: AWS::Serverless-2016-10-31
 
+Description: >
+  Suspends fulfilment of digital voucher subscriptions.
+  Source: https://github.com/guardian/support-service-lambdas/tree/main/handlers/digital-voucher-suspension-processor
+
 Parameters:
 
   Stage:
@@ -9,6 +13,9 @@ Parameters:
       - PROD
       - CODE
     Default: CODE
+
+Conditions:
+  IsProd: !Equals [!Ref "Stage", "PROD"]
 
 Resources:
 
@@ -36,3 +43,35 @@ Resources:
           salesforceToken: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:salesforceToken}}'
           imovoUrl: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:imovoUrl}}'
           imovoApiKey: !Sub '{{resolve:secretsmanager:digital-voucher-suspension-processor-${Stage}:SecretString:imovoApiKey}}'
+
+  LambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: SuspensionLambda
+    Properties:
+      LogGroupName: !Sub /aws/lambda/digital-voucher-suspension-processor-${Stage}
+      RetentionInDays: 90
+
+  LambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DependsOn: SuspensionLambda
+    Condition: IsProd
+    Properties:
+      AlarmName: "URGENT 9-5 - PROD: Failed to suspend digital voucher subscriptions"
+      AlarmDescription: >
+        IMPACT: If this goes unaddressed at least one subscription
+        that was supposed to be suspended will be fulfilled.
+        For troubleshooting, see
+        https://github.com/guardian/support-service-lambdas/blob/main/handlers/digital-voucher-suspension-processor/README.md.
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref SuspensionLambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching


### PR DESCRIPTION
The alarm will go off whenever the processor throws an exception. 
