### PR TITLE
Run snyk as GitHub Actions

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     - cron: '0 6 * * *'
   push:
+  workflow_dispatch:
 
 jobs:
   security:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,31 @@
+# Run snyk monitor at 6 AM every day (reports vulnerabilities to snyk.io)
+# Run snyk monitor on every push into main branch (reports vulnerabilities to snyk.io)
+# Run snyk test on every push into branches that are not main
+name: Snyk
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  push:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Run snyk test to check for vulnerabilities
+        if: github.ref != 'ref/head/main'
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Run snyk monitor and report vunerabilites to snyk.io
+        if: github.ref == 'ref/head/main'
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=guardian/manage-frontend
+          command: monitor


### PR DESCRIPTION
## What does this change?
This PR adds GitHub Actions to run snyk. This mean we can get rid of snyk integrations elsewhere (TeamCity, GH webhooks). 

`snyk monitor` will run every day at 6AM and on any push to main. `snyk test` will run on all other branches. A ✅ &nbsp;next to the action in a PR means that there were no security vulnerabilities found. An ❌ &nbsp;means security vulnerabilities were found and should be addressed. These action will not block builds or merges but if security vulnerabilities are found they should be addressed as soon as possible.

