### PR TITLE
Update cats-effect to 2.3.0

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -4,7 +4,7 @@ import java.time.{DayOfWeek, LocalDate, LocalDateTime}
 
 import cats.data.EitherT
 import cats.effect.{ContextShift, IO}
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.creditprocessor.{ProcessResult, Processor}
 import com.gu.effects.GetFromS3

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/ConfigLoader.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/ConfigLoader.scala
@@ -2,7 +2,6 @@ package com.gu.delivery_records_api
 
 import cats.data.EitherT
 import cats.effect.Sync
-import cats.implicits._
 import com.gu.effects.{GetFromS3, S3Location}
 import com.gu.util.config.{ConfigLocation, Stage}
 import io.circe.Decoder

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordApiRoutes.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordApiRoutes.scala
@@ -7,7 +7,7 @@ import cats.effect.Effect
 import org.http4s.{EntityEncoder, HttpRoutes, Request, Response}
 import io.circe.generic.auto._
 import org.http4s.circe.CirceEntityEncoder._
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.salesforce.sttp.SFApiCompositeResponse
 import com.gu.salesforce.{Contact, SalesforceHandlerSupport}
 import org.http4s.dsl.Http4sDsl

--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsService.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/DeliveryRecordsService.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 import cats.Monad
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.salesforce.SalesforceQueryConstants.{contactToWhereClausePart, escapeString}
 import com.gu.salesforce.sttp.{SFApiCompositeResponse, SalesforceClient}
 import com.gu.salesforce.{Contact, RecordsWrapperCaseClass}

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -3,7 +3,7 @@ package com.gu.cleaner
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 import java.time.LocalDate
 
-import cats.implicits._
+import cats.syntax.all._
 import com.amazonaws.services.lambda.runtime._
 import com.gu.aws.AwsCloudWatch
 import com.gu.aws.AwsCloudWatch._

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala
@@ -1,7 +1,7 @@
 package com.gu.digital_voucher_api
 
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.{ContextShift, IO}
 import com.gu.AppIdentity
 import com.gu.imovo.{ImovoClient, ImovoConfig}

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiRoutes.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import cats.Show
 import cats.data.EitherT
 import cats.effect.Effect
-import cats.implicits._
+import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.auto._
 import org.http4s.circe.CirceEntityDecoder._

--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
@@ -3,7 +3,7 @@ package com.gu.digital_voucher_api
 import java.time.LocalDate
 
 import cats.Monad
-import cats.implicits._
+import cats.syntax.all._
 import cats.data.EitherT
 import com.gu.imovo.{ImovoClient, ImovoSubscriptionResponse, ImovoSubscriptionType, SchemeName, SfSubscriptionId}
 

--- a/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorService.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorService.scala
@@ -3,7 +3,7 @@ package com.gu.digital_voucher_cancellation_processor
 import java.time.{Clock, Instant, LocalDate}
 
 import cats.data.{EitherT, NonEmptyList}
-import cats.implicits._
+import cats.syntax.all._
 import cats.{Monad, Show}
 import com.gu.imovo.{ImovoClient, ImovoClientException, SfSubscriptionId}
 import com.gu.salesforce.sttp.{SFApiCompositePart, SFApiCompositeRequest, SalesforceClient}

--- a/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/Handler.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/Handler.scala
@@ -5,7 +5,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, Output
 import com.gu.AppIdentity
 import com.typesafe.scalalogging.LazyLogging
 import scala.io.Source
