### PR TITLE
Generate a balancing invoice when auto-cancelling a subscription

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -15,7 +15,8 @@ object ZuoraCancelSubscription extends LazyLogging {
     def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(
       "cancellationEffectiveDate" -> subscriptionCancellation.cancellationEffectiveDate,
       "cancellationPolicy" -> "SpecificDate",
-      "invoiceCollect" -> false
+      "runBilling" -> true,
+      "collect" -> false
     )
   }
 

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -10,9 +10,12 @@ import play.api.libs.json._
 
 object ZuoraRestRequestMaker extends LazyLogging {
 
+  private val zuoraApiMinorVersion = "315.0"
+
   def apply(response: Request => Response, config: ZuoraRestConfig): RestRequestMaker.Requests = {
     new RestRequestMaker.Requests(
       headers = Map(
+        "zuora-version" -> zuoraApiMinorVersion,
         "apiSecretAccessKey" -> config.password,
         "apiAccessKeyId" -> config.username
       ),


### PR DESCRIPTION
Previously, the auto-cancel process wouldn't generate a balancing invoice.  This made it impossible to do credit transfers to zero the last invoice for the cancelled subscription until a balancing invoice was generated on the next bill run.

Now, the balancing invoice will be generated immediately following the cancellation of the subscription.  So this will enable us to zero the last invoice on the account for the cancelled subscription in another PR.

See https://www.zuora.com/developer/api-reference/#operation/PUT_CancelSubscription

Tested on several accounts in UAT Zuora.
