### PR TITLE
Order by createddate and set limit to 2000

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/GetEmailsQuery.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/GetEmailsQuery.scala
@@ -31,9 +31,9 @@ object GetEmailsQuery {
        |WHERE
        | export_Status__c in ('Ready for export to s3')
        |ORDER BY
-       | ParentId
+       | Createddate
        |LIMIT
-       | 1000
+       | 2000
     """.stripMargin
   }
 }


### PR DESCRIPTION
## What does this change?

Order by createddate instead of ParentId
- this increases the efficiency of the query because createddate is an indexed field, whereas ParentId is not

Increase limit of records to process to 2000 from 1000
- Under normal conditions there may be up to 1400 emails per day to export to S3 (usually this is significantly lower). 

From previous performance testing, processing of 2000 emails is estimated to take 6-7 mins, which is comfortably within the 15 minute lambda execution limit

## How to test
Execute  the lambda and verify that that no errors are encountered when the initial query is executed