### PR TITLE
emails to s3 - handle sf writeback errors at both Request level and at Record level

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Handler.scala
@@ -38,16 +38,25 @@ object Handler extends LazyLogging {
   def processEmails(sfAuthDetails: SfAuthDetails, emailsDataFromSF: EmailsFromSfResponse.Response, bucketName: String): Any = {
     logger.info(s"Start processing ${emailsDataFromSF.records.size} emails...")
 
-    val emailIdsSuccessfullySavedToS3 = getEmailIdsSuccessfullySavedToS3(emailsDataFromSF, bucketName)
+    val emailIdsSuccessfullySavedToS3 = saveEmailsToS3(emailsDataFromSF, bucketName)
 
     if (!emailIdsSuccessfullySavedToS3.isEmpty) {
       writebackSuccessesToSf(sfAuthDetails, emailIdsSuccessfullySavedToS3).map(
-        response => response.map(
-          individualEmailUpdateAttempt =>
-            if (individualEmailUpdateAttempt.success.get) {
-              logger.info("Successful write back to sf for record:" + individualEmailUpdateAttempt.id)
-            } else {
-              logger.info("Failed to write back to sf for record:" + individualEmailUpdateAttempt)
+
+        responseArray => responseArray.map(
+
+          responseArrayItem =>
+
+            responseArrayItem.success.getOrElse(None) match {
+              case true => {
+                logger.info(s"Successful write back to sf for record:${responseArrayItem.id}")
+              }
+              case false => {
+                logger.error(s"Failed to write back to sf for record:$responseArrayItem")
+              }
+              case none => {
+                logger.error(s"Failed write back Request. errorCode(${responseArrayItem.errorCode}), message: ${responseArrayItem.message}")
+              }
             }
         )
       )
@@ -61,7 +70,7 @@ object Handler extends LazyLogging {
 
   }
 
-  def getEmailIdsSuccessfullySavedToS3(emailsDataFromSF: EmailsFromSfResponse.Response, bucketName: String): Seq[String] = {
+  def saveEmailsToS3(emailsDataFromSF: EmailsFromSfResponse.Response, bucketName: String): Seq[String] = {
 
     val saveToS3Attempts = for {
       saveToS3Attempt <- emailsDataFromSF


### PR DESCRIPTION
## What does this change?
Ensures appropriate error logging in two separate scenarios when a writeback to Salesforce is attempted.

## Context
When an email is successfully saved to S3, a writeback is made to Salesforce to indicate success. 

The writeback is a composite request that will likely contain several records and is intended to set the Most_Recent_Export__c field on email message to the current datetime. 

The body of the request looks like this:

```
{
  "allOrNone" : false,
  "records" : [
    {
      "id" : "02s9E000005AhiaQAC",
      "Most_Recent_Export__c" : "2022-02-32T17:22:03Z",
      "attributes" : {
        "type" : "EmailMessage"
      }
    },
    {
      "id" : "02s9E000005AhiXQAS",
      "Most_Recent_Export__c" : "2022-02-32T17:22:04Z",
      "attributes" : {
        "type" : "EmailMessage"
      }
    }
  ]
}
```
Upon error, the response from Salesforce may take 1 of 2 forms:

**1. Request level error**
_e.g. malformed json_
```
[
	{
		"message":"Extra JSON in request found after deserialization at: [line:1405, column:1453]",
		"errorCode":"JSON_PARSER_ERROR"
	}
]
```
**2. Record level error**
_e.g. malformed id_
```

[
	{
		"id":"02s9E000005E9E7QAK",
		"success":true,
		"errors":[]
	},
	{
		"success":false,
		"errors":[
			{
				"statusCode":"MALFORMED_ID",
				"message":"Email Message ID: id value of incorrect type: 02s9E000005E9IYQA0999",
				"fields":[
					"Id"
				]
			}
		]
	}
]

```

The changes in this PR enable a determination between Request level and Record level errors by inspecting the ``` success ``` attribute, which is present in the latter but not the former.

- If 'success' attribute is absent in the response then an error is logged indicating a Request level error

- If 'success' is present in the response (and the value is false) then an error is logged that captures the specific record details (including the composite key needed to identify the record and troubleshoot effectively)

_n.b. if success is present in the response (and the value is true) then an info level log line is generated to indicate a successful writeback._

## How to test

**Request Level Error**
- Ensure the json body for the composite request is malformed
- Execute the Lambda
- Verify that an error log line is output and that no records that are being processed are updated in Salesforce

**Record Level Error**
- Ensure the id value of the item in the composite request is not a valid record Id
- Execute the Lambda
- Verify that an error log line is output and that no records that are being processed are updated in Salesforce

