### PR TITLE
Log errors on error when lambda interacting with s3

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/CustomFailure.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/CustomFailure.scala
@@ -1,9 +1,12 @@
 package com.gu.sf_emails_to_s3_exporter
 
+import com.typesafe.scalalogging.LazyLogging
+
 case class CustomFailure(message: String)
 
-object CustomFailure {
+object CustomFailure extends LazyLogging {
   def fromThrowable(throwable: Throwable): CustomFailure = {
+    logger.error("CustomFailure:" + throwable.getMessage)
     CustomFailure(throwable.getMessage)
   }
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -70,7 +70,6 @@ object Handler extends LazyLogging {
     } yield saveToS3Attempt
 
     saveToS3Attempts.collect { case Right(value) => value }
-
   }
 
   def processNextPageOfEmails(sfAuthDetails: SfAuthDetails, url: String, bucketName: String): Unit = {

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -63,11 +63,14 @@ object Handler extends LazyLogging {
 
   def getEmailIdsSuccessfullySavedToS3(emailsDataFromSF: EmailsFromSfResponse.Response, bucketName: String): Seq[String] = {
 
-    emailsDataFromSF
-      .records
-      .map(email => saveEmailToS3(email, bucketName))
-      .collect { case Right(value) => value }
-      .flatten
+    val saveToS3Attempts = for {
+      saveToS3Attempt <- emailsDataFromSF
+        .records
+        .map(email => saveEmailToS3(email, bucketName))
+    } yield saveToS3Attempt
+
+    saveToS3Attempts.collect { case Right(value) => value }
+
   }
 
   def processNextPageOfEmails(sfAuthDetails: SfAuthDetails, url: String, bucketName: String): Unit = {

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -48,7 +48,6 @@ object S3Connector extends LazyLogging {
           generateJsonForS3FileIfEmailDoesNotExist(emailsInS3File.getOrElse(Seq[EmailsFromSfResponse.Records]()), caseEmail)
         })
         writeEmailsJsonToS3(caseEmail.Parent.CaseNumber, json, caseEmail.Id, bucketName)
-
       }
     }
 

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -24,6 +24,8 @@ object S3Connector extends LazyLogging {
       exists <- fileAlreadyExistsInS3(caseEmail.Parent.CaseNumber, bucketName)
     } yield exists
 
+    logger.info(s"${caseEmail.Parent.CaseNumber} already exists in S3: " + fileExists)
+
     fileExists match {
 
       case Left(ex) => { Left(ex) }
@@ -39,9 +41,7 @@ object S3Connector extends LazyLogging {
         val emailAlreadyExistsInS3File = emailsInS3File
           .getOrElse(Seq[EmailsFromSfResponse.Records]())
           .exists(_.Composite_Key__c == caseEmail.Composite_Key__c)
-
-        logger.info(s" ${caseEmail.Composite_Key__c} already exists in file: ${emailAlreadyExistsInS3File} ")
-
+        
         val json = (if (emailAlreadyExistsInS3File) {
           generateJsonForS3FileIfEmailAlreadyExists(emailsInS3File.getOrElse(Seq[EmailsFromSfResponse.Records]()), caseEmail)
         } else {

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -156,20 +156,6 @@ object S3Connector extends LazyLogging {
     )
   }
 
-  def updateFileContentsWithNewEmail(
-    emailsAlreadyInFile: Seq[EmailsFromSfResponse.Records],
-    newEmail: EmailsFromSfResponse.Records,
-    bucketName: String,
-    newEmailAlreadyExistsInFile: Boolean
-  ): Either[CustomFailure, String] =
-
-    writeEmailsJsonToS3(
-      newEmail.Parent.CaseNumber,
-      generateJsonForExistingFile(emailsAlreadyInFile, newEmail, newEmailAlreadyExistsInFile),
-      newEmail.Id,
-      bucketName
-    )
-
   def generateJsonForExistingFile(
     emailsAlreadyInFile: Seq[EmailsFromSfResponse.Records],
     newEmail: EmailsFromSfResponse.Records,

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.s3.model._
 
 import scala.io.Source
 import scala.jdk.CollectionConverters.CollectionHasAsScala
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object S3Connector extends LazyLogging {
 
@@ -93,8 +93,13 @@ object S3Connector extends LazyLogging {
     uploadResponse match {
       case Left(ex) => { Left(ex) }
       case Right(value) => {
-        logger.info(s"$fileName successfully saved to S3")
-        Right(emailId)
+        value match {
+          case Failure(ex) => { Left(CustomFailure.fromThrowable(ex)) }
+          case Success(success) => {
+            logger.info(s"$fileName successfully saved to S3")
+            Right(emailId)
+          }
+        }
       }
     }
   }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/S3Connector.scala
@@ -121,7 +121,7 @@ object S3Connector extends LazyLogging {
     safely(
       AwsS3.client.getObject(
         GetObjectRequest.builder
-          .bucket(bucketName + "22")
+          .bucket(bucketName)
           .key(fileName)
           .build()
       )
@@ -156,23 +156,28 @@ object S3Connector extends LazyLogging {
     )
   }
 
-  def updateFileContentsWithNewEmail(emailsAlreadyInFile: Seq[EmailsFromSfResponse.Records],
-                                     newEmail: EmailsFromSfResponse.Records,
-                                     bucketName: String,
-                                     newEmailAlreadyExistsInFile: Boolean): Either[CustomFailure, String] =
+  def updateFileContentsWithNewEmail(
+    emailsAlreadyInFile: Seq[EmailsFromSfResponse.Records],
+    newEmail: EmailsFromSfResponse.Records,
+    bucketName: String,
+    newEmailAlreadyExistsInFile: Boolean
+  ): Either[CustomFailure, String] =
 
-      writeEmailsJsonToS3(newEmail.Parent.CaseNumber,
-                          generateJsonForExistingFile(emailsAlreadyInFile, newEmail, newEmailAlreadyExistsInFile),
-                          newEmail.Id,
-                          bucketName)
+    writeEmailsJsonToS3(
+      newEmail.Parent.CaseNumber,
+      generateJsonForExistingFile(emailsAlreadyInFile, newEmail, newEmailAlreadyExistsInFile),
+      newEmail.Id,
+      bucketName
+    )
 
-
-  def generateJsonForExistingFile(emailsAlreadyInFile: Seq[EmailsFromSfResponse.Records],
-                                  newEmail: EmailsFromSfResponse.Records,
-                                  newEmailAlreadyExistsInFile: Boolean): String = {
+  def generateJsonForExistingFile(
+    emailsAlreadyInFile: Seq[EmailsFromSfResponse.Records],
+    newEmail: EmailsFromSfResponse.Records,
+    newEmailAlreadyExistsInFile: Boolean
+  ): String = {
     logger.info(s"Generating json for ${newEmail.Composite_Key__c}... ")
 
-    if (newEmailAlreadyExistsInFile){
+    if (newEmailAlreadyExistsInFile) {
       (emailsAlreadyInFile.filter(_.Composite_Key__c != newEmail.Composite_Key__c) :+ newEmail).asJson.toString()
     } else {
       (emailsAlreadyInFile :+ newEmail).asJson.toString()


### PR DESCRIPTION
## What does this change?
Addresses bugs found during integration testing ([Emails to S3 - Test Plan](https://docs.google.com/spreadsheets/d/1pOed7S1pUihszcDuxL11XAIereOImgfuJf1_x7mM5GE/edit?usp=sharing&gid=507774059)):

T7	Export Email	Fail (Check file exists in S3 fails) 
T8	Export Email	Fail (Get S3 File fails)
T9	Export Email	Fail (Overwrite S3 File fails)
T10	Export Email	Fail (Create File in S3) 

Changes have been made to:
- Log errors when ListObjects, GetObject or PutObject occur when reading/writing from/to S3 Bucket
- Ensure successful writeback to Salesforce does not happen when one of the above errors occur

## How to test

- Ensure that there is at least one email in Salesforce marked as 'Ready for Export to S3'
- Ensure that the logic is using a bucketname that does not exist in order to simulate a Read/Write error from S3
- Execute the Lambda
- Verify that a CustomFailure is returned and error message is logged
- Verify that a successful writeback to Salesforce does not occur