-import cats.implicits._
+import cats.syntax.all._
 
 object Handler extends LazyLogging {
   def handle(is: InputStream, os: OutputStream): Unit = {

--- a/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
@@ -3,7 +3,7 @@ package com.gu.digital_voucher_cancellation_processor
 import java.time.{Clock, Instant, ZoneId}
 
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.DevIdentity
 import com.gu.digital_voucher_cancellation_processor.DigitalVoucherCancellationProcessorService._
 import com.gu.imovo.ImovoStub._

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Handler.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Handler.scala
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 import cats.arrow.FunctionK
 import cats.data.EitherT
 import cats.effect.{IO, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.digitalvouchersuspensionprocessor.Salesforce.Suspension
 import com.gu.imovo.ImovoClient
 import com.gu.salesforce.sttp.SalesforceClient

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -2,7 +2,7 @@ package com.gu.holiday_stops
 
 import java.time.{DayOfWeek, LocalDate, ZonedDateTime}
 
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.fulfilmentdates.FulfilmentDates
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Handler.scala
@@ -2,7 +2,7 @@ package com.gu.holidaystopprocessor
 
 import java.time.LocalDate
 
-import cats.implicits._
+import cats.syntax.all._
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.creditprocessor.ProcessResult
 import com.gu.effects.GetFromS3

--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ZuoraHolidayCreditAddResult.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/ZuoraHolidayCreditAddResult.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.{HolidayStopRequestsDetail, HolidayStopRequestsDetailId, ProductName}
 import com.gu.zuora.subscription.{AffectedPublicationDate, Price, RatePlanCharge, RatePlanChargeCode, SubscriptionName}
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.creditprocessor.ZuoraCreditAddResult
 
 case class ZuoraHolidayCreditAddResult(

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala
@@ -3,7 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.temporal.TemporalAdjusters
 import java.time.{DayOfWeek, LocalDate}
 
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.creditprocessor.Processor
 import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.fulfilmentdates.{FulfilmentDates, FulfilmentDatesFetcher, FulfilmentDatesFetcherError}

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ProcessorErrorHandlingSpec.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/ProcessorErrorHandlingSpec.scala
@@ -3,7 +3,7 @@ package com.gu.holidaystopprocessor
 import java.time.temporal.TemporalAdjusters
 import java.time.{DayOfWeek, LocalDate}
 
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.creditprocessor.Processor
 import com.gu.creditprocessor.Processor.CreditProductForSubscription
 import com.gu.fulfilmentdates.{FulfilmentDates, FulfilmentDatesFetcher, FulfilmentDatesFetcherError}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -7,7 +7,7 @@ import com.gu.util.resthttp.Types._
 import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
-import cats.implicits._
+import cats.syntax.all._
 
 object GetZuoraAccountsForEmail {
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
@@ -4,7 +4,6 @@ import java.time.LocalDate
 
 import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PlanId}
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
-import cats.implicits._
 
 import scala.util.Try
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFiles.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/StartDateFromFulfilmentFiles.scala
@@ -2,7 +2,7 @@ package com.gu.newproduct.api.productcatalog
 
 import java.time.{DayOfWeek, LocalDate}
 
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.effects.S3Location
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.Stage

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/DomainSteps.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/DomainSteps.scala
@@ -22,7 +22,6 @@ import com.gu.util.reader.Types.{ApiGatewayOp, _}
 import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.resthttp.{HttpOp, LazyClientFailableOp}
 import cats.data.NonEmptyList
-import cats.implicits._
 
 object DomainSteps {
 

--- a/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
+++ b/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
@@ -11,7 +11,7 @@ import manualTest.ReadFile.JsonString
 import okhttp3.Request
 import play.api.libs.json.{JsSuccess, Json}
 import scala.util.Try
-import cats.implicits._
+import cats.syntax.all._
 
 object RunBatch {
 

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
@@ -2,7 +2,7 @@ package com.gu.sf_datalake_export.handlers
 
 import java.io.{InputStream, OutputStream}
 
-import cats.implicits._
+import cats.syntax.all._
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects._
 import com.gu.salesforce.SalesforceReads._

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -2,7 +2,7 @@ package com.gu.sf.move.subscriptions.api
 
 import cats.data.EitherT
 import cats.effect.{ContextShift, IO}
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.AppIdentity
 import com.gu.util.config.ConfigLoader
 import com.softwaremill.sttp.{Id, SttpBackend}

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiRoutes.scala
@@ -2,7 +2,7 @@ package com.gu.sf.move.subscriptions.api
 
 import cats.data.EitherT
 import cats.effect.Effect
-import cats.implicits._
+import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import org.http4s.circe.CirceEntityDecoder._

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsService.scala
@@ -2,7 +2,7 @@ package com.gu.sf.move.subscriptions.api
 
 import cats.Monad
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.zuora.Zuora.{accessTokenGetResponseV2, subscriptionGetResponse, updateAccountByMovingSubscription}
 import com.gu.zuora._
 import com.gu.zuora.subscription._

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -15,7 +15,7 @@ import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.zuora.ZuoraGetAccountSummary.ZuoraAccount.PaymentMethodId
 import com.gu.util.zuora._
 import play.api.libs.json.JsPath
-import cats.implicits._
+import cats.syntax.all._
 import cats.data.NonEmptyList
 
 object SourceUpdatedSteps extends Logging {

--- a/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/S3Helper.scala
+++ b/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/S3Helper.scala
@@ -6,8 +6,6 @@ import com.typesafe.scalalogging.LazyLogging
 import com.gu.effects.{BucketName, CopyS3Objects, Key, ListS3Objects, S3Location, S3Path, UploadToS3}
 import com.gu.util.resthttp.RestRequestMaker.DownloadStream
 import cats.syntax.traverse._
-import cats.instances.list._
-import cats.instances.either._
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.{ObjectCannedACL, PutObjectRequest}
 

--- a/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/ZuoraPerformSarHandler.scala
+++ b/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/ZuoraPerformSarHandler.scala
@@ -4,8 +4,6 @@ import cats.effect.IO
 import com.gu.zuora.sar.BatonModels.{Completed, Failed, PerformSarRequest, PerformSarResponse, SarRequest, SarResponse}
 import com.typesafe.scalalogging.LazyLogging
 import cats.syntax.traverse._
-import cats.instances.list._
-import cats.instances.either._
 
 case class ZuoraPerformSarHandler(zuoraHelper: ZuoraSar, s3Service: S3Service, zuoraSarConfig: ZuoraSarConfig)
   extends LazyLogging

--- a/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/ZuoraSarService.scala
+++ b/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/ZuoraSarService.scala
@@ -7,8 +7,6 @@ import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsValue, Json, Reads}
 import cats.syntax.traverse._
-import cats.instances.list._
-import cats.instances.either._
 
 // For Zuora response deserialisation
 case class ZuoraContact(AccountId: String)

--- a/lib/config-cats/src/main/scala/com/gu/util/config/ConfigLoader.scala
+++ b/lib/config-cats/src/main/scala/com/gu/util/config/ConfigLoader.scala
@@ -1,7 +1,7 @@
 package com.gu.util.config
 
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.Sync
 import com.gu.conf.{ResourceConfigurationLocation, SSMConfigurationLocation}
 import com.gu.{AppIdentity, AwsIdentity, DevIdentity}

--- a/lib/credit-processor/src/main/scala/com/gu/creditprocessor/Processor.scala
+++ b/lib/credit-processor/src/main/scala/com/gu/creditprocessor/Processor.scala
@@ -1,7 +1,7 @@
 package com.gu.creditprocessor
 
 import java.time.LocalDate
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.fulfilmentdates.FulfilmentDatesFetcher
 import com.gu.zuora.ZuoraLockingContention.retryLockingContention
 import com.gu.zuora.ZuoraProductTypes.ZuoraProductType

--- a/lib/fulfilment-dates/src/main/scala/com/gu/fulfilmentdates/FulfilmentDatesFetcher.scala
+++ b/lib/fulfilment-dates/src/main/scala/com/gu/fulfilmentdates/FulfilmentDatesFetcher.scala
@@ -1,8 +1,6 @@
 package com.gu.fulfilmentdates
 
 import java.time.{DayOfWeek, LocalDate}
-
-import cats.implicits._
 import com.gu.effects.S3Location
 import com.gu.fulfilmentdates.FulfilmentDatesLocation.fulfilmentDatesFileLocation
 import com.gu.util.config.Stage

--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -8,7 +8,6 @@ import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import play.api.libs.json.{JsError, JsResult, JsSuccess}
 import scala.util.{Failure, Success, Try}
 import cats.Monad
-import cats.implicits._
 
 object Types extends Logging {
   object ApiGatewayOp {

--- a/lib/http4s-lambda-handler/src/main/scala/com/gu/http4s/Http4sLambdaHandler.scala
+++ b/lib/http4s-lambda-handler/src/main/scala/com/gu/http4s/Http4sLambdaHandler.scala
@@ -8,7 +8,7 @@ import org.http4s.{EmptyBody, Header, Headers, HttpRoutes, Method, Query, Reques
 import io.circe.parser._
 import io.circe.generic.auto._
 import io.circe.syntax._
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{Stream, text}
 
 import scala.collection.immutable

--- a/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
+++ b/lib/imovo/imovo-sttp-client/src/main/scala/com/gu/imovo/ImovoClient.scala
@@ -6,7 +6,7 @@ import java.time.format.DateTimeFormatter
 
 import cats.data.EitherT
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import com.softwaremill.sttp.Method.GET
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._

--- a/lib/imovo/imovo-sttp-test-stub/src/main/scala/com/gu/imovo/ImovoStub.scala
+++ b/lib/imovo/imovo-sttp-test-stub/src/main/scala/com/gu/imovo/ImovoStub.scala
@@ -7,7 +7,7 @@ import com.softwaremill.sttp.testing.SttpBackendStub
 import com.softwaremill.sttp.{Method, Request, Response}
 import io.circe.Encoder
 import io.circe.syntax._
-import cats.implicits._
+import cats.syntax.all._
 
 object ImovoStub {
   class ImovoStubSttpBackendStubOps[F[_], S](sttpStub: SttpBackendStub[F, S]) {

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/Types.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/Types.scala
@@ -1,6 +1,5 @@
 package com.gu.util.resthttp
 import cats.Monad
-import cats.implicits._
 
 import scala.annotation.tailrec
 

--- a/lib/salesforce/sttp-client/src/main/scala/com/gu/salesforce/sttp/SalesforceClient.scala
+++ b/lib/salesforce/sttp-client/src/main/scala/com/gu/salesforce/sttp/SalesforceClient.scala
@@ -5,7 +5,7 @@ import java.net.URI
 import cats.Show
 import cats.data.EitherT
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import com.gu.salesforce.SalesforceConstants.{compositeBaseUrl, sfObjectsBaseUrl, soqlQueryBaseUrl}
 import com.gu.salesforce.{RecordsWrapperCaseClass, SFAuthConfig, SalesforceAuth}
 import com.softwaremill.sttp.circe._

--- a/lib/salesforce/sttp-test-stub/src/main/scala/com/gu/salesforce/sttp/SalesforceStub.scala
+++ b/lib/salesforce/sttp-test-stub/src/main/scala/com/gu/salesforce/sttp/SalesforceStub.scala
@@ -8,7 +8,7 @@ import com.softwaremill.sttp.testing.SttpBackendStub
 import io.circe.{Decoder, Encoder}
 import io.circe.syntax._
 import io.circe.parser.decode
-import cats.implicits._
+import cats.syntax.all._
 
 object SalesforceStub {
   class SalesforceStubSttpBackendStubOps[F[_], S](sttpStub: SttpBackendStub[F, S]) {

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/RatePlanChargeBillingSchedule.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/RatePlanChargeBillingSchedule.scala
@@ -6,7 +6,7 @@ import java.time.temporal.{ChronoUnit, TemporalAdjusters}
 import java.time.LocalDate
 
 import cats.data.NonEmptyList
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.annotation.tailrec
 

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SubscriptionData.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SubscriptionData.scala
@@ -2,7 +2,7 @@ package com.gu.zuora.subscription
 
 import java.time.{DayOfWeek, LocalDate}
 import com.gu.zuora.ZuoraProductTypes.ZuoraProductType
-import cats.implicits._
+import cats.syntax.all._
 import RatePlanChargeData.round2Places
 
 import math.abs

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
@@ -2,7 +2,7 @@ package com.gu.util.zuora
 
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
 import cats.data.NonEmptyList
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.annotation.implicitNotFound
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,6 @@ object Dependencies {
   val catsVersion = "2.3.0"
   val catsEffectVersion = "2.3.0"
 
-
   val logging = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,8 +11,8 @@ object Dependencies {
   val circeVersion = "0.12.3"
   val sttpVersion = "1.7.0"
   val http4sVersion = "0.21.0"
-  val catsVersion = "2.1.1"
-  val catsEffectVersion = "2.1.4"
+  val catsVersion = "2.3.0"
+  val catsEffectVersion = "2.3.0"
 
   val logging = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
   val catsVersion = "2.3.0"
   val catsEffectVersion = "2.3.0"
 
+
   val logging = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"


### PR DESCRIPTION
## What does this change?

Related to scala-steward https://github.com/guardian/support-service-lambdas/pull/796 and https://github.com/guardian/support-service-lambdas/pull/792

`import cats.implicit._` is no longer necessary since 2.2.0

- https://github.com/typelevel/cats/releases/tag/v2.2.0
- https://stackoverflow.com/questions/63865759/why-is-import-cats-implicits-no-longer-necessary-for-importing-type-class-inst

