### PR TITLE
Increase period of holiday stop processor alarm

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -115,7 +115,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: 300
+      Period: 3600
       Statistic: Sum
       Threshold: 2
       TreatMissingData: notBreaching


### PR DESCRIPTION
It was 5 minutes but it's impossible for the lambda to fail twice in 5 minutes as each failure is terminal.
So increasing to 1 hour will give us a meaningful value.  Now the alarm should go off when there are two or more failures in an hour.
