### PR TITLE
Update play-json-extensions to 0.42.0

### DIFF
--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/BrazeSqsMessage.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/BrazeSqsMessage.scala
@@ -3,6 +3,7 @@ package com.gu.batchemailsender.api.batchemail
 import ai.x.play.json.Jsonx
 import SalesforceMessage.SalesforceBatchItem
 import SalesforceToBrazeTransformations._
+import ai.x.play.json.Encoders._
 
 /**
  * This is what actually gets sent to SQS and the fields correspond to Braze api_trigger_properties.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val circeConfig = "io.circe" %% "circe-config" % "0.7.0"
   val playJson = "com.typesafe.play" %% "play-json" % "2.8.0"
-  val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.40.2"
+  val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.42.0"
 
   // HTTP clients
   val sttp = "com.softwaremill.sttp" %% "core" % sttpVersion


### PR DESCRIPTION
## What does this change?

In response to scala-steward https://github.com/guardian/support-service-lambdas/pull/799 because it contains breaking change

## How to test

Best to perform end-to-end test via Postman for email-batch-sender.

## How can we measure success?

email-batch-sender end-to-end test succeeding. 

## Have we considered potential risks?

This change would affect `email-batch-sender` which has been known to break.


