### PR TITLE
Remove API key config from payment failure comms

### DIFF
--- a/handlers/payment-failure-comms/cfn.yaml
+++ b/handlers/payment-failure-comms/cfn.yaml
@@ -30,12 +30,6 @@ Resources:
       OpenApiVersion: '2.0'
       Name: !Sub ${AppName}-${Stage}-ApiGateway
       StageName: !Sub ${Stage}
-      Auth:
-        ApiKeyRequired: true
-        UsagePlan:
-          CreateUsagePlan: PER_API
-          UsagePlanName: !Sub ${AppName}-${Stage}-UsagePlan
-          Description: !Sub Usage plan for ${AppName}-${Stage}
 
   PaymentFailureCommsLambda:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## What does this change?
Removes the API key CoudFormation config from payment-failure-comms.

Zuora does not offer the feature to authenticate using an API key so we will need to authenticate using a different way. For now though as this is a Proof of Concept we will leave it open.