### PR TITLE
Set correct today date in DiscountTest

### DIFF
--- a/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/DiscountTest.scala
+++ b/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/DiscountTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class DiscountTest extends AnyFlatSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
   "Credit calculation" should "take into account discounts" in {
+    MutableCalendar.setFakeToday(Some(LocalDate.parse("2019-10-04")))
     val subscription = Fixtures.subscriptionFromJson("Discounts.json")
     val account = Fixtures.mkAccount()
     val subscriptionData = SubscriptionData(subscription, account).right.value


### PR DESCRIPTION
## What does this change?

This test would fail if executed individually with 

```
testOnly com.gu.zuora.subscription.DiscountTest
```

It seems the reason it succeeded when executed as part of all tests `sbt test` is that some previous test by luck set good enough mutable value of via `MutableCalendar.setFakeToday`.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
