### PR TITLE
Don't schedule delivery credit processor in Dev

### DIFF
--- a/handlers/delivery-problem-credit-processor/cfn.yaml
+++ b/handlers/delivery-problem-credit-processor/cfn.yaml
@@ -14,6 +14,7 @@ Parameters:
 
 Conditions:
   IsProd: !Equals [!Ref "Stage", "PROD"]
+  IsNotDev: !Not [!Equals [!Ref "Stage", "DEV"]]
 
 Mappings:
   StageMap:
@@ -21,8 +22,6 @@ Mappings:
       ScheduleName: delivery-problem-credit-processor-schedule-prod
     CODE:
       ScheduleName: delivery-problem-credit-processor-schedule-code
-    DEV:
-      ScheduleName: delivery-problem-credit-processor-schedule-dev
 
 Resources:
 
@@ -112,6 +111,8 @@ Resources:
 
   DeliveryProblemCreditProcessorScheduleRule:
     Type: AWS::Events::Rule
+    # No need to run on a schedule in Dev stage
+    Condition: IsNotDev
     Properties:
       Description: Trigger processing of delivery-problem credits every 20 mins
       Name: !FindInMap [StageMap, !Ref Stage, ScheduleName]
@@ -126,11 +127,21 @@ Resources:
 
   DeliveryProblemCreditProcessorLambdaInvokePermission:
     Type: AWS::Lambda::Permission
+    Condition: IsNotDev
     Properties:
       Action: lambda:invokeFunction
       FunctionName: !Ref DeliveryProblemCreditProcessor
       Principal: events.amazonaws.com
       SourceArn: !GetAtt DeliveryProblemCreditProcessorScheduleRule.Arn
     DependsOn:
-      - DeliveryProblemCreditProcessor
       - DeliveryProblemCreditProcessorScheduleRule
+
+  # As processor runs every 20 mins anyway, there's no point in retrying on failure
+  DeliveryProblemCreditProcessorLambdaInvokeConfig:
+    Type: AWS::Lambda::EventInvokeConfig
+    Properties:
+      FunctionName: !Ref DeliveryProblemCreditProcessor
+      MaximumRetryAttempts: 0
+      Qualifier: '$LATEST'
+    DependsOn:
+      - DeliveryProblemCreditProcessor


### PR DESCRIPTION
According to our cost management chart, the cost of the delivery credit processor has gone up since 9 Sep:

![image](https://user-images.githubusercontent.com/1722550/135275285-b60cee59-d034-49f3-96bd-fd9e2cce129c.png)

However, digging into it I found that all the extra cost was in the Dev stage:

![image](https://user-images.githubusercontent.com/1722550/135275421-ed666803-e8f8-4c41-bfdc-54cd08cd0389.png)

Looking into the logs I found that there was a corresponding change in the behaviour of the Dev processor from that date.  It was timing out on every run and retrying twice on top of the scheduled run every 20 mins.  This was because of bad data in the Dev env, which we expect to crop up a lot.

So I've stopped the processor from running on a schedule in Dev but kept it running in Code to keep that stage as close to Prod as possible.  I've also stopped the processor from retrying on failure, as that seems unnecessary when it runs every 20 minutes anyway.

Deployed to Dev and Code.

