### PR TITLE
Updating SNS topics & threshold for cloudwatch alarms

### DIFF
--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -63,7 +63,7 @@ Resources:
       AlarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError"
       AlarmDescription: API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       MetricName: 5XXError
       Namespace: AWS/ApiGateway
       Dimensions:
@@ -86,7 +86,7 @@ Resources:
       AlarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash"
       AlarmDescription: Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/handlers/cancellation-sf-cases-api/cfn.yaml
+++ b/handlers/cancellation-sf-cases-api/cfn.yaml
@@ -164,7 +164,7 @@ Resources:
     Condition: CreateProdMonitoring
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub "5XX from cancellation-sf-cases-api-${Stage}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -109,7 +109,7 @@ Resources:
       - ContactUsApiGateway
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub 4XX rate from contact-us-api-${Stage}
       AlarmDescription: >
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/contact-us-api/README.md#4XX-Errors
@@ -135,7 +135,7 @@ Resources:
       - ContactUsApiGateway
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub 5XX rate from contact-us-api-${Stage}
       AlarmDescription: >
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/contact-us-api/README.md#5XX-Errors
@@ -161,7 +161,7 @@ Resources:
       - ContactUsApiGateway
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub No requests coming into contact-us-api-${Stage}
       AlarmDescription: >
         This is a last line catch-all alarm. It means no requests were received in the last 6 hours.

--- a/handlers/delivery-problem-credit-processor/cfn.yaml
+++ b/handlers/delivery-problem-credit-processor/cfn.yaml
@@ -94,7 +94,7 @@ Resources:
         For general advice, see
         https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/handlers/delivery-records-api/cfn.yaml
+++ b/handlers/delivery-records-api/cfn.yaml
@@ -173,7 +173,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName:
           !Sub
             - 5XX rate from ${ApiName}

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -193,7 +193,7 @@ Resources:
           IMPACT: If this goes unaddressed, some digital vouchers will not be generated or provisioned.
           It's likely that a SF subscription has been misconfigured.
         AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         ComparisonOperator: GreaterThanThreshold
         Dimensions:
           - Name: ApiName
@@ -217,7 +217,7 @@ Resources:
           IMPACT: If this goes unaddressed, some digital vouchers will not be generated or provisioned.
           It's likely that there's an error upstream in the voucher provider's API.
         AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         ComparisonOperator: GreaterThanThreshold
         Dimensions:
           - Name: ApiName

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -84,7 +84,7 @@ Resources:
         For troubleshooting, see
         https://github.com/guardian/support-service-lambdas/blob/main/handlers/digital-voucher-suspension-processor/README.md.
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/handlers/fulfilment-date-calculator/cfn.yaml
+++ b/handlers/fulfilment-date-calculator/cfn.yaml
@@ -129,7 +129,7 @@ Resources:
       AlarmName: fulfilment-date-calculator
       AlarmDescription: Failed to generate fulfilment-dates files in fulfilment-date-calculator S3 bucket for today
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -388,7 +388,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName:
           !Sub
             - 5XX rate from ${ApiName}

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -107,7 +107,7 @@ Resources:
         For general advice, see
         https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
@@ -115,9 +115,9 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: 3600
+      Period: 4500
       Statistic: Sum
-      Threshold: 2
+      Threshold: 3
       TreatMissingData: notBreaching
     DependsOn:
       - HolidayStopProcessor

--- a/handlers/identity-backfill/cfn.yaml
+++ b/handlers/identity-backfill/cfn.yaml
@@ -176,7 +176,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName:
           !Sub
             - 5XX rate from ${ApiName}
@@ -200,7 +200,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName:
           !Sub
            - 4XX rate from ${ApiName}

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -210,7 +210,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName:
           !Sub
             - 5XX rate from ${ApiName}

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -331,7 +331,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName:
           !Sub
             - 5XX rate from ${ApiName}

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -206,7 +206,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName:
           !Sub
             - 5XX rate from ${ApiName}

--- a/handlers/sf-gocardless-sync/cfn.yaml
+++ b/handlers/sf-gocardless-sync/cfn.yaml
@@ -129,7 +129,7 @@ Resources:
     Condition: CreateProdMonitoring
     Properties:
       AlarmActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub "URGENT 9-5 - ${Stage} ${LogGroupNamePrefix} - sustained errors observed"
       AlarmDescription: "IMPACT: If this goes unaddressed CSRs won't be able to see Direct Debit Mandate failures AND no DD failure emails will go out to customers. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit"
       ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -137,7 +137,7 @@ Resources:
       - LambdaFunction
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to run
       AlarmDescription: >
         Two or more runs found an error and were unable to complete.
@@ -162,7 +162,7 @@ Resources:
       - LambdaFunction
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:soft-opt-in-consent-setter-events
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
       AlarmDescription: >
         A run failed to update (some) records in Salesforce in the last hour.

--- a/handlers/zuora-callout-apis/cloudformation.yaml
+++ b/handlers/zuora-callout-apis/cloudformation.yaml
@@ -272,7 +272,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName: !Sub 5XX rate from ${ApiName}
         ComparisonOperator: GreaterThanThreshold
         Dimensions:
@@ -293,7 +293,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         AlarmName: !Sub 4XX rate from ${ApiName}
         ComparisonOperator: GreaterThanThreshold
         Dimensions:

--- a/handlers/zuora-datalake-export/cfn.yaml
+++ b/handlers/zuora-datalake-export/cfn.yaml
@@ -105,7 +105,7 @@ Resources:
         AlarmName: zuora-datalake-export
         AlarmDescription: Failed to export Zuora to Datalake. Corresponding Ophan clean tables, such as clean.zuora_account, will go out-of-date. Refer to https://github.com/guardian/support-service-lambdas/blob/main/handlers/sf-datalake-export/README.md on how to debug and retry.
         AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
         ComparisonOperator: GreaterThanOrEqualToThreshold
         Dimensions:
           - Name: FunctionName


### PR DESCRIPTION
## What does this change?

Setting support-service lambdas cloudwatch alarms to the correct topics.

Updating threshold for holiday stops processor alarm to filter out more noise and only alert on systemic failures.
