### PR TITLE
fix snyk issue from CAS library

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val simpleConfig = "com.gu" %% "simple-configuration-ssm" % "1.5.6"
   val supportInternationalisation =
     "com.gu" %% "support-internationalisation" % "0.13"
-  val contentAuthCommon = "com.gu" %% "content-authorisation-common" % "0.5"
+  val contentAuthCommon = "com.gu" %% "content-authorisation-common" % "0.6"
 
   // Other
   val zio = "dev.zio" %% "zio" % "1.0.7"


### PR DESCRIPTION
Just while I was in bumping https://github.com/guardian/content-authorisation-common/pull/7
for https://github.com/guardian/subscriptions-frontend/pull/1347
I thought it would be sensible to bump it here too, as it's causing the same vuln here too https://app.snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109