### PR TITLE
update client side errors alarm description to be more clear

### DIFF
--- a/handlers/metric-push-api/cfn.yaml
+++ b/handlers/metric-push-api/cfn.yaml
@@ -156,12 +156,12 @@ Resources:
           - ' '
           - - !FindInMap [ Constants, Alarm, Urgent ]
             - !Ref 'Stage'
-            - !FindInMap [StageMap, !Ref Stage, ApiName]
-            - 'fatal client side errors are being reported'
+            - 'client-side fatal errors are being reported to sentry for support-frontend'
         AlarmDescription: !Join
           - ' '
-          - - 'Impact - some or all browsers are failing to render support client side pages'
+          - - 'Impact - some or all browsers are failing to render support client side pages. Log in to Sentry.io to investigate.'
             - !FindInMap [ Constants, Alarm, Process ]
+            - !FindInMap [StageMap, !Ref Stage, ApiName]
         MetricName: Count
         Namespace: AWS/ApiGateway
         Dimensions:


### PR DESCRIPTION
This PR updates the description for the "metric-push-api" to be a bit clearer about what to do.

I have also added it to the table on the Alarms doc here: https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit#heading=h.4kntpe4bhga6

https://trello.com/c/D5iXGmuV/3701-update-metric-push-api-alarm-description