### PR TITLE
Revert guardian weekly 7 for 6 christmas change

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
@@ -139,7 +139,7 @@ object AddGuardianWeeklySub {
          */
         createSubRequest = ZuoraCreateSubRequest(
           request = request,
-          acceptanceDate = request.startDate.plusWeeks(7), // revert after christmas 2021 BEFORE reverting the zuora catalog changes https://github.com/guardian/support-frontend/pull/3319
+          acceptanceDate = request.startDate.plusWeeks(6),
           ratePlans = List(
             ZuoraCreateSubRequestRatePlan(
               productRatePlanId = zuora6for6RatePlanAndCharge.productRatePlanId,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
@@ -151,7 +151,7 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
   }
 
   it should "create subscription for 6-for-6 rate plan" in {
-    val monthlySubscriptionStartDate = testFirstPaymentDate.plusWeeks(7)
+    val monthlySubscriptionStartDate = testFirstPaymentDate.plusWeeks(6)
 
     def stubCreate(request: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
       request shouldBe ZuoraCreateSubRequest(


### PR DESCRIPTION
## What does this change?
This reverts the 7 weeks 6 issues christmas related change from https://github.com/guardian/support-service-lambdas/pull/1264

**NOTE**: This change must be reverted along with https://github.com/guardian/support-frontend/pull/3384, just before the catalog is changed back in zuora prod