### PR TITLE
Run snyk as GitHub Actions

### DIFF
--- a/.github/workflows/snyk.monitor.yml
+++ b/.github/workflows/snyk.monitor.yml
@@ -1,0 +1,18 @@
+# Run snyk monitor, which will report results to snyk.io
+name: Snyk Monitor
+on:
+  push:
+    branches:
+      - main
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=guardian/manage-frontend
+          command: monitor

--- a/.github/workflows/snyk.test.yml
+++ b/.github/workflows/snyk.test.yml
@@ -1,0 +1,15 @@
+# Run snyk test, which will not report results to snyk.io
+name: Snyk Test
+on:
+  push:
+    branches-ignore:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?
This PR adds GitHub Actions to run snyk. This mean we can get rid of snyk integrations elsewhere (TeamCity, GH webhooks). 

`snyk monitor` will run on any push to main. `snyk test` will run on all other branches. A ✅ &nbsp;next to the action means that there were no security vulnerabilities found. An ❌ &nbsp;means security vulnerabilities were found and should be addressed. These action will not block builds or merges but if security vulnerabilities are found they should be addressed as soon as possible.

