### PR TITLE
Bump simple-configuration to v1.5.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
   val http4sCore = "org.http4s" %% "http4s-core" % http4sVersion
 
   // Guardian
-  val simpleConfig = "com.gu" %% "simple-configuration-ssm" % "1.5.2"
+  val simpleConfig = "com.gu" %% "simple-configuration-ssm" % "1.5.4"
   val supportInternationalisation =
     "com.gu" %% "support-internationalisation" % "0.13"
   val contentAuthCommon = "com.gu" %% "content-authorisation-common" % "0.5"


### PR DESCRIPTION
This brings in the [upgrade of the AWS SDK](https://github.com/guardian/simple-configuration/pull/14) in simple-configuration to v2, which should in turn eliminate dependency on AWS SDK v1 throughout this project and its dependency on com.fasterxml.jackson.core:jackson-databind v2.6.  

This was raising high severity security issues in Snyk.
