### PR TITLE
Replace custom next invoice date calculation with billing-preview in credit processor

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -85,6 +85,8 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
+          InvoicingApiUrl: !Sub '{{resolve:secretsmanager:${Stage}/InvoicingApi:SecretString:InvoicingApiUrl}}'
+          InvoicingApiKey: !Sub '{{resolve:secretsmanager:${Stage}/InvoicingApi:SecretString:InvoicingApiKey}}'
       Role:
         !GetAtt HolidayStopProcessorRole.Arn
       MemorySize: 512

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopCreditProcessor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopCreditProcessor.scala
@@ -3,7 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.LocalDate
 
 import com.gu.creditprocessor.Processor.CreditProductForSubscription
-import com.gu.creditprocessor.{ProcessResult, Processor}
+import com.gu.creditprocessor.{NextInvoiceDate, ProcessResult, Processor}
 import com.gu.effects.S3Location
 import com.gu.fulfilmentdates.FulfilmentDatesFetcher
 import com.gu.holiday_stops.Config
@@ -88,7 +88,8 @@ object HolidayStopCreditProcessor {
             updateToApply,
             ZuoraHolidayCreditAddResult.apply,
             Salesforce.holidayStopUpdateResponse(config.sfConfig),
-            Zuora.accountGetResponse(config.zuoraConfig, zuoraAccessToken, backend)
+            Zuora.accountGetResponse(config.zuoraConfig, zuoraAccessToken, backend),
+            NextInvoiceDate.getNextInvoiceDate
           )
         }
         }

--- a/lib/credit-processor/src/main/scala/com/gu/creditprocessor/NextInvoiceDate.scala
+++ b/lib/credit-processor/src/main/scala/com/gu/creditprocessor/NextInvoiceDate.scala
@@ -6,9 +6,8 @@ import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 import io.circe.generic.auto._
 
-case class NextInvoiceDate(nextInvoiceDate: LocalDate)
-
 object NextInvoiceDate {
+  private case class NextInvoiceDate(nextInvoiceDate: LocalDate)
   private implicit val sttpBackend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
   private val xApiKey = sys.env.getOrElse("InvoicingApiKey", throw new RuntimeException("Missing x-api-key for invoicing-api"))
   private val invoicingApiUrl = sys.env.getOrElse("InvoicingApiUrl", throw new RuntimeException("Missing invoicing-api url"))

--- a/lib/credit-processor/src/main/scala/com/gu/creditprocessor/NextInvoiceDate.scala
+++ b/lib/credit-processor/src/main/scala/com/gu/creditprocessor/NextInvoiceDate.scala
@@ -1,0 +1,26 @@
+package com.gu.creditprocessor
+
+import java.time.LocalDate
+import com.gu.zuora.subscription.ZuoraApiFailure
+import com.softwaremill.sttp._
+import com.softwaremill.sttp.circe._
+import io.circe.generic.auto._
+
+case class NextInvoiceDate(nextInvoiceDate: LocalDate)
+
+object NextInvoiceDate {
+  private implicit val sttpBackend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
+  private val xApiKey = sys.env.getOrElse("InvoicingApiKey", throw new RuntimeException("Missing x-api-key for invoicing-api"))
+  private val invoicingApiUrl = sys.env.getOrElse("InvoicingApiUrl", throw new RuntimeException("Missing invoicing-api url"))
+
+  def getNextInvoiceDate(subscriptionName: String): Either[ZuoraApiFailure, LocalDate] = {
+    sttp.get(uri"$invoicingApiUrl/next-invoice-date/$subscriptionName")
+      .header("x-api-key", xApiKey)
+      .response(asJson[NextInvoiceDate])
+      .mapResponse(_.left.map(e => ZuoraApiFailure(e.message)))
+      .send()
+      .body.left.map(ZuoraApiFailure)
+      .joinRight
+      .map(_.nextInvoiceDate)
+  }
+}

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SubscriptionData.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SubscriptionData.scala
@@ -30,7 +30,7 @@ case class IssueData(issueDate: LocalDate, billDates: BillDates, credit: Double)
 }
 
 trait SubscriptionData {
-  def issueDataForDate(issueDate: LocalDate): Either[ZuoraApiFailure, IssueData]
+  @deprecated("Migrate to https://github.com/guardian/invoicing-api/pull/20") def issueDataForDate(issueDate: LocalDate): Either[ZuoraApiFailure, IssueData]
   def issueDataForPeriod(startDateInclusive: LocalDate, endDateInclusive: LocalDate): List[IssueData]
   def productType: ZuoraProductType
   def subscriptionAnnualIssueLimit: Int

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.4.1


### PR DESCRIPTION

## What does this change?

* https://trello.com/c/i0a10FyJ/1542-replace-billing-date-calculation-in-support-service-lambdas-with-calls-to-billing-preview-endpoint
* Start replacing https://github.com/guardian/support-service-lambdas/pull/550 with out-of-the-box functionality to predict when the credit should be applied.
* Start wiring in https://github.com/guardian/invoicing-api/pull/20
* Note for now the new functionality will run alongside the old one so we can validate by comparing the two calculations. Once validated I will address the `FIXME`s.

## How to test

* Let it run in PROD for a while and see if `testInProdNextInvoiceDate` ever logs the following error

```
ERROR - testInProdNextInvoiceDate failed because Add(2c92c0f96b03800b016b081fc04f1ba2,2020-12-11,2020-12-11,2020-12-11,List(ChargeOverride(2c92c0f96b03800b016b081fc0f41bb4,2020-11-06,2020-11-06,-1.0))) =/= 2020-10-08
```

## How can we measure success?

After few days if no errors are logged we can begin to switch over to new functionality.

## Have we considered potential risks?

The risks have been mitigated by deploying in steps, that is, not immediately switching over to the new calculation and yet exercising the new paths at the same time.
