### PR TITLE
Add metrics and alarms to Soft Opt In Consent Setter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -335,7 +335,7 @@ lazy val `soft-opt-in-consent-setter` = lambdaProject(
   "soft-opt-in-consent-setter",
   "sets or unsets soft opt in consents dependent on subscription product",
   Seq(awsSecretsManager, circe, circeParser, scalatest, scalajHttp, awsS3, simpleConfig) ++ logging
-).dependsOn(`effects-s3`, `salesforce-core`)
+).dependsOn(`effects-s3`, `effects-cloudwatch`, `salesforce-core`)
 
 lazy val `sf-api-user-credentials-setter` = lambdaProject(
   "sf-api-user-credentials-setter",

--- a/handlers/soft-opt-in-consent-setter/README.md
+++ b/handlers/soft-opt-in-consent-setter/README.md
@@ -43,6 +43,8 @@ When errors do occur they are always logged, and a metric emitted.
 
 ### failedRunAlarm
 
+Note: This Alarm is set to trigger after 2 failures to avoid alerting developers in case of a temporary failure such as outage of IDAPI or Salesforce.
+
 **CAUSE**: Two or more runs found an error and were unable to complete. This can be due to several reasons:
 
 1. Failed to obtain all environment variables.

--- a/handlers/soft-opt-in-consent-setter/README.md
+++ b/handlers/soft-opt-in-consent-setter/README.md
@@ -36,14 +36,18 @@ has been created to visualise these metrics and help monitor the lambda.
 
 ## Errors & Alarms
 
-The lambda was created in a way where if there are any errors, fixing the underlying cause and letting the lambda
-continue to run on its schedule will sort out any de-syncs between IDAPI and Salesforce that might have happened.
+The lambda was created robust enough to autonomously recover from errors with minimal developer input. Fixing the
+underlying cause of the error and letting the lambda continue to run on its schedule will cause the lambda to pick up
+where it left off and sort out any de-syncs between IDAPI and Salesforce that might have happened.
 
-When errors do occur they are always logged, and a metric emitted.
+When errors do occur they are always logged, and a metric is emitted.
+
+Because of the robustness of lambda, the `failedRunAlarm` and `failedUpdateAlarm` alarms can safely be configured to
+trigger only after a number of occurrences (instead of on first occurrence). This way these alarms will stay silent in
+the event of temporary problems (such as outage in IDAPI or Salesforce), meaning developers are only alerted when
+something actually needs addressing.
 
 ### failedRunAlarm
-
-Note: This Alarm is set to trigger after 2 failures to avoid alerting developers in case of a temporary failure such as outage of IDAPI or Salesforce.
 
 **CAUSE**: Two or more runs found an error and were unable to complete. This can be due to several reasons:
 

--- a/handlers/soft-opt-in-consent-setter/README.md
+++ b/handlers/soft-opt-in-consent-setter/README.md
@@ -1,0 +1,111 @@
+# soft-opt-in-consent-setter
+
+This is a lambda that alters a user's Soft Opt-In setting based on the subscriptions they acquire and cancel.
+
+The lambda will fetch 200 subscriptions at a time from Salesforce, process them, set the consents in IDAPI, and update
+their records in Salesforce with the outcome. It will first process acquisitions and then process cancellations.
+
+For an acquisition, it will enable the Soft Opt-In consents associated with that subscription according to the consents
+mapping.
+
+For a cancellation, it will disable the Soft Opt-In consents that are associated only with the subscription being
+cancelled, out of all the products the user has active.
+
+If it is unable to update a record, it will increment the number of retries and try again later in a subsequent run. It
+will only attempt to update records 5 times.
+
+## Metrics
+
+As it processes records, this lambda emits metrics.
+A [dashboard](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=Soft-Opt-In-Consent-Setter)
+has been created to visualise these metrics and help monitor the lambda.
+
+**successful_run**: Shows the occurrence of a successful lambda run.
+
+**failed_run**: Shows the occurrence of a failed run.
+
+**successful_consents_updates**: Shows how many successful IDAPI Soft Opt-In consent updates took place.
+
+**failed_consents_updates**: Shows how many failed IDAPI Soft Opt-In consent updates took place.
+
+**subs_with_five_retries**: Shows how many subscriptions reached 5 retries during the run.
+
+**successful_salesforce_update**: Shows how many successful Salesforce record updates took place.
+
+**failed_salesforce_update**: Shows how many failed Salesforce record updates took place.
+
+## Errors & Alarms
+
+The lambda was created in a way where if there are any errors, fixing the underlying cause and letting the lambda
+continue to run on its schedule will sort out any de-syncs between IDAPI and Salesforce that might have happened.
+
+When errors do occur they are always logged, and a metric emitted.
+
+### failedRunAlarm
+
+**CAUSE**: Two or more runs found an error and were unable to complete. This can be due to several reasons:
+
+1. Failed to obtain all environment variables.
+1. Failed to contact Salesforce endpoint.
+1. Failed to authenticate in Salesforce.
+1. Error decoding Salesforce's responses.
+
+The [lambda's logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fsoft-opt-in-consent-setter-PROD)
+will provide more details regarding which of these is taking place.
+
+**IMPACT**: Each of these situations will have different impacts:
+
+1. The lambda was unable to run and no subscriptions were processed.
+1. Depending on which endpoint it failed to contact, it might have been unable to fetch records to process, or it might
+   not have been able to update their state after processing the records.
+1. Failed to authenticate in Salesforce.
+1. Error decoding Salesforce's responses.
+
+**FIX**: For each corresponding cause:
+
+1. Check the CloudFormation template for environment variables and make sure all the necessary key-values are present.
+1. Check that the Salesforce endpoints are correct and online.
+1. Check that the Salesforce credentials fetched from secrets manager at deploy stage are valid.
+1. Check that the endpoint being used is correct and the version (`sfApiVersion` in CloudFormation) is correct. Check
+   that the Salesforce API version being used returns what the lambda expects. Check the code for any changes to how the
+   relevant response is decoded.
+
+For all the above, fixing the underlying issues and letting it run on schedule will put the system in a correct state.
+
+### failedUpdateAlarm
+
+**CAUSE**: A run failed to update (some) records in Salesforce in the last hour. This could be due to edge cases such as
+access permissions on the record being updates, record being locked due to another process making changes on it, or
+record being in a failed state.
+
+**IMPACT**: The user's Soft Opt-In consents were updated in IDAPI, but the result of this updated was not successfully
+written to it's Salesforce record. This means that the change will be retried again on the next lambda runs until the
+problem is fixed.
+
+**FIX**: Check the logs to determine what's cause of this error. Check the relevant record in Salesforce for any
+anomaly.
+
+After the underlying issue is fixed, letting the lambda continue to run on schedule will update Salesforce to the
+correct state.
+
+### subsWith5RetriesAlarm
+
+**CAUSE**: One or more subscription's Soft Opt-In consents failed to be set after five retries. This can be due to
+several reasons:
+
+1. Failed to contact the IDAPI endpoint
+1. IDAPI was unable to set the user's Soft Opt-In consents.
+
+The [lambda's logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fsoft-opt-in-consent-setter-PROD)
+will provide more details regarding which of these is taking place.
+
+**IMPACT**: The lambda will no longer try to process this request.
+
+**FIX**: For each corresponding cause:
+
+1. Check that the IDAPI endpoints are correct and online.
+1. Check the logs for the error code being returned by the endpoint and contact the Identity team to understand why
+   IDAPI was unable to set the user's Soft Opt-In consents.
+
+For all the above, after the underlying issue is resolved, the `Soft_Opt_in_Number_of_Attempts__c` fields needs to be
+reset to 0 for reach of the affected records. After that the lambda will pick up those record for processing again.

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -179,3 +179,28 @@ Resources:
         Statistic: Sum
         Threshold: 3
         TreatMissingData: notBreaching
+
+    subsWith5RetriesAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: IsProd
+      DependsOn:
+        - LambdaFunction
+      Properties:
+        AlarmActions:
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
+        AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to set consents on a subscription 5 times
+        AlarmDescription: >
+          One of more subscription's Soft Opt-In consents failed to be set after five retries.
+          See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
+          for possible causes, impacts and fixes.
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: Stage
+            Value: !Sub ${Stage}
+        EvaluationPeriods: 1
+        MetricName: failed_update
+        Namespace: soft-opt-in-consent-setter
+        Period: 3600
+        Statistic: Sum
+        Threshold: 1
+        TreatMissingData: notBreaching

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -129,3 +129,53 @@ Resources:
               Action: s3:GetObject
               Resource:
                 - arn:aws:s3::*:membership-dist/*
+
+  failedRunAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn:
+      - LambdaFunction
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
+      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to run
+      AlarmDescription: >
+        Two or more runs found an error and were unable to complete.
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
+        for possible causes, impacts and fixes.
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: failed_run
+      Namespace: soft-opt-in-consent-setter
+      Period: 3600
+      Statistic: Sum
+      Threshold: 2
+      TreatMissingData: notBreaching
+
+    failedUpdateAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: IsProd
+      DependsOn:
+        - LambdaFunction
+      Properties:
+        AlarmActions:
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
+        AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
+        AlarmDescription: >
+          Three or more runs failed to update (some) records in Salesforce in the last hour.
+          See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
+          for possible causes, impacts and fixes.
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: Stage
+            Value: !Sub ${Stage}
+        EvaluationPeriods: 1
+        MetricName: failed_update
+        Namespace: soft-opt-in-consent-setter
+        Period: 3600
+        Statistic: Sum
+        Threshold: 3
+        TreatMissingData: notBreaching

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -143,7 +143,7 @@ Resources:
         Two or more runs found an error and were unable to complete.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
         for possible causes, impacts and fixes.
-      ComparisonOperator: GreaterThanThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: Stage
           Value: !Sub ${Stage}
@@ -165,10 +165,10 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
       AlarmDescription: >
-        Three or more runs failed to update (some) records in Salesforce in the last hour.
+        A run failed to update (some) records in Salesforce in the last hour.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
         for possible causes, impacts and fixes.
-      ComparisonOperator: GreaterThanThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: Stage
           Value: !Sub ${Stage}
@@ -177,7 +177,7 @@ Resources:
       Namespace: soft-opt-in-consent-setter
       Period: 3600
       Statistic: Sum
-      Threshold: 3
+      Threshold: 1
       TreatMissingData: notBreaching
 
   subsWith5RetriesAlarm:
@@ -190,10 +190,10 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to set consents on a subscription 5 times
       AlarmDescription: >
-        One of more subscription's Soft Opt-In consents failed to be set after five retries.
+        One or more subscription's Soft Opt-In consents failed to be set after five retries.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
         for possible causes, impacts and fixes.
-      ComparisonOperator: GreaterThanThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: Stage
           Value: !Sub ${Stage}

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -132,7 +132,7 @@ Resources:
 
   failedRunAlarm:
     Type: AWS::CloudWatch::Alarm
-#    Condition: IsProd
+    Condition: IsProd
     DependsOn:
       - LambdaFunction
     Properties:
@@ -157,7 +157,7 @@ Resources:
 
   failedUpdateAlarm:
     Type: AWS::CloudWatch::Alarm
-#    Condition: IsProd
+    Condition: IsProd
     DependsOn:
       - LambdaFunction
     Properties:
@@ -182,7 +182,7 @@ Resources:
 
   subsWith5RetriesAlarm:
     Type: AWS::CloudWatch::Alarm
-#    Condition: IsProd
+    Condition: IsProd
     DependsOn:
       - LambdaFunction
     Properties:

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -141,7 +141,7 @@ Resources:
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to run
       AlarmDescription: >
         Two or more runs found an error and were unable to complete.
-        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm
         for possible causes, impacts and fixes.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -166,7 +166,7 @@ Resources:
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
       AlarmDescription: >
         A run failed to update (some) records in Salesforce in the last hour.
-        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedUpdateAlarm
         for possible causes, impacts and fixes.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -191,7 +191,7 @@ Resources:
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to set consents for a subscription 5 times
       AlarmDescription: >
         One or more subscription's Soft Opt-In consents failed to be set after five retries.
-        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#subsWith5RetriesAlarm
         for possible causes, impacts and fixes.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -155,52 +155,52 @@ Resources:
       Threshold: 2
       TreatMissingData: notBreaching
 
-    failedUpdateAlarm:
-      Type: AWS::CloudWatch::Alarm
-#      Condition: IsProd
-      DependsOn:
-        - LambdaFunction
-      Properties:
-        AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
-        AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
-        AlarmDescription: >
-          Three or more runs failed to update (some) records in Salesforce in the last hour.
-          See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
-          for possible causes, impacts and fixes.
-        ComparisonOperator: GreaterThanThreshold
-        Dimensions:
-          - Name: Stage
-            Value: !Sub ${Stage}
-        EvaluationPeriods: 1
-        MetricName: failed_update
-        Namespace: soft-opt-in-consent-setter
-        Period: 3600
-        Statistic: Sum
-        Threshold: 3
-        TreatMissingData: notBreaching
+  failedUpdateAlarm:
+    Type: AWS::CloudWatch::Alarm
+#    Condition: IsProd
+    DependsOn:
+      - LambdaFunction
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
+      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
+      AlarmDescription: >
+        Three or more runs failed to update (some) records in Salesforce in the last hour.
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
+        for possible causes, impacts and fixes.
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: failed_update
+      Namespace: soft-opt-in-consent-setter
+      Period: 3600
+      Statistic: Sum
+      Threshold: 3
+      TreatMissingData: notBreaching
 
-    subsWith5RetriesAlarm:
-      Type: AWS::CloudWatch::Alarm
-#      Condition: IsProd
-      DependsOn:
-        - LambdaFunction
-      Properties:
-        AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
-        AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to set consents on a subscription 5 times
-        AlarmDescription: >
-          One of more subscription's Soft Opt-In consents failed to be set after five retries.
-          See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
-          for possible causes, impacts and fixes.
-        ComparisonOperator: GreaterThanThreshold
-        Dimensions:
-          - Name: Stage
-            Value: !Sub ${Stage}
-        EvaluationPeriods: 1
-        MetricName: failed_update
-        Namespace: soft-opt-in-consent-setter
-        Period: 3600
-        Statistic: Sum
-        Threshold: 1
-        TreatMissingData: notBreaching
+  subsWith5RetriesAlarm:
+    Type: AWS::CloudWatch::Alarm
+#    Condition: IsProd
+    DependsOn:
+      - LambdaFunction
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
+      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to set consents on a subscription 5 times
+      AlarmDescription: >
+        One of more subscription's Soft Opt-In consents failed to be set after five retries.
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md
+        for possible causes, impacts and fixes.
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: failed_update
+      Namespace: soft-opt-in-consent-setter
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -173,7 +173,7 @@ Resources:
         - Name: Stage
           Value: !Sub ${Stage}
       EvaluationPeriods: 1
-      MetricName: failed_update
+      MetricName: failed_salesforce_update
       Namespace: soft-opt-in-consent-setter
       Period: 3600
       Statistic: Sum
@@ -198,7 +198,7 @@ Resources:
         - Name: Stage
           Value: !Sub ${Stage}
       EvaluationPeriods: 1
-      MetricName: failed_update
+      MetricName: subs_with_five_retries
       Namespace: soft-opt-in-consent-setter
       Period: 3600
       Statistic: Sum

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -188,7 +188,7 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
-      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to set consents on a subscription 5 times
+      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to set consents for a subscription 5 times
       AlarmDescription: >
         One or more subscription's Soft Opt-In consents failed to be set after five retries.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -145,11 +145,11 @@ Resources:
         for possible causes, impacts and fixes.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-        - Name: Stage
-          Value: !Sub ${Stage}
+        - Name: FunctionName
+          Value: !Ref LambdaFunction
       EvaluationPeriods: 1
-      MetricName: failed_run
-      Namespace: soft-opt-in-consent-setter
+      MetricName: Errors
+      Namespace: AWS/Lambda
       Period: 3600
       Statistic: Sum
       Threshold: 2

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -132,7 +132,7 @@ Resources:
 
   failedRunAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: IsProd
+#    Condition: IsProd
     DependsOn:
       - LambdaFunction
     Properties:
@@ -157,7 +157,7 @@ Resources:
 
     failedUpdateAlarm:
       Type: AWS::CloudWatch::Alarm
-      Condition: IsProd
+#      Condition: IsProd
       DependsOn:
         - LambdaFunction
       Properties:
@@ -182,7 +182,7 @@ Resources:
 
     subsWith5RetriesAlarm:
       Type: AWS::CloudWatch::Alarm
-      Condition: IsProd
+#      Condition: IsProd
       DependsOn:
         - LambdaFunction
       Properties:

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -40,7 +40,6 @@ object Handler extends LazyLogging {
         Metrics.put(event = "failed_run")
         logger.error(s"${error.errorType}: ${error.errorDetails}")
       })
-
   }
 
   def processAcquiredSubs(acquiredSubs: Seq[SFSubRecord], sendConsentsReq: (String, String) => Either[SoftOptInError, Unit], updateSubs: String => Either[SoftOptInError, Unit], consentsCalculator: ConsentsCalculator): Either[SoftOptInError, Unit] = {
@@ -95,7 +94,7 @@ object Handler extends LazyLogging {
       updateSubs(SFSubRecordUpdateRequest(recordsToUpdate).asJson.spaces2)
   }
 
-  def logErrors(something: Either[SoftOptInError, Unit]) = {
+  def logErrors(something: Either[SoftOptInError, Unit]): Unit = {
     something.left.foreach(error =>
       logger.warn(s"${error.errorType}: ${error.errorDetails}"))
   }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -33,25 +33,29 @@ object Handler extends LazyLogging {
 
       activeSubs <- sfConnector.getActiveSubs(cancelledSubsIdentityIds)
       _ <- processCancelledSubs(cancelledSubs, activeSubs, identityConnector.sendConsentsReq, sfConnector.updateSubs, consentsCalculator)
+      _ = Metrics.put(event = "successful_run")
     } yield ())
       .left
-      .map(error => {
-        // TODO: Surface this error outside of the lambda for alarm purposes
+      .foreach(error => {
+        Metrics.put(event = "failed_run")
         logger.error(s"${error.errorType}: ${error.errorDetails}")
       })
 
-    ()
   }
 
   def processAcquiredSubs(acquiredSubs: Seq[SFSubRecord], sendConsentsReq: (String, String) => Either[SoftOptInError, Unit], updateSubs: String => Either[SoftOptInError, Unit], consentsCalculator: ConsentsCalculator): Either[SoftOptInError, Unit] = {
     val recordsToUpdate = acquiredSubs
       .map(sub => {
-        SFSubRecordUpdate(sub, "Acquisition",
+        val updateResult =
           for {
             consents <- consentsCalculator.getAcquisitionConsents(sub.Product__c)
             consentsBody = consentsCalculator.buildConsentsBody(consents, state = true)
             _ <- sendConsentsReq(sub.Buyer__r.IdentityID__c, consentsBody)
-          } yield ())
+          } yield ()
+
+        logErrors(updateResult)
+
+        SFSubRecordUpdate(sub, "Acquisition", updateResult)
       })
 
     if (recordsToUpdate.isEmpty)
@@ -74,17 +78,26 @@ object Handler extends LazyLogging {
     val recordsToUpdate = cancelledSubs
       .map(EnhancedCancelledSub(_, activeSubs.records))
       .map(sub => {
-        SFSubRecordUpdate(sub.cancelledSub, "Cancellation",
+        val updateResult =
           for {
             consents <- consentsCalculator.getCancellationConsents(sub.cancelledSub.Product__c, sub.associatedActiveNonGiftSubs.map(_.Product__c).toSet)
             _ <- sendCancellationConsents(sub.identityId, consents)
-          } yield ())
+          } yield ()
+
+        logErrors(updateResult)
+
+        SFSubRecordUpdate(sub.cancelledSub, "Cancellation", updateResult)
       })
 
     if (recordsToUpdate.isEmpty)
       Right(())
     else
       updateSubs(SFSubRecordUpdateRequest(recordsToUpdate).asJson.spaces2)
+  }
+
+  def logErrors(something: Either[SoftOptInError, Unit]) = {
+    something.left.foreach(error =>
+      logger.warn(s"${error.errorType}: ${error.errorDetails}"))
   }
 
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -36,10 +36,12 @@ object Handler extends LazyLogging {
       _ <- processCancelledSubs(cancelledSubs, activeSubs, identityConnector.sendConsentsReq, sfConnector.updateSubs, consentsCalculator)
       _ = Metrics.put(event = "successful_run")
     } yield ())
+      .flatten
       .left
       .foreach(error => {
         logger.error(s"${error.errorType}: ${error.errorDetails}")
         Metrics.put(event = "failed_run")
+        throw new Exception(s"Run failed due to ${error.errorType}: ${error.errorDetails}")
       })
   }
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -104,10 +104,14 @@ object Handler extends LazyLogging {
   }
 
   def emitMetrics(records: Seq[SFSubRecordUpdate]): Unit = {
+    // Soft_Opt_in_Number_of_Attempts__c == 0 means the consents were set successfully
+    val successfullyUpdated = records.filter(_.Soft_Opt_in_Number_of_Attempts__c == 0).size
+    val unsuccessfullyUpdated = records.filter(_.Soft_Opt_in_Number_of_Attempts__c > 0).size
     val subsWith5Retries = records.filter(_.Soft_Opt_in_Number_of_Attempts__c >= 5).size
 
-    if (subsWith5Retries > 0)
-      Metrics.put(event = "subs_with_five_retries", subsWith5Retries)
+    Metrics.put(event = "successful_consents_updates", successfullyUpdated)
+    Metrics.put(event = "failed_consents_updates", unsuccessfullyUpdated)
+    Metrics.put(event = "subs_with_five_retries", subsWith5Retries)
   }
 
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -5,8 +5,6 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import io.circe.syntax._
 
-// TODO: introduce notifications when number of attempts is incremented to 5
-
 object Handler extends LazyLogging {
 
   val readyToProcessAcquisitionStatus = "Ready to process acquisition"
@@ -39,8 +37,8 @@ object Handler extends LazyLogging {
       .flatten
       .left
       .foreach(error => {
-        logger.error(s"${error.errorType}: ${error.errorDetails}")
         Metrics.put(event = "failed_run")
+        logger.error(s"${error.errorType}: ${error.errorDetails}")
         throw new Exception(s"Run failed due to ${error.errorType}: ${error.errorDetails}")
       })
   }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -100,8 +100,7 @@ object Handler extends LazyLogging {
 
   def logErrors(updateResults: Either[SoftOptInError, Unit]): Unit = {
     updateResults.left.foreach(error =>
-      logger.warn(s"${error.errorType}: ${error.errorDetails}")
-    )
+      logger.warn(s"${error.errorType}: ${error.errorDetails}"))
   }
 
   def emitMetrics(records: Seq[SFSubRecordUpdate]): Unit = {

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -19,6 +19,7 @@ object Handler extends LazyLogging {
   def handleRequest(): Unit = {
     (for {
       config <- SoftOptInConfig()
+    } yield for {
       sfConnector <- SalesforceConnector(config.sfConfig, config.sfApiVersion)
 
       allSubs <- sfConnector.getSubsToProcess()
@@ -37,8 +38,8 @@ object Handler extends LazyLogging {
     } yield ())
       .left
       .foreach(error => {
-        Metrics.put(event = "failed_run")
         logger.error(s"${error.errorType}: ${error.errorDetails}")
+        Metrics.put(event = "failed_run")
       })
   }
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
@@ -14,9 +14,6 @@ class IdentityConnector(config: IdentityConfig) {
   }
 
   def sendReq(url: String, body: String): Either[Throwable, HttpResponse[String]] = {
-    //returns 204 No Content if successful
-    //returns 404 Not Found if user not found
-    //returns 400 Bad Request if body is malformed
     Try(
       Http(url)
         .header("Content-Type", "application/json")

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Metrics.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Metrics.scala
@@ -1,0 +1,24 @@
+package com.gu.soft_opt_in_consent_setter
+
+import com.gu.aws.AwsCloudWatch
+import com.gu.aws.AwsCloudWatch._
+
+import scala.util.Try
+
+object Metrics {
+
+  // If Stage env variable isn't present assume PROD so we never miss a config error
+  private val stage = sys.env.get("Stage").getOrElse("PROD")
+
+  def put(event: String, value: Double = 1.0): Try[Unit] = {
+    AwsCloudWatch.metricPut(
+      MetricRequest(
+        MetricNamespace("soft-opt-in-consent-setter"),
+        MetricName(event),
+        Map(MetricDimensionName("Stage") -> MetricDimensionValue(stage)),
+        value
+      )
+    )
+  }
+
+}

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Metrics.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Metrics.scala
@@ -7,7 +7,7 @@ import scala.util.Try
 
 object Metrics {
   
-  private val stage = sys.env.get("Stage").getOrElse("PROD")
+  private val stage = sys.env.getOrElse("Stage", "DEV")
 
   def put(event: String, value: Double = 1.0): Try[Unit] = {
     AwsCloudWatch.metricPut(

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Metrics.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Metrics.scala
@@ -6,8 +6,7 @@ import com.gu.aws.AwsCloudWatch._
 import scala.util.Try
 
 object Metrics {
-
-  // If Stage env variable isn't present assume PROD so we never miss a config error
+  
   private val stage = sys.env.get("Stage").getOrElse("PROD")
 
   def put(event: String, value: Double = 1.0): Try[Unit] = {

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
@@ -80,6 +80,10 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
             SFCompositeResponse(compositeResponse).errorsAsString
               .foreach(logger.warn(_))
 
+            // Output metrics before returning
+            Metrics.put("successful_update", compositeResponse.filter(_.success).size)
+            Metrics.put("failed_update", compositeResponse.filter(!_.success).size)
+
             Right(())
           case Left(decodeError) =>
             Left(SoftOptInError("SalesforceConnector", s"Could not decode SfCompositeRequest.Response: $decodeError. String to decode: ${result.body}"))

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
@@ -82,8 +82,8 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
               .foreach(logger.warn(_))
 
             // Output metrics before returning
-            putMetric("successful_update", compositeResponse.filter(_.success).size)
-            putMetric("failed_update", compositeResponse.filter(!_.success).size)
+            putMetric("successful_salesforce_update", compositeResponse.filter(_.success).size)
+            putMetric("failed_salesforce_update", compositeResponse.filter(!_.success).size)
 
             Right(())
           case Left(decodeError) =>

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfSubRecordUpdate.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfSubRecordUpdate.scala
@@ -1,7 +1,5 @@
 package com.gu.soft_opt_in_consent_setter.models
 
-import com.typesafe.scalalogging.LazyLogging
-
 case class SFSubRecordUpdate(
   Id: String,
   Soft_Opt_in_Last_Stage_Processed__c: Option[String] = None,
@@ -15,14 +13,12 @@ case class SFSubRecordUpdateRequest(records: Seq[SFSubRecordUpdate]) {
   def allOrNone = false
 }
 
-object SFSubRecordUpdate extends LazyLogging {
+object SFSubRecordUpdate {
 
   def apply(sub: SFSubRecord, softOptInStage: String, updateResult: Either[SoftOptInError, Unit]): SFSubRecordUpdate = {
     updateResult match {
       case Right(_) => successfulUpdate(sub, softOptInStage)
-      case Left(error) =>
-        logger.warn(s"${error.errorType}: ${error.errorDetails}")
-        failedUpdate(sub)
+      case Left(_) => failedUpdate(sub)
     }
   }
 

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/SalesforceConnectorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/SalesforceConnectorTests.scala
@@ -57,12 +57,12 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
   // handleCompositeUpdateResp success cases
   "handleCompositeUpdateResp" should "return the body on a successful request" in {
-    sfConnector.handleCompositeUpdateResp(successfulCompositeUpdateResponse) shouldBe Right(())
+    sfConnector.handleCompositeUpdateResp(successfulCompositeUpdateResponse, (_, _) => ()) shouldBe Right(())
   }
 
   // handleCompositeUpdateResp failure cases
   "handleCompositeUpdateResp" should "return a SoftOptInError on an unsuccessful request" in {
-    val result = sfConnector.handleCompositeUpdateResp(thrownResponse)
+    val result = sfConnector.handleCompositeUpdateResp(thrownResponse, (_, _) => ())
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
@@ -70,7 +70,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
   }
 
   "handleCompositeUpdateResp" should "return a SoftOptInError if an unexpected body is found" in {
-    val result = sfConnector.handleCompositeUpdateResp(failedResponse)
+    val result = sfConnector.handleCompositeUpdateResp(failedResponse, (_, _) => ())
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]


### PR DESCRIPTION
## What does this change?
Soft Opt In Consent Setter now has alarms configured to warn us when bad things happen (dashboard [here](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=Soft-Opt-In-Consent-Setter)) and emits metrics that will help us monitor it. It now also has a README explaining how it generally works and causes/impact/fixes for possible errors.


## How to test
Here is the testing strategy used:

#### Environment variable not present
Method: Comment out one of the environment variables 
Expect results: Lambda logs the error, emits `run_failed` metric with 1 and crashes. `failedRunAlarm` is triggered after two events.

#### Product type doesn't have a consents mapping
Method: Do not provide consent mapping for all the subscription types present in Salesforce
Expected results: Lambda logs the errors, emits `failed_consents_updates` metric with number of failed updates, continues running. After 5 retries lambda emits the `subsWith5Retries` with number of records that reached that state and `subsWith5RetriesAlarm` is triggered.

#### Connection to IDAPI fails/returns an unexpected response
Method: Provide an invalid URL IDAPI URL
Expected results: Lambda logs the error, emits `run_failed` metric with 1 and crashes. `failedRunAlarm` is triggered after two events.

#### Fail to update Soft Opt-In consents in IDAPI
Method: Add a string to the end of the IDAPI URL to make it invalid. 
Expected results: Lambda logs the errors, emits `failed_consents_updates` metric with number of failed updates, continues running. After 5 retries lambda emits the `subsWith5Retries` with number of records that reached that state and `subsWith5RetriesAlarm` is triggered.

#### Connection to Salesforce fails/returns an unexpected response
Method: Provide an invalid Salesforce URL 
Expected results: Lambda logs the error, emits `run_failed` metric with 1 and crashes. `failedRunAlarm` is triggered after two events.

#### Fail to update record in Salesforce
Method: Force the response of a composite request to always evaluate to an error. 
Expected results: Lambda logs the errors, emits both `successful_salesforce_update` and `failed_salesforce_update` metrics with the corresponding numbers, continues running. `failedUpdateAlarm` is triggered.

#### Normal run
Method: Do none of those the above
Expected results: Lambda completes run successfully, emits `successful_consents_updates`, `successful_salesforce_update` metrics with the corresponding number, `failed_consents_updates`, `subs_with_five_retries`, `failed_salesforce_update` metrics with 0 and the `successful_run` with 1.