### PR TITLE
Order Soft Opt-In query by acquisition date

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
@@ -20,7 +20,7 @@ object SfQueries {
        |WHERE
        |	Soft_Opt_in_Status__c in ('Ready to process acquisition','Ready to process cancellation')
        |ORDER BY
-       |  SF_Status__c
+       |  SF_Status__c, Acquisition_Date__c
        |LIMIT
        |	$limit
     """.stripMargin


### PR DESCRIPTION
## What does this change?
Orders the Soft Opt-In query by acquisition date so that earlier acquisitions are processed first.
The goal of this change is to add a degree of predictability to the order in which records are processed so make it easier to debug if anything unexpected happens.