### PR TITLE
Create payment-failure-comms skeleton

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -498,6 +498,17 @@ lazy val `http4s-lambda-handler` = library(project in file("lib/http4s-lambda-ha
     libraryDependencies ++= Seq(circe, circeParser, http4sCore, http4sDsl % Test, scalatest) ++ logging
   )
 
+lazy val `payment-failure-comms` = lambdaProject(
+  "payment-failure-comms",
+  "Transforms calls from Zuora's payment failures into Braze custom events",
+  Seq(
+    circe,
+    circeParser,
+    scalatest,
+    scalajHttp,
+    awsEvents
+  )
+).dependsOn(handler)
 
 // ==== END handlers ====
 

--- a/handlers/payment-failure-comms/cfn.yaml
+++ b/handlers/payment-failure-comms/cfn.yaml
@@ -1,0 +1,52 @@
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - PROD
+      - CODE
+      - DEV
+    Default: CODE
+
+Conditions:
+  IsProd: !Equals [ !Ref Stage, PROD ]
+
+
+Resources:
+  PaymentFailureCommsGateway:
+    Type: AWS::Serverless::Api
+    Properties:
+      OpenApiVersion: '2.0'
+      Name: !Sub payment-failure-comms-${Stage}-ApiGateway
+      StageName: !Sub ${Stage}
+      Auth:
+        ApiKeyRequired: true
+        UsagePlan:
+          CreateUsagePlan: PER_API
+          UsagePlanName: !Sub payment-failure-comms-${Stage}-UsagePlan
+          Description: !Sub Usage plan for payment-failure-comms-${Stage}
+
+  PaymentFailureCommsLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub payment-failure-comms-${Stage}
+      Handler: com.gu.payment_failure_comms.Handler
+      Runtime: java8
+      CodeUri:
+        Bucket: support-service-lambdas-dist
+        Key: !Sub membership/${Stage}/payment-failure-comms/payment-failure-comms.jar
+      Timeout: 120
+      MemorySize: 256
+      Environment:
+        Variables:
+          Stage: !Sub ${Stage}
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: POST
+            RestApiId:
+              Ref: PaymentFailureCommsGateway

--- a/handlers/payment-failure-comms/cfn.yaml
+++ b/handlers/payment-failure-comms/cfn.yaml
@@ -9,6 +9,9 @@ Parameters:
       - CODE
       - DEV
     Default: CODE
+  AppName:
+    Type: String
+    Default: payment-failure-comms
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
@@ -19,24 +22,24 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       OpenApiVersion: '2.0'
-      Name: !Sub payment-failure-comms-${Stage}-ApiGateway
+      Name: !Sub ${AppName}-${Stage}-ApiGateway
       StageName: !Sub ${Stage}
       Auth:
         ApiKeyRequired: true
         UsagePlan:
           CreateUsagePlan: PER_API
-          UsagePlanName: !Sub payment-failure-comms-${Stage}-UsagePlan
-          Description: !Sub Usage plan for payment-failure-comms-${Stage}
+          UsagePlanName: !Sub ${AppName}-${Stage}-UsagePlan
+          Description: !Sub Usage plan for ${AppName}-${Stage}
 
   PaymentFailureCommsLambda:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub payment-failure-comms-${Stage}
+      FunctionName: !Sub ${AppName}-${Stage}
       Handler: com.gu.payment_failure_comms.Handler
       Runtime: java8
       CodeUri:
         Bucket: support-service-lambdas-dist
-        Key: !Sub membership/${Stage}/payment-failure-comms/payment-failure-comms.jar
+        Key: !Sub membership/${Stage}/${AppName}/${AppName}.jar
       Timeout: 120
       MemorySize: 256
       Environment:

--- a/handlers/payment-failure-comms/cfn.yaml
+++ b/handlers/payment-failure-comms/cfn.yaml
@@ -18,6 +18,12 @@ Conditions:
 
 
 Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AppName}-${Stage}
+      RetentionInDays: 90
+
   PaymentFailureCommsGateway:
     Type: AWS::Serverless::Api
     Properties:
@@ -33,6 +39,7 @@ Resources:
 
   PaymentFailureCommsLambda:
     Type: AWS::Serverless::Function
+    DependsOn: LogGroup
     Properties:
       FunctionName: !Sub ${AppName}-${Stage}
       Handler: com.gu.payment_failure_comms.Handler

--- a/handlers/payment-failure-comms/riff-raff.yaml
+++ b/handlers/payment-failure-comms/riff-raff.yaml
@@ -1,0 +1,21 @@
+stacks:
+  - membership
+regions:
+  - eu-west-1
+deployments:
+
+  cfn:
+    type: cloud-formation
+    app: payment-failure-comms
+    parameters:
+      templatePath: cfn.yaml
+
+  payment-failure-comms:
+    type: aws-lambda
+    parameters:
+      fileName: payment-failure-comms.jar
+      bucket: support-service-lambdas-dist
+      prefixStack: false
+      functionNames:
+        - payment-failure-comms-
+    dependencies: [ cfn ]

--- a/handlers/payment-failure-comms/src/main/scala/com.gu.payment_failure_comms/Handler.scala
+++ b/handlers/payment-failure-comms/src/main/scala/com.gu.payment_failure_comms/Handler.scala
@@ -1,0 +1,14 @@
+package com.gu.payment_failure_comms
+
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import com.gu.util.Logging
+
+class Handler extends RequestHandler[APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent] with Logging {
+
+  def handleRequest(event: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
+    logger.info("Received request with body: " + event.getBody)
+
+    new APIGatewayProxyResponseEvent().withStatusCode(200)
+  }
+}


### PR DESCRIPTION
## What does this change?
Creates a skeleton for the payment-failure-comms project, setting up basic CI/CD and CloudFormation config. This will allow easier testing of the project as it's built.