### PR TITLE
snyk monitor GitHub Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,14 @@
+name: snyk monitor 
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run Snyk to check for vulnerabilities
+      uses: snyk/actions/scala@master
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        args: --org=the-guardian-cuu --project-name=guardian/support-service-lambdas
+        command: monitor

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,5 +10,5 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
-        args: --org=the-guardian-cuu --project-name=guardian/support-service-lambdas
+        args: --org=the-guardian-cuu --project-name=guardian/support-service-lambdas./build.sbt 
         command: monitor


### PR DESCRIPTION
## What does this change?

 Runs `synk monitor` as GH Action in parallel with regular TeamCity build.

## How to test

## How can we measure success?

## Have we considered potential risks?

Confirmed `synk monitor` works via https://github.com/guardian/tip/pull/78
