### PR TITLE
emails to s3 - fix env var names

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -14,9 +14,11 @@ Mappings:
     PROD:
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
+      ToLowerCase: prod
     DEV:
       SalesforceUsername: EmailsToS3APIUser
       AppName: AwsConnectorSandbox
+      ToLowerCase: dev
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
@@ -68,24 +70,36 @@ Resources:
             - Effect: Allow
               Action: s3:GetObject
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
         - Statement:
             - Effect: Allow
               Action: s3:PutObject
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
         - Statement:
             - Effect: Allow
               Action: s3:ListBucket
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
         - Statement:
             - Effect: Allow
               Action: s3:ListObjectV2
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
         - Statement:
             - Sid: readDeployedArtefact
               Effect: Allow

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -14,11 +14,9 @@ Mappings:
     PROD:
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
-      ToLowerCase: prod
     DEV:
       SalesforceUsername: EmailsToS3APIUser
       AppName: AwsConnectorSandbox
-      ToLowerCase: dev
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
@@ -70,36 +68,24 @@ Resources:
             - Effect: Allow
               Action: s3:GetObject
               Resource:
-                - !Sub
-                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
-                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
         - Statement:
             - Effect: Allow
               Action: s3:PutObject
               Resource:
-                - !Sub
-                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
-                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
         - Statement:
             - Effect: Allow
               Action: s3:ListBucket
               Resource:
-                - !Sub
-                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}"
-                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
-                - !Sub
-                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
-                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+                - !Sub arn:aws:s3:::emails-from-sf-${Stage}
+                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
         - Statement:
             - Effect: Allow
               Action: s3:ListObjectV2
               Resource:
-                - !Sub
-                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}"
-                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
-                - !Sub
-                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
-                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+                - !Sub arn:aws:s3:::emails-from-sf-${Stage}
+                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
         - Statement:
             - Sid: readDeployedArtefact
               Effect: Allow

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -14,9 +14,11 @@ Mappings:
     PROD:
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
+      ToLowerCase: prod
     DEV:
       SalesforceUsername: EmailsToS3APIUser
       AppName: AwsConnectorSandbox
