### PR TITLE
Give region to Riffraff artefact plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -250,6 +250,7 @@ def lambdaProject(projectName: String, projectDescription: String, dependencies:
       description:= projectDescription,
       assemblyJarName := s"$projectName.jar",
       assemblyMergeStrategyDiscardModuleInfo,
+      riffRaffAwsRegion := "eu-west-1",
       riffRaffPackageType := assembly.value,
       riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
       riffRaffUploadManifestBucket := Option("riffraff-builds"),

--- a/handlers/zuora-callout-apis/build.sbt
+++ b/handlers/zuora-callout-apis/build.sbt
@@ -6,6 +6,7 @@ description:= "Handles auto-cancellations for membership and subscriptions"
 
 assemblyJarName := "support-service-lambdas.jar"
 
+riffRaffAwsRegion := "eu-west-1"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")


### PR DESCRIPTION
Currently, when starting up SBT, a call is made out to AWS to find the current region as a setting for the Riffraff artefact plugin.  So this output appears:
```
[info] resolving key references (51134 settings) ...
Oct 02, 2021 4:54:46 PM com.amazonaws.util.EC2MetadataUtils getItems
WARNING: Unable to retrieve the requested metadata (/latest/dynamic/instance-identity/document). The requested metadata is not found at http://169.254.169.254/latest/dynamic/instance-identity/document
com.amazonaws.SdkClientException: The requested metadata is not found at http://169.254.169.254/latest/dynamic/instance-identity/document
	at com.amazonaws.internal.EC2ResourceFetcher.doReadResource(EC2ResourceFetcher.java:89)
	at com.amazonaws.internal.EC2ResourceFetcher.doReadResource(EC2ResourceFetcher.java:70)
	at com.amazonaws.internal.InstanceMetadataServiceResourceFetcher.readResource(InstanceMetadataServiceResourceFetcher.java:75)
	at com.amazonaws.internal.EC2ResourceFetcher.readResource(EC2ResourceFetcher.java:66)
	at com.amazonaws.util.EC2MetadataUtils.getItems(EC2MetadataUtils.java:403)
	at com.amazonaws.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:372)
	at com.amazonaws.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:368)
	at com.amazonaws.util.EC2MetadataUtils.getEC2InstanceRegion(EC2MetadataUtils.java:283)
	at com.amazonaws.regions.Regions.getCurrentRegion(Regions.java:109)
	at com.gu.riffraff.artifact.RiffRaffArtifact$autoImport$.$anonfun$coreSettings$8(RiffRaffArtifact.scala:65)
```

This will always fail and fall back to 'eu-west-1', as the current region is only available in an EC2 environment.
So it's more efficient just to explicitly state the region.

