### PR TITLE
Point references to Imovo domain to the same definition

### DIFF
--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -24,7 +24,7 @@ Mappings:
     PROD:
       SalesforceUrl: https://gnmtouchpoint.my.salesforce.com
       SalesforceConnectedApp: TouchpointUpdate
-      ImovoUrlVersion: 2
+      ImovoUrlVersion: 3
 
 Conditions:
   IsProd: !Equals [!Ref "Stage", "PROD"]

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -20,11 +20,11 @@ Mappings:
     CODE:
       SalesforceUrl: https://test.salesforce.com
       SalesforceConnectedApp: AwsConnectorSandbox
-      ImovoUrl: https://core-uat-api.azurewebsites.net
+      ImovoUrlVersion: 1
     PROD:
       SalesforceUrl: https://gnmtouchpoint.my.salesforce.com
       SalesforceConnectedApp: TouchpointUpdate
-      ImovoUrl: https://imovo.org
+      ImovoUrlVersion: 2
 
 Conditions:
   IsProd: !Equals [!Ref "Stage", "PROD"]
@@ -37,7 +37,7 @@ Resources:
       FunctionName: !Sub digital-voucher-suspension-processor-${Stage}
       Description: >
         Suspends fulfilment of digital voucher subscriptions.
-        Source: https://github.com/guardian/support-service-lambdas/tree/main/handlers/digital-voucher-suspension-processor
+        Source: https://github.com/guardian/support-service-lambdas/tree/main/handlers/digital-voucher-suspension-processor.
       Runtime: java8
       MemorySize: 1536
       Timeout: 900
@@ -59,7 +59,10 @@ Resources:
           salesforceUserName: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/User/MembersDataAPI:SecretString:username}}'
           salesforcePassword: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/User/MembersDataAPI:SecretString:password}}'
           salesforceToken: !Sub '{{resolve:secretsmanager:${Stage}/Salesforce/User/MembersDataAPI:SecretString:token}}'
-          imovoUrl: !FindInMap [ StageMap, !Ref Stage, ImovoUrl ]
+          imovoUrl:
+            !Sub
+            - '{{resolve:ssm:/${Stage}/membership/support-service-lambdas-shared-imovo/imovoBaseUrl:${Version}}}'
+            - Version: !FindInMap [StageMap, !Ref Stage, ImovoUrlVersion]
           imovoApiKey: !Sub '{{resolve:secretsmanager:${Stage}/Imovo:SecretString:apiKey}}'
 
   LambdaLogGroup:


### PR DESCRIPTION
With this change, all the references to the Imovo domain use the same value stored in SSM.  This makes it easier to change the domain when it moves.

The domain is referenced in three places:
* The [digital voucher API](https://github.com/guardian/support-service-lambdas/blob/main/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherApiApp.scala#L29-L33)
* The [digital voucher cancellation processor](https://github.com/guardian/support-service-lambdas/blob/main/handlers/digital-voucher-cancellation-processor/src/main/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorApp.scala#L49-L50)
* The [digital voucher suspension processor](https://github.com/guardian/support-service-lambdas/compare/kc-imovo?expand=1#diff-3e5a626a250b3c7421130e04cdd7d87c633e7603ea1089f77aeab18a61e4d308R62-R65)

We have this [card](https://trello.com/c/tb64KAuy/251-digital-voucher-cancellation-processor-should-use-digital-voucher-api-instead-of-calling-imovo-directly) and this [card](https://trello.com/c/wgBbMkX1/250-digital-voucher-suspension-processor-should-use-digital-voucher-api-instead-of-calling-imovo-directly) on the health board to point the two processors at the digital voucher API so that everything goes through a single point in the digital voucher API.  Once that's done, this configuration can be removed.
