### PR TITLE
Include Scala in dependencies to update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*
 !/.gitignore
 !/.github
+!/.scala-steward.conf
 target/
 cdk-cfn.yaml
 metals.sbt

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,92 @@
+# Repository-specific configuration
+# Based on template at
+# https://github.com/scala-steward-org/scala-steward/blob/master/docs/repo-specific-configuration.md
+
+# pullRequests.frequency allows to control how often or when Scala Steward
+# is allowed to create pull requests.
+#
+# Possible values:
+#   @asap
+#     PRs are created without delay.
+#
+#   <timespan>
+#     PRs are created only again after the given timespan since the last PR
+#     has passed. Example values are "36 hours", "1 day", or "14 days".
+
+#   <CRON expression>
+#     PRs are created roughly according to the given CRON expression.
+#
+#     CRON expressions consist of five fields:
+#     minutes, hour of day, day of month, month, and day of week.
+#
+#     See https://www.alonsodomin.me/cron4s/userguide/index.html#parsing for
+#     more information about the CRON expressions that are supported.
+#
+#     Note that the date parts of the CRON expression are matched exactly
+#     while the the time parts are only used to abide to the frequency of
+#     the given expression.
+#
+# Default: @asap
+#
+#pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
+#pullRequests.frequency = "7 days"
+
+# Only these dependencies which match the given patterns are updated.
+#
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# Defaults to empty `[]` which mean Scala Steward will update all dependencies.
+#updates.allow  = [ { groupId = "com.example" } ]
+
+# The dependencies which match the given version pattern are updated.
+# Dependencies that are not listed will be updated.
+#
+# Each pattern must have `groupId`, `version` and optional `artifactId`.
+# Defaults to empty `[]` which mean Scala Steward will update all dependencies.
+# the following example will allow to update foo when version is 1.1.x
+#updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." } ]
+
+# The dependencies which match the given pattern are NOT updated.
+#
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
+#updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
+
+# If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
+# Useful if running frequently and/or CI build are costly
+# Default: None
+#updates.limit = 5
+
+# By default, Scala Steward does not update scala version since its tricky, error-prone
+# and results in bad PRs and/or failed builds
+# If set to true, Scala Steward will attempt to update the scala version
+# Since this feature is experimental, the default is set to false
+# Default: false
+updates.includeScala = true
+
+# The extensions of files that should be updated.
+# Default: [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", "pom.xml"]
+#updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md", ".markdown", ".txt"]
+
+# If "on-conflicts", Scala Steward will update the PR it created to resolve conflicts as
+# long as you don't change it yourself.
+# If "always", Scala Steward will always update the PR it created as long as
+# you don't change it yourself.
+# If "never", Scala Steward will never update the PR
+# Default: "on-conflicts"
+#updatePullRequests = "always" | "on-conflicts" | "never"
+
+# If set, Scala Steward will use this message template for the commit messages and PR titles.
+# Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
+# Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}" 
+#commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
+
+# If true and when upgrading version in .scalafmt.conf, Scala Steward will perform scalafmt 
+# and add a separate commit when format changed. So you don't need reformat manually and can merge PR.
+# If false, Scala Steward will not perform scalafmt, so your CI may abort when reformat needed.
+# Default: true
+#scalafmt.runAfterUpgrading = false
+
+# It is possible to have multiple scala projects in a single repository. In that case the folders containing the projects (build.sbt folders)
+# are specified using the buildRoots property. Note that the paths used there are relative and if the repo directory itself also contains a build.sbt the dot can be used to specify it.
+# Default: ["."]
+#buildRoots = [ ".", "subfolder/projectA" ]


### PR DESCRIPTION
## What does this change?
Adds a config file to customise the operation of Scala Steward.  The only line in it that has any effect is [enabling updates of the Scala library](https://github.com/guardian/support-service-lambdas/compare/kc-scala-steward?expand=1#diff-70457a09643cd476bea88a01e2bbf35729e75a94dba69bfb4a4a3179451704cfR64).

## How can we measure success?
Any new release of the Scala library should generate a Scala Steward PR.

## Have we considered potential risks?
Just merging any PRs that are generated as a result of this config change will probably break the build.  So will need to see if the Github action succeeds before merging them.
