### PR TITLE
Fix Cloudwatch MetricDatum building

### DIFF
--- a/handlers/dev-env-cleaner/src/test/scala/com/gu/aws/AwsCloudWatchTest.scala
+++ b/handlers/dev-env-cleaner/src/test/scala/com/gu/aws/AwsCloudWatchTest.scala
@@ -1,0 +1,28 @@
+package com.gu.aws
+
+import com.gu.aws.AwsCloudWatch._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit.COUNT
+
+class AwsCloudWatchTest extends AnyFlatSpec with Matchers {
+
+  "buildMetricDatum" should "build correct datum" in {
+    val datum = AwsCloudWatch.buildMetricDatum(MetricRequest(
+      MetricNamespace("support-service-lambdas"),
+      MetricName("cleanup-succeeded"),
+      Map(
+        MetricDimensionName("Stage") -> MetricDimensionValue("CODE"),
+        MetricDimensionName("app") -> MetricDimensionValue("dev-env-cleaner")
+      )
+    ))
+    datum.metricName shouldBe "cleanup-succeeded"
+    datum.dimensions.size shouldBe 2
+    datum.dimensions.get(0).name shouldBe "Stage"
+    datum.dimensions.get(0).value shouldBe "CODE"
+    datum.dimensions.get(1).name shouldBe "app"
+    datum.dimensions.get(1).value shouldBe "dev-env-cleaner"
+    datum.value shouldBe 1
+    datum.unit shouldBe COUNT
+  }
+}


### PR DESCRIPTION
There's an alarm that tells us the SF dev env has not been cleared out recently.  It went off because the metric that gets written at the end of the lambda was missing the `stage` dimension.  The last dimension was overwriting any previous dimensions as a result of PR #747.

The problem was [here](https://github.com/guardian/support-service-lambdas/compare/kc-cloudwatch-fix?expand=1#diff-c0af23d9ebd1f190cebbae557689d125723a313754b209a7f64b23fa990c361eL51-L58) where the dimensions are repeatedly being recreated each time around the fold.

