### PR TITLE
Run Snyk only to monitor vulnerabilities in the main branch

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,31 +1,31 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
+# This action runs Snyk Monitor every day at 6 AM and on every push to main
 name: Snyk
 
 on:
   schedule:
     - cron: '0 6 * * *'
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
   security:
     runs-on: ubuntu-latest
-    env:
-      SNYK_COMMAND: test
+
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
 
-      - name: Set command to monitor
-        if: github.ref == 'refs/heads/main'
-        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
-
-      - name: Run Snyk to check for vulnerabilities
+      - name: Update Snyk UI with current vulnerabilities
         uses: snyk/actions/scala@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=the-guardian-cuu --project-name=${{ github.repository }}
-          command: ${{ env.SNYK_COMMAND }}
+          command: monitor
+          args: --org=the-guardian-cuu --project-name=${{ github.repository }} --sarif-file-output=snyk.sarif
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif


### PR DESCRIPTION
Currently, we test all PRs with a Snyk check.  Unfortunately, it fails every time because it detects vulnerabilities that are unrelated to the changes in the PR as well as new vulnerabilities that the PR has introduced.  As a result, the test is ignored and new vulnerabilities are missed.

This PR changes the way we run Snyk so that it monitors instead of tests.  This means that Snyk is informed of current vulnerabilities in the main branch and they appear in its UI.  I've also added another step to show any vulnerabilities in the Security tab of the repo as well so that they remain visible and close to the code.  But we should get green lights on PRs.

See:
* https://github.com/snyk/actions/tree/master/scala
* https://docs.snyk.io/features/snyk-cli/guides-for-our-cli/cli-reference
