### PR TITLE
Bump diffx-scalatest to v0.4.0

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/test/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequestTest.scala
+++ b/handlers/delivery-problem-credit-processor/src/test/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequestTest.scala
@@ -1,8 +1,7 @@
 package com.gu.deliveryproblemcreditprocessor
 
-import java.time.LocalDate
-
 import com.gu.salesforce.RecordsWrapperCaseClass
+import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMatcher
 import io.circe.generic.auto._
 import io.circe.parser._
@@ -10,6 +9,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.time.LocalDate
 import scala.io.Source
 
 class DeliveryCreditRequestTest
@@ -20,7 +20,7 @@ class DeliveryCreditRequestTest
 
   "Json decode" should "decode SF response correctly" in {
     val json = Source.fromResource("sf-credit-request.json").mkString
-    decode[RecordsWrapperCaseClass[DeliveryCreditRequest]](json).right.value should matchTo(
+    decode[RecordsWrapperCaseClass[DeliveryCreditRequest]](json).value should matchTo(
       RecordsWrapperCaseClass(List(
         DeliveryCreditRequest(
           Id = "r1",

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/CreateVoucherRequestBodyTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/CreateVoucherRequestBodyTest.scala
@@ -1,5 +1,6 @@
 package com.gu.digital_voucher_api
 
+import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMatcher
 import io.circe.generic.auto._
 import io.circe.parser.decode
@@ -15,7 +16,7 @@ class CreateVoucherRequestBodyTest
 
   "Json decode" should "decode expected Json object successfully" in {
     val json = """{"ratePlanName": "Weekend"}"""
-    decode[CreateVoucherRequestBody](json).right.value should matchTo(
+    decode[CreateVoucherRequestBody](json).value should matchTo(
       CreateVoucherRequestBody("Weekend")
     )
   }

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -1,11 +1,10 @@
 package com.gu.digital_voucher_api
 
-import java.time.LocalDate
-
 import cats.effect.IO
 import com.gu.DevIdentity
 import com.gu.imovo.ImovoStub._
-import com.gu.imovo.{ImovoConfig, ImovoErrorResponse, ImovoRedemptionHistoryResponse, ImovoSubscriptionHistoryItem, ImovoSubscriptionResponse, ImovoSubscriptionType, ImovoSuccessResponse, ImovoVoucherResponse, SfSubscriptionId}
+import com.gu.imovo._
+import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMatcher
 import com.softwaremill.sttp.impl.cats.CatsMonadError
 import com.softwaremill.sttp.testing.SttpBackendStub
@@ -18,6 +17,8 @@ import org.scalatest.EitherValues
 import org.scalatest.Inside.inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
+
+import java.time.LocalDate
 
 class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMatcher with EitherValues {
 

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -1,14 +1,15 @@
 package com.gu.holidaystopprocessor
 
-import java.time.temporal.TemporalAdjusters
-import java.time.{DayOfWeek, LocalDate}
-
 import com.gu.holiday_stops.Fixtures
 import com.gu.zuora.subscription.{Add, AffectedPublicationDate, ChargeOverride, InvoiceDate, MutableCalendar, SubscriptionUpdate, Fixtures => SubscriptionFixtures}
+import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMatcher
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.time.temporal.TemporalAdjusters
+import java.time.{DayOfWeek, LocalDate}
 
 class SubscriptionUpdateTest extends AnyFlatSpec with Matchers with DiffMatcher with EitherValues {
   MutableCalendar.setFakeToday(Some(LocalDate.parse("2019-08-12")))
@@ -145,7 +146,7 @@ class SubscriptionUpdateTest extends AnyFlatSpec with Matchers with DiffMatcher 
       stoppedPublicationDate,
       Some(givenInvoiceDate)
     )
-    update.right.value should matchTo(SubscriptionUpdate(
+    update.value should matchTo(SubscriptionUpdate(
       currentTerm = Some(536),
       currentTermPeriodType = Some("Day"),
       List(Add(

--- a/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionUpdateTest.scala
+++ b/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionUpdateTest.scala
@@ -1,11 +1,12 @@
 package com.gu.zuora.subscription
 
-import java.time.LocalDate
-
+import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMatcher
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDate
 
 class SubscriptionUpdateTest
   extends AnyFlatSpec
@@ -29,7 +30,7 @@ class SubscriptionUpdateTest
       maybeInvoiceDate = Some(invoiceDate)
     )
 
-    update.right.value should matchTo(
+    update.value should matchTo(
       SubscriptionUpdate(
         currentTerm = Some(418),
         currentTermPeriodType = Some("Day"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val stripe = "com.stripe" % "stripe-java" % "20.34.0"
 
   // Testing
-  val diffx = "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.30" % Test
+  val diffx = "com.softwaremill.diffx" %% "diffx-scalatest" % "0.4.0" % Test
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.3" % Test
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.15.2" % Test
   val scalaMock = "org.scalamock" %% "scalamock" % "5.1.0" % Test


### PR DESCRIPTION
There were a few changes needed to support auto-derivation of Diff types, explained in the migration guide [here](https://github.com/softwaremill/diffx/releases/tag/v0.4.0).

Also some deprecated `Either` methods were changed along the way.

This supersedes #848.
