### PR TITLE
Soft Opt-In Consent Setter: Remove workaround

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
@@ -19,7 +19,6 @@ object SfQueries {
        |	SF_Subscription__c
        |WHERE
        |	Soft_Opt_in_Status__c in ('Ready to process acquisition','Ready to process cancellation')
-       |  AND AcquisitionCase__c = NULL
        |ORDER BY
        |  SF_Status__c, Acquisition_Date__c
        |LIMIT


### PR DESCRIPTION
## What does this change?
Removes the workaround introduced in #1115 because the issue has been fixed in Salesforce.