### PR TITLE
Sf emails exporter - writeback successes to Salesforce when email saved in S3

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
@@ -1,0 +1,18 @@
+package com.gu.sf_emails_to_s3_exporter
+
+import java.time.LocalDateTime
+
+object ConfirmationWriteBackToSF {
+  case class EmailMessageToUpdate(
+   id: String,
+   Most_Recent_Export__c: LocalDateTime = LocalDateTime.now(),
+   attributes: Attributes = Attributes(`type` = "EmailMessage")
+ )
+
+  case class EmailMessagesToUpdate(
+    allOrNone: Boolean,
+    records: Seq[EmailMessageToUpdate]
+  )
+
+  case class Attributes(`type`: String)
+}

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
@@ -1,11 +1,12 @@
 package com.gu.sf_emails_to_s3_exporter
 
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 object ConfirmationWriteBackToSF {
   case class EmailMessageToUpdate(
     id: String,
-    Most_Recent_Export__c: LocalDateTime = LocalDateTime.now(), //todo for some reason this is giving dodgy datetimes
+    Most_Recent_Export__c: String = getCurrentDateTimeForWriteback(),
     attributes: Attributes = Attributes(`type` = "EmailMessage")
   )
 
@@ -15,4 +16,11 @@ object ConfirmationWriteBackToSF {
   )
 
   case class Attributes(`type`: String)
+
+  def getCurrentDateTimeForWriteback(): String = {
+    DateTimeFormatter.ofPattern("YYYY-MM-DD").format(LocalDateTime.now) +
+      "T" +
+      DateTimeFormatter.ofPattern("HH:mm:SS").format(LocalDateTime.now) +
+      "Z"
+  }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
@@ -4,10 +4,10 @@ import java.time.LocalDateTime
 
 object ConfirmationWriteBackToSF {
   case class EmailMessageToUpdate(
-   id: String,
-   Most_Recent_Export__c: LocalDateTime = LocalDateTime.now(),
-   attributes: Attributes = Attributes(`type` = "EmailMessage")
- )
+    id: String,
+    Most_Recent_Export__c: LocalDateTime = LocalDateTime.now(), //todo for some reason this is giving dodgy datetimes
+    attributes: Attributes = Attributes(`type` = "EmailMessage")
+  )
 
   case class EmailMessagesToUpdate(
     allOrNone: Boolean,

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
@@ -18,9 +18,6 @@ object ConfirmationWriteBackToSF {
   case class Attributes(`type`: String)
 
   def getCurrentDateTimeForWriteback(): String = {
-    DateTimeFormatter.ofPattern("YYYY-MM-DD").format(LocalDateTime.now) +
-      "T" +
-      DateTimeFormatter.ofPattern("HH:mm:SS").format(LocalDateTime.now) +
-      "Z"
+    DateTimeFormatter.ofPattern("YYYY-MM-DD'T'HH:mm:SS'Z'").format(LocalDateTime.now)
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/CustomFailure.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/CustomFailure.scala
@@ -4,9 +4,7 @@ case class CustomFailure(message: String)
 
 object CustomFailure {
   def fromThrowable(throwable: Throwable): CustomFailure = {
-    print("Something went wrong:" + throwable.getMessage)
     CustomFailure(throwable.getMessage)
-
   }
 
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/CustomFailure.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/CustomFailure.scala
@@ -1,0 +1,12 @@
+package com.gu.sf_emails_to_s3_exporter
+
+case class CustomFailure(message: String)
+
+object CustomFailure {
+  def fromThrowable(throwable: Throwable): CustomFailure = {
+    print("Something went wrong:" + throwable.getMessage)
+    CustomFailure(throwable.getMessage)
+
+  }
+
+}

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/EmailsFromSfResponse.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/EmailsFromSfResponse.scala
@@ -9,6 +9,7 @@ object EmailsFromSfResponse {
 
   case class Records(
     Id: String,
+    ParentId: String,
     FromAddress: String,
     BccAddress: Option[String] = None,
     CcAddress: Option[String] = None,

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/GetEmailsQuery.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/GetEmailsQuery.scala
@@ -28,11 +28,9 @@ object GetEmailsQuery {
        |FROM
        | emailmessage
        |WHERE
-       | Export_Status__c in ('Ready for export to s3')
+       | Export_Status__c in ('Ready for export to s3') and parent.casenumber in ('01564462','01564463')
        |ORDER BY
        | ParentId
-       |LIMIT
-       | 1
     """.stripMargin
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/GetEmailsQuery.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/GetEmailsQuery.scala
@@ -5,6 +5,7 @@ object GetEmailsQuery {
     s"""
        |SELECT
        | Id,
+       | ParentId,
        | BccAddress,
        | CcAddress,
        | FirstOpenedDate,

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/GetEmailsQuery.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/GetEmailsQuery.scala
@@ -29,9 +29,11 @@ object GetEmailsQuery {
        |FROM
        | emailmessage
        |WHERE
-       | Export_Status__c in ('Ready for export to s3') and parent.casenumber in ('01564462','01564463')
+       | export_Status__c in ('Ready for export to s3')
        |ORDER BY
        | ParentId
+       |LIMIT
+       | 1000
     """.stripMargin
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -1,7 +1,7 @@
 package com.gu.sf_emails_to_s3_exporter
 
 import com.gu.sf_emails_to_s3_exporter.S3Connector.saveEmailToS3
-import com.gu.sf_emails_to_s3_exporter.SFConnector.{getEmailsFromSfByRecordsetReference, _}
+import com.gu.sf_emails_to_s3_exporter.SFConnector._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import io.circe.parser._

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -13,27 +13,46 @@ object Handler extends LazyLogging {
   }
 
   def handleRequest(): Unit = {
-    for {
+    (for {
       config <- SalesforceConfig.fromEnvironment.toRight("Missing config value")
-      sfAuthDetails <- decode[SfAuthDetails](auth(config))
+    } yield for {
+      sfAuthDetails <- decode[SfAuthDetails](auth(config).getOrElse(throw new RuntimeException("Error in SF Authentication")))
       emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails)
-    } yield processEmails(sfAuthDetails, emailsFromSF)
-
+    } yield processEmails(sfAuthDetails, emailsFromSF)) match {
+      case Left(abc) => { println(abc) }
+      case Right(fff) => { println(fff) }
+    }
   }
 
-  def processEmails(sfAuthDetails: SfAuthDetails, emailsDataFromSF: EmailsFromSfResponse.Response): Unit = {
+  def processEmails(sfAuthDetails: SfAuthDetails, emailsDataFromSF: EmailsFromSfResponse.Response): Any = {
 
-    val emailIdsSuccessfullySavedToS3 = emailsDataFromSF.records.map(saveEmailToS3)
+    val emailIdsSuccessfullySavedToS3 = getEmailIdsSuccessfullySavedToS3(emailsDataFromSF)
 
-    writebackSuccessesToSf(sfAuthDetails, emailIdsSuccessfullySavedToS3)
+    println("emailIdsSuccessfullySavedToS3:" + emailIdsSuccessfullySavedToS3)
+
+    if (!emailIdsSuccessfullySavedToS3.isEmpty) {
+      val sfWritebackResponse = writebackSuccessesToSf(sfAuthDetails, emailIdsSuccessfullySavedToS3)
+      println("sfWritebackResponse:" + sfWritebackResponse)
+    }
 
     //process more emails if they exist
     if (!emailsDataFromSF.done) {
-
-      for {
-        nextBatchOfEmails <- getEmailsFromSfByRecordsetReference(sfAuthDetails, emailsDataFromSF.nextRecordsUrl.get)
-      } yield processEmails(sfAuthDetails, nextBatchOfEmails)
-
+      processNextPageOfEmails(sfAuthDetails, emailsDataFromSF.nextRecordsUrl.get)
     }
+
+  }
+
+  def getEmailIdsSuccessfullySavedToS3(emailsDataFromSF: EmailsFromSfResponse.Response): Seq[String] = {
+    emailsDataFromSF
+      .records
+      .map(saveEmailToS3)
+      .collect { case Right(value) => value }
+      .flatten
+  }
+
+  def processNextPageOfEmails(sfAuthDetails: SfAuthDetails, url: String): Unit = {
+    for {
+      nextBatchOfEmails <- getEmailsFromSfByRecordsetReference(sfAuthDetails, url)
+    } yield processEmails(sfAuthDetails, nextBatchOfEmails)
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -24,6 +24,7 @@ object Handler extends LazyLogging {
     emailsFromSF match {
       case Left(ex) => {
         logger.error("Error: " + ex)
+        throw new RuntimeException(ex.toString)
       }
       case Right(success) => {
         logger.info("Processing complete")

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -1,7 +1,6 @@
 package com.gu.sf_emails_to_s3_exporter
 
-import java.time.LocalDateTime
-
+import com.gu.sf_emails_to_s3_exporter.ConfirmationWriteBackToSF.{EmailMessageToUpdate, EmailMessagesToUpdate}
 import com.gu.sf_emails_to_s3_exporter.S3Connector.{fileExistsInS3, getJsonForAppend, writeEmailsJsonToS3}
 import com.gu.sf_emails_to_s3_exporter.SFConnector.{SfAuthDetails, auth, doSfCompositeRequest, getEmailsFromSfByQuery}
 import com.typesafe.scalalogging.LazyLogging
@@ -10,20 +9,6 @@ import io.circe.parser._
 import io.circe.syntax._
 
 object Handler extends LazyLogging {
-
-  case class EmailMessageToUpdate(
-    id: String,
-    //Subject: String = "I have been updated",
-    Most_Recent_Export__c: LocalDateTime = LocalDateTime.now(),
-    attributes: Attributes = Attributes(`type` = "EmailMessage")
-  )
-
-  case class EmailMessagesToUpdate(
-    allOrNone: Boolean,
-    records: Seq[EmailMessageToUpdate]
-  )
-
-  case class Attributes(`type`: String)
 
   def main(args: Array[String]): Unit = {
     handleRequest()

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -1,7 +1,7 @@
 package com.gu.sf_emails_to_s3_exporter
 
-import com.gu.sf_emails_to_s3_exporter.S3Connector.saveEmailsToS3
-import com.gu.sf_emails_to_s3_exporter.SFConnector._
+import com.gu.sf_emails_to_s3_exporter.S3Connector.saveEmailToS3
+import com.gu.sf_emails_to_s3_exporter.SFConnector.{getEmailsFromSfByRecordsetReference, _}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import io.circe.parser._
@@ -23,21 +23,21 @@ object Handler extends LazyLogging {
   }
 
   def processEmails(sfAuthDetails: SfAuthDetails, emailsDataFromSF: EmailsFromSfResponse.Response): Unit = {
-    val emailIdsSuccessfullySavedToS3 = saveEmailsToS3(emailsDataFromSF)
 
-    writebackSuccessesToSf(sfAuthDetails: SfAuthDetails, emailIdsSuccessfullySavedToS3)
+    val emailIdsSuccessfullySavedToS3 = emailsDataFromSF.records.map(caseEmail => {
+      saveEmailToS3(caseEmail)
+    })
+
+    writebackSuccessesToSf(sfAuthDetails, emailIdsSuccessfullySavedToS3)
 
     //process more emails if they exist
     if (!emailsDataFromSF.done) {
-      val nextBatchOfEmails = getEmailsFromSfByRecordsetReference(sfAuthDetails, emailsDataFromSF.nextRecordsUrl.get)
 
-      nextBatchOfEmails
-        .map(
-          nextPageEmails => {
-            processEmails(sfAuthDetails, nextPageEmails)
-          }
-        )
+      for {
+        nextBatchOfEmails <- getEmailsFromSfByRecordsetReference(sfAuthDetails, emailsDataFromSF.nextRecordsUrl.get)
+        _ = processEmails(sfAuthDetails, nextBatchOfEmails)
+      } yield ()
+
     }
-
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -48,11 +48,12 @@ object Handler extends LazyLogging {
   }
 
   def getEmailIdsSuccessfullySavedToS3(emailsDataFromSF: EmailsFromSfResponse.Response): Seq[String] = {
+
     emailsDataFromSF
       .records
       .map(saveEmailToS3)
-      .filter(id => id != Right(""))
       .collect { case Right(value) => value }
+      .flatten
   }
 
   def processNextPageOfEmails(sfAuthDetails: SfAuthDetails, url: String): Unit = {

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -40,7 +40,15 @@ object Handler extends LazyLogging {
     val emailIdsSuccessfullySavedToS3 = getEmailIdsSuccessfullySavedToS3(emailsDataFromSF)
 
     if (!emailIdsSuccessfullySavedToS3.isEmpty) {
-      val sfWritebackResponse = writebackSuccessesToSf(sfAuthDetails, emailIdsSuccessfullySavedToS3)
+      writebackSuccessesToSf(sfAuthDetails, emailIdsSuccessfullySavedToS3).map(
+        response => response.map(
+          individualEmailUpdateAttempt =>
+            if (individualEmailUpdateAttempt.success.get) {
+              logger.info("Successful write back to sf for record:" + individualEmailUpdateAttempt.id)
+            } else {
+              logger.info("Failed to write back to sf for record:" + individualEmailUpdateAttempt)
+            })
+      )
     }
 
     //process more emails if they exist

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -1,13 +1,29 @@
 package com.gu.sf_emails_to_s3_exporter
 
-import com.gu.sf_emails_to_s3_exporter.S3Connector.{appendToFileInS3, fileExistsInS3, writeEmailsJsonToS3}
-import com.gu.sf_emails_to_s3_exporter.SFConnector.{SfAuthDetails, auth, getEmailsFromSfByQuery, getEmailsFromSfByRecordsetReference}
+import java.time.LocalDateTime
+
+import com.gu.sf_emails_to_s3_exporter.S3Connector.{fileExistsInS3, getJsonForAppend, writeEmailsJsonToS3}
+import com.gu.sf_emails_to_s3_exporter.SFConnector.{SfAuthDetails, auth, doSfCompositeRequest, getEmailsFromSfByQuery}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import io.circe.parser._
 import io.circe.syntax._
 
 object Handler extends LazyLogging {
+
+  case class EmailMessageToUpdate(
+    id: String,
+    //Subject: String = "I have been updated",
+    Most_Recent_Export__c: LocalDateTime = LocalDateTime.now(),
+    attributes: Attributes = Attributes(`type` = "EmailMessage")
+  )
+
+  case class EmailMessagesToUpdate(
+    allOrNone: Boolean,
+    records: Seq[EmailMessageToUpdate]
+  )
+
+  case class Attributes(`type`: String)
 
   def main(args: Array[String]): Unit = {
     handleRequest()
@@ -17,57 +33,93 @@ object Handler extends LazyLogging {
     val sfAuth = for {
       config <- SalesforceConfig.fromEnvironment.toRight("Missing config value")
       sfAuthDetails <- decode[SfAuthDetails](auth(config))
-    } yield sfAuthDetails
 
-    sfAuth match {
+      emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails)
+      s3SaveResponses = saveEmailsToS3ThenWriteSuccessToSFThenQueryForMoreIfTheyExist(sfAuthDetails, emailsFromSF)
+    } yield {
 
-      case Left(failure) => {
-        logger.error("Error occurred. details:" + failure)
-        throw new RuntimeException("Error occurred. details: " + failure)
-      }
-
-      case Right(successfulAuth) => {
-        getEmailsFromSfByQuery(successfulAuth).map(emailsForExportFromSf =>
-          saveEmailsToS3AndQueryForMoreIfTheyExist(successfulAuth, emailsForExportFromSf))
-      }
+      //      sfAuth match {
+      //
+      //        case Left(failure) => {
+      //          logger.error("Error occurred. details:" + failure)
+      //          throw new RuntimeException("Error occurred. details: " + failure)
+      //        }
+      //
+      //        case Right(successfulAuth) => {}
+      //      }
     }
   }
 
-  def saveEmailsToS3AndQueryForMoreIfTheyExist(sfAuthDetails: SfAuthDetails, response: EmailsFromSfResponse.Response): Unit = {
+  def saveEmailsToS3ThenWriteSuccessToSFThenQueryForMoreIfTheyExist(sfAuthDetails: SfAuthDetails, response: EmailsFromSfResponse.Response): Unit = {
 
     val sfEmailsGroupedByCaseNumber = response
       .records
       .groupBy(_.Parent.CaseNumber)
 
-    createOrAppendToS3Files(sfEmailsGroupedByCaseNumber)
+    //save files to s3 and return successes
 
-    if (response.done) logger.info("Batch Complete")
-    else
-      getEmailsFromSfByRecordsetReference(sfAuthDetails, response.nextRecordsUrl.get)
-        .map(nextPageEmails => saveEmailsToS3AndQueryForMoreIfTheyExist(sfAuthDetails, nextPageEmails))
+    val awsResponses = sfEmailsGroupedByCaseNumber.map {
+      case (caseNumber, caseRecords) => {
+
+        val json = getCreateOrAppendJson(caseNumber, caseRecords)
+        println("json:" + json)
+
+        val awsResponse = writeEmailsJsonToS3(
+          caseNumber,
+          json
+        )
+
+        awsResponse
+
+      }
+    }
+
+    val successIds = awsResponses
+      .toSeq
+      .filter(_.isRight).flatMap(_.right.get)
+    println("successIds:" + successIds);
+
+    val abc = successIds.map(
+      a => EmailMessageToUpdate(a)
+    )
+    println("abc:" + abc.asJson.toString())
+    println("Updating sf records:....")
+
+    val bbb = EmailMessagesToUpdate(false, abc)
+    println("bbb:" + bbb.asJson.toString())
+
+    val ccc = doSfCompositeRequest(sfAuthDetails, bbb.asJson.toString(), "PATCH")
+    println("ccc:" + ccc)
+    //parse successes to request body for sf rest write
+
+    //process more emails if they exist
+    //    if (!response.done) {
+    //      val nextBatchOfEmails = getEmailsFromSfByRecordsetReference(sfAuthDetails, response.nextRecordsUrl.get)
+    //
+    //      nextBatchOfEmails
+    //        .map(
+    //          nextPageEmails => saveEmailsToS3AndQueryForMoreIfTheyExist(sfAuthDetails, nextPageEmails)
+    //        )
+    //    }
   }
 
-  def createOrAppendToS3Files(sfEmailsByCaseNumber: Map[String, Seq[EmailsFromSfResponse.Records]]): Unit = {
+  def getCreateOrAppendJson(caseNumber: String, caseRecords: Seq[EmailsFromSfResponse.Records]): String = {
 
-    sfEmailsByCaseNumber.foreach {
-      case (caseNumber, caseRecords) =>
+    fileExistsInS3(caseNumber) match {
 
-        fileExistsInS3(caseNumber) match {
+      case true => {
+        println("IS APPEND")
+        getJsonForAppend(
+          caseNumber,
+          caseRecords
+        )
+      }
 
-          case true => {
-            appendToFileInS3(
-              caseNumber,
-              caseRecords
-            )
-          }
-
-          case false => {
-            writeEmailsJsonToS3(
-              caseNumber,
-              caseRecords.asJson.toString()
-            )
-          }
-        }
+      case false => {
+        println("IS CREATE")
+        caseRecords.asJson.toString()
+      }
     }
+
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -6,6 +6,8 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import io.circe.parser._
 
+import scala.util.Try
+
 object Handler extends LazyLogging {
 
   def main(args: Array[String]): Unit = {
@@ -62,4 +64,7 @@ object Handler extends LazyLogging {
       nextBatchOfEmails <- getEmailsFromSfByRecordsetReference(sfAuthDetails, url)
     } yield processEmails(sfAuthDetails, nextBatchOfEmails)
   }
+
+  def safely[A](doSomething: => A): Either[CustomFailure, A] =
+    Try(doSomething).toEither.left.map(CustomFailure.fromThrowable)
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -1,12 +1,10 @@
 package com.gu.sf_emails_to_s3_exporter
 
-import com.gu.sf_emails_to_s3_exporter.ConfirmationWriteBackToSF.{EmailMessageToUpdate, EmailMessagesToUpdate}
-import com.gu.sf_emails_to_s3_exporter.S3Connector.{fileExistsInS3, getJsonForAppend, writeEmailsJsonToS3}
-import com.gu.sf_emails_to_s3_exporter.SFConnector.{SfAuthDetails, auth, doSfCompositeRequest, getEmailsFromSfByQuery}
+import com.gu.sf_emails_to_s3_exporter.S3Connector.saveEmailsToS3
+import com.gu.sf_emails_to_s3_exporter.SFConnector._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import io.circe.parser._
-import io.circe.syntax._
 
 object Handler extends LazyLogging {
 
@@ -15,95 +13,30 @@ object Handler extends LazyLogging {
   }
 
   def handleRequest(): Unit = {
-    val sfAuth = for {
+    for {
       config <- SalesforceConfig.fromEnvironment.toRight("Missing config value")
       sfAuthDetails <- decode[SfAuthDetails](auth(config))
-
       emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails)
-      s3SaveResponses = saveEmailsToS3ThenWriteSuccessToSFThenQueryForMoreIfTheyExist(sfAuthDetails, emailsFromSF)
-    } yield {
+      _ = processEmails(sfAuthDetails, emailsFromSF)
+    } yield ()
 
-      //      sfAuth match {
-      //
-      //        case Left(failure) => {
-      //          logger.error("Error occurred. details:" + failure)
-      //          throw new RuntimeException("Error occurred. details: " + failure)
-      //        }
-      //
-      //        case Right(successfulAuth) => {}
-      //      }
-    }
   }
 
-  def saveEmailsToS3ThenWriteSuccessToSFThenQueryForMoreIfTheyExist(sfAuthDetails: SfAuthDetails, response: EmailsFromSfResponse.Response): Unit = {
+  def processEmails(sfAuthDetails: SfAuthDetails, emailsDataFromSF: EmailsFromSfResponse.Response): Unit = {
+    val emailIdsSuccessfullySavedToS3 = saveEmailsToS3(emailsDataFromSF)
 
-    val sfEmailsGroupedByCaseNumber = response
-      .records
-      .groupBy(_.Parent.CaseNumber)
-
-    //save files to s3 and return successes
-
-    val awsResponses = sfEmailsGroupedByCaseNumber.map {
-      case (caseNumber, caseRecords) => {
-
-        val json = getCreateOrAppendJson(caseNumber, caseRecords)
-        println("json:" + json)
-
-        val awsResponse = writeEmailsJsonToS3(
-          caseNumber,
-          json
-        )
-
-        awsResponse
-
-      }
-    }
-
-    val successIds = awsResponses
-      .toSeq
-      .filter(_.isRight).flatMap(_.right.get)
-    println("successIds:" + successIds);
-
-    val abc = successIds.map(
-      a => EmailMessageToUpdate(a)
-    )
-    println("abc:" + abc.asJson.toString())
-    println("Updating sf records:....")
-
-    val bbb = EmailMessagesToUpdate(false, abc)
-    println("bbb:" + bbb.asJson.toString())
-
-    val ccc = doSfCompositeRequest(sfAuthDetails, bbb.asJson.toString(), "PATCH")
-    println("ccc:" + ccc)
-    //parse successes to request body for sf rest write
+    writebackSuccessesToSf(sfAuthDetails: SfAuthDetails, emailIdsSuccessfullySavedToS3)
 
     //process more emails if they exist
-    //    if (!response.done) {
-    //      val nextBatchOfEmails = getEmailsFromSfByRecordsetReference(sfAuthDetails, response.nextRecordsUrl.get)
-    //
-    //      nextBatchOfEmails
-    //        .map(
-    //          nextPageEmails => saveEmailsToS3AndQueryForMoreIfTheyExist(sfAuthDetails, nextPageEmails)
-    //        )
-    //    }
-  }
+    if (!emailsDataFromSF.done) {
+      val nextBatchOfEmails = getEmailsFromSfByRecordsetReference(sfAuthDetails, emailsDataFromSF.nextRecordsUrl.get)
 
-  def getCreateOrAppendJson(caseNumber: String, caseRecords: Seq[EmailsFromSfResponse.Records]): String = {
-
-    fileExistsInS3(caseNumber) match {
-
-      case true => {
-        println("IS APPEND")
-        getJsonForAppend(
-          caseNumber,
-          caseRecords
+      nextBatchOfEmails
+        .map(
+          nextPageEmails => {
+            processEmails(sfAuthDetails, nextPageEmails)
+          }
         )
-      }
-
-      case false => {
-        println("IS CREATE")
-        caseRecords.asJson.toString()
-      }
     }
 
   }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -58,6 +58,7 @@ object S3Connector extends LazyLogging {
     else {
       val caseEmailsToSaveToS3 = emailsInS3File :+ caseEmail
       val successfulEmailId = writeEmailsJsonToS3(caseEmail.Parent.CaseNumber, caseEmailsToSaveToS3.asJson.toString(), caseEmail.Id)
+      //todo what happens if there is a failure writing to S3?
       caseEmail.Id
     }
   }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -29,7 +29,7 @@ object S3Connector extends LazyLogging {
 
   }
 
-  def saveEmailToS3(caseEmail: EmailsFromSfResponse.Records): Either[CustomFailure, String] = {
+  def saveEmailToS3(caseEmail: EmailsFromSfResponse.Records): Either[CustomFailure, Option[String]] = {
 
     val fileExists = for {
       fileIsInS3 <- fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber)
@@ -57,7 +57,7 @@ object S3Connector extends LazyLogging {
               val json = generateJsonForS3FileIfEmailDoesNotExist(caseEmail: EmailsFromSfResponse.Records)
               writeEmailsJsonToS3(caseEmail.Parent.CaseNumber, json, caseEmail.Id)
             } else {
-              Right("")
+              Right(None)
             }
           }
         }
@@ -96,7 +96,7 @@ object S3Connector extends LazyLogging {
       .map(CustomFailure.fromThrowable)
   } yield decodedEmails
 
-  def writeEmailsJsonToS3(fileName: String, caseEmailsJson: String, emailId: String): Either[CustomFailure, String] = {
+  def writeEmailsJsonToS3(fileName: String, caseEmailsJson: String, emailId: String): Either[CustomFailure, Option[String]] = {
 
     val uploadResponse = for {
       putRequest <- generateS3PutRequest(bucketName, fileName)
@@ -106,7 +106,7 @@ object S3Connector extends LazyLogging {
 
     uploadResponse match {
       case Left(ex) => { Left(CustomFailure(ex.message)) }
-      case Right(value) => { Right(emailId) }
+      case Right(value) => { Right(Some(emailId)) }
     }
   }
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -36,9 +36,7 @@ object S3Connector extends LazyLogging {
 
     fileExists match {
 
-      case Left(ex) => {
-        Left(CustomFailure(ex.message))
-      }
+      case Left(ex) => { Left(ex) }
 
       case Right(false) => {
         val json = generateJsonForS3FileIfFileDoesNotExist(Seq[EmailsFromSfResponse.Records](caseEmail))
@@ -92,7 +90,7 @@ object S3Connector extends LazyLogging {
     } yield uploadResult
 
     uploadResponse match {
-      case Left(ex) => { Left(CustomFailure(ex.message)) }
+      case Left(ex) => { Left(ex) }
       case Right(value) => { Right(Some(emailId)) }
     }
   }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -55,7 +55,7 @@ object S3Connector extends LazyLogging {
   }
 
   def updateS3FileIfEmailDoesNotExist(caseEmail: EmailsFromSfResponse.Records): String = {
-    //get json body of file
+
     val s3FileJsonBody = getEmailsJsonFromS3File(bucketName, caseEmail.Parent.CaseNumber)
     val decodedCaseEmailsFromS3 = decode[Seq[EmailsFromSfResponse.Records]](s3FileJsonBody)
     val emailsInS3File = decodedCaseEmailsFromS3.getOrElse(Seq[EmailsFromSfResponse.Records]())

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -51,19 +51,14 @@ object S3Connector extends LazyLogging {
     val decodedCaseEmailsFromS3 = decode[Seq[EmailsFromSfResponse.Records]](s3FileJsonBody)
     val emailsInS3File = decodedCaseEmailsFromS3.getOrElse(Seq[EmailsFromSfResponse.Records]())
 
-    val emailAlreadyExistsInS3File = emailsInS3File.exists(s3Email =>
-      s3Email.Composite_Key__c == caseEmail.Composite_Key__c)
+    val emailAlreadyExistsInS3File = emailsInS3File.exists(_.Composite_Key__c == caseEmail.Composite_Key__c)
 
-    emailAlreadyExistsInS3File match {
-      case true => {
-        //do nothing
-        ""
-      }
-      case false => {
-        val caseEmailsToSaveToS3 = emailsInS3File :+ caseEmail
-        val successfulEmailId = writeEmailsJsonToS3(caseEmail.Parent.CaseNumber, caseEmailsToSaveToS3.asJson.toString(), caseEmail.Id)
-        caseEmail.Id
-      }
+    if (emailAlreadyExistsInS3File)
+      ""
+    else {
+      val caseEmailsToSaveToS3 = emailsInS3File :+ caseEmail
+      val successfulEmailId = writeEmailsJsonToS3(caseEmail.Parent.CaseNumber, caseEmailsToSaveToS3.asJson.toString(), caseEmail.Id)
+      caseEmail.Id
     }
   }
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -31,14 +31,12 @@ object S3Connector extends LazyLogging {
 
   def saveEmailToS3(caseEmail: EmailsFromSfResponse.Records): Either[CustomFailure, Option[String]] = {
 
-    val fileExists = for {
-      fileIsInS3 <- fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber)
-    } yield fileIsInS3
+    val fileExists = fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber)
 
     fileExists match {
 
       case Left(ex) => {
-        Left(CustomFailure(ex.message))
+        Left(CustomFailure.fromThrowable(ex))
       }
 
       case Right(false) => {

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -18,24 +18,15 @@ object S3Connector extends LazyLogging {
   val bucketName = "emails-from-sf"
 
   def saveEmailToS3(caseEmail: EmailsFromSfResponse.Records): String = {
-    val fileExistsInS3 = fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber)
-
-    fileExistsInS3 match {
-
-      //Append
-      case true => {
-        updateS3FileIfEmailDoesNotExist(caseEmail)
-      }
-
-      //Create
-      case false => {
-        val successfulEmailId = writeEmailsJsonToS3(
-          caseEmail.Parent.CaseNumber,
-          Seq[EmailsFromSfResponse.Records](caseEmail).asJson.toString(),
-          caseEmail.Id
-        )
+    if (fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber))
+      updateS3FileIfEmailDoesNotExist(caseEmail)
+    else {
+      writeEmailsJsonToS3(
+        caseEmail.Parent.CaseNumber,
+        Seq[EmailsFromSfResponse.Records](caseEmail).asJson.toString(),
         caseEmail.Id
-      }
+      )
+      caseEmail.Id
     }
   }
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -12,56 +12,75 @@ import software.amazon.awssdk.services.s3.model.{GetObjectRequest, ListObjectsRe
 
 import scala.io.Source
 import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.util.{Failure, Success, Try}
 
 object S3Connector extends LazyLogging {
 
   val bucketName = "emails-from-sf"
 
-  def saveEmailToS3(caseEmail: EmailsFromSfResponse.Records): String = {
-    if (fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber))
-      updateS3FileIfEmailDoesNotExist(caseEmail)
-    else {
-      writeEmailsJsonToS3(
-        caseEmail.Parent.CaseNumber,
-        Seq[EmailsFromSfResponse.Records](caseEmail).asJson.toString(),
-        caseEmail.Id
-      )
-      caseEmail.Id
+  def saveEmailToS3(caseEmail: EmailsFromSfResponse.Records): Either[CustomFailure, Option[String]] = {
+
+    for {
+      fileIsInS3 <- fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber)
+    } yield {
+      if (fileIsInS3)
+        updateS3FileIfEmailDoesNotExist(caseEmail)
+      else {
+        writeEmailsJsonToS3(
+          caseEmail.Parent.CaseNumber,
+          Seq[EmailsFromSfResponse.Records](caseEmail).asJson.toString(),
+          caseEmail.Id
+        )
+        Some(caseEmail.Id)
+      }
+    }
+
+  }
+
+  def fileAlreadyExistsInS3(fileName: String): Either[CustomFailure, Boolean] = {
+
+    Try {
+      val filesInS3MatchingFileName = AwsS3.client.listObjects(
+        ListObjectsRequest.builder
+          .bucket(bucketName)
+          .prefix(fileName)
+          .build()
+      ).contents.asScala.toList
+
+      filesInS3MatchingFileName
+        .map(
+          objSummary => Key(objSummary.key)
+        ).contains(Key(fileName))
+    } match {
+      case Failure(f) => { Left(CustomFailure.fromThrowable(f)) }
+      case Success(s) => { Right(s) }
     }
   }
 
-  def fileAlreadyExistsInS3(fileName: String): Boolean = {
+  def updateS3FileIfEmailDoesNotExist(caseEmail: EmailsFromSfResponse.Records): Option[String] = {
+    println("updateS3FileIfEmailDoesNotExist...")
+    val emailsInS3File = getEmailsInS3File(caseEmail)
 
-    val filesInS3MatchingFileName = AwsS3.client.listObjects(
-      ListObjectsRequest.builder
-        .bucket(bucketName)
-        .prefix(fileName)
-        .build()
-    ).contents.asScala.toList
-
-    filesInS3MatchingFileName
-      .map(
-        objSummary => Key(objSummary.key)
-      ).contains(Key(fileName))
-  }
-
-  def updateS3FileIfEmailDoesNotExist(caseEmail: EmailsFromSfResponse.Records): String = {
-
-    val s3FileJsonBody = getEmailsJsonFromS3File(bucketName, caseEmail.Parent.CaseNumber)
-    val decodedCaseEmailsFromS3 = decode[Seq[EmailsFromSfResponse.Records]](s3FileJsonBody)
-    val emailsInS3File = decodedCaseEmailsFromS3.getOrElse(Seq[EmailsFromSfResponse.Records]())
-
-    val emailAlreadyExistsInS3File = emailsInS3File.exists(_.Composite_Key__c == caseEmail.Composite_Key__c)
+    val emailAlreadyExistsInS3File = emailsInS3File
+      .getOrElse(Seq[EmailsFromSfResponse.Records]())
+      .exists(_.Composite_Key__c == caseEmail.Composite_Key__c)
 
     if (emailAlreadyExistsInS3File)
-      ""
+      None
     else {
-      val caseEmailsToSaveToS3 = emailsInS3File :+ caseEmail
+      val caseEmailsToSaveToS3 = emailsInS3File.getOrElse(Seq[EmailsFromSfResponse.Records]()) :+ caseEmail
       val successfulEmailId = writeEmailsJsonToS3(caseEmail.Parent.CaseNumber, caseEmailsToSaveToS3.asJson.toString(), caseEmail.Id)
       //todo what happens if there is a failure writing to S3?
-      caseEmail.Id
+      Some(caseEmail.Id)
     }
   }
+
+  def getEmailsInS3File(caseEmail: EmailsFromSfResponse.Records): Either[CustomFailure, Seq[EmailsFromSfResponse.Records]] = for {
+    s3FileJsonBody <- getEmailsJsonFromS3File(bucketName, caseEmail.Parent.CaseNumber)
+    decodedEmails <- decode[Seq[EmailsFromSfResponse.Records]](s3FileJsonBody)
+      .left
+      .map(CustomFailure.fromThrowable)
+  } yield decodedEmails
 
   def writeEmailsJsonToS3(fileName: String, caseEmailsJson: String, emailId: String): Either[Throwable, String] = {
 
@@ -87,14 +106,25 @@ object S3Connector extends LazyLogging {
       )
   }
 
-  def getEmailsJsonFromS3File(bucketName: String, fileName: String): String = {
-    val inputStream = AwsS3.client.getObject(
-      GetObjectRequest.builder
-        .bucket(bucketName)
-        .key(fileName)
-        .build()
-    )
-    Source.fromInputStream(inputStream).mkString
+  def getEmailsJsonFromS3File(bucketName: String, fileName: String): Either[CustomFailure, String] = {
+    println("get file from S3.....")
+    Try {
+      val inputStream = AwsS3.client.getObject(
+        GetObjectRequest.builder
+          .bucket(bucketName)
+          .key(fileName)
+          .build()
+      )
+      Source.fromInputStream(inputStream).mkString
+    } match {
+      case Success(s) => {
+        Right(s)
+      }
+      case Failure(ex) => {
+        println("ABC")
+        Left(CustomFailure(ex.getMessage))
+      }
+    }
   }
 
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -54,6 +54,7 @@ object S3Connector extends LazyLogging {
           val json = generateJsonForS3FileIfEmailDoesNotExist(caseEmail: EmailsFromSfResponse.Records)
           writeEmailsJsonToS3(caseEmail.Parent.CaseNumber, json, caseEmail.Id)
         } else {
+          logger.warn(s"${caseEmail.Composite_Key__c} already exists in S3")
           Right(None)
         }
       }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -5,6 +5,8 @@ import io.circe.generic.auto.exportDecoder
 import io.circe.parser.decode
 import scalaj.http.Http
 
+import scala.util.Try
+
 object SFConnector {
 
   case class SfAuthDetails(access_token: String, instance_url: String)
@@ -43,5 +45,23 @@ object SFConnector {
       )
       .asString
       .body
+  }
+
+  def doSfCompositeRequest(
+    sfAuthDetails: SfAuthDetails,
+    jsonBody: String,
+    requestType: String
+  ): Either[Throwable, String] = {
+
+    Try {
+      Http(
+        s"${sfAuthDetails.instance_url}/services/data/v45.0/composite/sobjects"
+      ).header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
+        .header("Content-Type", "application/json")
+        .put(jsonBody)
+        .method(requestType)
+        .asString
+        .body
+    }.toEither
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -2,7 +2,7 @@ package com.gu.sf_emails_to_s3_exporter
 
 import com.gu.sf_emails_to_s3_exporter.ConfirmationWriteBackToSF.{EmailMessageToUpdate, EmailMessagesToUpdate}
 import io.circe.Error
-import io.circe.generic.auto.{_}
+import io.circe.generic.auto._
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
 import scalaj.http.Http

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -37,7 +37,7 @@ object SFConnector {
       "PATCH"
     )
   }
-  
+
   def getEmailsFromSfByRecordsetReference(sfAuthDetails: SfAuthDetails, nextRecordsURL: String): Either[Error, EmailsFromSfResponse.Response] = {
     val responseBody = Http(s"${sfAuthDetails.instance_url}" + nextRecordsURL)
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -67,7 +67,7 @@ object SFConnector {
     sfAuthDetails: SfAuthDetails,
     jsonBody: String,
     requestType: String
-  ): Either[Throwable, String] = {
+  ): Try[String] = {
 
     Try {
       Http(
@@ -78,6 +78,6 @@ object SFConnector {
         .method(requestType)
         .asString
         .body
-    }.toEither
+    }
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -26,7 +26,6 @@ object SFConnector {
   }
 
   def writebackSuccessesToSf(sfAuthDetails: SfAuthDetails, successIds: Seq[String]): Either[Throwable, String] = {
-    println("writing success back to SF")
     val writebackResponse = doSfCompositeRequest(
       sfAuthDetails,
       EmailMessagesToUpdate(

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -25,7 +25,7 @@ object SFConnector {
     decode[EmailsFromSfResponse.Response](responseBody)
   }
 
-  def writebackSuccessesToSf(sfAuthDetails: SfAuthDetails, successIds: Seq[String]): Either[Throwable, String] = {
+  def writebackSuccessesToSf(sfAuthDetails: SfAuthDetails, successIds: Seq[String]): Try[String] = {
     doSfCompositeRequest(
       sfAuthDetails,
       EmailMessagesToUpdate(

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -26,7 +26,7 @@ object SFConnector {
   }
 
   def writebackSuccessesToSf(sfAuthDetails: SfAuthDetails, successIds: Seq[String]): Either[Throwable, String] = {
-    val writebackResponse = doSfCompositeRequest(
+    doSfCompositeRequest(
       sfAuthDetails,
       EmailMessagesToUpdate(
         false,
@@ -36,9 +36,8 @@ object SFConnector {
       ).asJson.toString(),
       "PATCH"
     )
-    println("writebackResponse:" + writebackResponse)
-    writebackResponse
   }
+  
   def getEmailsFromSfByRecordsetReference(sfAuthDetails: SfAuthDetails, nextRecordsURL: String): Either[Error, EmailsFromSfResponse.Response] = {
     val responseBody = Http(s"${sfAuthDetails.instance_url}" + nextRecordsURL)
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SalesforceConfig.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SalesforceConfig.scala
@@ -10,10 +10,10 @@ case class SalesforceConfig(
   apiVersion: String
 )
 
-object SalesforceConfig{
+object SalesforceConfig {
 
-  lazy val fromEnvironment : Option[SalesforceConfig] = {
-    for{
+  lazy val fromEnvironment: Option[SalesforceConfig] = {
+    for {
       sfUserName <- Option(System.getenv("username"))
       sfClientId <- Option(System.getenv("clientId"))
       sfClientSecret <- Option(System.getenv("clientSecret"))

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/WritebackToSFResponse.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/WritebackToSFResponse.scala
@@ -1,0 +1,9 @@
+package com.gu.sf_emails_to_s3_exporter
+
+object WritebackToSFResponse {
+  case class WritebackResponse(
+    id: String,
+    success: Boolean,
+    errors: Seq[Option[String]]
+  )
+}

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/WritebackToSFResponse.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/WritebackToSFResponse.scala
@@ -2,8 +2,16 @@ package com.gu.sf_emails_to_s3_exporter
 
 object WritebackToSFResponse {
   case class WritebackResponse(
-    id: String,
-    success: Boolean,
-    errors: Seq[Option[String]]
+    id: Option[String],
+    message: Option[String],
+    errorCode: Option[String],
+    success: Option[Boolean],
+    errors: Option[Seq[Option[Errors]]]
+  )
+
+  case class Errors(
+    statusCode: Option[String],
+    message: Option[String],
+    fields: Option[Seq[String]]
   )
 }


### PR DESCRIPTION
## Todo
- **[DONE]** LocalDateTime.now() is currently being used to get the datetime stamp but when it is being set in Salesforce is is significantly off what the actual datetime is. This should be fixed before deploying.
- **[DONE]** Error handling could do with some improvement. Any suggestions on this are welcome

## What does this change?

- Set a datestamp on EmailMessage.Most_Recent_Export__c when emails have been successfully saved to S3
- I needed to refactor the logic somewhat to obtain the email Ids from successful saves to S3. Now each email is being individually added to s3 files rather than being grouped by parent CaseNumber and then saving to S3.

## Execution Flow
[Document](https://docs.google.com/drawings/d/1RK5Ns3-yy3D5VJWg2hTEyr7XSXLZblbtC-JhRC7yyFY/edit?usp=sharing)

![image](https://user-images.githubusercontent.com/36296660/149968298-b1f929f6-a4e3-4007-ad7d-e7935e536da8.png)

## How to test

### Functional
1. Ensure there are emails to retrieve from Salesforce
2. Run the lambda.
3. Ensure that the emails are all saved to S3.
4. Ensure that the Most_Recent_Export__c timestamp is set on the Email Message records in Salesforce

### Performance
Perform the functional tests on large record sets.

I tested it with 1000 records and the lambda took 3mins 40s to complete, which is comfortably within the 15 min limit for a Lambda to run

## Error Handling

**Fatal Errors should log an error and exit**

- _Get config from env vars_
Remove password from environment vars (not username as a default username will be applied instead and ruin the test)
- _Authenticate with SF_
Alter password in environment vars so that authentication fails
- _Get emails from SF by query_
add malformed json to the query body

**Non-fatal error should log the error and continue**

_- Check if Case file exists in S3_
update s3 credentials for failure (as this is the first interaction with S3 in the execution flow)
- _Get file from S3_
add a malformed put request specifying a bucket name that does not exist
- _Create/Overwrite file in S3_
add a malformed put request specifying a bucket name that does not exist
- _Writeback successes to SF_
There are 2 types of failure that could occur in the writeback to Salesforce:

1. Problem with the request itself (malformed json/credentials issue etc)
Tested by using malformed json

2. Problem with the individual record that is being updated (record has been deleted, access to record not allowed etc)
Tested by using a malformed Id in the update call

## Notes
There has been a significant refactor to bring in error handling.

### Previous PRs

[Emails to s3 exporter - add pagination for larger recordsets #1324](https://github.com/guardian/support-service-lambdas/pull/1324)

[Create Basic Lambda - Sf emails to s3 exporter #1316](https://github.com/guardian/support-service-lambdas/pull/1316)

[Sf email exporter - authenticate with sf and get emails #1317](https://github.com/guardian/support-service-lambdas/pull/1317)

[Sf emails exporter group emails by case number and save as json in s3 #1320](https://github.com/guardian/support-service-lambdas/pull/1320)

[Emails to s3 exporter - Append to files in S3 instead of simple overwrite #1323](https://github.com/guardian/support-service-lambdas/pull/1323)


