### PR TITLE
Replace email in s3 file if it already exists

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -36,6 +36,7 @@ object Handler extends LazyLogging {
   }
 
   def processEmails(sfAuthDetails: SfAuthDetails, emailsDataFromSF: EmailsFromSfResponse.Response, bucketName: String): Any = {
+    logger.info(s"Start processing ${emailsDataFromSF.records.size} emails...")
 
     val emailIdsSuccessfullySavedToS3 = getEmailIdsSuccessfullySavedToS3(emailsDataFromSF, bucketName)
 
@@ -52,6 +53,7 @@ object Handler extends LazyLogging {
       )
     }
 
+    logger.info("More emails to retrieve from Salesforce:" + !emailsDataFromSF.done)
     //process more emails if they exist
     if (!emailsDataFromSF.done) {
       processNextPageOfEmails(sfAuthDetails, emailsDataFromSF.nextRecordsUrl.get, bucketName)

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -21,10 +21,13 @@ object S3Connector extends LazyLogging {
   def saveEmailToS3(caseEmail: EmailsFromSfResponse.Records, bucketName: String): Either[CustomFailure, Option[String]] = {
 
     val fileExists = fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber, bucketName)
+    logger.info(s"${caseEmail.Parent.CaseNumber} already exists in S3: " + fileExists)
 
     fileExists match {
 
-      case Left(ex) => { Left(ex) }
+      case Left(ex) => {
+        Left(ex)
+      }
 
       case Right(false) => {
         val json = generateJsonForS3FileIfFileDoesNotExist(Seq[EmailsFromSfResponse.Records](caseEmail), bucketName)
@@ -38,6 +41,8 @@ object S3Connector extends LazyLogging {
           .getOrElse(Seq[EmailsFromSfResponse.Records]())
           .exists(_.Composite_Key__c == caseEmail.Composite_Key__c)
 
+        logger.info(s" ${caseEmail.Composite_Key__c} already exists in file: ${emailAlreadyExistsInS3File} ")
+
         val json = (if (emailAlreadyExistsInS3File) {
           generateJsonForS3FileIfEmailAlreadyExists(emailsInS3File.getOrElse(Seq[EmailsFromSfResponse.Records]()), caseEmail)
         } else {
@@ -49,26 +54,34 @@ object S3Connector extends LazyLogging {
     }
   }
 
-  def fileAlreadyExistsInS3(fileName: String, bucketName: String): Either[CustomFailure, Boolean] = safely({
-    val filesInS3MatchingFileName = AwsS3.client.listObjects(
-      ListObjectsRequest.builder
-        .bucket(bucketName)
-        .prefix(fileName)
-        .build()
-    ).contents.asScala.toList
+  def fileAlreadyExistsInS3(fileName: String, bucketName: String): Either[CustomFailure, Boolean] = {
+    logger.info(s"Checking if $fileName exists in S3...")
 
-    filesInS3MatchingFileName
-      .map(
-        objSummary => Key(objSummary.key)
-      ).contains(Key(fileName))
-  })
+    safely({
+      val filesInS3MatchingFileName = AwsS3.client.listObjects(
+        ListObjectsRequest.builder
+          .bucket(bucketName)
+          .prefix(fileName)
+          .build()
+      ).contents.asScala.toList
 
-  def getEmailsInS3File(caseEmail: EmailsFromSfResponse.Records, bucketName: String): Either[CustomFailure, Seq[EmailsFromSfResponse.Records]] = for {
-    s3FileJsonBody <- getEmailsJsonFromS3File(caseEmail.Parent.CaseNumber, bucketName)
-    decodedEmails <- decode[Seq[EmailsFromSfResponse.Records]](s3FileJsonBody)
-      .left
-      .map(CustomFailure.fromThrowable)
-  } yield decodedEmails
+      filesInS3MatchingFileName
+        .map(
+          objSummary => Key(objSummary.key)
+        ).contains(Key(fileName))
+    })
+  }
+
+  def getEmailsInS3File(caseEmail: EmailsFromSfResponse.Records, bucketName: String): Either[CustomFailure, Seq[EmailsFromSfResponse.Records]] = {
+    logger.info(s"Retrieving emails from ${caseEmail.Parent.CaseNumber}... ")
+
+    for {
+      s3FileJsonBody <- getEmailsJsonFromS3File(caseEmail.Parent.CaseNumber, bucketName)
+      decodedEmails <- decode[Seq[EmailsFromSfResponse.Records]](s3FileJsonBody)
+        .left
+        .map(CustomFailure.fromThrowable)
+    } yield decodedEmails
+  }
 
   def writeEmailsJsonToS3(fileName: String, caseEmailsJson: String, emailId: String, bucketName: String): Either[CustomFailure, Option[String]] = {
 
@@ -80,7 +93,10 @@ object S3Connector extends LazyLogging {
 
     uploadResponse match {
       case Left(ex) => { Left(ex) }
-      case Right(value) => { Right(Some(emailId)) }
+      case Right(value) => {
+        logger.info(s"$fileName successfully saved to S3")
+        Right(Some(emailId))
+      }
     }
   }
 
@@ -90,42 +106,63 @@ object S3Connector extends LazyLogging {
     Source.fromInputStream(inputStream).mkString
   }
 
-  def getS3File(fileName: String, bucketName: String): Either[CustomFailure, ResponseInputStream[GetObjectResponse]] = safely(
-    AwsS3.client.getObject(
-      GetObjectRequest.builder
+  def getS3File(fileName: String, bucketName: String): Either[CustomFailure, ResponseInputStream[GetObjectResponse]] = {
+    logger.info(s"Getting $fileName from S3")
+
+    safely(
+      AwsS3.client.getObject(
+        GetObjectRequest.builder
+          .bucket(bucketName)
+          .key(fileName)
+          .build()
+      )
+    )
+  }
+
+  def generatePutRequestBody(caseEmailsJson: String): Either[CustomFailure, RequestBody] = {
+    logger.info(s"Generating PutRequestBody... ")
+
+    safely(
+      RequestBody.fromString(caseEmailsJson, StandardCharsets.UTF_8)
+    )
+  }
+
+  def uploadFileToS3(putRequest: PutObjectRequest, requestBody: RequestBody): Either[CustomFailure, Try[PutObjectResponse]] = {
+    logger.info(s"saving file (${putRequest.key()}) to S3... ")
+
+    safely(
+      UploadToS3.putObject(putRequest, requestBody)
+    )
+  }
+
+  def generateS3PutRequest(bucketName: String, fileName: String): Either[CustomFailure, PutObjectRequest] = {
+    logger.info(s"Generating PutRequest for ${fileName}... ")
+
+    safely(
+      PutObjectRequest
+        .builder
         .bucket(bucketName)
         .key(fileName)
         .build()
     )
-  )
-
-  def generatePutRequestBody(caseEmailsJson: String): Either[CustomFailure, RequestBody] = safely(
-    RequestBody.fromString(caseEmailsJson, StandardCharsets.UTF_8)
-  )
-
-  def uploadFileToS3(putRequest: PutObjectRequest, requestBody: RequestBody): Either[CustomFailure, Try[PutObjectResponse]] = safely(
-    UploadToS3.putObject(putRequest, requestBody)
-  )
-
-  def generateS3PutRequest(bucketName: String, fileName: String): Either[CustomFailure, PutObjectRequest] = safely(
-    PutObjectRequest
-      .builder
-      .bucket(bucketName)
-      .key(fileName)
-      .build()
-  )
+  }
 
   def generateJsonForS3FileIfEmailDoesNotExist(emailsInS3File: Seq[EmailsFromSfResponse.Records], caseEmail: EmailsFromSfResponse.Records): String = {
+    logger.info(s"Generating json for ${caseEmail.Composite_Key__c}... ")
 
     (emailsInS3File :+ caseEmail).asJson.toString()
 
   }
 
   def generateJsonForS3FileIfFileDoesNotExist(caseEmailsToSaveToS3: Seq[EmailsFromSfResponse.Records], bucketName: String): String = {
+    logger.info(s"Generating json for ${caseEmailsToSaveToS3.head.Composite_Key__c}... ")
+
     caseEmailsToSaveToS3.asJson.toString()
   }
 
   def generateJsonForS3FileIfEmailAlreadyExists(emailsInS3File: Seq[EmailsFromSfResponse.Records], caseEmail: EmailsFromSfResponse.Records): String = {
+    logger.info(s"Generating json for ${caseEmail.Composite_Key__c}... ")
+
     (emailsInS3File.filter(_.Composite_Key__c != caseEmail.Composite_Key__c) :+ caseEmail).asJson.toString()
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -13,7 +13,9 @@ object SFConnector extends LazyLogging {
 
   case class SfAuthDetails(access_token: String, instance_url: String)
 
-  def getEmailsFromSfByQuery(sfAuthDetails: SfAuthDetails, sfApiVersion:String): Either[Error, EmailsFromSfResponse.Response] = {
+  def getEmailsFromSfByQuery(sfAuthDetails: SfAuthDetails, sfApiVersion: String): Either[Error, EmailsFromSfResponse.Response] = {
+    logger.info("Getting emails from sf by query...")
+
     val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/$sfApiVersion/query/")
       .param("q", GetEmailsQuery.query)
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
@@ -26,6 +28,7 @@ object SFConnector extends LazyLogging {
   }
 
   def writebackSuccessesToSf(sfAuthDetails: SfAuthDetails, successIds: Seq[String]): Either[Error, Seq[WritebackToSFResponse.WritebackResponse]] = {
+    logger.info("Writing successes back to Salesforce...")
 
     doSfCompositeRequest(
       sfAuthDetails,
@@ -49,6 +52,8 @@ object SFConnector extends LazyLogging {
   }
 
   def getEmailsFromSfByRecordsetReference(sfAuthDetails: SfAuthDetails, nextRecordsURL: String): Either[Error, EmailsFromSfResponse.Response] = {
+    logger.info("Getting next batch of emails from sf by recordset reference...")
+
     val responseBody = Http(s"${sfAuthDetails.instance_url}" + nextRecordsURL)
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
       .method("GET")
@@ -58,21 +63,25 @@ object SFConnector extends LazyLogging {
     decode[EmailsFromSfResponse.Response](responseBody)
   }
 
-  def auth(salesforceConfig: SalesforceConfig): Either[CustomFailure, String] = safely(
+  def auth(salesforceConfig: SalesforceConfig): Either[CustomFailure, String] = {
+    logger.info("Authenticating with Salesforce...")
 
-    Http(s"${salesforceConfig.authUrl}/services/oauth2/token")
-      .postForm(
-        Seq(
-          "grant_type" -> "password",
-          "client_id" -> salesforceConfig.clientId,
-          "client_secret" -> salesforceConfig.clientSecret,
-          "username" -> salesforceConfig.userName,
-          "password" -> s"${salesforceConfig.password}${salesforceConfig.token}"
+    safely(
+
+      Http(s"${salesforceConfig.authUrl}/services/oauth2/token")
+        .postForm(
+          Seq(
+            "grant_type" -> "password",
+            "client_id" -> salesforceConfig.clientId,
+            "client_secret" -> salesforceConfig.clientSecret,
+            "username" -> salesforceConfig.userName,
+            "password" -> s"${salesforceConfig.password}${salesforceConfig.token}"
+          )
         )
-      )
-      .asString
-      .body
-  )
+        .asString
+        .body
+    )
+  }
 
   def doSfCompositeRequest(
     sfAuthDetails: SfAuthDetails,


### PR DESCRIPTION
## What does this change?
When an email is exported from Salesforce to S3, a check is made as to whether or not the email already exists in the S3 file. The changes in this PR _replace_ the email in the S3 file if it already exists.

## Context
Previously if an email already existed in the S3 file, the logic would just do nothing and continue processing (i.e. it would not replace the email in the file because there was no need). 

This had the side effect of no writeback to Salesforce to indicate a successful export. We have decided to replace the email in the file rather than ignore it so that the datetime of the export can be written back to Salesforce to drive the state in the 'Export_Status__c' field and thus enable the deletion of the record in Salesforce once successfully exported


## How to test
- export an email from Salesforce to S3
- verify the email has been successfully saved in a file in S3
- Change a value on the email in Salesforce on one of the fields that are part of the export
- export the same email again
- verify that the email has been overwritten in the S3 file
- verify that the timestamp of the action has been written back to the email in Salesforce
