### PR TITLE
Update config of Digital Voucher Suspension Processor to use correct secrets

### DIFF
--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -19,9 +19,11 @@ Mappings:
   StageMap:
     CODE:
       SalesforceUrl: https://test.salesforce.com
+      SalesforceConnectedApp: AwsConnectorSandbox
       ImovoUrl: https://core-uat-api.azurewebsites.net
     PROD:
       SalesforceUrl: https://gnmtouchpoint.my.salesforce.com
+      SalesforceConnectedApp: TouchpointUpdate
       ImovoUrl: https://imovo.org
 
 Conditions:
@@ -46,11 +48,17 @@ Resources:
       Environment:
         Variables:
           salesforceUrl: !FindInMap [ StageMap, !Ref Stage, SalesforceUrl ]
-          salesforceClientId: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:clientId}}'
-          salesforceClientSecret: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:clientSecret}}'
-          salesforceUserName: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:userName}}'
-          salesforcePassword: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:password}}'
-          salesforceToken: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/MembersDataApi:SecretString:token}}'
+          salesforceClientId:
+            !Sub
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${ConnectedApp}:SecretString:clientId}}'
+            - ConnectedApp: !FindInMap [StageMap, !Ref Stage, SalesforceConnectedApp]
+          salesforceClientSecret:
+            !Sub
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${ConnectedApp}:SecretString:clientSecret}}'
+            - ConnectedApp: !FindInMap [StageMap, !Ref Stage, SalesforceConnectedApp]
+          salesforceUserName: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/User/MembersDataAPI:SecretString:username}}'
+          salesforcePassword: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/User/MembersDataAPI:SecretString:password}}'
+          salesforceToken: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/User/MembersDataAPI:SecretString:token}}'
           imovoUrl: !FindInMap [ StageMap, !Ref Stage, ImovoUrl ]
           imovoApiKey: !Sub '{{resolve:secretsmanager:${Stage}/Imovo:SecretString:apiKey}}'
 


### PR DESCRIPTION
The naming convention for secrets has changed since this subproject was last deployed.
Salesforce connections now have a connected app and a user.
The secrets are in the format <ConnectionType>/<Connection>.

Once this is deployed  we should be able to remove the old secret.
