### PR TITLE
Change how we log Salesforce composite errors in Soft Opt-In Consent setter

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
@@ -76,7 +76,6 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
     response
       .left.map(i => SoftOptInError("SalesforceConnector", s"Salesforce composite request failed: $i"))
       .flatMap { result =>
-        logger.info(result.body)
         decode[List[SFResponse]](result.body) match {
           case Right(compositeResponse) =>
             SFCompositeResponse(compositeResponse).errorsAsString

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfCompositeRequest.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfCompositeRequest.scala
@@ -6,7 +6,7 @@ case class SFCompositeResponse(responses: List[SFResponse]) {
 }
 
 case class SFResponse(id: Option[String], success: Boolean, errors: List[SFResponseError]) {
-  def errorAsString: Option[String] = if (success) None else Some(s"RecordId: ${id.getOrElse("N/A")}; Errors: ${errors.map(a => a.errorAsString)}.")
+  def errorAsString: Option[String] = if (success) None else Some(s"Errors: ${errors.map(a => a.errorAsString)}.")
 }
 
 case class SFResponseError(statusCode: String, message: String, fields: List[String]) {


### PR DESCRIPTION
## What does this change?
Revert the change in #1113. Removes `recordId` from the log when a Salesforce error occurs inside a composite request as this field is only populated on successful requests.
