### PR TITLE
Remove references to AWS SDK v1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -301,13 +301,13 @@ lazy val `zuora-retention` = lambdaProject(
 lazy val `zuora-sar` = lambdaProject(
   "zuora-sar",
   "Performs a Subject Access Requests against Zuora",
-  Seq(catsEffect, circeParser, circe, awsStepFunction)
+  Seq(catsEffect, circeParser, circe)
 ).dependsOn(`zuora-reports`, handler, effectsDepIncludingTestFolder, testDep, `effects-s3`, `effects-lambda`)
 
 lazy val `dev-env-cleaner` = lambdaProject(
   "dev-env-cleaner",
   "Cleans up the salesforce to free up storage via 360 sync/zuora",
-  Seq(awsCloudwatch, catsEffect, circeParser, circe, awsStepFunction)
+  Seq(awsCloudwatch, catsEffect, circeParser, circe)
 ).dependsOn(`zuora-reports`, handler, effectsDepIncludingTestFolder, testDep, `effects-s3`, `effects-lambda`)
 
 lazy val `sf-contact-merge` = lambdaProject(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,7 @@ import sbtassembly.AssemblyPlugin.autoImport.{
 import sbtassembly.PathList
 
 object Dependencies {
-  val awsV1Version = "1.11.901"
-  val awsV2Version = "2.15.30"
+  val awsSdkVersion = "2.15.30"
   val circeVersion = "0.12.3"
   val sttpVersion = "1.7.0"
   val http4sVersion = "0.21.0"
@@ -21,16 +20,15 @@ object Dependencies {
   )
 
   // AWS
-  val awsStepFunction = "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsV1Version
-
-  val awsCloudwatch = "software.amazon.awssdk" % "cloudwatch" % awsV2Version
-  val awsSdkLambda = "software.amazon.awssdk" % "lambda" % awsV2Version
-  val awsSecretsManager = "software.amazon.awssdk" % "secretsmanager" % awsV2Version
-  val awsSQS = "software.amazon.awssdk" % "sqs" % awsV2Version
-  val awsS3 = "software.amazon.awssdk" % "s3" % awsV2Version
+  val awsCloudwatch = "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion
+  val awsSdkLambda = "software.amazon.awssdk" % "lambda" % awsSdkVersion
+  val awsSecretsManager = "software.amazon.awssdk" % "secretsmanager" % awsSdkVersion
+  val awsSQS = "software.amazon.awssdk" % "sqs" % awsSdkVersion
+  val awsS3 = "software.amazon.awssdk" % "s3" % awsSdkVersion
 
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-  val awsEvents = "com.amazonaws" % "aws-lambda-java-events" % "2.2.5"
+  val awsEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.4.0"
+
   val scalaLambda = "io.github.mkotsur" %% "aws-lambda-scala" % "0.2.0"
 
   // Cats


### PR DESCRIPTION
This removes the last unused references to AWS SDK v1.
It completes the process of migrating to v2 in these PRs:
* Cloudwatch upgrade: #747
* SQS upgrade: #753
* S3 upgrade: #758
* SecretsManager upgrade: #759
* Lambda upgrade: #761 
