### PR TITLE
Update play-json to 2.9.1

### DIFF
--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/SalesforceToBrazeTransformations.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/SalesforceToBrazeTransformations.scala
@@ -1,14 +1,14 @@
 package com.gu.batchemailsender.api.batchemail
 
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import scala.util.{Failure, Success, Try}
 
 object SalesforceToBrazeTransformations {
   def fromSfDateToDisplayDate(sfDate: String): String = {
     val formattedDate: Try[String] = Try {
-      val asDateTime = DateTime.parse(sfDate, DateTimeFormat.forPattern("yyyy-MM-dd"))
-      asDateTime.toString(DateTimeFormat.forPattern("d MMMM yyyy"))
+      val asDateTime = LocalDate.parse(sfDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+      asDateTime.format(DateTimeFormatter.ofPattern("d MMMM yyyy"))
     }
 
     formattedDate match {

--- a/lib/test/src/test/scala/com/gu/test/JsonMatchersTest.scala
+++ b/lib/test/src/test/scala/com/gu/test/JsonMatchersTest.scala
@@ -1,6 +1,6 @@
 package com.gu.test
 
-import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.json.{JsSuccess, Json, JsonValidationError}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -14,7 +14,7 @@ class JSComparisonTest extends AnyFlatSpec with Matchers {
   it should "handle missed fields as normal" in {
     val testData = """{}"""
     val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
-    val expectedError = "List((/key,List(JsonValidationError(List(error.path.missing),ArraySeq()))))"
+    val expectedError = "List((/key,List(JsonValidationError(List(error.path.missing),List()))))"
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
@@ -27,7 +27,8 @@ class JSComparisonTest extends AnyFlatSpec with Matchers {
   it should "fail for extra fields" in {
     val testData = """{"key":"test", "extra": "bad"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
-    val expectedError = """List((,List(JsonValidationError(List(extra fields, {"key":"test"} == {"key":"test","extra":"bad"}),ArraySeq()))))"""
+    JsonValidationError
+    val expectedError = """List((,List(JsonValidationError(List(extra fields, {"key":"test"} == {"key":"test","extra":"bad"}),List()))))"""
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
@@ -45,14 +46,14 @@ class JSComparisonEmdeddedTest extends AnyFlatSpec with Matchers {
   it should "handle missed fields as normal" in {
     val testData = """{}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    val expectedError = "List((/embed,List(JsonValidationError(List(error.path.missing),ArraySeq()))))"
+    val expectedError = "List((/embed,List(JsonValidationError(List(error.path.missing),List()))))"
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
   it should "handle missed fields in the nested class" in {
     val testData = """{"embed":"{}"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    val expectedError = "List((/embed/key,List(JsonValidationError(List(error.path.missing),ArraySeq()))))"
+    val expectedError = "List((/embed/key,List(JsonValidationError(List(error.path.missing),List()))))"
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
@@ -65,7 +66,7 @@ class JSComparisonEmdeddedTest extends AnyFlatSpec with Matchers {
   it should "fail for extra fields in the nested class" in {
     val testData = """{"embed":"{\"key\":\"test\",  \"extra\":\"bad\"}"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    val expectedError = "List((/embed,List(JsonValidationError(List(extra fields, {\"key\":\"test\"} == {\"key\":\"test\",\"extra\":\"bad\"}),ArraySeq()))))"
+    val expectedError = "List((/embed,List(JsonValidationError(List(extra fields, {\"key\":\"test\"} == {\"key\":\"test\",\"extra\":\"bad\"}),List()))))"
     actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   val circe = "io.circe" %% "circe-generic" % circeVersion
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val circeConfig = "io.circe" %% "circe-config" % "0.8.0"
-  val playJson = "com.typesafe.play" %% "play-json" % "2.8.1"
+  val playJson = "com.typesafe.play" %% "play-json" % "2.9.1"
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.42.0"
 
   // HTTP clients


### PR DESCRIPTION
## What does this change?

* Resolves scala-steward https://github.com/guardian/support-service-lambdas/pull/804
* Not sure what `JsonMatchersTest.scala` is supposed to be testing. It looks like it tests a test... 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Changes in `SalesforceToBrazeTransformations.scala` affect batch-email-sender which is worth end-to-end testing as we had issues with it in the past.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
