### PR TITLE
Workaround for failing requests in Soft Opt-Int Consent Setter

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
@@ -19,6 +19,7 @@ object SfQueries {
        |	SF_Subscription__c
        |WHERE
        |	Soft_Opt_in_Status__c in ('Ready to process acquisition','Ready to process cancellation')
+       |  AND AcquisitionCase__c = NULL
        |ORDER BY
        |  SF_Status__c, Acquisition_Date__c
        |LIMIT


### PR DESCRIPTION
## What does this change?
This PR introduces a work around for failing requests to Salesforce.

We're seeing records that have a case attached to them being unsuccessfully updated in Salesforce after Soft Opt-In consents are updated in Identity. At this point we do not know why. These records will continue to be retried on each run of the lambda and will continue to fail until we find the root cause. For now we will exclude them so other records that are in a correct state can be processed and not delay the backfill of the delta while we investigate further.