### PR TITLE
gitignore hidden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
-.DS_Store
+.*
+!/.gitignore
 target/
-.idea*
 cdk-cfn.yaml
-.bloop*
-.metals*
-.vscode*
 metals.sbt


### PR DESCRIPTION
## What does this change?

New Scala tooling tends to have many hidden dot files for configuration which 

```
.*
!/.gitignore
```

trick should handle in one go.

## How to test

Create a dot file and see if git ignores it with `git status`.

## Have we considered potential risks?

No major risk apperent.
