### PR TITLE
contact-us-api: Add alarms

### DIFF
--- a/handlers/contact-us-api/README.md
+++ b/handlers/contact-us-api/README.md
@@ -1,0 +1,33 @@
+## Errors
+
+This lambda is designed to handle errors and exceptions gracefully and always return a response with an appropriate
+status code. Alarms have been added to notify of any issues that might arise.
+
+### 4XX Errors
+
+**CAUSE**: 4xx errors mean the contents of the requests are invalid. Looking at the logs will give a better
+ understanding ofwhat's going on but this will always be either an empty or a malformed request.
+
+**IMPACT**: These requests are not (cannot) be entered to Salesforce.
+
+**FIX**: Check this lambda for changes to how the request is decoded. Check the source of the requests
+ (manage-frontend) for changes to how the request is constructed.
+
+### 5XX Errors
+
+**CAUSE**: 5xx errors could mean one of 3 things:
+
+1. Failed to obtain all environment variables;
+2. Failed to contact Salesforce endpoint;
+3. Error decoding Salesforce's responses;
+
+The lambda logs wil provide more details regarding which of these is happening and where in the code.
+
+**IMPACT**: These requests are not entered into Salesforce.
+
+**FIX**: For each corresponding cause:
+
+1. Check the Cloud Formation template for environment variables and make sure all the necessary key-values are present
+1. Check the Salesforce endpoints are correct and online.
+1. Check this lambda for changes to how the relevant Salesforce response is decoded. Check this lambda for changes to
+ the version of the Salesforce API used and if that version's responses are the same the lambda expects.

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -115,7 +115,6 @@ Resources:
       AlarmName: !Sub 5XX rate from contact-us-api-${Stage}
       AlarmDescription: >
         IMPACT: Contact Us form requests are not being entered into Salesforce.
-        Branch name is rm requests are not being entered into Salesforce.
         CAUSE: Likely one of the following. a) Unable to obtain config;
         b) Failed to contact Salesforce endpoint;
         c) Error decoding Salesforce's responses;

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -103,7 +103,7 @@ Resources:
       Namespace: AWS/ApiGateway
       Period: 3600
       Statistic: Sum
-      Threshold: 5
+      Threshold: 1
       TreatMissingData: notBreaching
 
   5xxApiAlarm:
@@ -130,5 +130,5 @@ Resources:
       Namespace: AWS/ApiGateway
       Period: 3600
       Statistic: Sum
-      Threshold: 5
+      Threshold: 1
       TreatMissingData: notBreaching

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -94,8 +94,8 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
       AlarmName: !Sub 4XX rate from contact-us-api-${Stage}
       AlarmDescription: >
-        IMPACT: Contact Us API is receiving invalid requests.
-        CAUSE: Likely the requests being sent from manage-frontend are invalid.
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/contact-us-api/README.md#4XX-Errors
+        for possible causes, impacts and fixes.
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: ApiName
@@ -120,10 +120,8 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
       AlarmName: !Sub 5XX rate from contact-us-api-${Stage}
       AlarmDescription: >
-        IMPACT: Contact Us form requests are not being entered into Salesforce.
-        CAUSE: Likely one of the following. a) Unable to obtain config;
-        b) Failed to contact Salesforce endpoint;
-        c) Error decoding Salesforce's responses;
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/contact-us-api/README.md#5XX-Errors
+        for possible causes, impacts and fixes.
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: ApiName

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -34,6 +34,8 @@ Resources:
 
   ContactUsLambda:
     Type: AWS::Serverless::Function
+    DependsOn:
+      - ContactUsApiGateway
     Properties:
       FunctionName: !Sub contact-us-api-${Stage}
       Handler: com.gu.contact_us_api.Handler
@@ -85,6 +87,8 @@ Resources:
   4xxApiAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
+    DependsOn:
+      - ContactUsApiGateway
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
@@ -109,6 +113,8 @@ Resources:
   5xxApiAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
+    DependsOn:
+      - ContactUsApiGateway
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -9,6 +9,9 @@ Parameters:
       - CODE
     Default: CODE
 
+Conditions:
+  IsProd: !Equals [ !Ref Stage, PROD ]
+
 Mappings:
   StageMap:
     CODE:
@@ -20,6 +23,7 @@ Resources:
   ContactUsApiGateway:
     Type: AWS::Serverless::Api
     Properties:
+      Name: !Sub contact-us-api-${Stage}-ApiGateway
       StageName: !Sub ${Stage}
       Auth:
         ApiKeyRequired: true
@@ -77,3 +81,54 @@ Resources:
             Method: POST
             RestApiId:
               Ref: ContactUsApiGateway
+
+  4xxApiAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contact-us-api
+      AlarmName: !Sub 4XX rate from contact-us-api-${Stage}
+      AlarmDescription: >
+        IMPACT: Contact Us API is receiving invalid requests.
+        CAUSE: Likely the requests being sent from manage-frontend are invalid.
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub membership-${Stage}-contact-us-api
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: 4XXError
+      Namespace: AWS/ApiGateway
+      Period: 3600
+      Statistic: Sum
+      Threshold: 5
+      TreatMissingData: notBreaching
+
+  5xxApiAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contact-us-api
+      AlarmName: !Sub 5XX rate from contact-us-api-${Stage}
+      AlarmDescription: >
+        IMPACT: Contact Us form requests are not being entered into Salesforce.
+        Branch name is rm requests are not being entered into Salesforce.
+        CAUSE: Likely one of the following. a) Unable to obtain config;
+        b) Failed to contact Salesforce endpoint;
+        c) Error decoding Salesforce's responses;
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub membership-${Stage}-contact-us-api
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: 5XXError
+      Namespace: AWS/ApiGateway
+      Period: 3600
+      Statistic: Sum
+      Threshold: 5
+      TreatMissingData: notBreaching

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -87,7 +87,7 @@ Resources:
     Condition: IsProd
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contact-us-api
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
       AlarmName: !Sub 4XX rate from contact-us-api-${Stage}
       AlarmDescription: >
         IMPACT: Contact Us API is receiving invalid requests.
@@ -111,7 +111,7 @@ Resources:
     Condition: IsProd
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contact-us-api
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
       AlarmName: !Sub 5XX rate from contact-us-api-${Stage}
       AlarmDescription: >
         IMPACT: Contact Us form requests are not being entered into Salesforce.

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -34,8 +34,6 @@ Resources:
 
   ContactUsLambda:
     Type: AWS::Serverless::Function
-    DependsOn:
-      - ContactUsApiGateway
     Properties:
       FunctionName: !Sub contact-us-api-${Stage}
       Handler: com.gu.contact_us_api.Handler


### PR DESCRIPTION
## What does this change?
This PR adds two alarms to contact-us-api for 4XX errors and 5XX errors. These are triggered when more than 5 responses are detected with a 4XX or 5XX status code, respectively.