### PR TITLE
output sf response

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -24,7 +24,7 @@ object SFConnector extends LazyLogging {
       .method("GET")
       .asString
       .body
-
+    logger.info(s"responseBody:$responseBody")
     decode[EmailsFromSfResponse.Response](responseBody)
   }
 


### PR DESCRIPTION
## What does this change?
Output the response from Salesforce query to REST API. This could be a read time out or something related to field permissions (or something else)

We will remove this output line once we have identified the issue