### PR TITLE
Soft Opt-In Consent Setter: Final Release

### DIFF
--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -53,7 +53,7 @@ Resources:
       CodeUri:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
-      MemorySize: 2048
+      MemorySize: 256
       Runtime: java8
       Timeout: 900
       Environment:

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -112,7 +112,7 @@ Resources:
           Properties:
             Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule]
             Description: Runs Soft Opt-In Consent Setter
-            Enabled: False
+            Enabled: True
       Policies:
         - Statement:
             - Effect: Allow

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -13,7 +13,7 @@ Parameters:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(15 minutes)'
+      Schedule: 'rate(30 minutes)'
       SalesforceStage: PROD
       IdentityStage: PROD
       SalesforceUsername: SoftOptInConsentSetterAPIUser


### PR DESCRIPTION
## What does this change?
Releases the Soft Opt-In Consent Setter lambda in normal operation mode.

Reduces the rate at which the lambda runs to every 30 minutes. Logs shows the lambda never processed more than 26 subscriptions per run except for a peak of 200 that happened at midnight, meaning we can decrease the rate. We should continue to monitor though.

Reduces lambda memory size to 256MB. Logs show the most this lambda has used is 203MB so 256MB should a safe limit.