### PR TITLE
Increase memory available for Java Corretto

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -222,8 +222,8 @@ Resources:
           Stage: !Ref Stage
       Role:
         !GetAtt DownloadBatchRole.Arn
-      MemorySize: 1536
-      Runtime: java8
+      MemorySize: 1792
+      Runtime: java8.al2
       Timeout: 900
     DependsOn:
     - DownloadBatchRole


### PR DESCRIPTION
The Salesforce export download step is failing with an out-of-memory error when using Corretto.
Increasing the memory available to the lambda sorts it out.

This has been tested in Prod.