### PR TITLE
Apply hardcoded values for 'uses' properties

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,15 +13,12 @@ jobs:
   security:
     runs-on: ubuntu-latest
 
-    env:
-      SNYK_ACTION: snyk/actions/scala@0.3.0
-
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
 
       - name: Update Snyk UI with current vulnerabilities
-        uses: ${{ env.SNYK_ACTION }}
+        uses: snyk/actions/scala@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -29,7 +26,7 @@ jobs:
           args: --org=the-guardian-cuu --project-name=${{ github.repository }}
 
       - name: Update Github Code Scanning file with current vulnerabilities
-        uses: ${{ env.SNYK_ACTION }}
+        uses: snyk/actions/scala@0.3.0
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Not able to use env vars in a 'uses' argument so having to repeat the value:
`the 'uses' attribute must be a path, a Docker image, or owner/repo@ref`.