### PR TITLE
Add BrazeConnector to payment-failure-comms

### DIFF
--- a/handlers/payment-failure-comms/cfn.yaml
+++ b/handlers/payment-failure-comms/cfn.yaml
@@ -36,7 +36,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AppName}-${Stage}
-      RetentionInDays: 90
+      RetentionInDays: 30
 
   PaymentFailureCommsGateway:
     Type: AWS::Serverless::Api

--- a/handlers/payment-failure-comms/cfn.yaml
+++ b/handlers/payment-failure-comms/cfn.yaml
@@ -36,7 +36,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AppName}-${Stage}
-      RetentionInDays: 30
+      RetentionInDays: 14
 
   PaymentFailureCommsGateway:
     Type: AWS::Serverless::Api

--- a/handlers/payment-failure-comms/src/main/scala/com.gu.payment_failure_comms/BrazeConnector.scala
+++ b/handlers/payment-failure-comms/src/main/scala/com.gu.payment_failure_comms/BrazeConnector.scala
@@ -1,0 +1,43 @@
+package com.gu.payment_failure_comms
+
+import com.gu.payment_failure_comms.models.{BrazeConfig, BrazeRequestFailure, BrazeResponseFailure, Failure}
+import scalaj.http.{Http, HttpResponse}
+
+import scala.util.Try
+
+object BrazeConnector {
+
+  def sendCustomEvent(brazeConfig: BrazeConfig, payload: String): Either[Failure, Unit] = {
+    handleRequestResult(
+      sendRequest(
+        url = s"https://${brazeConfig.instanceUrl}/users/track",
+        bearerToken = brazeConfig.bearerToken,
+        payload = payload)
+    )
+  }
+
+  def sendRequest(url: String, bearerToken: String, payload: String): Either[Throwable, HttpResponse[String]] = {
+    Try(
+      Http(url)
+        .header("Content-Type", "application/json")
+        .header("Authorization", s"Bearer ${bearerToken}")
+        .postData(payload)
+        .method("PATCH")
+        .asString
+    )
+      .toEither
+  }
+
+  def handleRequestResult(result: Either[Throwable, HttpResponse[String]]): Either[Failure, Unit] = {
+    result
+      .left.map(i => BrazeRequestFailure(s"Attempt to contact Braze failed with error: ${i.toString}"))
+      .flatMap(response =>
+        if (response.isSuccess) {
+          Right(())
+        } else {
+          Left(BrazeResponseFailure(s"The request to Braze was unsuccessful: ${response.code} - ${response.body}"))
+        }
+      )
+  }
+
+}

--- a/handlers/payment-failure-comms/src/main/scala/com.gu.payment_failure_comms/models/CustomEvent.scala
+++ b/handlers/payment-failure-comms/src/main/scala/com.gu.payment_failure_comms/models/CustomEvent.scala
@@ -1,0 +1,4 @@
+package com.gu.payment_failure_comms.models
+
+// Based on https://www.braze.com/docs/api/objects_filters/event_object/
+case class CustomEvent(braze_id: String, app_id: String, name: String, time: String, properties: Map[String, String])

--- a/handlers/payment-failure-comms/src/main/scala/com.gu.payment_failure_comms/models/Failure.scala
+++ b/handlers/payment-failure-comms/src/main/scala/com.gu.payment_failure_comms/models/Failure.scala
@@ -8,3 +8,11 @@ sealed trait Failure {
 case class ConfigFailure(details: String) extends Failure {
   val kind: String = "Config"
 }
+
+case class BrazeRequestFailure(details: String) extends Failure {
+  val kind: String = "Braze Request"
+}
+
+case class BrazeResponseFailure(details: String) extends Failure {
+  val kind: String = "Braze Response"
+}


### PR DESCRIPTION
## What does this change?
Adds code for inserting Custom Events into Braze. Also decreases the log retention time to 14 because we cannot guarantee that Braze won't echo personal data in the event of an error (Thanks @johnduffell for the [tip](https://github.com/guardian/support-service-lambdas/pull/1086#discussion_r646508094)).

This code isn't actually in use right now. The next PR will plug everything together. Merging this separately to make it easier to review.

Intended use: A `CustomEvent` will be created based on the messages received from Zuora and `Config`. This will then be encoded into JSON and fed into `BrazeConnector.sendCustomEvent`. which will add it to Braze. `Unit` or `Failure` will be returned depending on whether the request was successful or not.