### PR TITLE
Increase Salesforce read timeout threshold

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
@@ -38,7 +38,7 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
 
   private def sfHttp(url: String): HttpRequest = {
     Http(url)
-      .option(HttpOptions.readTimeout(30000))
+      .option(HttpOptions.readTimeout(60000))
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
       .header("Content-Type", "application/json")
   }


### PR DESCRIPTION
We're seeing occasional timeouts when reading from Salesforce, which appears to be down to the time it takes to build up the query result set in Salesforce.  This is a short-term measure while we look at optimising the query.