### PR TITLE
Filter out debug entries from DV API log

### DIFF
--- a/handlers/batch-email-sender/src/main/resources/logback.xml
+++ b/handlers/batch-email-sender/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/cancellation-sf-cases-api/src/main/resources/logback.xml
+++ b/handlers/cancellation-sf-cases-api/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/catalog-service/src/main/resources/logback.xml
+++ b/handlers/catalog-service/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/contact-us-api/src/main/resources/logback.xml
+++ b/handlers/contact-us-api/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<!--<configuration debug="true">-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- see http://logback.qos.ch/manual/layouts.html -->
+            <pattern>%level %class:%line - %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/handlers/delivery-problem-credit-processor/src/main/resources/logback.xml
+++ b/handlers/delivery-problem-credit-processor/src/main/resources/logback.xml
@@ -6,6 +6,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/handlers/delivery-records-api/src/main/resources/logback.xml
+++ b/handlers/delivery-records-api/src/main/resources/logback.xml
@@ -6,6 +6,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/handlers/digital-subscription-expiry/src/main/resources/logback.xml
+++ b/handlers/digital-subscription-expiry/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/digital-voucher-api/src/main/resources/logback.xml
+++ b/handlers/digital-voucher-api/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<!--<configuration debug="true">-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- see http://logback.qos.ch/manual/layouts.html -->
+            <pattern>%level %class:%line - %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/handlers/digital-voucher-cancellation-processor/src/main/resources/logback.xml
+++ b/handlers/digital-voucher-cancellation-processor/src/main/resources/logback.xml
@@ -6,6 +6,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/handlers/digital-voucher-suspension-processor/src/main/resources/logback.xml
+++ b/handlers/digital-voucher-suspension-processor/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<!--<configuration debug="true">-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- see http://logback.qos.ch/manual/layouts.html -->
+            <pattern>%level %class:%line - %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/handlers/fulfilment-date-calculator/src/main/resources/logback.xml
+++ b/handlers/fulfilment-date-calculator/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/holiday-stop-processor/src/main/resources/logback.xml
+++ b/handlers/holiday-stop-processor/src/main/resources/logback.xml
@@ -6,6 +6,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/handlers/identity-backfill/src/main/resources/logback.xml
+++ b/handlers/identity-backfill/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/identity-retention/src/main/resources/logback.xml
+++ b/handlers/identity-retention/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/new-product-api/src/main/resources/logback.xml
+++ b/handlers/new-product-api/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/sf-api-user-credentials-setter/src/main/resources/logback.xml
+++ b/handlers/sf-api-user-credentials-setter/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<!--<configuration debug="true">-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- see http://logback.qos.ch/manual/layouts.html -->
+            <pattern>%level %class:%line - %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/handlers/sf-billing-account-remover/src/main/resources/logback.xml
+++ b/handlers/sf-billing-account-remover/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<!--<configuration debug="true">-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- see http://logback.qos.ch/manual/layouts.html -->
+            <pattern>%level %class:%line - %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/handlers/sf-contact-merge/src/main/resources/logback.xml
+++ b/handlers/sf-contact-merge/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/sf-datalake-export/src/main/resources/logback.xml
+++ b/handlers/sf-datalake-export/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/sf-gocardless-sync/src/main/resources/logback.xml
+++ b/handlers/sf-gocardless-sync/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/sf-move-subscriptions-api/src/main/resources/logback.xml
+++ b/handlers/sf-move-subscriptions-api/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<!--<configuration debug="true">-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- see http://logback.qos.ch/manual/layouts.html -->
+            <pattern>%level %class:%line - %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/handlers/zuora-callout-apis/src/main/resources/logback.xml
+++ b/handlers/zuora-callout-apis/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/zuora-datalake-export/src/main/resources/logback.xml
+++ b/handlers/zuora-datalake-export/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/zuora-retention/src/main/resources/logback.xml
+++ b/handlers/zuora-retention/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/handlers/zuora-sar/src/main/resources/logback.xml
+++ b/handlers/zuora-sar/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
The digital voucher API log has debug entries from the AWS SDK and from Netty.  They can obscure what's going on and are generally not very helpful.

This will filter them out.  AWS have no better suggestion for filtering them out.
