### PR TITLE
Emails to s3 exporter - Append to files in S3 instead of simple overwrite

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -19,9 +19,7 @@ object Handler extends LazyLogging {
       sfAuthDetails <- decode[SfAuthDetails](auth(config))
       emailsForExportFromSf <- getEmailsFromSf(sfAuthDetails)
     } yield emailsForExportFromSf
-
-    logger.info("emails:" + emails)
-
+    
     emails match {
 
       case Left(failure) => {
@@ -30,8 +28,6 @@ object Handler extends LazyLogging {
       }
 
       case Right(emailsFromSF) => {
-        logger.info("emailsFromSF size:" + emailsFromSF.records.size)
-
         val sfEmailsGroupedByCaseNumber = emailsFromSF
           .records
           .groupBy(_.Parent.CaseNumber)

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -26,7 +26,7 @@ object Handler extends LazyLogging {
 
       case Left(failure) => {
         logger.error("Error occurred. details: " + failure)
-        throw new RuntimeException("Missing config value")
+        throw new RuntimeException("Error occurred. details: " + failure)
       }
 
       case Right(emailsFromSF) => {

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -30,6 +30,8 @@ object Handler extends LazyLogging {
       }
 
       case Right(emailsFromSF) => {
+        logger.info("emailsFromSF size:" + emailsFromSF.records.size)
+
         val sfEmailsGroupedByCaseNumber = emailsFromSF
           .records
           .groupBy(_.Parent.CaseNumber)
@@ -44,7 +46,7 @@ object Handler extends LazyLogging {
     sfEmailsByCaseNumber.foreach {
       case (caseNumber, caseRecords) =>
 
-        fileExistsInS3(caseNumber + ".json") match {
+        fileExistsInS3(caseNumber) match {
 
           case true => {
             appendToFileInS3(

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -4,6 +4,9 @@ import java.nio.charset.StandardCharsets
 
 import com.gu.effects.{AwsS3, Key, UploadToS3}
 import com.typesafe.scalalogging.LazyLogging
+import io.circe.generic.auto._
+import io.circe.parser._
+import io.circe.syntax._
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.{GetObjectRequest, ListObjectsRequest, PutObjectRequest}
 
@@ -60,5 +63,34 @@ object S3Connector extends LazyLogging{
     )
 
     Source.fromInputStream(inputStream).mkString
+  }
+
+  def appendToFileInS3(fileName: String, caseEmailsFromSf: Seq[EmailsFromSfResponse.Records]): Unit = {
+
+    val emailsJsonFromS3File = getEmailsJsonFromS3File("emails-from-sf", fileName)
+    val decodedCaseEmailsFromS3 = decode[Seq[EmailsFromSfResponse.Records]](emailsJsonFromS3File)
+
+    decodedCaseEmailsFromS3 match {
+      case Right(caseEmailsFromS3) => {
+        println("decoded from s3:" + caseEmailsFromS3)
+        val mergedEmails = mergeSfEmailsWithS3Emails(caseEmailsFromSf, caseEmailsFromS3)
+
+        writeEmailsJsonToS3(fileName, mergedEmails.asJson.toString())
+      }
+      case Left(error) => throw new RuntimeException(s"something went wrong $error")
+    }
+  }
+
+  def mergeSfEmailsWithS3Emails(
+    caseEmailsFromSf: Seq[EmailsFromSfResponse.Records],
+    fileContentFromS3: Seq[EmailsFromSfResponse.Records]
+  ): Seq[EmailsFromSfResponse.Records] = {
+
+    val emailsThatExistInSfButNotS3 =
+      caseEmailsFromSf.filter(sfEmail =>
+        fileContentFromS3.count(S3Email =>
+          S3Email.Composite_Key__c == sfEmail.Composite_Key__c) == 0)
+
+    fileContentFromS3 ++ emailsThatExistInSfButNotS3
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.s3.model.{GetObjectRequest, ListObjectsRe
 import scala.io.Source
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-object S3Connector extends LazyLogging{
+object S3Connector extends LazyLogging {
 
   val bucketName = "emails-from-sf"
 
@@ -58,7 +58,7 @@ object S3Connector extends LazyLogging{
     val inputStream = AwsS3.client.getObject(
       GetObjectRequest.builder
         .bucket("emails-from-sf")
-        .key(fileName + ".json")
+        .key(fileName)
         .build()
     )
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -5,8 +5,9 @@ import java.nio.charset.StandardCharsets
 import com.gu.effects.{AwsS3, Key, UploadToS3}
 import com.typesafe.scalalogging.LazyLogging
 import software.amazon.awssdk.core.sync.RequestBody
-import software.amazon.awssdk.services.s3.model.{ListObjectsRequest, PutObjectRequest}
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, ListObjectsRequest, PutObjectRequest}
 
+import scala.io.Source
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 object S3Connector extends LazyLogging{
@@ -48,5 +49,16 @@ object S3Connector extends LazyLogging{
       .map(
         objSummary => Key(objSummary.key)
       ).contains(Key(fileName))
+  }
+
+  def getEmailsJsonFromS3File(bucketName: String, fileName: String): String = {
+    val inputStream = AwsS3.client.getObject(
+      GetObjectRequest.builder
+        .bucket("emails-from-sf")
+        .key(fileName + ".json")
+        .build()
+    )
+
+    Source.fromInputStream(inputStream).mkString
   }
 }


### PR DESCRIPTION
## What does this change?
Add logic to append to S3 file if it already exists in S3

## Context
In Salesforce, the possibility exists that an email could be sent from a Case after the Case emails have been exported to S3.

We want to avoid an export on that email overwriting any file containing previously exported emails relating to that Case.

To ensure that previously exported emails do not get overwritten in S3, the changes in this PR will append the json representing the new email to any S3 file that matches the Parent CaseNumber

## How to test
**Verifying that a file is created in S3 when one does not already exist**
Create a case and a child email in Salesforce ensuring the email export_status__c field is ‘Ready for export to S3’

Run the lambda and verify that a new json file is created in S3 containing the email data as json, and the file is named by the casenumber

**Verifying that a file in S3 appended to when one already exists**

Complete the steps above for verifying that a file is created in S3 when one does not already exist

Add another email to the Case in Salesforce, ensuring the email export_status__c field is ‘Ready for export to S3’

Run the lambda and verify that the S3 file relating to the Case has been updated to contain the new email json from Salesforce and the original email json remains intact within the file


## Coming Next

Paginating through recordsets returned from Salesforce in the initial GET request

### Previous PRs

[Create Basic Lambda - Sf emails to s3 exporter #1316](https://github.com/guardian/support-service-lambdas/pull/1316)

[Sf email exporter - authenticate with sf and get emails #1317](https://github.com/guardian/support-service-lambdas/pull/1317)

[Sf emails exporter group emails by case number and save as json in s3 #1320](https://github.com/guardian/support-service-lambdas/pull/1320)
