### PR TITLE
Update AwsConnectorSandbox secret version

### DIFF
--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -27,14 +27,14 @@ Mappings:
       reqDomain: gnmtouchpoint--DEV1.my.salesforce.com
       SalesforceStage: DEV
       AppName: AwsConnectorSandbox
-      AppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      AppSecretsVersion: abaa595b-e6c8-4d13-81e0-2d02627536c7
       UserSecretsVersion: 4a0eabf6-7940-47ef-87d0-36c3ef7f5741
     DEV:
       authDomain: test.salesforce.com
       reqDomain: gnmtouchpoint--DEV1.my.salesforce.com
       SalesforceStage: DEV
       AppName: AwsConnectorSandbox
-      AppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      AppSecretsVersion: abaa595b-e6c8-4d13-81e0-2d02627536c7
       UserSecretsVersion: 4a0eabf6-7940-47ef-87d0-36c3ef7f5741
 
 Resources:

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -27,7 +27,7 @@ Mappings:
       IdentityStage: CODE
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: AwsConnectorSandbox
-      AppSecretsVersion: 81f50c47-b1f3-400b-94b3-46413377f3d3
+      AppSecretsVersion: 6fc22312-3ddb-4577-8a37-d58222a09db4
       SalesforceUserSecretsVersion: 9d7777f6-78d7-4ec3-8c93-d4912ce6316e
       IdentityUserSecretsVersion: ec3fd3ca-f237-4d2d-bbb2-0c9482e636c1
     DEV:
@@ -36,7 +36,7 @@ Mappings:
       IdentityStage: CODE
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: AwsConnectorSandbox
-      AppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      AppSecretsVersion: abaa595b-e6c8-4d13-81e0-2d02627536c7
       SalesforceUserSecretsVersion: 08036ddd-9fc0-43b1-b478-4023a936751e
       IdentityUserSecretsVersion: ec3fd3ca-f237-4d2d-bbb2-0c9482e636c1
 


### PR DESCRIPTION
## What does this change?
Updates the secret version for the AwsConnectorSandbox app that enables access to Salesforce DEV and UAT following an update of these credentials.

Note: `sf-billing-account-remover` and `digital-voucher-suspension-processor` also use this app but do not have the secret version configured. CloudFormation will not trigger a redeployment due to the contents of a secret changing so the credentials for these apps were updated manually. Ideally their CloudFormation config should be changed to use the secrets version instead but that is not part of the scope of this PR.