### PR TITLE
Removing 5 retries alarm from soft opt in

### DIFF
--- a/handlers/soft-opt-in-consent-setter/README.md
+++ b/handlers/soft-opt-in-consent-setter/README.md
@@ -28,8 +28,6 @@ has been created to visualise these metrics and help monitor the lambda.
 
 **failed_consents_updates**: Shows how many failed IDAPI Soft Opt-In consent updates took place.
 
-**subs_with_five_retries**: Shows how many subscriptions reached 5 retries during the run.
-
 **successful_salesforce_update**: Shows how many successful Salesforce record updates took place.
 
 **failed_salesforce_update**: Shows how many failed Salesforce record updates took place.
@@ -93,28 +91,6 @@ anomaly.
 
 After the underlying issue is fixed, letting the lambda continue to run on schedule will update Salesforce to the
 correct state.
-
-### subsWith5RetriesAlarm
-
-**CAUSE**: One or more subscription's Soft Opt-In consents failed to be set after five retries. This can be due to
-several reasons:
-
-1. Failed to contact the IDAPI endpoint
-1. IDAPI was unable to set the user's Soft Opt-In consents.
-
-The [lambda's logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fsoft-opt-in-consent-setter-PROD)
-will provide more details regarding which of these is taking place.
-
-**IMPACT**: The lambda will no longer try to process this request.
-
-**FIX**: For each corresponding cause:
-
-1. Check that the IDAPI endpoints are correct and online.
-1. Check the logs for the error code being returned by the endpoint and contact the Identity team to understand why
-   IDAPI was unable to set the user's Soft Opt-In consents. Most of the time this will be a user who no longer has an 
-   Identity account (ID stored in `SF_Subscription__c.Buyer__r.IdentityID__c`), in which case no action is necessary. *
-
-\* You can use the [useradmin tool](https://useradmin.gutools.co.uk/) to find out if an Identity ID exists in the Identity system. This is a tool that allows you to tie together identities with email addresses, subscriptions, physical addresses etc. If the ID doesn't exist in the system, there's no need to take any further action.
 
 For all the above, after the underlying issue is resolved, the `Soft_Opt_in_Number_of_Attempts__c` fields needs to be
 reset to 0 for each of the affected records. After that the lambda will pick up those records for processing again.

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -179,28 +179,3 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
-
-  subsWith5RetriesAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: IsProd
-    DependsOn:
-      - LambdaFunction
-    Properties:
-      AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
-      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to set consents for a subscription 5 times
-      AlarmDescription: >
-        One or more subscription's Soft Opt-In consents failed to be set after five retries.
-        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#subsWith5RetriesAlarm
-        for possible causes, impacts and fixes.
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: Stage
-          Value: !Sub ${Stage}
-      EvaluationPeriods: 1
-      MetricName: subs_with_five_retries
-      Namespace: soft-opt-in-consent-setter
-      Period: 3600
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -110,13 +110,11 @@ object Handler extends LazyLogging {
 
   def emitIdentityMetrics(records: Seq[SFSubRecordUpdate]): Unit = {
     // Soft_Opt_in_Number_of_Attempts__c == 0 means the consents were set successfully
-    val successfullyUpdated = records.filter(_.Soft_Opt_in_Number_of_Attempts__c == 0).size
-    val unsuccessfullyUpdated = records.filter(_.Soft_Opt_in_Number_of_Attempts__c > 0).size
-    val subsWith5Retries = records.filter(_.Soft_Opt_in_Number_of_Attempts__c >= 5).size
+    val successfullyUpdated = records.count(_.Soft_Opt_in_Number_of_Attempts__c == 0)
+    val unsuccessfullyUpdated = records.count(_.Soft_Opt_in_Number_of_Attempts__c > 0)
 
     Metrics.put(event = "successful_consents_updates", successfullyUpdated)
     Metrics.put(event = "failed_consents_updates", unsuccessfullyUpdated)
-    Metrics.put(event = "subs_with_five_retries", subsWith5Retries)
   }
 
 }


### PR DESCRIPTION
## What does this change?
Removing the alarm on 5 retries within the soft-opt-in-consent-setter lambda. This alarm has only ever alerted us on identity not found issues, which have so far always been caused by an account being deleted in identity before a request is made by the lambda, which we cannot resolve. Other errors should be recoverable by retry or alerted by an entire failed run.

## Have we considered potential risks?
The chance we won't be alerted to widespread failures is reduced by the other alarms in place

