### PR TITLE
Update schedule for delta backfill

### DIFF
--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -13,7 +13,7 @@ Parameters:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(12 hours)'
+      Schedule: 'rate(5 minutes)'
       SalesforceStage: PROD
       IdentityStage: PROD
       SalesforceUsername: SoftOptInConsentSetterAPIUser
@@ -112,7 +112,7 @@ Resources:
           Properties:
             Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule]
             Description: Runs Soft Opt-In Consent Setter
-            Enabled: False
+            Enabled: True
       Policies:
         - Statement:
             - Effect: Allow


### PR DESCRIPTION
## What does this change?
Changes the schedule of the Soft Opt-In Consent setter to enabled and to run every 5 minutes. This is necessary to process the backfill delta (step 3 of the [backfill plan](https://docs.google.com/document/d/1hziR1KHrY0445Tkg8t6HwB5xB4QcZuUIQqGnXv61zJQ/edit?usp=sharing))