### PR TITLE
Create Basic Lambda - Sf emails to s3 exporter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -339,6 +339,11 @@ lazy val `soft-opt-in-consent-setter` = lambdaProject(
   Seq(awsSecretsManager, circe, circeParser, scalatest, scalajHttp, awsS3, simpleConfig) ++ logging
 ).dependsOn(`effects-s3`, `effects-cloudwatch`, `salesforce-core`)
 
+lazy val `sf-emails-to-s3-exporter` = lambdaProject(
+  "sf-emails-to-s3-exporter",
+  "Runs regularly to retrieve emails from Salesforce and save as json in S3",
+  Seq(awsSecretsManager, circe, circeParser, scalajHttp, awsS3))
+
 lazy val `sf-api-user-credentials-setter` = lambdaProject(
   "sf-api-user-credentials-setter",
   "Set passwords for Aws API Users in SF, and then create or update an entry for the credentials in AWS secrets manager",

--- a/build.sbt
+++ b/build.sbt
@@ -342,7 +342,7 @@ lazy val `soft-opt-in-consent-setter` = lambdaProject(
 lazy val `sf-emails-to-s3-exporter` = lambdaProject(
   "sf-emails-to-s3-exporter",
   "Runs regularly to retrieve emails from Salesforce and save as json in S3",
-  Seq(awsSecretsManager, circe, circeParser, scalajHttp, awsS3))
+  Seq(circe, circeParser, scalajHttp, awsS3))
 
 lazy val `sf-api-user-credentials-setter` = lambdaProject(
   "sf-api-user-credentials-setter",

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -1,0 +1,94 @@
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - PROD
+      - DEV
+    Default: DEV
+
+Mappings:
+  StageMap:
+    PROD:
+      SalesforceStage: PROD
+      SalesforceUsername: EmailsToS3APIUser
+      AppName: SFEmailsToS3
+      AppSecretsVersion: de769b81-3245-414a-acfb-a15c8ead92e5
+      SalesforceUserSecretsVersion: f0ef9b35-de4c-4fc7-a566-81aab194b9f4
+    DEV:
+      SalesforceStage: DEV
+      SalesforceUsername: EmailsToS3APIUser
+      AppName: AwsConnectorSandbox
+      AppSecretsVersion: abaa595b-e6c8-4d13-81e0-2d02627536c7
+      SalesforceUserSecretsVersion: a73eadbb-c5f4-4249-bf90-31fa5d6738e3
+
+Conditions:
+  IsProd: !Equals [ !Ref Stage, PROD ]
+
+Resources:
+  LambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: Retrieves emails from Salesforce and saves as Json to S3
+      FunctionName: !Sub sf-emails-to-s3-exporter-${Stage}
+      Handler: com.gu.sf_emails_to_s3_exporter.Handler::handleRequest
+      CodeUri:
+        Bucket: support-service-lambdas-dist
+        Key: !Sub membership/${Stage}/sf-emails-to-s3-exporter/sf-emails-to-s3-exporter.jar
+      MemorySize: 512
+      Runtime: java8.al2
+      Timeout: 900
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          sfApiVersion: v46.0
+          sfAuthUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl::${AppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
+          sfClientId:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientId::${AppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
+          sfClientSecret:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientSecret::${AppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
+          sfPassword:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          sfToken:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          sfUsername:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action: s3:GetObject
+              Resource:
+                - !Sub arn:aws:s3:::emails-from-sf/${Stage}/*
+        - Statement:
+            - Sid: readDeployedArtefact
+              Effect: Allow
+              Action: s3:GetObject
+              Resource:
+                - arn:aws:s3::*:membership-dist/*

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -14,13 +14,9 @@ Mappings:
     PROD:
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
-      AppSecretsVersion: de769b81-3245-414a-acfb-a15c8ead92e5
-      SalesforceUserSecretsVersion: f0ef9b35-de4c-4fc7-a566-81aab194b9f4
     DEV:
       SalesforceUsername: EmailsToS3APIUser
       AppName: AwsConnectorSandbox
-      AppSecretsVersion: abaa595b-e6c8-4d13-81e0-2d02627536c7
-      SalesforceUserSecretsVersion: a73eadbb-c5f4-4249-bf90-31fa5d6738e3
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
@@ -44,34 +40,28 @@ Resources:
           sfApiVersion: v46.0
           sfAuthUrl:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl::${AppSecretsVersion}}}'
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl}}'
             - AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
-              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
           sfClientId:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientId::${AppSecretsVersion}}}'
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientId}}'
             - AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
-              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
           sfClientSecret:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientSecret::${AppSecretsVersion}}}'
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientSecret}}'
             - AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
-              AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
           sfPassword:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword::${SalesforceUserSecretsVersion}}}'
-            - SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
-              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword}}'
+            - SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           sfToken:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken::${SalesforceUserSecretsVersion}}}'
-            - SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
-              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken}}'
+            - SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           sfUsername:
             !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername::${SalesforceUserSecretsVersion}}}'
-            - SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
-              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername}}'
+            - SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
       Policies:
         - Statement:
             - Effect: Allow

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -12,13 +12,11 @@ Parameters:
 Mappings:
   StageMap:
     PROD:
-      SalesforceStage: ${Stage}
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
       AppSecretsVersion: de769b81-3245-414a-acfb-a15c8ead92e5
       SalesforceUserSecretsVersion: f0ef9b35-de4c-4fc7-a566-81aab194b9f4
     DEV:
-      SalesforceStage: ${Stage}
       SalesforceUsername: EmailsToS3APIUser
       AppName: AwsConnectorSandbox
       AppSecretsVersion: abaa595b-e6c8-4d13-81e0-2d02627536c7
@@ -46,39 +44,33 @@ Resources:
           sfApiVersion: v46.0
           sfAuthUrl:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl::${AppSecretsVersion}}}'
-            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl::${AppSecretsVersion}}}'
+            - AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
               AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
           sfClientId:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientId::${AppSecretsVersion}}}'
-            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientId::${AppSecretsVersion}}}'
+            - AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
               AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
           sfClientSecret:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientSecret::${AppSecretsVersion}}}'
-            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientSecret::${AppSecretsVersion}}}'
+            - AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
               AppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, AppSecretsVersion ]
           sfPassword:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword::${SalesforceUserSecretsVersion}}}'
-            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword::${SalesforceUserSecretsVersion}}}'
+            - SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
               SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           sfToken:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken::${SalesforceUserSecretsVersion}}}'
-            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken::${SalesforceUserSecretsVersion}}}'
+            - SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
               SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           sfUsername:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername::${SalesforceUserSecretsVersion}}}'
-            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername::${SalesforceUserSecretsVersion}}}'
+            - SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
               SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
       Policies:
         - Statement:

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -86,9 +86,14 @@ Resources:
               Action: s3:GetObject
               Resource:
                 - !Sub arn:aws:s3:::emails-from-sf/${Stage}/*
-                    - Statement:
+        - Statement:
             - Effect: Allow
               Action: s3:PutObject
+              Resource:
+                - !Sub arn:aws:s3:::emails-from-sf/${Stage}/*
+        - Statement:
+            - Effect: Allow
+              Action: s3:ListBucket
               Resource:
                 - !Sub arn:aws:s3:::emails-from-sf/${Stage}/*
         - Statement:

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -86,6 +86,11 @@ Resources:
               Action: s3:GetObject
               Resource:
                 - !Sub arn:aws:s3:::emails-from-sf/${Stage}/*
+                    - Statement:
+            - Effect: Allow
+              Action: s3:PutObject
+              Resource:
+                - !Sub arn:aws:s3:::emails-from-sf/${Stage}/*
         - Statement:
             - Sid: readDeployedArtefact
               Effect: Allow

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -12,13 +12,13 @@ Parameters:
 Mappings:
   StageMap:
     PROD:
-      SalesforceStage: PROD
+      SalesforceStage: ${Stage}
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
       AppSecretsVersion: de769b81-3245-414a-acfb-a15c8ead92e5
       SalesforceUserSecretsVersion: f0ef9b35-de4c-4fc7-a566-81aab194b9f4
     DEV:
-      SalesforceStage: DEV
+      SalesforceStage: ${Stage}
       SalesforceUsername: EmailsToS3APIUser
       AppName: AwsConnectorSandbox
       AppSecretsVersion: abaa595b-e6c8-4d13-81e0-2d02627536c7

--- a/handlers/sf-emails-to-s3-exporter/project/build.properties
+++ b/handlers/sf-emails-to-s3-exporter/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.3

--- a/handlers/sf-emails-to-s3-exporter/project/build.properties
+++ b/handlers/sf-emails-to-s3-exporter/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.5.6

--- a/handlers/sf-emails-to-s3-exporter/riff-raff.yaml
+++ b/handlers/sf-emails-to-s3-exporter/riff-raff.yaml
@@ -1,0 +1,21 @@
+stacks:
+  - membership
+regions:
+  - eu-west-1
+deployments:
+
+  cfn:
+    type: cloud-formation
+    app: sf-emails-to-s3-exporter
+    parameters:
+      templatePath: cfn.yaml
+
+  sf-emails-to-s3-exporter:
+    type: aws-lambda
+    parameters:
+      fileName: sf-emails-to-s3-exporter.jar
+      bucket: support-service-lambdas-dist
+      prefixStack: false
+      functionNames:
+        - sf-emails-to-s3-exporter-
+    dependencies: [ cfn ]

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -1,0 +1,14 @@
+package com.gu.sf_emails_to_s3_exporter
+
+import com.typesafe.scalalogging.LazyLogging
+
+object Handler extends LazyLogging {
+
+  def main(args: Array[String]): Unit = {
+    handleRequest()
+  }
+
+  def handleRequest(): Unit = {
+    
+  }
+}

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -4,11 +4,12 @@ import com.typesafe.scalalogging.LazyLogging
 
 object Handler extends LazyLogging {
 
+
   def main(args: Array[String]): Unit = {
     handleRequest()
   }
 
   def handleRequest(): Unit = {
-    
+    logger.info("It works")
   }
 }


### PR DESCRIPTION
**What does this change?**
Contains the Handler, cfn.yaml and riff-raff.yaml files for as basic lambda in AWS that will be iterated upon with business logic and tests in subsequent PRs.

**Lambda purpose**
The intention of the Lambda is to regularly query for emails from Salesforce which as marked as 'Ready for Export to S3'.

The records returned by the query will be converted to Json and saved to S3

The lambda should be able to GET and PUT files in new S3 bucket (emails-from-sf/{Stage})

Scheduling and Error logging will follow in subsequent dedicated PRs