### PR TITLE
Include cloudformation stack update in deployment

### DIFF
--- a/handlers/zuora-callout-apis/riff-raff.yaml
+++ b/handlers/zuora-callout-apis/riff-raff.yaml
@@ -3,6 +3,14 @@ stacks:
 regions:
 - eu-west-1
 deployments:
+  cfn:
+    type: cloud-formation
+    parameters:
+      templatePath: cfn.yaml
+      cloudFormationStackName: zuora-auto-cancel
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      createStackIfAbsent: false
   support-service-lambdas:
     type: aws-lambda
     parameters:
@@ -13,3 +21,5 @@ deployments:
       - zuora-auto-cancel-
       - payment-failure-
       - stripe-customer-source-updated-
+    dependencies: [cfn]
+    


### PR DESCRIPTION
The Zuora callout APIs module now deploys the cloudformation template as well as the updated lambdas.