### PR TITLE
Bump okhttp to v4

### DIFF
--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -47,7 +47,7 @@ class TestingRawEffects(
         .request(req)
         .protocol(Protocol.HTTP_1_1)
         .code(code)
-        .body(ResponseBody.create(MediaType.parse("text/plain"), response))
+        .body(ResponseBody.create(response, MediaType.parse("text/plain")))
         .message("message??")
         .build()
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
     "com.softwaremill.sttp" %% "async-http-client-backend-cats" % sttpVersion
   val sttpOkhttpBackend =
     "com.softwaremill.sttp" %% "okhttp-backend" % sttpVersion
-  val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.14.9"
+  val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "4.9.0"
   val scalajHttp = "org.scalaj" %% "scalaj-http" % "2.4.2"
 
   // HTTP4S


### PR DESCRIPTION
The signature of `ResponseBody.create` has changed.

Tested in Code holiday credit processor.
