### PR TITLE
Support Saturday digital voucher rate plans

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -39,6 +39,8 @@ case class Catalog(
   digitalVoucherWeekendPlus: Plan,
   digitalVoucherEveryday: Plan,
   digitalVoucherEverydayPlus: Plan,
+  digitalVoucherSaturday: Plan,
+  digitalVoucherSaturdayPlus: Plan,
   digitalVoucherSunday: Plan,
   digitalVoucherSundayPlus: Plan,
   digitalVoucherSixday: Plan,
@@ -79,6 +81,8 @@ case class Catalog(
     digitalVoucherWeekendPlus,
     digitalVoucherEveryday,
     digitalVoucherEverydayPlus,
+    digitalVoucherSaturday,
+    digitalVoucherSaturdayPlus,
     digitalVoucherSunday,
     digitalVoucherSundayPlus,
     digitalVoucherSixday,
@@ -165,6 +169,10 @@ object PlanId {
 
   case object DigitalVoucherEverydayPlus extends PlanId("digital_voucher_everyday_plus") with DigitalVoucherPlanId
 
+  case object DigitalVoucherSaturday extends PlanId("digital_voucher_saturday") with DigitalVoucherPlanId
+
+  case object DigitalVoucherSaturdayPlus extends PlanId("digital_voucher_saturday_plus") with DigitalVoucherPlanId
+
   case object DigitalVoucherSunday extends PlanId("digital_voucher_sunday") with DigitalVoucherPlanId
 
   case object DigitalVoucherSundayPlus extends PlanId("digital_voucher_sunday_plus") with DigitalVoucherPlanId
@@ -224,6 +232,8 @@ object PlanId {
     DigitalVoucherWeekendPlus,
     DigitalVoucherEveryday,
     DigitalVoucherEverydayPlus,
+    DigitalVoucherSaturday,
+    DigitalVoucherSaturdayPlus,
     DigitalVoucherSunday,
     DigitalVoucherSundayPlus,
     DigitalVoucherSixday,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -167,6 +167,8 @@ object NewProductApi {
       digitalVoucherWeekendPlus = planWithPayment(DigitalVoucherWeekendPlus, PlanDescription("Weekend+"), digitalVoucherStartDateRule(weekendDays), Monthly),
       digitalVoucherEveryday = planWithPayment(DigitalVoucherEveryday, PlanDescription("Everyday"), digitalVoucherStartDateRule(everyDayDays), Monthly),
       digitalVoucherEverydayPlus = planWithPayment(DigitalVoucherEverydayPlus, PlanDescription("Everyday+"), digitalVoucherStartDateRule(everyDayDays), Monthly),
+      digitalVoucherSaturday = planWithPayment(DigitalVoucherSaturday, PlanDescription("Saturday"), digitalVoucherStartDateRule(saturdayDays), Monthly),
+      digitalVoucherSaturdayPlus = planWithPayment(DigitalVoucherSaturdayPlus, PlanDescription("Saturday+"), digitalVoucherStartDateRule(saturdayDays), Monthly),
       digitalVoucherSunday = planWithPayment(DigitalVoucherSunday, PlanDescription("Sunday"), digitalVoucherStartDateRule(sundayDays), Monthly),
       digitalVoucherSundayPlus = planWithPayment(DigitalVoucherSundayPlus, PlanDescription("Sunday+"), digitalVoucherStartDateRule(sundayDays), Monthly),
       digitalVoucherSixday = planWithPayment(DigitalVoucherSixday, PlanDescription("Sixday"), digitalVoucherStartDateRule(sixDayDays), Monthly),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -854,6 +854,46 @@ class CatalogWireTest extends AnyFlatSpec with Matchers {
         |          "paymentPlan": "GBP 70.02 every month"
         |        },
         |        {
+        |          "id": "digital_voucher_saturday",
+        |          "label": "Saturday",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-04",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.07 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.07 every month"
+        |        },
+        |        {
+        |          "id": "digital_voucher_saturday_plus",
+        |          "label": "Saturday+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "startDate": "2020-04-04",
+        |              "sizeInDays": 1
+        |            }
+        |          },
+        |          "paymentPlans": [
+        |            {
+        |              "currencyCode": "GBP",
+        |              "description": "GBP 70.08 every month"
+        |            }
+        |          ],
+        |          "paymentPlan": "GBP 70.08 every month"
+        |        },
+        |        {
         |          "id": "digital_voucher_sunday",
         |          "label": "Sunday",
         |          "startDateRules": {
@@ -1016,6 +1056,8 @@ class CatalogWireTest extends AnyFlatSpec with Matchers {
       case DigitalVoucherSixdayPlus => gbpPrice(7004)
       case DigitalVoucherWeekend => gbpPrice(7005)
       case DigitalVoucherWeekendPlus => gbpPrice(7006)
+      case DigitalVoucherSaturday => gbpPrice(7007)
+      case DigitalVoucherSaturdayPlus => gbpPrice(7008)
       case DigitalVoucherSunday => gbpPrice(7009)
       case DigitalVoucherSundayPlus => gbpPrice(7010)
     }


### PR DESCRIPTION
CSRs should be able to create Saturday and Saturday+ rate plans for digital vouchers.
