### PR TITLE
Raising memory for soft opt in consent setter to 512 due to out of me…

### DIFF
--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -53,7 +53,7 @@ Resources:
       CodeUri:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
-      MemorySize: 256
+      MemorySize: 512
       Runtime: java8
       Timeout: 900
       Environment:


### PR DESCRIPTION
…mory erros in line with https://github.com/guardian/ophan-housekeeper/issues/4

## What does this change?
Soft opt-in-consent-setter lambda is getting out of memory errors due to Metaspace issues. It's believed to be a duplicate of this issue https://github.com/guardian/ophan-housekeeper/issues/4 so raising the memory from 256 to 512, as has been done elsewhere, should resolve the issue.

