### PR TITLE
Allow optional fields in Imovo redemption history

### DIFF
--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Model.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Model.scala
@@ -14,8 +14,8 @@ case class RedemptionAttempt(
   voucherType: String,
   actionDate: String,
   activityType: String,
-  address: String,
-  postCode: String,
+  address: Option[String],
+  postCode: Option[String],
   message: String,
   amount: Double
 )

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -346,8 +346,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
         "card",
         "2020-06-29T19:19:21.816Z",
         "redemption",
-        "221B Baker Street, London, U.K.",
-        "NW1 6XE",
+        Some("221B Baker Street, London, U.K."),
+        Some("NW1 6XE"),
         "Success",
         2.22
       ),
@@ -356,8 +356,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
         "card",
         "2020-07-29T19:19:21.816Z",
         "redemption",
-        "221B Baker Street, London, U.K.",
-        "NW1 6XE",
+        Some("221B Baker Street, London, U.K."),
+        Some("NW1 6XE"),
         "Redemption rejected - this voucher has been used the maximum number of times this period. Please check terms and conditions",
         0.0
       )
@@ -370,8 +370,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
           "card",
           "2020-06-29T19:19:21.816Z",
           "redemption",
-          "221B Baker Street, London, U.K.",
-          "NW1 6XE",
+          Some("221B Baker Street, London, U.K."),
+          Some("NW1 6XE"),
           "Success",
           2.22
         ),
@@ -380,8 +380,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
           "card",
           "2020-07-29T19:19:21.816Z",
           "redemption",
-          "221B Baker Street, London, U.K.",
-          "NW1 6XE",
+          Some("221B Baker Street, London, U.K."),
+          Some("NW1 6XE"),
           "Redemption rejected - this voucher has been used the maximum number of times this period. Please check terms and conditions",
           0.0
         )

--- a/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
+++ b/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
@@ -61,8 +61,8 @@ case class ImovoSubscriptionHistoryItem(
   voucherType: String,
   date: String,
   activityType: String,
-  address: String,
-  postCode: String,
+  address: Option[String],
+  postCode: Option[String],
   reason: String,
   value: Double
 )

--- a/lib/imovo/imovo-sttp-client/src/test/scala/com/gu/imovo/ImovoSubscriptionHistoryItemTest.scala
+++ b/lib/imovo/imovo-sttp-client/src/test/scala/com/gu/imovo/ImovoSubscriptionHistoryItemTest.scala
@@ -1,0 +1,63 @@
+package com.gu.imovo
+
+import io.circe.generic.auto._
+import io.circe.parser.decode
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ImovoSubscriptionHistoryItemTest extends AnyFlatSpec with Matchers {
+
+  "Json decode" should "decode successful redemption" in {
+    val json = """{
+                 |  "voucherType": "Card",
+                 |  "date": "2020-11-23T13:10:17",
+                 |  "activityType": "Redemption",
+                 |  "address": "1 High Street, London",
+                 |  "postCode": "N1 9GU ",
+                 |  "reason": "Success",
+                 |  "voucherCode": "0123456789",
+                 |  "value": 2.20
+                 |}
+                 |""".stripMargin
+    decode[ImovoSubscriptionHistoryItem](json) shouldBe
+      Right(
+        ImovoSubscriptionHistoryItem(
+          voucherCode = "0123456789",
+          voucherType = "Card",
+          date = "2020-11-23T13:10:17",
+          activityType = "Redemption",
+          address = Some("1 High Street, London"),
+          postCode = Some("N1 9GU "),
+          reason = "Success",
+          value = 2.2
+        )
+      )
+  }
+
+  it should "decode failed redemption" in {
+    val json = """{
+                 |  "voucherType": "Card",
+                 |  "date": "2020-11-22T12:44:50",
+                 |  "activityType": "Redemption",
+                 |  "address": null,
+                 |  "postCode": null,
+                 |  "reason": "Redemption rejected - the voucher cannot be used today",
+                 |  "voucherCode": "9876543210",
+                 |  "value": 0
+                 |}
+                 |""".stripMargin
+    decode[ImovoSubscriptionHistoryItem](json) shouldBe
+      Right(
+        ImovoSubscriptionHistoryItem(
+          voucherCode = "9876543210",
+          voucherType = "Card",
+          date = "2020-11-22T12:44:50",
+          activityType = "Redemption",
+          address = None,
+          postCode = None,
+          reason = "Redemption rejected - the voucher cannot be used today",
+          value = 0
+        )
+      )
+  }
+}


### PR DESCRIPTION
When a redemption fails, the address and postcode fields are left empty.
