### PR TITLE
Limit number of cancelled digital vouchers to process

### DIFF
--- a/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/Handler.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/Handler.scala
@@ -13,7 +13,10 @@ object Handler extends LazyLogging {
     val results = DigitalVoucherCancellationProcessorApp(AppIdentity.whoAmI(defaultAppName = "digital-voucher-api"))
       .value
       .unsafeRunSync()
-      .valueOr(error => throw new RuntimeException(error.toString)).show
+      .valueOr { error =>
+        logger.error(s"Processor failed: ${error.toString}")
+        throw new RuntimeException(error.toString)
+      }.show
     logger.info(s"Processor ran successfully: ${results.show}")
     os.write(s"Processor ran successfully: ${results.show}".getBytes("UTF-8"))
   }

--- a/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
@@ -1,23 +1,22 @@
 package com.gu.digital_voucher_cancellation_processor
 
-import java.time.{Clock, Instant, LocalDate, ZoneId}
+import java.time.{Clock, Instant, ZoneId}
 
 import cats.effect.IO
+import cats.implicits._
 import com.gu.DevIdentity
-import com.gu.digital_voucher_cancellation_processor.DigitalVoucherCancellationProcessorService.{CObjectAttribues, DigitalVoucherQueryResult, DigitalVoucherUpdate, ImovoCancellationResults, SubscriptionQueryResult, subscrptionsCancelledTodayQuery}
-import com.gu.imovo.{ImovoClientException, ImovoConfig, ImovoErrorResponse, ImovoSuccessResponse}
-import com.gu.salesforce.sttp.{QueryRecordsWrapperCaseClass, SFApiCompositePart, SFApiCompositeRequest, SFApiCompositeResponse, SFApiCompositeResponsePart}
-import com.gu.salesforce.{SFAuthConfig, SalesforceAuth}
+import com.gu.digital_voucher_cancellation_processor.DigitalVoucherCancellationProcessorService._
 import com.gu.imovo.ImovoStub._
+import com.gu.imovo.{ImovoClientException, ImovoConfig, ImovoErrorResponse, ImovoSuccessResponse}
 import com.gu.salesforce.sttp.SalesforceStub._
+import com.gu.salesforce.sttp._
+import com.gu.salesforce.{SFAuthConfig, SalesforceAuth}
 import com.softwaremill.sttp.impl.cats.CatsMonadError
 import com.softwaremill.sttp.testing.SttpBackendStub
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-import com.gu.salesforce.sttp.SalesforceStub._
 import io.circe.generic.auto._
 import org.scalatest.Inside.inside
-import cats.implicits._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Matchers {
   val authConfig = SFAuthConfig(
@@ -65,7 +64,7 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
           .stubAuth(authConfig, authResponse)
           .stubQuery(
             auth = authResponse,
-            query = subscrptionsCancelledTodayQuery(LocalDate.parse("2020-03-18")),
+            query = subscriptionsCancelledTodayQuery,
             response = QueryRecordsWrapperCaseClass(
               List(
                 voucherToCancelQueryResult("valid-sub-1"),
@@ -119,7 +118,7 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
         .stubAuth(authConfig, authResponse)
         .stubQuery(
           auth = authResponse,
-          query = subscrptionsCancelledTodayQuery(LocalDate.parse("2020-03-18")),
+          query = subscriptionsCancelledTodayQuery,
           response = QueryRecordsWrapperCaseClass(
             List(
               voucherToCancelQueryResult("valid-sub"),
@@ -178,7 +177,7 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
         .stubAuth(authConfig, authResponse)
         .stubQuery(
           auth = authResponse,
-          query = subscrptionsCancelledTodayQuery(LocalDate.parse("2020-03-18")),
+          query = subscriptionsCancelledTodayQuery,
           response = QueryRecordsWrapperCaseClass(
             List(
               voucherToCancelQueryResult("valid-sub"),
@@ -250,7 +249,7 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
         .stubAuth(authConfig, authResponse)
         .stubQuery(
           auth = authResponse,
-          query = subscrptionsCancelledTodayQuery(LocalDate.parse("2020-03-18")),
+          query = subscriptionsCancelledTodayQuery,
           response = QueryRecordsWrapperCaseClass(
             records = List[SFApiCompositePart[DigitalVoucherUpdate]](),
             nextRecordsUrl = None
@@ -265,7 +264,7 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
         .stubAuth(authConfig, authResponse)
         .stubQuery(
           auth = authResponse,
-          query = subscrptionsCancelledTodayQuery(LocalDate.parse("2020-03-18")),
+          query = subscriptionsCancelledTodayQuery,
           response = QueryRecordsWrapperCaseClass(
             List(
               voucherToCancelQueryResult("valid-sub"),


### PR DESCRIPTION
We were seeing errors in the log like:
```
{"compositeResponse":[{"body":[{"errorCode":"LIMIT_EXCEEDED","message":"The request can’t contain more than 25 operations."}],"httpHeaders":{},"httpStatusCode":400,"referenceId":null}]}
```
when attempting to write results back to Salesforce.  
This is because the number of cancellations had built up following the upstream outage.

This change fixes the problem by limiting how many cancellations we attempt to process at one go.
As the processor runs every hour we'll have to have > 25 cancellations every hour over a prolonged period before the process runs into trouble.

This has been tested in Prod.
