### PR TITLE
Update cfn.yaml

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -80,7 +80,7 @@ Resources:
       Role:
         !GetAtt StartJobRole.Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java8
       Timeout: 300
     DependsOn:
     - StartJobRole


### PR DESCRIPTION
Returning to openjdk 8 for testing of why export failed for out of memory heap error which happened after upgrading to amazon linux 2 image