### PR TITLE
contact-us-api: Cloud Formation fixes

### DIFF
--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -16,13 +16,16 @@ Conditions:
 Mappings:
   StageMap:
     PROD:
-      Domain: gnmtouchpoint.my.salesforce.com
+      authDomain: gnmtouchpoint.my.salesforce.com
+      reqDomain: gnmtouchpoint.my.salesforce.com
       SecretsVersion: cfe10466-bd62-45f2-a61f-3fcf9c12ef9f
     CODE:
-      Domain: test.salesforce.com
+      authDomain: test.salesforce.com
+      reqDomain: gnmtouchpoint--DEV.my.salesforce.com
       SecretsVersion: 5a68b23e-6d75-4bb4-9131-a4d94c121010
     DEV:
-      Domain: test.salesforce.com
+      authDomain: test.salesforce.com
+      reqDomain: gnmtouchpoint--DEV.my.salesforce.com
       SecretsVersion: 89ac830e-166c-444a-a61b-72fb5173e761
 
 Resources:
@@ -71,8 +74,8 @@ Resources:
             !Sub
             - '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:token::${SecretsVersion}}}'
             - SecretsVersion: !FindInMap [ StageMap, !Ref Stage, SecretsVersion ]
-          authDomain: !FindInMap [ StageMap, !Ref Stage, Domain ]
-          reqDomain: !FindInMap [ StageMap, !Ref Stage, Domain ]
+          authDomain: !FindInMap [ StageMap, !Ref Stage, authDomain ]
+          reqDomain: !FindInMap [ StageMap, !Ref Stage, reqDomain ]
       Events:
         ApiEvent:
           Type: Api

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -20,7 +20,7 @@ Mappings:
       reqDomain: gnmtouchpoint.my.salesforce.com
       SalesforceStage: PROD
       AppName: TouchpointUpdate
-      AppSecretsVersion: 0f374e2e-5b4e-4fda-8cba-2c02368ff937
+      AppSecretsVersion: d338b761-cb81-4adf-aca4-163678e65a59
       UserSecretsVersion: dfbf9eba-5215-4cb8-91f1-ff5bcbbf5201
     CODE:
       authDomain: test.salesforce.com

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -101,7 +101,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: ApiName
-          Value: !Sub membership-${Stage}-contact-us-api
+          Value: !Sub contact-us-api-${Stage}-ApiGateway
         - Name: Stage
           Value: !Sub ${Stage}
       EvaluationPeriods: 1
@@ -127,7 +127,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: ApiName
-          Value: !Sub membership-${Stage}-contact-us-api
+          Value: !Sub contact-us-api-${Stage}-ApiGateway
         - Name: Stage
           Value: !Sub ${Stage}
       EvaluationPeriods: 1

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -32,6 +32,7 @@ Resources:
   ContactUsApiGateway:
     Type: AWS::Serverless::Api
     Properties:
+      OpenApiVersion: '2.0'
       Name: !Sub contact-us-api-${Stage}-ApiGateway
       StageName: !Sub ${Stage}
       Auth:

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -18,15 +18,24 @@ Mappings:
     PROD:
       authDomain: gnmtouchpoint.my.salesforce.com
       reqDomain: gnmtouchpoint.my.salesforce.com
-      SecretsVersion: cfe10466-bd62-45f2-a61f-3fcf9c12ef9f
+      SalesforceStage: PROD
+      AppName: TouchpointUpdate
+      AppSecretsVersion: 0f374e2e-5b4e-4fda-8cba-2c02368ff937
+      UserSecretsVersion: dfbf9eba-5215-4cb8-91f1-ff5bcbbf5201
     CODE:
       authDomain: test.salesforce.com
-      reqDomain: gnmtouchpoint--DEV.my.salesforce.com
-      SecretsVersion: 5a68b23e-6d75-4bb4-9131-a4d94c121010
+      reqDomain: gnmtouchpoint--DEV1.my.salesforce.com
+      SalesforceStage: DEV
+      AppName: AwsConnectorSandbox
+      AppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      UserSecretsVersion: 4a0eabf6-7940-47ef-87d0-36c3ef7f5741
     DEV:
       authDomain: test.salesforce.com
