### PR TITLE
Turn down DV suspension alarm

### DIFF
--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -92,10 +92,10 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: 300
+      Period: 3600
       Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching
+      Threshold: 3
+      TreatMissingData: ignore
 
   LambdaScheduleRule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
This change will make the alarm less sensitive so that it goes off after 3 failed lambda runs in an hour rather than a single failed run.

Occasionally, the Imovo API gives a 500 response but succeeds on the second attempt so doesn't require immediate intervention.