### PR TITLE
Process digital voucher suspensions a day in advance of their effective date

### DIFF
--- a/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDates.scala
+++ b/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDates.scala
@@ -13,40 +13,43 @@ import scala.collection.immutable.ListMap
 
 object DigitalVoucherFulfilmentDates {
 
-  lazy val VoucherHolidayStopNoticePeriodDays = 1
-  lazy val FulfilmentCutoffDays = NonEmptyList.of(DayOfWeek.MONDAY, DayOfWeek.THURSDAY)
-  lazy val WeekStartDay = DayOfWeek.MONDAY
+  private final val VoucherHolidayStopNoticePeriodDays: Int = 2
+  private final val FulfilmentCutoffDays: NonEmptyList[DayOfWeek] =
+    NonEmptyList.of(DayOfWeek.MONDAY, DayOfWeek.THURSDAY)
 
   def apply(today: LocalDate): ListMap[String, FulfilmentDates] =
     ListMap( // to preserve insertion order, so the file is easier to read
       List(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(targetDayOfWeek =>
         targetDayOfWeek.getDisplayName(FULL, ENGLISH) -> FulfilmentDates(
-          today,
-          holidayStopFirstAvailableDate(today),
-          holidayStopProcessorTargetDate(targetDayOfWeek, today),
-          newSubscriptionEarliestStartDate(targetDayOfWeek, today)
+          today = today,
+          holidayStopFirstAvailableDate = holidayStopFirstAvailableDate(today),
+          holidayStopProcessorTargetDate = holidayStopProcessorTargetDate(targetDayOfWeek, today),
+          newSubscriptionEarliestStartDate = newSubscriptionEarliestStartDate(targetDayOfWeek, today)
         )): _*
     )
 
-  def holidayStopFirstAvailableDate(today: LocalDate): LocalDate = today plusDays VoucherHolidayStopNoticePeriodDays
+  private def holidayStopFirstAvailableDate(today: LocalDate): LocalDate =
+    today plusDays VoucherHolidayStopNoticePeriodDays
 
-  def holidayStopProcessorTargetDate(targetDayOfWeek: DayOfWeek, today: LocalDate): Option[LocalDate] = {
-    if (today.getDayOfWeek == targetDayOfWeek) {
-      Some(today) // we process voucher holiday stops on the day they're scheduled for
-    } else {
-      None
-    }
-  }
+  private def holidayStopProcessorTargetDate(targetDayOfWeek: DayOfWeek, today: LocalDate): Option[LocalDate] =
+    /*
+     * We process voucher holiday stops the day before they're scheduled
+     * to ensure they are disabled on the suspension date
+     */
+    Option.when(today.getDayOfWeek == targetDayOfWeek)(today.plusDays(1))
 
-  def newSubscriptionEarliestStartDate(issueDay: DayOfWeek, today: LocalDate) = {
+  private def newSubscriptionEarliestStartDate(issueDay: DayOfWeek, today: LocalDate): LocalDate = {
     //Fulfilment files are generated on Mondays and Thursdays
     //There is a delay of up to 7 days for the voucher cards to be printed and sent to the customer
     //The earliest start date will be the issue day on or after that date
     val soonestFulfilmentFileDate =
-      soonest(FulfilmentCutoffDays.map(fulfilmentCutoffDay => today `with` next(fulfilmentCutoffDay)))
+      soonest(
+        FulfilmentCutoffDays.map(fulfilmentCutoffDay => today `with` next(fulfilmentCutoffDay))
+      )
 
-    soonestFulfilmentFileDate plusDays (7) `with` nextOrSame(issueDay)
+    soonestFulfilmentFileDate plusDays 7 `with` nextOrSame(issueDay)
   }
 
-  def soonest(dates: NonEmptyList[LocalDate]): LocalDate = dates.toList.min[LocalDate](_ compareTo _)
+  private def soonest(dates: NonEmptyList[LocalDate]): LocalDate =
+    dates.toList.min[LocalDate](_ compareTo _)
 }

--- a/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDatesSpec.scala
+++ b/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/DigitalVoucherFulfilmentDatesSpec.scala
@@ -3,11 +3,12 @@ package com.gu.supporter.fulfilment
 import java.time.LocalDate
 
 import com.gu.supporter.fulfilment.DigitalVoucherFulfilmentDates.apply
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DigitalVoucherFulfilmentDatesSpec extends FlatSpec with Matchers with DateSupport {
+class DigitalVoucherFulfilmentDatesSpec extends AnyFlatSpec with Matchers with DateSupport {
 
-  def shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek(
+  private def shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek(
     today: LocalDate,
     expectedDayOfWeek: String,
     expectedDate: LocalDate
@@ -17,19 +18,41 @@ class DigitalVoucherFulfilmentDatesSpec extends FlatSpec with Matchers with Date
     result(expectedDayOfWeek).holidayStopProcessorTargetDate.get should equalDate(expectedDate)
   }
 
+  private def shouldHaveCorrectEarliestHolidayStopAvailableDate(today: LocalDate, expectedDate: LocalDate) =
+    apply(today)
+      .values
+      .map(_.holidayStopFirstAvailableDate)
+      .toList
+      .distinct shouldBe List(expectedDate)
+
   it should "calculate holidayStopProcessorTargetDate" in {
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-02", "Monday", "2019-12-02")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-03", "Tuesday", "2019-12-03")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-04", "Wednesday", "2019-12-04")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-05", "Thursday", "2019-12-05")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-06", "Friday", "2019-12-06")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-07", "Saturday", "2019-12-07")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-08", "Sunday", "2019-12-08")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-09", "Monday", "2019-12-09")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-10", "Tuesday", "2019-12-10")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-11", "Wednesday", "2019-12-11")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-12", "Thursday", "2019-12-12")
-    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-13", "Friday", "2019-12-13")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-02", "Monday", "2019-12-03")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-03", "Tuesday", "2019-12-04")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-04", "Wednesday", "2019-12-05")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-05", "Thursday", "2019-12-06")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-06", "Friday", "2019-12-07")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-07", "Saturday", "2019-12-08")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-08", "Sunday", "2019-12-09")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-09", "Monday", "2019-12-10")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-10", "Tuesday", "2019-12-11")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-11", "Wednesday", "2019-12-12")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-12", "Thursday", "2019-12-13")
+    shouldHaveOnlyOneHolidayStopProcessorTargetDateOnTheCorrectDayOfWeek("2019-12-13", "Friday", "2019-12-14")
+  }
+
+  it should "have correct earliest holiday-stop available date" in {
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-02", "2019-12-04")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-03", "2019-12-05")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-04", "2019-12-06")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-05", "2019-12-07")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-06", "2019-12-08")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-07", "2019-12-09")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-08", "2019-12-10")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-09", "2019-12-11")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-10", "2019-12-12")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-11", "2019-12-13")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-12", "2019-12-14")
+    shouldHaveCorrectEarliestHolidayStopAvailableDate("2019-12-13", "2019-12-15")
   }
 
   "MONDAY DigitalVoucherFulfilmentDates" should "have correct newSubscriptionEarliestStartDate" in {


### PR DESCRIPTION
Currently we process suspensions on the day that they are effective.  This means that the subscription card is usable for at least the start of the suspension day and potentially for several hours during the day if there is any problem with either the holiday-stop processor or the digital voucher suspension processor.

This change pushes the threshold for holiday stops back a day so that the suspension can be processed the day before it becomes effective.  This gives us some confidence that the suspension will be processed correctly in advance of when it becomes effective.

To test:
* Should be blocked from creating a holiday stop for tomorrow in frontend and in Salesforce.  But should be able to create a stop for the day after tomorrow.
* Holiday stops should be being processed for the next day.
