### PR TITLE
Remove explicit jackson databind dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val zuora = library(project in file("lib/zuora"))
     effects % "test->test"
   )
   .settings(
-    libraryDependencies ++= Seq(okhttp3, playJson, scalatest, jacksonDatabind) ++ logging
+    libraryDependencies ++= Seq(okhttp3, playJson, scalatest) ++ logging
   )
 
 lazy val `salesforce-core` = library(project in file("lib/salesforce/core"))
@@ -165,7 +165,7 @@ lazy val handler = library(project in file("lib/handler"))
 lazy val effects = library(project in file("lib/effects"))
   .dependsOn(handler)
   .settings(
-    libraryDependencies ++= Seq(okhttp3, playJson, scalatest, awsS3, jacksonDatabind) ++ logging
+    libraryDependencies ++= Seq(okhttp3, playJson, scalatest, awsS3) ++ logging
   )
 lazy val `effects-s3` = library(project in file("lib/effects-s3"))
   .settings(

--- a/handlers/zuora-callout-apis/build.sbt
+++ b/handlers/zuora-callout-apis/build.sbt
@@ -17,7 +17,6 @@ libraryDependencies ++= Seq(
   okhttp3,
   scalatest,
   stripe,
-  jacksonDatabind
 ) ++ logging
 
 assemblyMergeStrategyDiscardModuleInfo

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,8 +43,6 @@ object Dependencies {
   val circeConfig = "io.circe" %% "circe-config" % "0.7.0"
   val playJson = "com.typesafe.play" %% "play-json" % "2.8.0"
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.40.1"
-  val jacksonDatabind =
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.0" // FIXME: Why is this necessery?
 
   // HTTP clients
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion


### PR DESCRIPTION
Version 2.10.4 is now coming in as a transitive dependency so this explicit dependence seems to be redundant.
