### PR TITLE
[contact-us-api] Add catch-all alarm

### DIFF
--- a/handlers/contact-us-api/README.md
+++ b/handlers/contact-us-api/README.md
@@ -34,7 +34,7 @@ Once the request has been processed a response with an appropriate status code w
 }
 ```
 
-## Errors
+## Errors & Alarms
 
 This lambda is designed to handle errors and exceptions gracefully and always return a response with an appropriate
 status code. Alarms have been added to notify of any issues that might arise.
@@ -69,3 +69,16 @@ The [lambda logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?regio
 1. Check the Salesforce endpoints are correct and online.
 1. Check this lambda for changes to how the relevant Salesforce response is decoded. Check this lambda for changes to
  the version of the Salesforce API used and if that version's responses are the same the lambda expects.
+ 
+ ### No incoming requests
+ 
+ **CAUSE**: This is catch-all alarm to address our lack of end-to-end testing.
+ No requests coming into contact-us-api could mean one of two things:
+ 
+ 1. Something is preventing requests from being sent through to contact-us-api. Eg: a change that breaks the form submission flow
+ 2. Our users are happy and don't need to contact us :)
+ 
+ **IMPACT**: No Contact Us form are reaching the lambda.
+ 
+ **FIX**: Go through MMA logs to determine if any form submissions failed to be routed to the lambda.
+Try submitting a form in PROD and following it in the logs. If it shows up in Salesforce it means all is good.

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -156,7 +156,6 @@ Resources:
 
   noRequestsAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: IsProd
     DependsOn:
       - ContactUsApiGateway
     Properties:
@@ -168,15 +167,23 @@ Resources:
         It might mean something's (silently) gone wrong with a part of the system that sends these requests (eg. MMA client or server-side).
         Or it could mean our users are happy and don't need to contact us. :)
       ComparisonOperator: LessThanThreshold
-      Dimensions:
-        - Name: ApiName
-          Value: !Sub contact-us-api-${Stage}-ApiGateway
-        - Name: Stage
-          Value: !Sub ${Stage}
-      EvaluationPeriods: 6
-      MetricName: Count
-      Namespace: AWS/ApiGateway
-      Period: 3600
-      Statistic: Sum
       Threshold: 1
+      EvaluationPeriods: 6
+      Metrics:
+        - Id: actualCount
+          Expression: "FILL(rawCount, 0)"
+        - Id: rawCount
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: Count
+              Namespace: AWS/ApiGateway
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub contact-us-api-${Stage}-ApiGateway
+                - Name: Stage
+                  Value: !Sub ${Stage}
+            Period: 3600
+            Stat: Sum
+            Unit: Count
       TreatMissingData: breaching

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -153,3 +153,30 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
+
+  noRequestsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn:
+      - ContactUsApiGateway
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+      AlarmName: !Sub No requests coming into contact-us-api-${Stage}
+      AlarmDescription: >
+        This is a last line catch-all alarm. It means no requests were received in the last 6 hours.
+        It might mean something's (silently) gone wrong with a part of the system that sends these requests (eg. MMA client or server-side).
+        Or it could mean our users are happy and don't need to contact us. :)
+      ComparisonOperator: LessThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub contact-us-api-${Stage}-ApiGateway
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 6
+      MetricName: Count
+      Namespace: AWS/ApiGateway
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: breaching


### PR DESCRIPTION
## What does this change?
Adds an alarm that will trigger if no requests are received for 6 hours. This should help us catch any silent issues that might happen.

## Why are we doing this?
A few weeks ago there was a change in MMA that broke the submission of the Contact Us form. This went unnoticed for over 3 days (2 of these were the weekend) because we did not have a way to catch these.

We don't currently have a method in place to test systems end-to-end and there's still a conversation to be had around how to do that. In the meantime this catch-all alarm will help us detect any such issues by alerting us if the it hasn't received any requests for 6 hours.