### PR TITLE
Productionise Soft Opt-In Consent Setter Lambda

### DIFF
--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -123,3 +123,9 @@ Resources:
             - Effect: Allow
               Action: cloudwatch:PutMetricData
               Resource: "*"
+        - Statement:
+            - Sid: readDeployedArtefact
+              Effect: Allow
+              Action: s3:GetObject
+              Resource:
+                - arn:aws:s3::*:membership-dist/*

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -16,6 +16,13 @@ Mappings:
       Schedule: 'rate(12 hours)'
     CODE:
       Schedule: 'rate(365 days)'
+      SalesforceStage: DEV
+      IdentityStage: CODE
+      SalesforceUsername: SoftOptInConsentSetterAPIUser
+      AppName: AwsConnectorSandbox
+      AppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      SalesforceUserSecretsVersion: 08036ddd-9fc0-43b1-b478-4023a936751e
+      IdentityUserSecretsVersion: ec3fd3ca-f237-4d2d-bbb2-0c9482e636c1
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
@@ -36,6 +43,52 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
+          sfAuthUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl::${AppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
+          sfClientId:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientId::${AppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
+          sfClientSecret:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientSecret::${AppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
+          sfPassword:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          sfToken:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          sfUsername:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          identityUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityUrl::${IdentityUserSecretsVersion}}}'
+            - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+              IdentityUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdentityUserSecretsVersion ]
+          identityToken:
+            !Sub
+            - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken::${IdentityUserSecretsVersion}}}'
+            - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+              IdentityUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdentityUserSecretsVersion ]
       Events:
         ScheduledRun:
           Type: Schedule

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -23,12 +23,12 @@ Mappings:
       IdentityUserSecretsVersion: fe7df2e2-73a4-4d3f-9513-b8a6e7476aeb
     CODE:
       Schedule: 'rate(365 days)'
-      SalesforceStage: DEV
+      SalesforceStage: CODE
       IdentityStage: CODE
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: AwsConnectorSandbox
-      AppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
-      SalesforceUserSecretsVersion: 08036ddd-9fc0-43b1-b478-4023a936751e
+      AppSecretsVersion: 81f50c47-b1f3-400b-94b3-46413377f3d3
+      SalesforceUserSecretsVersion: 9d7777f6-78d7-4ec3-8c93-d4912ce6316e
       IdentityUserSecretsVersion: ec3fd3ca-f237-4d2d-bbb2-0c9482e636c1
     DEV:
       Schedule: 'rate(365 days)'

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -1,0 +1,55 @@
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - PROD
+      - CODE
+      - DEV
+    Default: CODE
+
+Mappings:
+  StageMap:
+    PROD:
+      Schedule: 'rate(12 hours)'
+    CODE:
+      Schedule: 'rate(365 days)'
+
+Conditions:
+  IsProd: !Equals [ !Ref Stage, PROD ]
+
+Resources:
+  LambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation of Subscriptions in Salesforce
+      FunctionName: !Sub soft-opt-in-consent-setter-${Stage}
+      Handler: com.gu.soft_opt_in_consent_setter.Handler::handleRequest
+      CodeUri:
+        Bucket: support-service-lambdas-dist
+        Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
+      MemorySize: 2048
+      Runtime: java8
+      Timeout: 900
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+      Events:
+        ScheduledRun:
+          Type: Schedule
+          Properties:
+            Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule]
+            Description: Runs Soft Opt-In Consent Setter
+            Enabled: False
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action: s3:GetObject
+              Resource:
+                - !Sub arn:aws:s3:::soft-opt-in-consent-setter/${Stage}/ConsentsByProductMapping.json
+        - Statement:
+            - Effect: Allow
+              Action: cloudwatch:PutMetricData
+              Resource: "*"

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -85,11 +85,11 @@ Resources:
             - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityUrl::${IdentityUserSecretsVersion}}}'
             - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
               IdentityUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdentityUserSecretsVersion ]
-                identityToken:
-                  !Sub
-                  - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken::${IdentityUserSecretsVersion}}}'
-                  - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
-                    IdentityUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdentityUserSecretsVersion ]
+          identityToken:
+            !Sub
+            - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken::${IdentityUserSecretsVersion}}}'
+            - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+              IdentityUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdentityUserSecretsVersion ]
       Events:
         ScheduledRun:
           Type: Schedule

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -14,7 +14,23 @@ Mappings:
   StageMap:
     PROD:
       Schedule: 'rate(12 hours)'
+      SalesforceStage: PROD
+      IdentityStage: PROD
+      SalesforceUsername: SoftOptInConsentSetterAPIUser
+      AppName: TouchpointUpdate
+      AppSecretsVersion: d338b761-cb81-4adf-aca4-163678e65a59
+      SalesforceUserSecretsVersion: 3afb6b4e-0a7d-47a0-950c-e9837d13e39d
+      IdentityUserSecretsVersion: fe7df2e2-73a4-4d3f-9513-b8a6e7476aeb
     CODE:
+      Schedule: 'rate(365 days)'
+      SalesforceStage: DEV
+      IdentityStage: CODE
+      SalesforceUsername: SoftOptInConsentSetterAPIUser
+      AppName: AwsConnectorSandbox
+      AppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      SalesforceUserSecretsVersion: 08036ddd-9fc0-43b1-b478-4023a936751e
+      IdentityUserSecretsVersion: ec3fd3ca-f237-4d2d-bbb2-0c9482e636c1
+    DEV:
       Schedule: 'rate(365 days)'
       SalesforceStage: DEV
       IdentityStage: CODE

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -65,19 +65,19 @@ Resources:
             !Sub
             - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword::${SalesforceUserSecretsVersion}}}'
             - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
               SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           sfToken:
             !Sub
             - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken::${SalesforceUserSecretsVersion}}}'
             - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
               SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           sfUsername:
             !Sub
             - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername::${SalesforceUserSecretsVersion}}}'
             - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              UserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
               SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           identityUrl:
             !Sub

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -43,6 +43,7 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
+          sfApiVersion: v46.0
           sfAuthUrl:
             !Sub
             - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl::${AppSecretsVersion}}}'
@@ -84,11 +85,11 @@ Resources:
             - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityUrl::${IdentityUserSecretsVersion}}}'
             - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
               IdentityUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdentityUserSecretsVersion ]
-          identityToken:
-            !Sub
-            - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken::${IdentityUserSecretsVersion}}}'
-            - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
-              IdentityUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdentityUserSecretsVersion ]
+                identityToken:
+                  !Sub
+                  - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken::${IdentityUserSecretsVersion}}}'
+                  - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+                    IdentityUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdentityUserSecretsVersion ]
       Events:
         ScheduledRun:
           Type: Schedule

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -19,7 +19,7 @@ Mappings:
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: TouchpointUpdate
       AppSecretsVersion: d338b761-cb81-4adf-aca4-163678e65a59
-      SalesforceUserSecretsVersion: 3afb6b4e-0a7d-47a0-950c-e9837d13e39d
+      SalesforceUserSecretsVersion: 31220691-ba9c-44b8-9483-d7939e30779e
       IdentityUserSecretsVersion: fe7df2e2-73a4-4d3f-9513-b8a6e7476aeb
     CODE:
       Schedule: 'rate(365 days)'

--- a/handlers/soft-opt-in-consent-setter/riff-raff.yaml
+++ b/handlers/soft-opt-in-consent-setter/riff-raff.yaml
@@ -1,0 +1,21 @@
+stacks:
+  - membership
+regions:
+  - eu-west-1
+deployments:
+
+  cfn:
+    type: cloud-formation
+    app: soft-opt-in-consent-setter
+    parameters:
+      templatePath: cfn.yaml
+
+  soft-opt-in-consent-setter:
+    type: aws-lambda
+    parameters:
+      fileName: soft-opt-in-consent-setter.jar
+      bucket: support-service-lambdas-dist
+      prefixStack: false
+      functionNames:
+        - soft-opt-in-consent-setter-
+    dependencies: [ cfn ]

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
@@ -56,10 +56,7 @@ object SoftOptInConfig {
     // TODO: Obtain CODE/PROD version of file depending on env variable
     fetchString(S3Location("soft-opt-in-consent-setter", "CODE/ConsentsByProductMapping.json")) match {
       case Success(jsonContent) => decode[Map[String, Set[String]]](jsonContent).toOption
-      case Failure(f) => {
-        println("failure: " + f)
-        None
-      }
+      case Failure(f) => None
     }
   }
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
@@ -56,7 +56,10 @@ object SoftOptInConfig {
     // TODO: Obtain CODE/PROD version of file depending on env variable
     fetchString(S3Location("soft-opt-in-consent-setter", "CODE/ConsentsByProductMapping.json")) match {
       case Success(jsonContent) => decode[Map[String, Set[String]]](jsonContent).toOption
-      case Failure(f) => None
+      case Failure(f) => {
+        println("failure: " + f)
+        None
+      }
     }
   }
 


### PR DESCRIPTION
## What does this change?
This PR contains the necessary files to create the Soft Opt-In Consent Setter Lambda and associated configuration for deployment

new files:
- cfn.yaml
- riffraff.yaml

Updated files:
- SoftOptInConfig.scala 
updated to dynamically obtain the stage variable used to retrieve the Stage-specific ConsentsByProductMapping.json file from S3

- Main 
updated to align with naming standards and a handler method has been added for the Lambda to hook into

## How to test and measuring success
- The configuration was used to deploy the solution to the CODE environment. 
- The Lambda was executed to operate on a subset of records in Salesforce. The Identity consents were successfully written and results written back to Salesforce as expected.

Notes:
- There is no Identity DEV environment - only CODE, which points to both Salesforce DEV and UAT
- This represented in the Stage mappings in cfn.yaml
