### PR TITLE
Emails to s3 exporter  - add pagination for larger recordsets

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -30,13 +30,13 @@ object Handler extends LazyLogging {
         for {
           emailsForExportFromSf <- getEmailsFromSfByQuery(successfulAuth)
         } yield {
-          processEmails(successfulAuth, emailsForExportFromSf)
+          saveEmailsToS3AndQueryForMoreIfTheyExist(successfulAuth, emailsForExportFromSf)
         }
       }
     }
   }
 
-  def processEmails(sfAuthDetails: SfAuthDetails, response: EmailsFromSfResponse.Response): Unit = {
+  def saveEmailsToS3AndQueryForMoreIfTheyExist(sfAuthDetails: SfAuthDetails, response: EmailsFromSfResponse.Response): Unit = {
 
     val sfEmailsGroupedByCaseNumber = response
       .records
@@ -50,7 +50,7 @@ object Handler extends LazyLogging {
         for {
           nextPageEmails <- getEmailsFromSfByRecordsetReference(sfAuthDetails, response.nextRecordsUrl.get)
         } yield {
-          processEmails(sfAuthDetails, nextPageEmails)
+          saveEmailsToS3AndQueryForMoreIfTheyExist(sfAuthDetails, nextPageEmails)
         }
       }
     }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -22,7 +22,7 @@ object Handler extends LazyLogging {
     sfAuth match {
 
       case Left(failure) => {
-        logger.error("Error occurred. details: " + failure)
+        logger.error("Error occurred. details:" + failure)
         throw new RuntimeException("Error occurred. details: " + failure)
       }
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -43,7 +43,7 @@ object S3Connector extends LazyLogging {
 
     val filesInS3MatchingFileName = AwsS3.client.listObjects(
       ListObjectsRequest.builder
-        .bucket("emails-from-sf")
+        .bucket(bucketName)
         .prefix(fileName)
         .build()
     ).contents.asScala.toList
@@ -57,7 +57,7 @@ object S3Connector extends LazyLogging {
   def getEmailsJsonFromS3File(bucketName: String, fileName: String): String = {
     val inputStream = AwsS3.client.getObject(
       GetObjectRequest.builder
-        .bucket("emails-from-sf")
+        .bucket(bucketName)
         .key(fileName)
         .build()
     )
@@ -72,9 +72,7 @@ object S3Connector extends LazyLogging {
 
     decodedCaseEmailsFromS3 match {
       case Right(caseEmailsFromS3) => {
-        println("decoded from s3:" + caseEmailsFromS3)
         val mergedEmails = mergeSfEmailsWithS3Emails(caseEmailsFromSf, caseEmailsFromS3)
-
         writeEmailsJsonToS3(fileName, mergedEmails.asJson.toString())
       }
       case Left(error) => throw new RuntimeException(s"something went wrong $error")

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -9,18 +9,25 @@ object SFConnector {
 
   case class SfAuthDetails(access_token: String, instance_url: String)
 
-  def getEmailsFromSf(sfAuthDetails: SfAuthDetails): Either[Error, EmailsFromSfResponse.Response] = {
-    val responseBody = doSfGetWithQuery(sfAuthDetails, GetEmailsQuery.query)
-    decode[EmailsFromSfResponse.Response](responseBody)
-  }
-
-  def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
-    Http(s"${sfAuthDetails.instance_url}/services/data/${System.getenv("apiVersion")}/query/")
-      .param("q", query)
+  def getEmailsFromSfByQuery(sfAuthDetails: SfAuthDetails): Either[Error, EmailsFromSfResponse.Response] = {
+    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/${System.getenv("apiVersion")}/query/")
+      .param("q", GetEmailsQuery.query)
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
       .method("GET")
       .asString
       .body
+
+    decode[EmailsFromSfResponse.Response](responseBody)
+  }
+
+  def getEmailsFromSfByRecordsetReference(sfAuthDetails: SfAuthDetails, nextRecordsURL: String): Either[Error, EmailsFromSfResponse.Response] = {
+    val responseBody = Http(s"${sfAuthDetails.instance_url}" + nextRecordsURL)
+      .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
+      .method("GET")
+      .asString
+      .body
+
+    decode[EmailsFromSfResponse.Response](responseBody)
   }
 
   def auth(salesforceConfig: SalesforceConfig): String = {


### PR DESCRIPTION
## What does this change?
Enables processing of more than 200 emails per lambda execution

## Context
Queries via the REST API to Salesforce return a maximum of 200 records in one callout. If there are more than 200 records in the resultset returned by the query, the REST API provides the first 200, and a nextRecordsUrl to indicate the endpoint to hit that return the next set of 200 records, and so on.

The changes in this PR recursively retrieve the records and save to s3


## How to test

1. Ensure there are more than 200 emails to retrieve from Salesforce

2. Run the lambda.

3. Ensure that the emails are all saved to S3.

## Coming Next

Updating records in Salesforce that have been successfully saved to S3 to surface them for deletion

## Notes
We should still apply some limit based on anticipated upper boundary of the number of emails that may be processed in one day. To safely navigate the maximum 15 minute execution time, this limit will be applied to the query to ensure that the lambda runs for less than 10 minutes. The specific limitation will be determined in a subsequent piece of work to performance test the solution.

### Previous PRs

[Create Basic Lambda - Sf emails to s3 exporter #1316](https://github.com/guardian/support-service-lambdas/pull/1316)

[Sf email exporter - authenticate with sf and get emails #1317](https://github.com/guardian/support-service-lambdas/pull/1317)

[Sf emails exporter group emails by case number and save as json in s3 #1320](https://github.com/guardian/support-service-lambdas/pull/1320)

[Emails to s3 exporter - Append to files in S3 instead of simple overwrite #1323](https://github.com/guardian/support-service-lambdas/pull/1323)


