### PR TITLE
add query and 1 year writeoff function to recogniser cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -316,8 +316,11 @@ lazy val `dev-env-cleaner` = lambdaProject(
 lazy val `revenue-recogniser-job` = lambdaProject(
   "revenue-recogniser-job",
   "Finds unrecognised revenue in zuora and recognises it appropariately",
-  Seq()
-).dependsOn(handler, effectsDepIncludingTestFolder, testDep, `effects-s3`, `effects-cloudwatch`)
+  Seq(
+    "com.nrinaudo" %% "kantan.csv-generic" % "0.6.1",
+    "com.nrinaudo" %% "kantan.csv-java8" % "0.6.1",
+  )
+).dependsOn(`zuora-reports`, handler, effectsDepIncludingTestFolder, testDep, `effects-s3`, `effects-cloudwatch`)
 
 lazy val `sf-contact-merge` = lambdaProject(
   "sf-contact-merge",

--- a/handlers/revenue-recogniser-job/README.md
+++ b/handlers/revenue-recogniser-job/README.md
@@ -10,6 +10,15 @@ Also, if a refund is made, the refund is not distributed.
 The job will search for all subscriptions that need to be recognised, and distribute the schedules
 as appropriate.
 
+## Testing
+
+This is not possible to test with an EffectsTest as when you create a subscription, the revenue
+schedules are not created immediately by zuora.  This means you can't distribute them without
+polling them and waiting a while. (seems to be seconds in DEV, but minutes in PROD)
+
+As a result, there is a HandlerManualTest file which has one App to create a DEV test sub, and one
+to run the lambda in DEV.  Run one and then the other to see if it's working right.
+
 ## Alarms
 
 If the job fails, an alarm will be sent saying that there is an issue.

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/BlockingAquaQuery.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/BlockingAquaQuery.scala
@@ -1,0 +1,66 @@
+package com.gu.recogniser
+
+import cats.syntax.all._
+import com.gu.util.resthttp.RestRequestMaker
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientFailure, ClientSuccess}
+import com.gu.zuora.reports.aqua.{AquaJobResponse, AquaQuery, AquaQueryRequest}
+import com.gu.zuora.reports.dataModel.Batch
+import com.gu.zuora.reports._
+import kantan.csv.ops._
+import kantan.csv.{CsvReader, HeaderDecoder, ReadResult, rfc}
+
+import scala.annotation.tailrec
+
+/*
+This blocking query is only suitable for ones that will definitely execute within the lambda execution timeout.
+For longer running queries either wait for the zuora callback via API gateway, or poll with step functions or similar.
+ */
+trait BlockingAquaQuery {
+  def executeQuery[CsvHeaderDecoder: HeaderDecoder](queryString: String): ClientFailableOp[CsvReader[ReadResult[CsvHeaderDecoder]]]
+}
+
+class BlockingAquaQueryImpl(
+  aquaQuerier: AquaQueryRequest => ClientFailableOp[String],
+  downloadRequests: RestRequestMaker.Requests,
+  log: String => Unit,
+) extends BlockingAquaQuery {
+
+  override def executeQuery[CsvHeaderDecoder : HeaderDecoder](queryString: String): ClientFailableOp[CsvReader[ReadResult[CsvHeaderDecoder]]] = {
+    val queryName = "expired_gift_and_refunds_undistributed"
+    val subsQuery = AquaQuery(queryName, queryString)
+    val request = AquaQueryRequest(
+      name = "undistributed_revenue_schedules",
+      queries = List(subsQuery)
+    )
+    for {
+      jobId <- aquaQuerier(request)
+      batches <- waitForResult(jobId, GetJobResult(downloadRequests.get[AquaJobResponse]))
+      streams <- batches.toList.traverse { batch =>
+        downloadRequests.getDownloadStream(s"batch-query/file/${batch.fileId}").map(
+          stream => (batch.name, stream.stream))
+      }
+      queryResults = streams.map {
+        case (name, csvStream) =>
+          val values = csvStream.asCsvReader[CsvHeaderDecoder](rfc.withHeader)
+          (name, values)
+      }.toMap
+      results = queryResults(queryName)
+    } yield results
+  }
+
+  @tailrec
+  final def waitForResult(jobId: String, getJobResult: JobResultRequest => ClientFailableOp[JobResult]): ClientFailableOp[Seq[Batch]] = {
+    getJobResult(JobResultRequest(jobId, false, None)) match {
+      case ClientSuccess(success) => success match {
+        case pending: Pending =>
+          Thread.sleep(1000)
+          log(s"still pending: $pending")
+          waitForResult(jobId, getJobResult)
+        case c: Completed =>
+          ClientSuccess(c.batches)
+      }
+      case fail: ClientFailure => fail
+    }
+  }
+
+}

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/BlockingAquaQuery.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/BlockingAquaQuery.scala
@@ -22,10 +22,10 @@ trait BlockingAquaQuery {
 class BlockingAquaQueryImpl(
   aquaQuerier: AquaQueryRequest => ClientFailableOp[String],
   downloadRequests: RestRequestMaker.Requests,
-  log: String => Unit,
+  log: String => Unit
 ) extends BlockingAquaQuery {
 
-  override def executeQuery[CsvHeaderDecoder : HeaderDecoder](queryString: String): ClientFailableOp[CsvReader[ReadResult[CsvHeaderDecoder]]] = {
+  override def executeQuery[CsvHeaderDecoder: HeaderDecoder](queryString: String): ClientFailableOp[CsvReader[ReadResult[CsvHeaderDecoder]]] = {
     val queryName = "expired_gift_and_refunds_undistributed"
     val subsQuery = AquaQuery(queryName, queryString)
     val request = AquaQueryRequest(
@@ -37,7 +37,8 @@ class BlockingAquaQueryImpl(
       batches <- waitForResult(jobId, GetJobResult(downloadRequests.get[AquaJobResponse]))
       streams <- batches.toList.traverse { batch =>
         downloadRequests.getDownloadStream(s"batch-query/file/${batch.fileId}").map(
-          stream => (batch.name, stream.stream))
+          stream => (batch.name, stream.stream)
+        )
       }
       queryResults = streams.map {
         case (name, csvStream) =>

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/DistributeRevenueOnSpecificDate.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/DistributeRevenueOnSpecificDate.scala
@@ -5,29 +5,13 @@ import play.api.libs.json.{JsSuccess, Json, Reads}
 
 import java.time.LocalDate
 
-case class DistributeRevenueOnSpecificDate(restRequestMaker: RestRequestMaker.Requests) {
-
-  import DistributeRevenueOnSpecificDate._
-
-  // https://www.zuora.com/developer/api-reference/#operation/PUT_RevenueSpecificDate
-  def distribute(
-    revenueScheduleNumber: String,
-    dateToDistribute: LocalDate,
-  ) = {
-    restRequestMaker.put[DistributeRevenueOnSpecificDateRequest, Unit](
-      DistributeRevenueOnSpecificDateRequest(dateToDistribute),
-      s"revenue-schedules/${revenueScheduleNumber}/distribute-revenue-on-specific-date"
-    )
-  }
-}
-
 object DistributeRevenueOnSpecificDate {
 
   case class DistributeRevenueOnSpecificDateRequest(
     distributeOn: LocalDate,
     percentage: Int = 100,
     distributionType: String = "specific date (delta percent undistributed)",
-    eventTypeSystemId: String = "DigitalSubscriptionGiftRedeemed",
+    eventTypeSystemId: String = "DigitalSubscriptionGiftRedeemed"
   )
 
   implicit val writes = Json.writes[DistributeRevenueOnSpecificDateRequest]
@@ -35,4 +19,20 @@ object DistributeRevenueOnSpecificDate {
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))
 
+}
+
+case class DistributeRevenueOnSpecificDate(restRequestMaker: RestRequestMaker.Requests) {
+
+  import DistributeRevenueOnSpecificDate._
+
+  // https://www.zuora.com/developer/api-reference/#operation/PUT_RevenueSpecificDate
+  def distribute(
+    revenueScheduleNumber: String,
+    dateToDistribute: LocalDate
+  ) = {
+    restRequestMaker.put[DistributeRevenueOnSpecificDateRequest, Unit](
+      DistributeRevenueOnSpecificDateRequest(dateToDistribute),
+      s"revenue-schedules/${revenueScheduleNumber}/distribute-revenue-on-specific-date"
+    )
+  }
 }

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/DistributeRevenueOnSpecificDate.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/DistributeRevenueOnSpecificDate.scala
@@ -1,0 +1,38 @@
+package com.gu.recogniser
+
+import com.gu.util.resthttp.RestRequestMaker
+import play.api.libs.json.{JsSuccess, Json, Reads}
+
+import java.time.LocalDate
+
+case class DistributeRevenueOnSpecificDate(restRequestMaker: RestRequestMaker.Requests) {
+
+  import DistributeRevenueOnSpecificDate._
+
+  // https://www.zuora.com/developer/api-reference/#operation/PUT_RevenueSpecificDate
+  def distribute(
+    revenueScheduleNumber: String,
+    dateToDistribute: LocalDate,
+  ) = {
+    restRequestMaker.put[DistributeRevenueOnSpecificDateRequest, Unit](
+      DistributeRevenueOnSpecificDateRequest(dateToDistribute),
+      s"revenue-schedules/${revenueScheduleNumber}/distribute-revenue-on-specific-date"
+    )
+  }
+}
+
+object DistributeRevenueOnSpecificDate {
+
+  case class DistributeRevenueOnSpecificDateRequest(
+    distributeOn: LocalDate,
+    percentage: Int = 100,
+    distributionType: String = "specific date (delta percent undistributed)",
+    eventTypeSystemId: String = "DigitalSubscriptionGiftRedeemed",
+  )
+
+  implicit val writes = Json.writes[DistributeRevenueOnSpecificDateRequest]
+
+  implicit val unitReads: Reads[Unit] =
+    Reads(_ => JsSuccess(()))
+
+}

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/DistributeRevenueWithDateRange.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/DistributeRevenueWithDateRange.scala
@@ -1,0 +1,39 @@
+package com.gu.recogniser
+
+import com.gu.util.resthttp.RestRequestMaker
+import play.api.libs.json.{JsSuccess, Json, Reads}
+
+import java.time.LocalDate
+
+case class DistributeRevenueWithDateRange(restRequestMaker: RestRequestMaker.Requests) {
+
+  import DistributeRevenueWithDateRange._
+
+  // https://www.zuora.com/developer/api-reference/#operation/PUT_RevenueByRecognitionStartandEndDates
+  def distribute(
+    revenueScheduleNumber: String,
+    startDate: LocalDate,
+    endDate: LocalDate,
+  ) = {
+    restRequestMaker.put[DistributeRevenueWithDateRangeRequest, Unit](
+      DistributeRevenueWithDateRangeRequest(startDate, endDate),
+      s"revenue-schedules/${revenueScheduleNumber}/distribute-revenue-with-date-range"
+    )
+  }
+}
+
+object DistributeRevenueWithDateRange {
+
+  case class DistributeRevenueWithDateRangeRequest(
+    recognitionStart: LocalDate,
+    recognitionEnd: LocalDate,
+    distributionType: String = "Daily distribution",
+    eventTypeSystemId: String = "DigitalSubscriptionGiftRedeemed",
+  )
+
+  implicit val writes = Json.writes[DistributeRevenueWithDateRangeRequest]
+
+  implicit val unitReads: Reads[Unit] =
+    Reads(_ => JsSuccess(()))
+
+}

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/DistributeRevenueWithDateRange.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/DistributeRevenueWithDateRange.scala
@@ -5,6 +5,22 @@ import play.api.libs.json.{JsSuccess, Json, Reads}
 
 import java.time.LocalDate
 
+object DistributeRevenueWithDateRange {
+
+  case class DistributeRevenueWithDateRangeRequest(
+    recognitionStart: LocalDate,
+    recognitionEnd: LocalDate,
+    distributionType: String = "Daily distribution",
+    eventTypeSystemId: String = "DigitalSubscriptionGiftRedeemed"
+  )
+
+  implicit val writes = Json.writes[DistributeRevenueWithDateRangeRequest]
+
+  implicit val unitReads: Reads[Unit] =
+    Reads(_ => JsSuccess(()))
+
+}
+
 case class DistributeRevenueWithDateRange(restRequestMaker: RestRequestMaker.Requests) {
 
   import DistributeRevenueWithDateRange._
@@ -13,27 +29,11 @@ case class DistributeRevenueWithDateRange(restRequestMaker: RestRequestMaker.Req
   def distribute(
     revenueScheduleNumber: String,
     startDate: LocalDate,
-    endDate: LocalDate,
+    endDate: LocalDate
   ) = {
     restRequestMaker.put[DistributeRevenueWithDateRangeRequest, Unit](
       DistributeRevenueWithDateRangeRequest(startDate, endDate),
       s"revenue-schedules/${revenueScheduleNumber}/distribute-revenue-with-date-range"
     )
   }
-}
-
-object DistributeRevenueWithDateRange {
-
-  case class DistributeRevenueWithDateRangeRequest(
-    recognitionStart: LocalDate,
-    recognitionEnd: LocalDate,
-    distributionType: String = "Daily distribution",
-    eventTypeSystemId: String = "DigitalSubscriptionGiftRedeemed",
-  )
-
-  implicit val writes = Json.writes[DistributeRevenueWithDateRangeRequest]
-
-  implicit val unitReads: Reads[Unit] =
-    Reads(_ => JsSuccess(()))
-
 }

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/Handler.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/Handler.scala
@@ -113,8 +113,7 @@ class Steps(
          |from RevenueSchedule
          |where Rule = 'Digital Subscription Gift Rule'
          | AND (
-         |      UndistributedAmount < 0
-         |  OR (UndistributedAmount > 0 AND subscription.termstartdate <= '$oneYearAgo')
+         |     (UndistributedAmount > 0 AND subscription.termstartdate <= '$oneYearAgo')
          | )
          |""".stripMargin
     for {

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/Handler.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/Handler.scala
@@ -1,49 +1,20 @@
 package com.gu.recogniser
 
+import cats.syntax.all._
 import com.amazonaws.services.lambda.runtime._
 import com.gu.aws.AwsCloudWatch
 import com.gu.aws.AwsCloudWatch._
-import com.gu.effects.RawEffects
-import com.gu.util.config.Stage
+import com.gu.effects.{GetFromS3, RawEffects}
+import com.gu.recogniser.RevenueSchedule.csvFields
+import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
+import com.gu.zuora.reports._
+import com.gu.zuora.reports.aqua.ZuoraAquaRequestMaker
+import okhttp3.{Request, Response}
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+import java.io.{InputStream, OutputStream}
 
 object Handler extends RequestStreamHandler {
-
-  def main(args: Array[String]): Unit = {
-    println("main: STARTING!")
-    // FOR TESTING
-    handleRequest(
-      new ByteArrayInputStream(Array[Byte]()), new ByteArrayOutputStream(), new Context {
-        override def getAwsRequestId: String = ???
-
-        override def getLogGroupName: String = ???
-
-        override def getLogStreamName: String = ???
-
-        override def getFunctionName: String = ???
-
-        override def getFunctionVersion: String = ???
-
-        override def getInvokedFunctionArn: String = ???
-
-        override def getIdentity: CognitoIdentity = ???
-
-        override def getClientContext: ClientContext = ???
-
-        override def getRemainingTimeInMillis: Int = ???
-
-        override def getMemoryLimitInMB: Int = ???
-
-        override def getLogger: LambdaLogger = new LambdaLogger {
-          override def log(message: String): Unit = println("LOG: " + message)
-
-          override def log(message: Array[Byte]): Unit = ???
-        }
-      }
-    )
-    println("main: FINISHED!")
-  }
 
   //referenced in cloudformation, change with care
   def handleRequest(
@@ -52,12 +23,16 @@ object Handler extends RequestStreamHandler {
     context: Context
   ): Unit = {
     def log(message: String) = context.getLogger.log(message)
-    val stage = RawEffects.stage
 
     log("starting lambda!")
-
-    // TODO write the code to go here!
-
+    val stage = RawEffects.stage
+    val loadConfig = LoadConfigModule(stage, GetFromS3.fetchString)
+    val maybeSuccess = for {
+      zuoraRestConfig <- loadConfig[ZuoraRestConfig]
+      steps = Steps(log, RawEffects.downloadResponse, RawEffects.response, zuoraRestConfig, () => RawEffects.now().toLocalDate)
+      _ <- steps.execute().leftMap(failure => new RuntimeException(s"execution has failed: $failure"))
+    } yield ()
+    val _ = maybeSuccess.toTry.get // throws exception if something failed
     log("finished successfully - sending metric!")
     putMetric(stage)
   }
@@ -74,6 +49,90 @@ object Handler extends RequestStreamHandler {
         MetricDimensionName("app") -> MetricDimensionValue("revenue-recogniser-job")
       )
     ))
+  }
+
+}
+import kantan.csv.HeaderDecoder
+
+import java.time.LocalDate
+
+case class RevenueSchedule(
+  number: String,
+  undistributedAmountInPence: Int,
+)
+
+object RevenueSchedule {
+
+  val csvFields = List(
+    "RevenueSchedule.Number",
+    "RevenueSchedule.UndistributedAmount",
+  )
+
+  implicit val decoder: HeaderDecoder[RevenueSchedule] = csvFields match {
+    case a1 :: a2 :: Nil =>
+      HeaderDecoder.decoder(a1, a2)((number: String, amount: Double) => RevenueSchedule(number, (amount * 100).toInt))
+  }
+
+}
+
+
+object Steps {
+  def apply(
+    log: String => Unit,
+    downloadResponse: Request => Response,
+    response: Request => Response,
+    zuoraRestConfig: ZuoraRestConfig,
+    today: () => LocalDate
+  ): Steps = {
+    val requests = ZuoraRestRequestMaker(response, zuoraRestConfig)
+    val downloadRequests = ZuoraAquaRequestMaker(downloadResponse, zuoraRestConfig)
+    val aquaQuerier = Querier.lowLevel(downloadRequests) _
+    new Steps(
+      log,
+      new BlockingAquaQueryImpl(aquaQuerier, downloadRequests, log),
+      today,
+      DistributeRevenueOnSpecificDate(requests),
+      DistributeRevenueWithDateRange(requests),
+    )
+  }
+}
+
+class Steps(
+  log: String => Unit,
+  blockingAquaQuery: BlockingAquaQuery,
+  today: () => LocalDate,
+  distributeRevenueOnSpecificDate: DistributeRevenueOnSpecificDate,
+  distributeRevenueWithDateRange: DistributeRevenueWithDateRange,
+) {
+
+  def execute(): Either[String, Unit] = {
+    val oneYearAgo: LocalDate = today().minusYears(1)
+    val expiredGiftsAndRefunds =
+      s"""select ${csvFields.mkString(", ")}
+         |from RevenueSchedule
+         |where Rule = 'Digital Subscription Gift Rule'
+         | AND (
+         |      UndistributedAmount < 0
+         |  OR (UndistributedAmount > 0 AND subscription.termstartdate <= '$oneYearAgo')
+         | )
+         |""".stripMargin
+    for {
+      undistributedRevenue <- blockingAquaQuery.executeQuery[RevenueSchedule](expiredGiftsAndRefunds).toDisjunction.leftMap(_.toString)
+      revenueSchedulesToDistribute <- undistributedRevenue.toList.sequence.leftMap(_.toString)
+      _ = revenueSchedulesToDistribute.map {
+        case RevenueSchedule(expiredCodeSchedule, amount) if amount > 0 =>
+          log(s"distribute on a single day: $expiredCodeSchedule $amount")
+          distributeRevenueOnSpecificDate.distribute(expiredCodeSchedule, today())
+        case RevenueSchedule(refundSchedule, amount) if amount < 0 =>
+          log(s"distribute refund: $refundSchedule $amount")
+        //TODO
+      }
+      _ = log("now query again and assert there are none")
+      stillUndistributedRevenue <- blockingAquaQuery.executeQuery[RevenueSchedule](expiredGiftsAndRefunds).toDisjunction.leftMap(_.toString)
+      numberNotDone = stillUndistributedRevenue.to(LazyList).length
+      _ <- if (numberNotDone > 0) Left(s"there were still revenue schedules: $numberNotDone") else Right(())
+    } yield ()
+
   }
 
 }

--- a/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/HandlerManualTest.scala
+++ b/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/HandlerManualTest.scala
@@ -37,7 +37,6 @@ object RunLambdaManualTest {
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
       downloadRequests = ZuoraAquaRequestMaker(RawEffects.downloadResponse, zuoraRestConfig)
-      aquaQuerier = Querier.lowLevel(downloadRequests) _
       _ <- Steps(
         println,
         RawEffects.downloadResponse,

--- a/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/HandlerManualTest.scala
+++ b/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/HandlerManualTest.scala
@@ -1,0 +1,199 @@
+package com.gu.recogniser
+
+import com.gu.effects.{GetFromS3, RawEffects}
+import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.resthttp.RestRequestMaker
+import com.gu.util.resthttp.RestRequestMaker.{Requests, WithoutCheck}
+import com.gu.util.resthttp.Types.ClientFailableOp
+import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
+import com.gu.zuora.reports.Querier
+import com.gu.zuora.reports.aqua.ZuoraAquaRequestMaker
+import play.api.libs.json.{JsValue, Json, Reads, __}
+
+import java.time.LocalDate
+
+/*
+Run this in order to set up data in dev so that you can run the job and it will find some data
+ */
+object CreateTestSubscriptionManualTest {
+
+  def main(args: Array[String]): Unit = {
+
+    val actual = for {
+      zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
+      subNumber <- ZuoraGiftSubscribe.subscribe(zuoraDeps).toDisjunction
+    } yield subNumber
+    println("result: " + actual)
+    println("****\nNOTE: wait a while as the revenue schedule isn't created straight away\n****")
+
+  }
+}
+
+object RunLambdaManualTest {
+
+  def main(args: Array[String]): Unit = {
+
+    val actual = for {
+      zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
+      downloadRequests = ZuoraAquaRequestMaker(RawEffects.downloadResponse, zuoraRestConfig)
+      aquaQuerier = Querier.lowLevel(downloadRequests) _
+      _ <- Steps(
+        println,
+        RawEffects.downloadResponse,
+        RawEffects.response,
+        zuoraRestConfig,
+        () => LocalDate.of(2021, 2, 10)
+      ).execute()
+    } yield ()
+    println("result: " + actual)
+
+  }
+}
+
+object GetSubscriptionChargeId {
+
+  case class SubscriptionResult(chargeId: String)
+
+  implicit val reads: Reads[SubscriptionResult] =
+    (((__ \ "ratePlans")(0) \ "ratePlanCharges")(0) \ "id").read[String].map(SubscriptionResult)
+
+  def apply(requests: Requests, subscriptionName: String): ClientFailableOp[String] =
+    requests.get[SubscriptionResult](s"subscriptions/$subscriptionName").map(_.chargeId)
+
+}
+
+object CreateRevenueSchedule {
+
+  case class RevenueEvent(
+    eventType: String = "Digital Subscription Gift Redeemed",
+    eventTypeSystemId: String = "DigitalSubscriptionGiftRedeemed",
+  )
+
+  case class RevenueDistribution(
+    newAmount: String,
+    accountingPeriodName: String = "Open-Ended",
+  )
+
+  case class CreateRevenueScheduleRequest(
+    amount: String,
+    revenueScheduleDate: LocalDate,
+    revenueDistributions: List[RevenueDistribution],
+    revenueEvent: RevenueEvent = RevenueEvent(),
+  )
+
+  implicit val eventWrites = Json.writes[RevenueEvent]
+  implicit val revenueDistributionWrites = Json.writes[RevenueDistribution]
+  implicit val writes = Json.writes[CreateRevenueScheduleRequest]
+
+  case class CreateRevenueScheduleResult(
+    number: String,
+  )
+
+  implicit val reads: Reads[CreateRevenueScheduleResult] =
+    ((__ \ "revenueScheduleNumber").read[String]).map(CreateRevenueScheduleResult.apply _)
+
+}
+case class CreateRevenueSchedule(restRequestMaker: RestRequestMaker.Requests) {
+
+  import CreateRevenueSchedule._
+
+  // https://www.zuora.com/developer/api-reference/#operation/POST_RSforSubscCharge
+  def create(
+    chargeId: String,
+    today: LocalDate,
+  ) = {
+    restRequestMaker.post[CreateRevenueScheduleRequest, CreateRevenueScheduleResult](
+      CreateRevenueScheduleRequest("10.01", today, List(RevenueDistribution("0.00"))),
+      s"revenue-schedules/subscription-charges/${chargeId}"
+    ).map(_.number)
+  }
+}
+
+object GetRevenueSchedule {
+
+  case class SubscriptionResult(
+    undistributedUnrecognizedRevenueInPence: Int,
+  )
+
+  implicit val reads: Reads[SubscriptionResult] =
+    (((__ \ "revenueSchedules")(0) \ "undistributedUnrecognizedRevenue").read[Double].map(amount => (amount * 100).toInt)
+      ).map(SubscriptionResult.apply _)
+
+  def apply(requests: Requests, chargeId: String): ClientFailableOp[Int] =
+    requests.get[SubscriptionResult](s"revenue-schedules/subscription-charges/$chargeId").map(_.undistributedUnrecognizedRevenueInPence)
+
+}
+
+object ZuoraGiftSubscribe {
+
+  case class SubscribeResult(
+    SubscriptionNumber: String,
+  )
+
+  implicit val reads: Reads[SubscribeResult] =
+    (__(0) \ "SubscriptionNumber").read[String].map(SubscribeResult)
+
+
+  def subscribe(requests: Requests): ClientFailableOp[String] =
+    requests.post[JsValue, SubscribeResult](requestJson, s"action/subscribe", WithoutCheck).map(_.SubscriptionNumber)
+
+  val requestJson = Json.parse(
+    """{
+      |    "subscribes": [
+      |        {
+      |            "Account": {
+      |                "Name": "revenue-recogniser-job",
+      |                "Currency": "GBP",
+      |                "CrmId": "001g000001gOR06AAG",
+      |                "sfContactId__c": "003g000001UnFItAAN",
+      |                "IdentityId__c": "9999999",
+      |                "PaymentGateway": "PayPal Express",
+      |                "CreatedRequestId__c": "e18f6418-45f2-11e7-8bfa-8faac2182601",
+      |                "BillCycleDay": 0,
+      |                "AutoPay": true,
+      |                "PaymentTerm": "Due Upon Receipt",
+      |                "BcdSettingOption": "AutoSet",
+      |                "Batch": "Batch1"
+      |            },
+      |            "BillToContact": {
+      |                "FirstName": "revenue-recogniser-job",
+      |                "LastName": "support-service-lambdas",
+      |                "WorkEmail": "test@gu.com",
+      |                "Country": "GB"
+      |            },
+      |            "PaymentMethod": {
+      |                "PaypalBaid": "B-23637766K5365543J",
+      |                "PaypalEmail": "test@paypal.com",
+      |                "PaypalType": "ExpressCheckout",
+      |                "Type": "PayPal"
+      |            },
+      |            "SubscriptionData": {
+      |                "RatePlanData": [
+      |                    {
+      |                        "RatePlan": {
+      |                            "ProductRatePlanId": "2c92c0f8778bf8f60177915b477714aa"
+      |                        },
+      |                        "RatePlanChargeData": [],
+      |                        "SubscriptionProductFeatureList": []
+      |                    }
+      |                ],
+      |                "Subscription": {
+      |                    "ContractEffectiveDate": "2020-02-09",
+      |                    "ContractAcceptanceDate": "2020-02-09",
+      |                    "TermStartDate": "2020-02-09",
+      |                    "AutoRenew": false,
+      |                    "InitialTerm": 13,
+      |                    "RenewalTerm": 12,
+      |                    "TermType": "TERMED"
+      |                }
+      |            },
+      |            "SubscribeOptions": {
+      |                "GenerateInvoice": true,
+      |                "ProcessPayments": true
+      |            }
+      |        }
+      |    ]
+      |}""".stripMargin
+  )
+}


### PR DESCRIPTION
This PR adds the query to find the DS gift subscriptions' revenue schedules that have not been redeemed within a year.  Also to find any refunded DS gift subscriptions' revenue schedules.
It also adds the code to recognise the revenue for the former subscriptions on today's date.
It does not yet distribute the refunds as this is more complicated and will come in the next PR.

This is needed so the finance team can correctly attribute the revenue in to the right months, even if the subscription doesn't follow the standard path of purchase and redemption.

Tested in DEV against DEV zuora using the Manual Test, working okay.