### PR TITLE
use correct jar name for dev-env-cleaner

### DIFF
--- a/handlers/dev-env-cleaner/cfn.yaml
+++ b/handlers/dev-env-cleaner/cfn.yaml
@@ -33,7 +33,7 @@ Resources:
       Handler: com.gu.cleaner.Handler::handleRequest
       CodeUri:
         Bucket: support-service-lambdas-dist
-        Key: !Sub membership/${Stage}/dev-env-cleaner/lambda.jar
+        Key: !Sub membership/${Stage}/dev-env-cleaner/dev-env-cleaner.jar
       MemorySize: 2048
       Runtime: java8
       Timeout: 900


### PR DESCRIPTION
This corrects dev-env-cleaner to use the jar that was deployed by riffraff rather than an old one that was still around.

This change was introduced in the big cleanup PR https://github.com/guardian/support-service-lambdas/pull/740 but the old jar name was inadvertantly retained.

If you look at a deploy
https://riffraff.gutools.co.uk/deployment/view/bdecfb4d-627b-4d15-96ed-15e2b595fa4c?verbose=1
```
08:34:26] Deploying dev-env-cleaner [uploadLambda] => eu-west-1/membership
  [08:34:26] task S3Upload Upload 1 file to S3 bucket support-service-lambdas-dist using file mapping List((S3Path(riffraff-artifact,support-service-lambdas::dev-env-cleaner/4702/dev-env-cleaner/dev-env-cleaner.jar),membership/PROD/dev-env-cleaner/dev-env-cleaner.jar))
```
i.e. `membership/PROD/dev-env-cleaner/dev-env-cleaner.jar`

This is confirmed by this line https://github.com/guardian/support-service-lambdas/blob/55fe0b0e10d62265f73ee3065418b4eb4fccf230/build.sbt#L246
which used to be specified as this in the handler
https://github.com/guardian/support-service-lambdas/blob/6bca8a106bbcdf8aad3b8331395e14939826adfa/handlers/dev-env-cleaner/build.sbt#L6