### PR TITLE
Add GH action to test Scala-steward PRs

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     # Assuming Scala-steward branches are always named 'update/...' and other branches aren't.
-    if: startsWith(github.head_ref, 'update/')
+#    if: startsWith(github.head_ref, 'update/')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -12,10 +12,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Echo name of source branch
+      - name: Echo significant env vars
         env:
            HEAD_REF: ${{ github.head_ref }}
-        run: echo "$HEAD_REF"
+           REF: ${{ github.ref }}
+           REPO_OWNER: ${{ github.repository_owner }}
+           EVENT: ${{ github.event }}
+           ACTOR: ${{ github.actor }}
+        run: |
+          echo "HEAD_REF = $HEAD_REF"
+          echo "REF = $REF"
+          echo "REPO_OWNER = $REPO_OWNER"
+          echo "EVENT = $EVENT"
+          echo "ACTOR = $ACTOR"
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Set up Java

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -17,7 +17,7 @@ jobs:
            HEAD_REF: ${{ github.head_ref }}
            REF: ${{ github.ref }}
            REPO_OWNER: ${{ github.repository_owner }}
-           EVENT: ${{ github.event }}
+           EVENT: ${{ toJson(github.event) }}
            ACTOR: ${{ github.actor }}
         run: |
           echo "HEAD_REF = $HEAD_REF"

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,26 @@
+name: Test Scala-steward PRs
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    # Assuming Scala-steward branches are always named 'update/...' and other branches aren't.
+    if: startsWith(github.head_ref, 'update/')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Echo name of source branch
+        env:
+           HEAD_REF: ${{ github.head_ref }}
+        run: echo "$HEAD_REF"
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Run tests
+        run: sbt test

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      # This is to see if condition above can be tightened a little more.
+      # It can be removed once condition is as tight as possible.
       - name: Echo significant env vars
         env:
            HEAD_REF: ${{ github.head_ref }}
@@ -25,6 +28,7 @@ jobs:
           echo "REPO_OWNER = $REPO_OWNER"
           echo "EVENT = $EVENT"
           echo "ACTOR = $ACTOR"
+
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Set up Java

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     # Assuming Scala-steward branches are always named 'update/...' and other branches aren't.
-#    if: startsWith(github.head_ref, 'update/')
+    if: startsWith(github.head_ref, 'update/')
 
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !/.gitignore
+!/.github
 target/
 cdk-cfn.yaml
 metals.sbt


### PR DESCRIPTION
This adds an action to test Scala-steward PRs so that we can see if more work is needed before merging.
It will tell us if the code compiles and tests pass but won't tell us about runtime binary incompatibilities or if something dangerous has been imported into the repo.
So it gives more confidence but not complete confidence.

This is done as a GH action rather than in Teamcity to avoid polluting our general CI processes and generating potentially dangerous artefacts.
