### PR TITLE
make sure gw 6 for 6 don't get overlapping issues over christmas

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
@@ -139,7 +139,7 @@ object AddGuardianWeeklySub {
          */
         createSubRequest = ZuoraCreateSubRequest(
           request = request,
-          acceptanceDate = request.startDate.plusWeeks(6),
+          acceptanceDate = request.startDate.plusWeeks(7), // revert after christmas 2021 BEFORE reverting the zuora catalog changes https://github.com/guardian/support-frontend/pull/3319
           ratePlans = List(
             ZuoraCreateSubRequestRatePlan(
               productRatePlanId = zuora6for6RatePlanAndCharge.productRatePlanId,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
@@ -9,7 +9,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest, ZuoraCreateSubRequestRatePlan}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.{BillToAddress, SoldToAddress}
-import com.gu.newproduct.api.productcatalog.PlanId.{GuardianWeeklyDomestic6for6, GuardianWeeklyDomesticQuarterly}
+import com.gu.newproduct.api.productcatalog.PlanId.{GuardianWeeklyDomestic6for6, GuardianWeekl/(yDomesticQuarterly}
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.productcatalog.{Plan, PlanDescription, PlanId}
@@ -151,7 +151,7 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
   }
 
   it should "create subscription for 6-for-6 rate plan" in {
-    val monthlySubscriptionStartDate = testFirstPaymentDate.plusWeeks(6)
+    val monthlySubscriptionStartDate = testFirstPaymentDate.plusWeeks(7)
 
     def stubCreate(request: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
       request shouldBe ZuoraCreateSubRequest(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
@@ -9,7 +9,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest, ZuoraCreateSubRequestRatePlan}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.{BillToAddress, SoldToAddress}
-import com.gu.newproduct.api.productcatalog.PlanId.{GuardianWeeklyDomestic6for6, GuardianWeekl/(yDomesticQuarterly}
+import com.gu.newproduct.api.productcatalog.PlanId.{GuardianWeeklyDomestic6for6, GuardianWeeklyDomesticQuarterly}
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.productcatalog.{Plan, PlanDescription, PlanId}


### PR DESCRIPTION
## What does this change?

This makes the main plan for 6 for 6 start and extra week after the first, to allow for the 7 weeks 6 issues problem at christmas
Also related
https://github.com/guardian/support-frontend/pull/3319

This change must be reverted along with the above PR, just before the catalog is changed back in zuora prod