### PR TITLE
Bump okhttp to v3.14.9

### DIFF
--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -42,7 +42,7 @@ class EndToEndHandlerTest extends AnyFlatSpec with Matchers {
       BasicRequest("POST", "/action/query",
         """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c, CrmId FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}"""),
-      BasicRequest("GET", "/user?emailAddress=email@address", "")
+      BasicRequest("GET", "/user?emailAddress=email%40address", "")
     ))
   }
 
@@ -71,7 +71,7 @@ class EndToEndHandlerTest extends AnyFlatSpec with Matchers {
       BasicRequest("POST", "/action/query",
         """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c, CrmId FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}"""),
-      BasicRequest("GET", "/user?emailAddress=email@address", "")
+      BasicRequest("GET", "/user?emailAddress=email%40address", "")
     ))
   }
 
@@ -119,7 +119,7 @@ object EndToEndData {
   }
 
   def GetByEmailTestresponses: Map[String, HTTPResponse] = Map(
-    "/user?emailAddress=email@address" -> HTTPResponse(200, dummyIdentityResponse)
+    "/user?emailAddress=email%40address" -> HTTPResponse(200, dummyIdentityResponse)
   )
 
   def responses: Map[String, HTTPResponse] =

--- a/lib/effects/src/main/scala/com/gu/effects/Http.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/Http.scala
@@ -1,11 +1,11 @@
 package com.gu.effects
 
-import java.util.concurrent.TimeUnit
-
 import com.gu.util.Logging
-import okhttp3.internal.Util.UTF_8
 import okhttp3.{OkHttpClient, Request, RequestBody, Response}
 import okio.Buffer
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.TimeUnit
 
 object Http extends Logging {
 

--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -2,12 +2,12 @@ package com.gu.effects
 
 import com.gu.effects.TestingRawEffects._
 import com.gu.util.Logging
-import okhttp3.internal.Util.UTF_8
 import okhttp3._
 import okio.Buffer
 import software.amazon.awssdk.core.sync.{RequestBody => S3RequestBody}
 import software.amazon.awssdk.services.s3.model.{PutObjectRequest, PutObjectResponse}
 
+import java.nio.charset.StandardCharsets.UTF_8
 import scala.util.{Failure, Success}
 
 class TestingRawEffects(

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesForceHolidayStopsEffects.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesForceHolidayStopsEffects.scala
@@ -28,14 +28,8 @@ object SalesForceHolidayStopsEffects {
     }"
   }
 
-  def escapeQueryStringValue(value: String) = {
-    URLEncoder
-      .encode(value, "UTF-8")
-      .replace("+", "%20")
-      .replace("%2C", ",")
-      .replace("%28", "(")
-      .replace("%29", ")")
-  }
+  def escapeQueryStringValue(value: String) =
+    URLEncoder.encode(value, "UTF-8").replace("+", "%20")
 
   def listHolidayStops(contactId: String, subscriptionName: String, holidayStops: List[HolidayStopRequest], optionalHistoricalCutOff: Option[LocalDate] = None): (String, HTTPResponse) =
     listHolidayRequestUrl(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
     "com.softwaremill.sttp" %% "async-http-client-backend-cats" % sttpVersion
   val sttpOkhttpBackend =
     "com.softwaremill.sttp" %% "okhttp-backend" % sttpVersion
-  val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.9.1"
+  val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.14.9"
   val scalajHttp = "org.scalaj" %% "scalaj-http" % "2.4.2"
 
   // HTTP4S


### PR DESCRIPTION
This supersedes #777 

In release 3.10.0 more URL characters are percent-escaped so I've had to update some test fixtures.

It's also considered bad practice to rely on the `okhttp3.internal` package so I've got rid of any uses of it.

See https://square.github.io/okhttp/changelog_3x/

Tested in Code holiday stop processor.
