### PR TITLE
Revert "Generate a balancing invoice when auto-cancelling a subscription"

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -15,8 +15,7 @@ object ZuoraCancelSubscription extends LazyLogging {
     def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(
       "cancellationEffectiveDate" -> subscriptionCancellation.cancellationEffectiveDate,
       "cancellationPolicy" -> "SpecificDate",
-      "runBilling" -> true,
-      "collect" -> false
+      "invoiceCollect" -> false
     )
   }
 

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -10,12 +10,9 @@ import play.api.libs.json._
 
 object ZuoraRestRequestMaker extends LazyLogging {
 
-  private val zuoraApiMinorVersion = "315.0"
-
   def apply(response: Request => Response, config: ZuoraRestConfig): RestRequestMaker.Requests = {
     new RestRequestMaker.Requests(
       headers = Map(
-        "zuora-version" -> zuoraApiMinorVersion,
         "apiSecretAccessKey" -> config.password,
         "apiAccessKeyId" -> config.username
       ),


### PR DESCRIPTION
Reverts guardian/support-service-lambdas#1406
The Zuora version change appears to be breaking the writing of the product catalogue.  It probably needs to be restricted a bit.