### PR TITLE
Fix deprecation warnings in Circe library

### DIFF
--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -470,7 +470,7 @@ object SaveCsvToBucket extends LazyLogging {
 
       case "PROD" =>
         val bucket = Query.withName(batch.name).s3Bucket
-        val metadata: String = Printer.spaces2.pretty(Metadata(job, batch).asJson)
+        val metadata: String = Printer.spaces2.print(Metadata(job, batch).asJson)
         val csvRequestWithAcl = putRequestWithAcl(bucket, key = Query.withName(batch.name).s3Key)
         val metadataRequestWithAcl = putRequestWithAcl(bucket, key = s"metadata/${batch.name}.json")
         s3Client.putObject(

--- a/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/Handler.scala
+++ b/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/Handler.scala
@@ -33,7 +33,7 @@ trait ZuoraHandler[Req, Res] {
         )
         response <- handle(request)
       } yield response
-      output.write(response.unsafeRunSync.asJson.pretty(jsonPrinter).getBytes)
+      output.write(response.unsafeRunSync().asJson.printWith(jsonPrinter).getBytes)
     } finally {
       output.close()
     }


### PR DESCRIPTION
The print ops have changed in recent versions.