### PR TITLE
Run test in production off the main thread

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -212,6 +212,7 @@ object Handler extends Logging {
   // FIXME: Temporary test in production to validate migration to https://github.com/guardian/invoicing-api/pull/23
   import scala.concurrent.{ExecutionContext, Future}
   import java.util.concurrent.Executors
+  private val ecForTestInProd = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor)
   private def testInProdPreviewPublications(
     previewPublications: (String, String, String) => Either[ApiFailure, PreviewPublicationsResponse],
     subscription: Subscription,
@@ -238,7 +239,7 @@ object Handler extends Logging {
     }).left.map { e =>
       logger.error(s"testInProdNextInvoiceDate failed because invoicing-api error: $e")
     }
-  }(ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor))
+  }(ecForTestInProd)
 
   def stepsForPotentialHolidayStop(
     getAccessToken: () => Either[ApiFailure, AccessToken],

--- a/lib/credit-processor/src/main/scala/com/gu/creditprocessor/Processor.scala
+++ b/lib/credit-processor/src/main/scala/com/gu/creditprocessor/Processor.scala
@@ -114,11 +114,13 @@ object Processor {
   }
 
   // FIXME: Temporary test in production to validate migration to https://github.com/guardian/invoicing-api/pull/20
+  import scala.concurrent.{ExecutionContext, Future}
+  import java.util.concurrent.Executors
   private def testInProdNextInvoiceDate(
     subscription: Subscription,
     getNextInvoiceDate: String => ZuoraApiResponse[LocalDate],
     expected: SubscriptionUpdate,
-  ): Try[Unit] = Try {
+  ): Future[_] = Future {
     (getNextInvoiceDate(subscription.subscriptionNumber).map { actual =>
       if (expected.add.forall(_.contractEffectiveDate == actual)) {
         // logger.info("testInProdNextInvoiceDate OK")
@@ -128,7 +130,7 @@ object Processor {
     }).left.map { e =>
       logger.error(s"testInProdNextInvoiceDate failed because invoicing-api error: $e")
     }
-  }
+  }(ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor))
 
 
   /**

--- a/lib/credit-processor/src/main/scala/com/gu/creditprocessor/Processor.scala
+++ b/lib/credit-processor/src/main/scala/com/gu/creditprocessor/Processor.scala
@@ -116,6 +116,7 @@ object Processor {
   // FIXME: Temporary test in production to validate migration to https://github.com/guardian/invoicing-api/pull/20
   import scala.concurrent.{ExecutionContext, Future}
   import java.util.concurrent.Executors
+  private val ecForTestInProd = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor)
   private def testInProdNextInvoiceDate(
     subscription: Subscription,
     getNextInvoiceDate: String => ZuoraApiResponse[LocalDate],
@@ -130,7 +131,7 @@ object Processor {
     }).left.map { e =>
       logger.error(s"testInProdNextInvoiceDate failed because invoicing-api error: $e")
     }
-  }(ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor))
+  }(ecForTestInProd)
 
 
   /**


### PR DESCRIPTION
## What does this change?

Make sure tests in prod do not slow down main business logic.

## How to test

Maybe measure response before and after with Postman by hitting `{{holidayStopApiUrl}}/potential/A-S00000000?startDate=2020-11-24&endDate=2020-12-02`

## How can we measure success?

N/A

## Have we considered potential risks?

No risk.
