### PR TITLE
Add Saturday rate plans to Imovo schemes

### DIFF
--- a/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
+++ b/handlers/digital-voucher-api/src/main/scala/com/gu/digital_voucher_api/DigitalVoucherService.scala
@@ -20,6 +20,7 @@ object DigitalVoucherService {
 
   private val schemeNames: Map[RatePlanName, SchemeName] = {
     val everydaySchemeName = SchemeName("Guardian7Day")
+    val saturdaySchemeName = SchemeName("GuardianSaturday")
     val sundaySchemeName = SchemeName("GuardianSunday")
     val weekendSchemeName = SchemeName("GuardianWeekend")
     val sixDaySchemeName = SchemeName("Guardian6Day")
@@ -27,6 +28,8 @@ object DigitalVoucherService {
     Map(
       RatePlanName("Everyday") -> everydaySchemeName,
       RatePlanName("Everyday+") -> everydaySchemeName,
+      RatePlanName("Saturday") -> saturdaySchemeName,
+      RatePlanName("Saturday+") -> saturdaySchemeName,
       RatePlanName("Sunday") -> sundaySchemeName,
       RatePlanName("Sunday+") -> sundaySchemeName,
       RatePlanName("Weekend") -> weekendSchemeName,


### PR DESCRIPTION
This will allow us to support new Saturday rate plans for digital vouchers.

Assuming that the new Imovo scheme for Saturday will follow the conventional naming pattern, this PR maps our standard and plus Saturday rate plans to the new Imovo scheme.
