### PR TITLE
Increase alarm threshold for holiday stop processor

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -117,7 +117,7 @@ Resources:
       Namespace: AWS/Lambda
       Period: 300
       Statistic: Sum
-      Threshold: 1
+      Threshold: 2
       TreatMissingData: notBreaching
     DependsOn:
       - HolidayStopProcessor


### PR DESCRIPTION
Because it occasionally goes off once but it's only a problem if it keeps going off.
