### PR TITLE
Don't try to suspend today's digital vouchers

### DIFF
--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Salesforce.scala
@@ -44,7 +44,7 @@ object Salesforce {
          |SELECT Id, Holiday_Stop_Request__r.SF_Subscription__c, Stopped_Publication_Date__c, Holiday_Stop_Request__r.Subscription_Name__c
          |FROM Holiday_Stop_Requests_Detail__c
          |WHERE Holiday_Stop_Request__r.SF_Subscription__r.Product_Type__c = 'Newspaper - Digital Voucher'
-         |AND Stopped_Publication_Date__c >= TODAY
+         |AND Stopped_Publication_Date__c >= TOMORROW
          |AND Is_Withdrawn__c = false
          |AND Is_Actioned__c = true
          |AND Sent_To_Digital_Voucher_Service__c = null


### PR DESCRIPTION
This is a workaround for the problem where CSRs can apply holiday stops retrospectively.
If we try to suspend a voucher for today it will fail as Imovo will only accept suspensions from tomorrow onwards.


