### PR TITLE
Log input on holiday-stop-api-failure

### DIFF
--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Handler.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/Handler.scala
@@ -10,3 +10,4 @@ object Handler extends Http4sLambdaHandler(
     .unsafeRunSync()
     .valueOr((error: DigitalVoucherApiError) => throw new RuntimeException(error.toString))
 )
+

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -263,7 +263,7 @@ object SalesforceHolidayStopRequest extends Logging {
       issuesData: List[IssueData],
       existingPublicationsThatWereToBeStopped: List[HolidayStopRequestsDetail],
       zuoraSubscription: Subscription
-    ) = {
+    ): CompositeRequest = {
 
       val masterRecordToBePatched = CompositePart(
         method = "PATCH",


### PR DESCRIPTION
## What does this change?

Old message looks something like

```
Failed to amend Holiday Stop Request for subscription SubscriptionName(A-S01243167) (contact SalesforceContactId(0035I000006Y5WMQA0)): CustomError(MULTIPLE ERRORS : List(LIMIT_EXCEEDED : The request can’t contain more than 25 operations.))
```

whilst new one will also log the `inputThatCausedError`. 

This information could be deduced from existing logs, however it is quite hard as logs can be out-of-order etc., so this PR attempts to simplify debugging a bit.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

This extra error information is not returned to the client as part of response.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
