### PR TITLE
Replace custom billing preview with out-of-the-box one in holiday-stop-api

### DIFF
--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -91,6 +91,8 @@ Resources:
             Environment:
                 Variables:
                   Stage: !Ref Stage
+                  InvoicingApiUrl: !Sub '{{resolve:secretsmanager:${Stage}/InvoicingApi:SecretString:InvoicingApiUrl}}'
+                  InvoicingApiKey: !Sub '{{resolve:secretsmanager:${Stage}/InvoicingApi:SecretString:InvoicingApiKey}}'
             Role:
                 Fn::GetAtt:
                 - HolidayStopApiRole

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/PreviewPublications.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/PreviewPublications.scala
@@ -1,0 +1,47 @@
+package com.gu.holiday_stops
+
+import java.time.LocalDate
+
+import com.gu.zuora.subscription.ZuoraApiFailure
+import com.softwaremill.sttp._
+import com.softwaremill.sttp.circe._
+import io.circe.generic.auto._
+
+/** https://github.com/guardian/invoicing-api/blob/master/src/main/scala/com/gu/invoicing/preview/README.md */
+case class Publication(       /* Contrast with InvoiceItem                               */
+  publicationDate: LocalDate, /* Date of paper printed on cover                          */
+  invoiceDate: LocalDate,     /* Publication falls on this invoice                       */
+  nextInvoiceDate: LocalDate, /* The invoice on which this publication would be credited */
+  productName: String,        /* For example Newspaper Delivery                          */
+  chargeName: String,         /* For example Sunday                                      */
+  price: Double,              /* Charge of single publication                            */
+)
+
+case class PreviewPublicationsResponse(
+  subscriptionName: String,
+  nextInvoiceDateAfterToday: LocalDate,
+  rangeStartDate: LocalDate,
+  rangeEndDate: LocalDate,
+  publicationsWithinRange: List[Publication],
+)
+
+object PreviewPublications {
+  private implicit val sttpBackend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
+  private lazy val xApiKey = sys.env.getOrElse("InvoicingApiKey", throw new RuntimeException("Missing x-api-key for invoicing-api"))
+  private lazy val invoicingApiUrl = sys.env.getOrElse("InvoicingApiUrl", throw new RuntimeException("Missing invoicing-api url"))
+
+  def preview(
+    subscriptionName: String,
+    startDate: String,
+    endDate: String
+  ): Either[ZuoraApiFailure, PreviewPublicationsResponse] = {
+    sttp
+      .get(uri"$invoicingApiUrl/preview/$subscriptionName?startDate=$startDate&endDate=$endDate")
+      .header("x-api-key", xApiKey)
+      .response(asJson[PreviewPublicationsResponse])
+      .mapResponse(_.left.map(e => ZuoraApiFailure(e.message)))
+      .send()
+      .body.left.map(ZuoraApiFailure)
+      .joinRight
+  }
+}


### PR DESCRIPTION
## What does this change?

* Similar to https://github.com/guardian/support-service-lambdas/pull/743
* https://trello.com/c/i0a10FyJ/1542-replace-billing-date-calculation-in-support-service-lambdas-with-calls-to-billing-preview-endpoint
* Start replacing https://github.com/guardian/support-service-lambdas/pull/550 with out-of-the-box functionality
* Start wiring in https://github.com/guardian/invoicing-api/pull/23
* Note for now the new functionality will run alongside the old one so we can validate by comparing the two calculations. Once validated I will address the `FIXME`s.

## How to test

* Let it run in PROD for a while and see if `testInProdPreviewPublications` ever logs the following error

```
ERROR com.gu.holiday_stops.Handler$ - testInProdPreviewPublications failed A-S0000000?startDate=2020-11-13&endDate=2020-12-25 because List(PotentialHolidayStop(2020-11-29,Credit(-3.0,2020-12-29)), PotentialHolidayStop(2020-12-06,Credit(-3.0,2020-12-29)), PotentialHolidayStop(2020-12-13,Credit(-3.0,2020-12-29)), PotentialHolidayStop(2020-12-20,Credit(-3.0,2020-12-29))) =/= List(PotentialHolidayStop(2020-11-29,Credit(-3.0,2020-12-29)), PotentialHolidayStop(2020-12-06,Credit(-3.0,2020-12-29)), PotentialHolidayStop(2020-12-13,Credit(-3.0,2020-12-29)), PotentialHolidayStop(2020-12-20,Credit(-3.0,2020-12-29))) or 2020-12-29 =/= 2020-11-29
```

## How can we measure success?

After few days if no errors are logged we can begin to switch over to new functionality.

## Have we considered potential risks?

The risks have been mitigated by deploying in steps, that is, not immediately switching over to the new calculation and yet exercising the new paths at the same time.