+      ToLowerCase: dev
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
@@ -68,24 +70,36 @@ Resources:
             - Effect: Allow
               Action: s3:GetObject
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-dev/*
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
         - Statement:
             - Effect: Allow
               Action: s3:PutObject
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-dev/*
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
         - Statement:
             - Effect: Allow
               Action: s3:ListBucket
               Resource:
-                - arn:aws:s3:::emails-from-sf-dev
-                - arn:aws:s3:::emails-from-sf-dev/*
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
         - Statement:
             - Effect: Allow
               Action: s3:ListObjectV2
               Resource:
-                - arn:aws:s3:::emails-from-sf-dev
-                - arn:aws:s3:::emails-from-sf-dev/*
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+                - !Sub
+                  - "arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*"
+                  - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
         - Statement:
             - Sid: readDeployedArtefact
               Effect: Allow

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -78,12 +78,14 @@ Resources:
             - Effect: Allow
               Action: s3:ListBucket
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-dev/*
+                - arn:aws:s3:::emails-from-sf-dev
+                - arn:aws:s3:::emails-from-sf-dev/*
         - Statement:
             - Effect: Allow
               Action: s3:ListObjectV2
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-dev/*
+                - arn:aws:s3:::emails-from-sf-dev
+                - arn:aws:s3:::emails-from-sf-dev/*
         - Statement:
             - Sid: readDeployedArtefact
               Effect: Allow

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -80,6 +80,11 @@ Resources:
               Resource:
                 - !Sub arn:aws:s3:::emails-from-sf-dev/*
         - Statement:
+            - Effect: Allow
+              Action: s3:ListObjectV2
+              Resource:
+                - !Sub arn:aws:s3:::emails-from-sf-dev/*
+        - Statement:
             - Sid: readDeployedArtefact
               Effect: Allow
               Action: s3:GetObject

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -68,17 +68,17 @@ Resources:
             - Effect: Allow
               Action: s3:GetObject
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
+                - !Sub arn:aws:s3:::emails-from-sf-dev/*
         - Statement:
             - Effect: Allow
               Action: s3:PutObject
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
+                - !Sub arn:aws:s3:::emails-from-sf-dev/*
         - Statement:
             - Effect: Allow
               Action: s3:ListBucket
               Resource:
-                - !Sub arn:aws:s3:::emails-from-sf-${Stage}/*
+                - !Sub arn:aws:s3:::emails-from-sf-dev/*
         - Statement:
             - Sid: readDeployedArtefact
               Effect: Allow

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Config.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Config.scala
@@ -22,7 +22,7 @@ case class S3Config(
 object Config {
   lazy val fromEnvironment: Option[Config] = {
     for {
-      sfUserName <- Option(System.getenv("sfUserName"))
+      sfUserName <- Option(System.getenv("sfUsername"))
       sfClientId <- Option(System.getenv("sfClientId"))
       sfClientSecret <- Option(System.getenv("sfClientSecret"))
       sfPassword <- Option(System.getenv("sfPassword"))

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Config.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Config.scala
@@ -22,13 +22,13 @@ case class S3Config(
 object Config {
   lazy val fromEnvironment: Option[Config] = {
     for {
-      sfUserName <- Option(System.getenv("username"))
-      sfClientId <- Option(System.getenv("clientId"))
-      sfClientSecret <- Option(System.getenv("clientSecret"))
-      sfPassword <- Option(System.getenv("password"))
-      sfToken <- Option(System.getenv("token"))
-      sfAuthUrl <- Option(System.getenv("authUrl"))
-      sfApiVersion <- Option(System.getenv("apiVersion"))
+      sfUserName <- Option(System.getenv("sfUserName"))
+      sfClientId <- Option(System.getenv("sfClientId"))
+      sfClientSecret <- Option(System.getenv("sfClientSecret"))
+      sfPassword <- Option(System.getenv("sfPassword"))
+      sfToken <- Option(System.getenv("sfToken"))
+      sfAuthUrl <- Option(System.getenv("sfAuthUrl"))
+      sfApiVersion <- Option(System.getenv("sfApiVersion"))
       s3BucketName <- Option(System.getenv("bucketName"))
     } yield Config(
       SalesforceConfig(

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -20,7 +20,7 @@ object Handler extends LazyLogging {
       config <- Config.fromEnvironment.toRight("Missing config value")
       authentication <- auth(config.sfConfig)
       sfAuthDetails <- decode[SfAuthDetails](authentication)
-      emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails)
+      emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails, config.sfConfig.apiVersion)
     } yield processEmails(sfAuthDetails, emailsFromSF, config.s3Config.bucketName)
 
     emailsFromSF match {

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -3,8 +3,6 @@ package com.gu.sf_emails_to_s3_exporter
 import com.gu.sf_emails_to_s3_exporter.S3Connector.saveEmailToS3
 import com.gu.sf_emails_to_s3_exporter.SFConnector._
 import com.typesafe.scalalogging.LazyLogging
-import io.circe.generic.auto._
-import io.circe.parser._
 
 import scala.util.Try
 
@@ -16,22 +14,33 @@ object Handler extends LazyLogging {
 
   def handleRequest(): Unit = {
 
-    val emailsFromSF = for {
-      config <- Config.fromEnvironment.toRight("Missing config value")
-      authentication <- auth(config.sfConfig)
-      sfAuthDetails <- decode[SfAuthDetails](authentication)
-      emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails, config.sfConfig.apiVersion)
-    } yield processEmails(sfAuthDetails, emailsFromSF, config.s3Config.bucketName)
+    println("sfUserName:"+System.getenv("sfUserName"))
+    println("sfClientId:"+System.getenv("sfClientId"))
+    println("sfClientSecret:"+System.getenv("sfClientSecret"))
+    println("sfPassword:"+System.getenv("sfPassword"))
+    println("sfToken:"+System.getenv("sfToken"))
+    println("sfAuthUrl:"+System.getenv("sfAuthUrl"))
+    println("sfApiVersion:"+System.getenv("sfApiVersion"))
+    println("bucketName:"+System.getenv("bucketName"))
 
-    emailsFromSF match {
-      case Left(ex) => {
-        logger.error("Error: " + ex)
-        throw new RuntimeException(ex.toString)
-      }
-      case Right(success) => {
-        logger.info("Processing complete")
-      }
-    }
+//    val emailsFromSF = for {
+//      config <- Config.fromEnvironment.toRight("Missing config value")
+//      authentication <- auth(config.sfConfig)
+//      sfAuthDetails <- decode[SfAuthDetails](authentication)
+//      emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails, config.sfConfig.apiVersion)
+//    } yield config
+
+
+
+//    emailsFromSF match {
+//      case Left(ex) => {
+//        logger.error("Error: " + ex)
+//        throw new RuntimeException(ex.toString)
+//      }
+//      case Right(success) => {
+//        logger.info("Processing complete")
+//      }
+//    }
 
   }
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -3,6 +3,8 @@ package com.gu.sf_emails_to_s3_exporter
 import com.gu.sf_emails_to_s3_exporter.S3Connector.saveEmailToS3
 import com.gu.sf_emails_to_s3_exporter.SFConnector._
 import com.typesafe.scalalogging.LazyLogging
+import io.circe.generic.auto._
+import io.circe.parser._
 
 import scala.util.Try
 
@@ -14,33 +16,22 @@ object Handler extends LazyLogging {
 
   def handleRequest(): Unit = {
 
-    println("sfUserName:"+System.getenv("sfUserName"))
-    println("sfClientId:"+System.getenv("sfClientId"))
-    println("sfClientSecret:"+System.getenv("sfClientSecret"))
-    println("sfPassword:"+System.getenv("sfPassword"))
-    println("sfToken:"+System.getenv("sfToken"))
-    println("sfAuthUrl:"+System.getenv("sfAuthUrl"))
-    println("sfApiVersion:"+System.getenv("sfApiVersion"))
-    println("bucketName:"+System.getenv("bucketName"))
+    val emailsFromSF = for {
+      config <- Config.fromEnvironment.toRight("Missing config value")
+      authentication <- auth(config.sfConfig)
+      sfAuthDetails <- decode[SfAuthDetails](authentication)
+      emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails, config.sfConfig.apiVersion)
+    } yield processEmails(sfAuthDetails, emailsFromSF, config.s3Config.bucketName)
 
-//    val emailsFromSF = for {
-//      config <- Config.fromEnvironment.toRight("Missing config value")
-//      authentication <- auth(config.sfConfig)
-//      sfAuthDetails <- decode[SfAuthDetails](authentication)
-//      emailsFromSF <- getEmailsFromSfByQuery(sfAuthDetails, config.sfConfig.apiVersion)
-//    } yield config
-
-
-
-//    emailsFromSF match {
-//      case Left(ex) => {
-//        logger.error("Error: " + ex)
-//        throw new RuntimeException(ex.toString)
-//      }
-//      case Right(success) => {
-//        logger.info("Processing complete")
-//      }
-//    }
+    emailsFromSF match {
+      case Left(ex) => {
+        logger.error("Error: " + ex)
+        throw new RuntimeException(ex.toString)
+      }
+      case Right(success) => {
+        logger.info("Processing complete")
+      }
+    }
 
   }
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -50,12 +50,14 @@ object S3Connector extends LazyLogging {
   }
 
   def fileAlreadyExistsInS3(fileName: String, bucketName: String): Either[CustomFailure, Boolean] = safely({
+    println("bucketName:"+bucketName)
     val filesInS3MatchingFileName = AwsS3.client.listObjects(
       ListObjectsRequest.builder
         .bucket(bucketName)
         .prefix(fileName)
         .build()
     ).contents.asScala.toList
+    println("filesInS3MatchingFileName:"+filesInS3MatchingFileName)
 
     filesInS3MatchingFileName
       .map(

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -50,14 +50,12 @@ object S3Connector extends LazyLogging {
   }
 
   def fileAlreadyExistsInS3(fileName: String, bucketName: String): Either[CustomFailure, Boolean] = safely({
-    println("bucketName:"+bucketName)
     val filesInS3MatchingFileName = AwsS3.client.listObjects(
       ListObjectsRequest.builder
         .bucket(bucketName)
         .prefix(fileName)
         .build()
     ).contents.asScala.toList
-    println("filesInS3MatchingFileName:"+filesInS3MatchingFileName)
 
     filesInS3MatchingFileName
       .map(

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -13,8 +13,8 @@ object SFConnector extends LazyLogging {
 
   case class SfAuthDetails(access_token: String, instance_url: String)
 
-  def getEmailsFromSfByQuery(sfAuthDetails: SfAuthDetails): Either[Error, EmailsFromSfResponse.Response] = {
-    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/${System.getenv("sfApiVersion")}/query/")
+  def getEmailsFromSfByQuery(sfAuthDetails: SfAuthDetails, sfApiVersion:String): Either[Error, EmailsFromSfResponse.Response] = {
+    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/$sfApiVersion/query/")
       .param("q", GetEmailsQuery.query)
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
       .header("Sforce-Query-Options", "batchSize=200")

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -14,7 +14,7 @@ object SFConnector extends LazyLogging {
   case class SfAuthDetails(access_token: String, instance_url: String)
 
   def getEmailsFromSfByQuery(sfAuthDetails: SfAuthDetails): Either[Error, EmailsFromSfResponse.Response] = {
-    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/${System.getenv("apiVersion")}/query/")
+    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/${System.getenv("sfApiVersion")}/query/")
       .param("q", GetEmailsQuery.query)
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
       .header("Sforce-Query-Options", "batchSize=200")


### PR DESCRIPTION
## What does this change?

Somehow the environment variable names fell out of sync with their references within the logic. This PR ensures they remain consistent between their definitions and their references

## How to test
- execute the lambda and verify that files are saved to s3 and successes are written back as a timestamps to EmailMessage.Most_Recent_Export__c
