### PR TITLE
Use product type to find digital voucher subscriptions to suspend

### DIFF
--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala
@@ -43,7 +43,7 @@ object Salesforce {
       s"""
          |SELECT Id, Holiday_Stop_Request__r.SF_Subscription__c, Stopped_Publication_Date__c, Holiday_Stop_Request__r.Subscription_Name__c
          |FROM Holiday_Stop_Requests_Detail__c
-         |WHERE Holiday_Stop_Request__r.SF_Subscription__r.Product_Name__c = 'Newspaper Digital Voucher'
+         |WHERE Holiday_Stop_Request__r.SF_Subscription__r.Product_Type__c = 'Newspaper - Digital Voucher'
          |AND Stopped_Publication_Date__c >= TODAY
          |AND Is_Withdrawn__c = false
          |AND Is_Actioned__c = true


### PR DESCRIPTION
Currently, we use the [product type](https://github.com/guardian/support-service-lambdas/blob/main/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestsDetail.scala#L106) to determine what the holiday-stop processor should process but the [product name](https://github.com/guardian/support-service-lambdas/blob/main/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala#L46) to determine what the suspension processor should process, since #727, even though both processes should be working on the same subs.

This change introduces consistency so that the suspension processor uses the same criterion to fetch subscriptions from Salesforce. ie product type rather than name.

Running the [query](https://github.com/guardian/support-service-lambdas/blob/main/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala#L44-L50) produces the same results regardless of whether we use type or name, which is what we want.

There are three fields for identifying products in Salesforce: `product__c`, `product_type__c` and `product_name__c`.
It isn't clear what the first is but its values for the new digital voucher are different in each environment.  The other two have consistent names across environments.  But we seem to use product type in general and in principle there's a 1-to-many relationship between a type and its products.