-      reqDomain: gnmtouchpoint--DEV.my.salesforce.com
-      SecretsVersion: 89ac830e-166c-444a-a61b-72fb5173e761
+      reqDomain: gnmtouchpoint--DEV1.my.salesforce.com
+      SalesforceStage: DEV
+      AppName: AwsConnectorSandbox
+      AppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      UserSecretsVersion: 4a0eabf6-7940-47ef-87d0-36c3ef7f5741
 
 Resources:
   ContactUsApiGateway:
@@ -57,24 +66,31 @@ Resources:
         Variables:
           clientID:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:clientId::${SecretsVersion}}}'
-            - SecretsVersion: !FindInMap [ StageMap, !Ref Stage, SecretsVersion ]
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientId::${AppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
           clientSecret:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:clientSecret::${SecretsVersion}}}'
-            - SecretsVersion: !FindInMap [ StageMap, !Ref Stage, SecretsVersion ]
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientSecret::${AppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
           username:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:userName::${SecretsVersion}}}'
-            - SecretsVersion: !FindInMap [ StageMap, !Ref Stage, SecretsVersion ]
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/MembersDataAPI:SecretString:username::${UserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, UserSecretsVersion ]
           password:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:password::${SecretsVersion}}}'
-            - SecretsVersion: !FindInMap [ StageMap, !Ref Stage, SecretsVersion ]
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/MembersDataAPI:SecretString:password::${UserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, UserSecretsVersion ]
           token:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:token::${SecretsVersion}}}'
-            - SecretsVersion: !FindInMap [ StageMap, !Ref Stage, SecretsVersion ]
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/MembersDataAPI:SecretString:token::${UserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, UserSecretsVersion ]
           authDomain: !FindInMap [ StageMap, !Ref Stage, authDomain ]
           reqDomain: !FindInMap [ StageMap, !Ref Stage, reqDomain ]
       Events:

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -7,6 +7,7 @@ Parameters:
     AllowedValues:
       - PROD
       - CODE
+      - DEV
     Default: CODE
 
 Conditions:
@@ -14,12 +15,15 @@ Conditions:
 
 Mappings:
   StageMap:
-    CODE:
-      Domain: test.salesforce.com
-      SecretsVersion: 5a68b23e-6d75-4bb4-9131-a4d94c121010
     PROD:
       Domain: gnmtouchpoint.my.salesforce.com
       SecretsVersion: cfe10466-bd62-45f2-a61f-3fcf9c12ef9f
+    CODE:
+      Domain: test.salesforce.com
+      SecretsVersion: 5a68b23e-6d75-4bb4-9131-a4d94c121010
+    DEV:
+      Domain: test.salesforce.com
+      SecretsVersion: 89ac830e-166c-444a-a61b-72fb5173e761
 
 Resources:
   ContactUsApiGateway:


### PR DESCRIPTION
## What does this change?
This PR addresses 3 issues were were seeing in the `contact-us-api` related to the Cloud Formation template. It also adds a DEV stage so it's simpler to test in the future and switches to using the new secrets created by our newly created [User Credential Setter](https://github.com/guardian/support-service-lambdas/pull/744) or similarly named ones (for PROD).

### Problems
1. `authDomain` and `reqDomain` were being set to the same domain, which prevented the creation of cases in DEV and PROD environment.
2. A ghost stage (called 'Stage') was being created in the API Gateway.
3. Cloud Watch metrics were not being published under the expected name (should be published under API Gateway name according to [the documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html#api-gateway-metricdimensions))

### Solutions
1. `authDomain` and `reqDomain` are set explicitly and independently. This is a temporary fix. Ideally the reqDomain should be obtained from Salesforce's authentication response.
2. This is a [known issue](https://github.com/aws/serverless-application-model/issues/191). To work around it the [`OpenApiVersion` property](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html#sam-api-openapiversion) is set to `2.0` on the AWS::Serverless::Api resource's property.
3. The Cloud Formation stack needs to be deleted and created again, now using the correct ApiName. The cause of this issue was that the API Gateway resource was initially created with no name and an explicit name was only set after as an update. When the stack was created and the resource had no explicit name so it assumed the stack's name instead. Later when an explicit name was set the metrics continued to be published under the original name instead of updating to the new name. AWS support has confirmed this is not the expected behaviour and have created an internal ticket for the API Gateway to investigate. In the meantime recreating the stack will fix it.