### PR TITLE
add comment to update zuora everywhere if the callout is changed

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
@@ -14,7 +14,7 @@ case class AutoCancelCallout(
   creditCardExpirationYear: String,
   invoiceId: String,
   currency: String,
-  sfContactId: String
+  sfContactId: String // NOTE: if this payload is changed, you MUST change all the notification "profiles" in zuora to match
 ) {
   def isAutoPay = autoPay == "true"
   def nonDirectDebit = paymentMethodType != "BankTransfer"


### PR DESCRIPTION
## What does this change?

This adds a comment to remind us to change all relevant notification profiles in zuora prod if we change the auto cancel callout case class.

This is needed because otherwise people not on the default profile would no longer be auto cancelled correctly.
![image](https://user-images.githubusercontent.com/7304387/151187600-40bb42a0-f830-4e84-8093-ea9c891980b1.png)

![image](https://user-images.githubusercontent.com/7304387/151187408-69e96138-bcbc-409d-a6ba-5a5e6fe7fb27.png)
