### PR TITLE
Log failed testCase for testInProdPreviewPublications

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -222,6 +222,8 @@ object Handler extends Logging {
     potentialHolidayStops: List[PotentialHolidayStop],
     nextInvoiceDateAfterToday: LocalDate
   ): Future[_] = Future {
+    lazy val testCase = s"${subscription.subscriptionNumber}?startDate=${queryParams.startDate}&endDate=${queryParams.endDate}"
+
     (previewPublications(subscription.subscriptionNumber, queryParams.startDate.toString, queryParams.endDate.toString).map { actual =>
       val actualPotentialHolidayStops =
         actual
@@ -235,11 +237,11 @@ object Handler extends Logging {
         // 1logger.info("testInProdPreviewPublications OK")
       } else {
         logger.error(
-          s"testInProdPreviewPublications failed ${subscription.subscriptionNumber}?startDate=${queryParams.startDate}&endDate=${queryParams.endDate} because $potentialHolidayStops =/= $actualPotentialHolidayStops or $nextInvoiceDateAfterToday =/= $actualNextInvoiceDateAfterToday"
+          s"testInProdPreviewPublications failed $testCase because $potentialHolidayStops =/= $actualPotentialHolidayStops or $nextInvoiceDateAfterToday =/= $actualNextInvoiceDateAfterToday"
         )
       }
     }).left.map { e =>
-      logger.error(s"testInProdPreviewPublications failed because invoicing-api error: $e")
+      logger.error(s"testInProdPreviewPublications failed $testCase because invoicing-api error: $e")
     }
   }(ecForTestInProd)
 


### PR DESCRIPTION
Needed to identify exact subscription that is failing.

Before

```
testInProdPreviewPublications failed because invoicing-api error: ZuoraApiFailure(DecodingFailure at .publicationsWithinRange: Attempt to decode value on failed cursor)
```

After

```
testInProdPreviewPublications failed A-S0000000?startDate=2020-11-13&endDate=2021-02-12 because invoicing-api error: ZuoraApiFailure(DecodingFailure at .publicationsWithinRange: Attempt to decode value on failed cursor)
```