### PR TITLE
Ensure that an account with an auto-cancelled subscription has no outstanding invoices

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -30,7 +30,8 @@ object AutoCancel extends Logging {
   /*
    * This process applies at the subscription level.  It will potentially run multiple times per invoice.
    * The cancellation call generates a balancing invoice that should be negative and the same amount
-   * as the amount outstanding for the invoice item corresponding to the subscription being processed.
+   * as the amount outstanding for the invoice items corresponding to the subscription being processed
+   * (there could be multiple invoice items per sub - it could include discounts and multi-day paper subs)
    * This means that after all subscriptions on an invoice have been cancelled, the balance of all
    * invoices should be 0.
    */

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -1,17 +1,25 @@
 package com.gu.autoCancel
 
-import java.time.LocalDate
-
 import com.gu.autoCancel.AutoCancelSteps.AutoCancelUrlParams
 import com.gu.stripeCustomerSourceUpdated.TypeConvert._
 import com.gu.util.Logging
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.RestRequestMaker.Requests
-import com.gu.util.zuora.{SubscriptionNumber, ZuoraCancelSubscription, ZuoraUpdateCancellationReason}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, NotFound}
+import com.gu.util.zuora._
+import play.api.libs.json.{JsDefined, JsString, JsValue}
+
+import java.time.LocalDate
 
 object AutoCancel extends Logging {
 
-  case class AutoCancelRequest(accountId: String, subToCancel: SubscriptionNumber, cancellationDate: LocalDate)
+  case class AutoCancelRequest(
+    accountId: String,
+    subToCancel: SubscriptionNumber,
+    cancellationDate: LocalDate,
+    invoiceId: String,
+    invoiceAmount: BigDecimal
+  )
 
   def apply(requests: Requests)(acRequests: List[AutoCancelRequest], urlParams: AutoCancelUrlParams): ApiGatewayOp[Unit] = {
     logger.info(s"dryRun: ${urlParams.dryRun}")
@@ -22,14 +30,25 @@ object AutoCancel extends Logging {
     responses.head
   }
 
+  private def findBalancingInvoiceId(cancelSubscriptionResponse: JsValue): ClientFailableOp[String] =
+    cancelSubscriptionResponse \ "invoiceId" match {
+      case JsDefined(JsString(value)) => ClientSuccess(value)
+      case _ => NotFound(s"Subscription cancellation response '$cancelSubscriptionResponse' doesn't contain an invoice ID")
+    }
+
   private def executeCancel(requests: Requests, dryRun: Boolean)(acRequest: AutoCancelRequest): ApiGatewayOp[Unit] = {
-    val AutoCancelRequest(accountId, subToCancel, cancellationDate) = acRequest
+    val AutoCancelRequest(accountId, subToCancel, cancellationDate, invoiceId, invoiceAmount) = acRequest
     logger.info(s"Attempting to perform auto-cancellation on account: $accountId for subscription: ${subToCancel.value}")
     val zuoraUpdateCancellationReasonF = if (dryRun) ZuoraUpdateCancellationReason.dryRun(requests) _ else ZuoraUpdateCancellationReason(requests) _
     val zuoraCancelSubscriptionF = if (dryRun) ZuoraCancelSubscription.dryRun(requests) _ else ZuoraCancelSubscription(requests) _
+    val zuoraTransferToCreditBalanceF = if (dryRun) TransferToCreditBalance.dryRun(requests) _ else TransferToCreditBalance(requests) _
+    val zuoraApplyCreditBalanceF = if (dryRun) ApplyCreditBalance.dryRun(requests) _ else ApplyCreditBalance(requests) _
     val zuoraOp = for {
       _ <- zuoraUpdateCancellationReasonF(subToCancel).withLogging("updateCancellationReason")
-      _ <- zuoraCancelSubscriptionF(subToCancel, cancellationDate).withLogging("cancelSubscription")
+      cancellationResponse <- zuoraCancelSubscriptionF(subToCancel, cancellationDate).withLogging("cancelSubscription")
+      balancingInvoiceId <- findBalancingInvoiceId(cancellationResponse)
+      _ <- zuoraTransferToCreditBalanceF(balancingInvoiceId, invoiceAmount, "Auto-cancellation").withLogging("transferToCreditBalance")
+      _ <- zuoraApplyCreditBalanceF(invoiceId, invoiceAmount, "Auto-cancellation").withLogging("applyCreditBalance")
     } yield ()
     zuoraOp.toApiGatewayOp("AutoCancel failed")
   }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -45,8 +45,8 @@ object AutoCancel extends Logging {
     val zuoraOp = for {
       _ <- zuoraUpdateCancellationReasonF(subToCancel).withLogging("updateCancellationReason")
       cancellationResponse <- zuoraCancelSubscriptionF(subToCancel, cancellationDate).withLogging("cancelSubscription")
-      creditTransferInvoice <- zuoraGetInvoiceF(cancellationResponse.invoiceId)
-      creditTransferAmount = -creditTransferInvoice.Balance
+      cancellationNegativeInvoice <- zuoraGetInvoiceF(cancellationResponse.invoiceId)
+      creditTransferAmount = -cancellationNegativeInvoice.Balance
       _ <- zuoraTransferToCreditBalanceF(cancellationResponse.invoiceId, creditTransferAmount, "Auto-cancellation").withLogging("transferToCreditBalance")
       _ <- zuoraApplyCreditBalanceF(invoiceId, creditTransferAmount, "Auto-cancellation").withLogging("applyCreditBalance")
     } yield ()

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -35,7 +35,7 @@ object AutoCancel extends Logging {
    * invoices should be 0.
    */
   private def executeCancel(requests: Requests, dryRun: Boolean)(acRequest: AutoCancelRequest): ApiGatewayOp[Unit] = {
-    val AutoCancelRequest(accountId, subToCancel, cancellationDate, invoiceId) = acRequest
+    val AutoCancelRequest(accountId, subToCancel, cancellationDate, overdueInvoiceId) = acRequest
     logger.info(s"Attempting to perform auto-cancellation on account: $accountId for subscription: ${subToCancel.value}")
     val zuoraUpdateCancellationReasonF = if (dryRun) ZuoraUpdateCancellationReason.dryRun(requests) _ else ZuoraUpdateCancellationReason(requests) _
     val zuoraCancelSubscriptionF = if (dryRun) ZuoraCancelSubscription.dryRun(requests) _ else ZuoraCancelSubscription(requests) _

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -36,6 +36,13 @@ object AutoCancel extends Logging {
       case _ => NotFound(s"Subscription cancellation response '$cancelSubscriptionResponse' doesn't contain an invoice ID")
     }
 
+  /*
+   * This process applies at the subscription level.  It will potentially run multiple times per invoice.
+   * The cancellation call generates a balancing invoice that should be negative and the same amount
+   * as the amount outstanding for the invoice item corresponding to the subscription being processed.
+   * This means that after all subscriptions on an invoice have been cancelled, the balance of all
+   * invoices should be 0.
+   */
   private def executeCancel(requests: Requests, dryRun: Boolean)(acRequest: AutoCancelRequest): ApiGatewayOp[Unit] = {
     val AutoCancelRequest(accountId, subToCancel, cancellationDate, invoiceId, invoiceAmount) = acRequest
     logger.info(s"Attempting to perform auto-cancellation on account: $accountId for subscription: ${subToCancel.value}")

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -49,7 +49,7 @@ object AutoCancel extends Logging {
       cancellationNegativeInvoice <- zuoraGetInvoiceF(cancellationResponse.invoiceId)
       creditTransferAmount = -cancellationNegativeInvoice.Balance
       _ <- zuoraTransferToCreditBalanceF(cancellationResponse.invoiceId, creditTransferAmount, "Auto-cancellation").withLogging("transferToCreditBalance")
-      _ <- zuoraApplyCreditBalanceF(invoiceId, creditTransferAmount, "Auto-cancellation").withLogging("applyCreditBalance")
+      _ <- zuoraApplyCreditBalanceF(overdueInvoiceId, creditTransferAmount, "Auto-cancellation").withLogging("applyCreditBalance")
     } yield ()
     zuoraOp.toApiGatewayOp("AutoCancel failed")
   }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
@@ -32,7 +32,7 @@ object AutoCancelDataCollectionFilter extends Logging {
       invoiceAmount <- getInvoiceBalance(invoiceId, accountSummary).withLogging("getInvoiceBalance")
     } yield subsToCancel
       .map { subToCancel =>
-        AutoCancelRequest(accountId, subToCancel, cancellationDate, invoiceId, invoiceAmount)
+        AutoCancelRequest(accountId, subToCancel, cancellationDate, invoiceId)
       }
   }
 

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
@@ -1,11 +1,10 @@
 package com.gu.autoCancel
 
 import java.time.LocalDate
-
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.stripeCustomerSourceUpdated.TypeConvert._
 import com.gu.util.Logging
-import com.gu.util.apigateway.ApiGatewayResponse.noActionRequired
+import com.gu.util.apigateway.ApiGatewayResponse.{internalServerError, noActionRequired}
 import com.gu.util.reader.Types.ApiGatewayOp._
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.ClientFailableOp
@@ -30,9 +29,10 @@ object AutoCancelDataCollectionFilter extends Logging {
         .withLogging("getAccountSubscriptions")
       subsToCancel <- filterNotActiveSubscriptions(subsOnAccount, subsOnInvoice).withLogging("filterNotActiveSubscriptions")
       cancellationDate <- getCancellationDateFromInvoice(invoiceId, accountSummary, now).withLogging("getCancellationDateFromInvoice")
+      invoiceAmount <- getInvoiceBalance(invoiceId, accountSummary).withLogging("getInvoiceBalance")
     } yield subsToCancel
       .map { subToCancel =>
-        AutoCancelRequest(accountId, subToCancel, cancellationDate)
+        AutoCancelRequest(accountId, subToCancel, cancellationDate, autoCancelCallout.invoiceId, invoiceAmount)
       }
   }
 
@@ -51,6 +51,20 @@ object AutoCancelDataCollectionFilter extends Logging {
           ContinueProcessing(inv.dueDate)
       }
   }
+
+  def getInvoiceBalance(invoiceId: String, accountSummary: AccountSummary): ApiGatewayOp[BigDecimal] =
+    accountSummary.invoices
+      .find(inv => {
+        logger.info(s"found callout invoice in accountSummary: $inv")
+        inv.id == invoiceId
+      }) match {
+        case None =>
+          logger.error(s"Failed to get invoice balance: invoiceId: $invoiceId")
+          ReturnWithResponse(internalServerError("Invoice not found in account!"))
+        case Some(inv) =>
+          logger.info(s"Found invoice balance: ${inv.balance}. Invoice: $inv")
+          ContinueProcessing(inv.balance)
+      }
 
   def invoiceOverdue(invoice: Invoice, dateToday: LocalDate): Boolean = {
     /**

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
@@ -32,7 +32,7 @@ object AutoCancelDataCollectionFilter extends Logging {
       invoiceAmount <- getInvoiceBalance(invoiceId, accountSummary).withLogging("getInvoiceBalance")
     } yield subsToCancel
       .map { subToCancel =>
-        AutoCancelRequest(accountId, subToCancel, cancellationDate, autoCancelCallout.invoiceId, invoiceAmount)
+        AutoCancelRequest(accountId, subToCancel, cancellationDate, invoiceId, invoiceAmount)
       }
   }
 

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
@@ -28,6 +28,10 @@ object AutoCancelSteps extends Logging {
     implicit val autoCancelUrlParamsReads: Reads[AutoCancelUrlParams] = json => wireReads.reads(json).map(_.toAutoCancelUrlParams)
   }
 
+  /*
+   * This process applies at the invoice level.
+   * Each invoice can have multiple invoice items applying to a different subscription.
+   */
   def apply(
     callZuoraAutoCancel: (List[AutoCancelRequest], AutoCancelUrlParams) => ApiGatewayOp[Unit],
     autoCancelReqProducer: AutoCancelCallout => ApiGatewayOp[List[AutoCancelRequest]],

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
@@ -7,40 +7,34 @@ import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{InvoiceItem, InvoiceTransa
 
 object GetPaymentData extends Logging {
 
-  case class PaymentFailureInformation(subscriptionName: String, product: String, amount: Double, serviceStartDate: LocalDate, serviceEndDate: LocalDate)
+  case class PaymentFailureInformation(subscriptionName: String, product: String, serviceStartDate: LocalDate, serviceEndDate: LocalDate)
 
   def apply(message: String)(invoiceTransactionSummary: InvoiceTransactionSummary): Either[String, PaymentFailureInformation] = {
     logger.info(s"Attempting to get further details from account $message")
-    val unpaidInvoices =
-      invoiceTransactionSummary.invoices.filter {
-        invoice => unpaid(invoice)
-      }
-    unpaidInvoices.headOption match {
-      case Some(invoice) => {
-        logger.info(s"Found the following unpaid invoice: $invoice")
-        val positiveInvoiceItems = invoice.invoiceItems.filter(item => invoiceItemFilter(item))
+    val positiveInvoices = invoiceTransactionSummary.invoices.filter(isPositive)
+    positiveInvoices.headOption match {
+      case Some(invoice) =>
+        logger.info(s"Found the following latest invoice: $invoice")
+        val positiveInvoiceItems = invoice.invoiceItems.filter(invoiceItemFilter)
         // TODO payment failure may be subjected to invoice that have multiple items not only one
         // here we are generating PaymentFailureInformation based on the head of InvoiceItems
         val maybePaymentFailureInfo = positiveInvoiceItems.headOption.map {
           item =>
             {
-              val paymentFailureInfo = PaymentFailureInformation(item.subscriptionName, item.productName, invoice.amount, item.serviceStartDate, item.serviceEndDate)
+              val paymentFailureInfo = PaymentFailureInformation(item.subscriptionName, item.productName, item.serviceStartDate, item.serviceEndDate)
               logger.info(s"Payment failure information for account: $message is: $paymentFailureInfo")
               paymentFailureInfo
             }
         }
         maybePaymentFailureInfo.toRight(s"Could not retrieve additional data for account $message")
-      }
-      case None => {
-        logger.error(s"No unpaid invoice found - nothing to do")
+      case None =>
+        logger.error(s"No invoice found - nothing to do")
         Left(s"Could not retrieve additional data for account $message")
-      }
     }
   }
 
-  def unpaid(itemisedInvoice: ItemisedInvoice): Boolean = {
-    itemisedInvoice.balance > 0 && itemisedInvoice.status == "Posted"
-  }
+  def isPositive(itemisedInvoice: ItemisedInvoice): Boolean =
+    itemisedInvoice.amount > 0 && itemisedInvoice.status == "Posted"
 
   def invoiceItemFilter(item: InvoiceItem): Boolean = {
     item.chargeAmount > 0 // remove discounts, holiday credits and free products

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
@@ -14,7 +14,7 @@ object GetPaymentData extends Logging {
     val positiveInvoices = invoiceTransactionSummary.invoices.filter(isPositive)
     positiveInvoices.headOption match {
       case Some(invoice) =>
-        logger.info(s"Found the following latest invoice: $invoice")
+        logger.info(s"Found the following positive invoice: $invoice")
         val positiveInvoiceItems = invoice.invoiceItems.filter(invoiceItemFilter)
         // TODO payment failure may be subjected to invoice that have multiple items not only one
         // here we are generating PaymentFailureInformation based on the head of InvoiceItems
@@ -28,7 +28,7 @@ object GetPaymentData extends Logging {
         }
         maybePaymentFailureInfo.toRight(s"Could not retrieve additional data for account $message")
       case None =>
-        logger.error(s"No invoice found - nothing to do")
+        logger.error(s"No positive invoice found - nothing to do")
         Left(s"Could not retrieve additional data for account $message")
     }
   }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/ToMessage.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/ToMessage.scala
@@ -29,7 +29,6 @@ object ToMessage {
               first_name = paymentFailureCallout.firstName,
               last_name = paymentFailureCallout.lastName,
               primaryKey = PaymentId(paymentFailureCallout.paymentId),
-              price = price(paymentFailureInformation.amount, paymentFailureCallout.currency),
               serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
               serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate),
               billing_address1 = paymentFailureCallout.billingDetails.address1,
@@ -63,7 +62,6 @@ object ToMessage {
               first_name = callout.firstName,
               last_name = callout.lastName,
               primaryKey = InvoiceId(callout.invoiceId),
-              price = price(paymentFailureInformation.amount, callout.currency),
               serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
               serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)
             )

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/ToMessage.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/paymentFailure/ToMessage.scala
@@ -77,13 +77,6 @@ object ToMessage {
 
   val decimalFormat = new DecimalFormat("###,###.00")
 
-  def price(amount: Double, currency: String): String = {
-    val formattedAmount: String = decimalFormat.format(decimal(amount))
-    val upperCaseCurrency = currency.toUpperCase
-    val symbol: String = currencySymbol.getOrElse(upperCaseCurrency, upperCaseCurrency)
-    symbol + formattedAmount
-  }
-
   def serviceDateFormat(d: LocalDate) = d.format(DateTimeFormatter.ofPattern("dd MMMM yyyy"))
 
 }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/email/EmailSendSteps.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/email/EmailSendSteps.scala
@@ -18,7 +18,6 @@ case class SubscriberAttributesDef(
   first_name: String,
   last_name: String,
   primaryKey: PrimaryKey,
-  price: String,
   serviceStartDate: String,
   serviceEndDate: String,
   billing_address1: Option[String] = None,
@@ -68,7 +67,6 @@ trait EmailSqsSerialisation {
           case PaymentId(id) => "paymentId" -> JsString(id)
           case InvoiceId(id) => "invoiceId" -> JsString(id)
         },
-        "price" -> JsString(o.price),
         "serviceStartDate" -> JsString(o.serviceStartDate),
         "serviceEndDate" -> JsString(o.serviceEndDate)
       )

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -1,11 +1,11 @@
 package com.gu.util.zuora
 
-import java.time.LocalDate
-
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
 import com.typesafe.scalalogging.LazyLogging
-import play.api.libs.json.{JsSuccess, Json, Reads, Writes}
+import play.api.libs.json.{JsNull, JsValue, Json, Writes}
+
+import java.time.LocalDate
 
 object ZuoraCancelSubscription extends LazyLogging {
 
@@ -20,21 +20,18 @@ object ZuoraCancelSubscription extends LazyLogging {
     )
   }
 
-  implicit val unitReads: Reads[Unit] =
-    Reads(_ => JsSuccess(()))
-
   private def toBodyAndPath(subscription: SubscriptionNumber, cancellationDate: LocalDate) =
     (SubscriptionCancellation(cancellationDate), s"subscriptions/${subscription.value}/cancel")
 
-  def apply(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
+  def apply(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[JsValue] = {
     val (body, path) = toBodyAndPath(subscription, cancellationDate)
-    requests.put(body, path)
+    requests.put[SubscriptionCancellation, JsValue](body, path)
   }
 
-  def dryRun(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
+  def dryRun(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[JsValue] = {
     val (body, path) = toBodyAndPath(subscription, cancellationDate)
     val msg = s"DryRun for ZuoraCancelSubscription: body=$body, path=$path"
     logger.info(msg)
-    ClientSuccess(())
+    ClientSuccess(JsNull)
   }
 }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -3,13 +3,17 @@ package com.gu.util.zuora
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
 import com.typesafe.scalalogging.LazyLogging
-import play.api.libs.json.{JsNull, JsValue, Json, Writes}
+import play.api.libs.json.{Json, Writes}
 
 import java.time.LocalDate
 
 object ZuoraCancelSubscription extends LazyLogging {
 
   case class SubscriptionCancellation(cancellationEffectiveDate: LocalDate)
+
+  case class CancellationResponse(invoiceId: String)
+
+  implicit val cancellationResponseReads = Json.reads[CancellationResponse]
 
   implicit val subscriptionCancellationWrites = new Writes[SubscriptionCancellation] {
     def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(
@@ -23,15 +27,15 @@ object ZuoraCancelSubscription extends LazyLogging {
   private def toBodyAndPath(subscription: SubscriptionNumber, cancellationDate: LocalDate) =
     (SubscriptionCancellation(cancellationDate), s"subscriptions/${subscription.value}/cancel")
 
-  def apply(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[JsValue] = {
+  def apply(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[CancellationResponse] = {
     val (body, path) = toBodyAndPath(subscription, cancellationDate)
-    requests.put[SubscriptionCancellation, JsValue](body, path)
+    requests.put[SubscriptionCancellation, CancellationResponse](body, path)
   }
 
-  def dryRun(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[JsValue] = {
+  def dryRun(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[CancellationResponse] = {
     val (body, path) = toBodyAndPath(subscription, cancellationDate)
     val msg = s"DryRun for ZuoraCancelSubscription: body=$body, path=$path"
     logger.info(msg)
-    ClientSuccess(Json.obj("invoiceId" -> "balancingInvoiceId"))
+    ClientSuccess(CancellationResponse("balancingInvoiceId"))
   }
 }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -32,6 +32,6 @@ object ZuoraCancelSubscription extends LazyLogging {
     val (body, path) = toBodyAndPath(subscription, cancellationDate)
     val msg = s"DryRun for ZuoraCancelSubscription: body=$body, path=$path"
     logger.info(msg)
-    ClientSuccess(JsNull)
+    ClientSuccess(Json.obj("invoiceId" -> "balancingInvoiceId"))
   }
 }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCreditTransfer.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCreditTransfer.scala
@@ -1,0 +1,64 @@
+package com.gu.util.zuora
+
+import com.gu.util.resthttp.RestRequestMaker.Requests
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
+import com.typesafe.scalalogging.LazyLogging
+import play.api.libs.json._
+
+object ZuoraCreditTransfer extends LazyLogging {
+
+  case class CreditTransfer(
+    invoiceId: String,
+    amount: BigDecimal,
+    increase: Boolean,
+    comment: String
+  )
+
+  implicit val transferWrites = new Writes[CreditTransfer] {
+    def writes(transfer: CreditTransfer) = Json.obj(
+      "sourceTransactionId" -> transfer.invoiceId,
+      "amount" -> transfer.amount,
+      "type" -> {if (transfer.increase) "Increase" else "Decrease"},
+      "comment" -> transfer.comment
+    )
+  }
+
+  def toBodyAndPath(invoiceId: String, amount: BigDecimal, increase: Boolean, comment: String) =
+    (CreditTransfer(invoiceId, amount, increase, comment), "object/credit-balance-adjustment")
+}
+
+object TransferToCreditBalance extends LazyLogging {
+
+  implicit val unitReads: Reads[Unit] =
+    Reads(_ => JsSuccess(()))
+
+  def apply(requests: Requests)(invoiceId: String, amount: BigDecimal, comment: String): ClientFailableOp[Unit] = {
+    val (body, path) = ZuoraCreditTransfer.toBodyAndPath(invoiceId, amount, increase = true, comment)
+    requests.put(body, path)
+  }
+
+  def dryRun(requests: Requests)(invoiceId: String, amount: BigDecimal, comment: String): ClientFailableOp[Unit] = {
+    val (body, path) = ZuoraCreditTransfer.toBodyAndPath(invoiceId, amount, increase = true, comment)
+    val msg = s"DryRun for ZuoraCreditTransfer: body=$body, path=$path"
+    logger.info(msg)
+    ClientSuccess(JsNull)
+  }
+}
+
+object ApplyCreditBalance extends LazyLogging {
+
+  implicit val unitReads: Reads[Unit] =
+    Reads(_ => JsSuccess(()))
+
+  def apply(requests: Requests)(invoiceId: String, amount: BigDecimal, comment: String): ClientFailableOp[Unit] = {
+    val (body, path) = ZuoraCreditTransfer.toBodyAndPath(invoiceId, amount, increase = false, comment)
+    requests.put(body, path)
+  }
+
+  def dryRun(requests: Requests)(invoiceId: String, amount: BigDecimal, comment: String): ClientFailableOp[Unit] = {
+    val (body, path) = ZuoraCreditTransfer.toBodyAndPath(invoiceId, amount, increase = false, comment)
+    val msg = s"DryRun for ZuoraCreditTransfer: body=$body, path=$path"
+    logger.info(msg)
+    ClientSuccess(JsNull)
+  }
+}

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCreditTransfer.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCreditTransfer.scala
@@ -18,7 +18,7 @@ object ZuoraCreditTransfer extends LazyLogging {
     def writes(transfer: CreditTransfer) = Json.obj(
       "sourceTransactionId" -> transfer.invoiceId,
       "amount" -> transfer.amount,
-      "type" -> {if (transfer.increase) "Increase" else "Decrease"},
+      "type" -> { if (transfer.increase) "Increase" else "Decrease" },
       "comment" -> transfer.comment
     )
   }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCreditTransfer.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCreditTransfer.scala
@@ -16,10 +16,10 @@ object ZuoraCreditTransfer extends LazyLogging {
 
   implicit val transferWrites = new Writes[CreditTransfer] {
     def writes(transfer: CreditTransfer) = Json.obj(
-      "sourceTransactionId" -> transfer.invoiceId,
-      "amount" -> transfer.amount,
-      "type" -> { if (transfer.increase) "Increase" else "Decrease" },
-      "comment" -> transfer.comment
+      "SourceTransactionId" -> transfer.invoiceId,
+      "Amount" -> transfer.amount,
+      "Type" -> { if (transfer.increase) "Increase" else "Decrease" },
+      "Comment" -> transfer.comment
     )
   }
 
@@ -34,7 +34,7 @@ object TransferToCreditBalance extends LazyLogging {
 
   def apply(requests: Requests)(invoiceId: String, amount: BigDecimal, comment: String): ClientFailableOp[Unit] = {
     val (body, path) = ZuoraCreditTransfer.toBodyAndPath(invoiceId, amount, increase = true, comment)
-    requests.put(body, path)
+    requests.post(body, path)
   }
 
   def dryRun(requests: Requests)(invoiceId: String, amount: BigDecimal, comment: String): ClientFailableOp[Unit] = {
@@ -52,7 +52,7 @@ object ApplyCreditBalance extends LazyLogging {
 
   def apply(requests: Requests)(invoiceId: String, amount: BigDecimal, comment: String): ClientFailableOp[Unit] = {
     val (body, path) = ZuoraCreditTransfer.toBodyAndPath(invoiceId, amount, increase = false, comment)
-    requests.put(body, path)
+    requests.post(body, path)
   }
 
   def dryRun(requests: Requests)(invoiceId: String, amount: BigDecimal, comment: String): ClientFailableOp[Unit] = {

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCreditTransfer.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCreditTransfer.scala
@@ -8,10 +8,10 @@ import play.api.libs.json._
 
 object ZuoraCreditTransfer extends LazyLogging {
 
-  sealed trait AdjustmentType { def value: String }
+  sealed abstract class AdjustmentType(val value: String)
   object AdjustmentType {
-    case object Increase extends AdjustmentType { val value = "Increase" }
-    case object Decrease extends AdjustmentType { val value = "Decrease" }
+    case object Increase extends AdjustmentType("Increase")
+    case object Decrease extends AdjustmentType("Decrease")
   }
 
   case class CreditTransfer(

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraGetInvoice.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraGetInvoice.scala
@@ -1,0 +1,22 @@
+package com.gu.util.zuora
+
+import com.gu.util.resthttp.RestRequestMaker.{Requests, WithoutCheck}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
+import com.typesafe.scalalogging.LazyLogging
+import play.api.libs.json.{Json, Reads}
+
+object ZuoraGetInvoice extends LazyLogging {
+
+  case class Invoice(Id: String, Balance: Double)
+
+  implicit val invoiceReads: Reads[Invoice] = Json.reads[Invoice]
+
+  def apply(requests: Requests)(invoiceId: String): ClientFailableOp[Invoice] =
+    requests.get[Invoice](s"object/invoice/$invoiceId?fields=Balance", WithoutCheck)
+
+  def dryRun(requests: Requests)(invoiceId: String): ClientFailableOp[Invoice] = {
+    val msg = s"DryRun for ZuoraGetInvoice: ID $invoiceId"
+    logger.info(msg)
+    ClientSuccess(Invoice(Id = "invoiceId", Balance = 0))
+  }
+}

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -1,16 +1,15 @@
 package com.gu.autoCancel
 
-import java.time.LocalDate
-
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.ClientSuccess
 import com.gu.util.zuora.ZuoraGetAccountSummary.ZuoraAccount.{AccountId, PaymentMethodId}
 import com.gu.util.zuora.ZuoraGetAccountSummary.{AccountSummary, BasicAccountInfo, Invoice, SubscriptionId, SubscriptionSummary}
 import com.gu.util.zuora.{SubscriptionNumber, SubscriptionNumberWithStatus}
-import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDate
 
 class AutoCancelStepsTest extends AnyFlatSpec with Matchers {
 
@@ -58,8 +57,8 @@ class AutoCancelStepsTest extends AnyFlatSpec with Matchers {
 
     val expected = Right(
       List(
-        AutoCancelRequest("accId123", SubscriptionNumber("A-S123"), LocalDate.now.minusDays(14)),
-        AutoCancelRequest("accId123", SubscriptionNumber("A-S456"), LocalDate.now.minusDays(14))
+        AutoCancelRequest("accId123", SubscriptionNumber("A-S123"), LocalDate.now.minusDays(14), "inv123", BigDecimal("11.99")),
+        AutoCancelRequest("accId123", SubscriptionNumber("A-S456"), LocalDate.now.minusDays(14), "inv123", BigDecimal("11.99"))
       )
     )
 

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -57,8 +57,8 @@ class AutoCancelStepsTest extends AnyFlatSpec with Matchers {
 
     val expected = Right(
       List(
-        AutoCancelRequest("accId123", SubscriptionNumber("A-S123"), LocalDate.now.minusDays(14), "inv123", BigDecimal("11.99")),
-        AutoCancelRequest("accId123", SubscriptionNumber("A-S456"), LocalDate.now.minusDays(14), "inv123", BigDecimal("11.99"))
+        AutoCancelRequest("accId123", SubscriptionNumber("A-S123"), LocalDate.now.minusDays(14), "inv123"),
+        AutoCancelRequest("accId123", SubscriptionNumber("A-S456"), LocalDate.now.minusDays(14), "inv123")
       )
     )
 

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
@@ -165,7 +165,6 @@ object EndToEndDataWithBillingDetails extends EndtoEndBaseData {
       |        "first_name": "eSAFaBwm4WJZNg5xhIc",
       |        "last_name": "eSAFaBwm4WJZNg5xhIc",
       |        "paymentId": "2c92c0f95fc912eb015fcb2a481720e6",
-      |        "price": "$49.00",
       |        "serviceStartDate": "17 November 2017",
       |        "serviceEndDate": "16 November 2018",
       |        "billing_address1": "billingAddress1Value",
@@ -257,7 +256,6 @@ object EndToEndData extends EndtoEndBaseData {
       |        "first_name": "eSAFaBwm4WJZNg5xhIc",
       |        "last_name": "eSAFaBwm4WJZNg5xhIc",
       |        "paymentId": "2c92c0f95fc912eb015fcb2a481720e6",
-      |        "price": "$49.00",
       |        "serviceStartDate": "17 November 2017",
       |        "serviceEndDate": "16 November 2018"
       |      }

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/paymentFailure/MessageWritesTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/paymentFailure/MessageWritesTest.scala
@@ -22,7 +22,6 @@ class MessageWritesTest extends AnyFlatSpec with EmailSqsSerialisation {
             first_name = "firstNameValue",
             last_name = "lastNameValue",
             primaryKey = PaymentId("paymentId"),
-            price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
             serviceEndDate = "31 January 2017"
           )
@@ -77,7 +76,6 @@ class MessageWritesTest extends AnyFlatSpec with EmailSqsSerialisation {
             first_name = "firstNameValue",
             last_name = "lastNameValue",
             primaryKey = InvoiceId("paymentId"),
-            price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
             serviceEndDate = "31 January 2017"
           )

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/paymentFailure/MessageWritesTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/paymentFailure/MessageWritesTest.scala
@@ -47,7 +47,6 @@ class MessageWritesTest extends AnyFlatSpec with EmailSqsSerialisation {
         |        "first_name":"firstNameValue",
         |        "last_name":"lastNameValue",
         |        "paymentId":"paymentId",
-        |        "price":"49.0 GBP",
         |        "serviceStartDate" : "31 January 2016",
         |        "serviceEndDate" : "31 January 2017"
         |      }
@@ -101,7 +100,6 @@ class MessageWritesTest extends AnyFlatSpec with EmailSqsSerialisation {
         |        "first_name":"firstNameValue",
         |        "last_name":"lastNameValue",
         |        "invoiceId":"paymentId",
-        |        "price":"49.0 GBP",
         |        "serviceStartDate" : "31 January 2016",
         |        "serviceEndDate" : "31 January 2017"
         |      }

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
@@ -79,7 +79,6 @@ class PaymentFailureHandlerTest extends AnyFlatSpec with Matchers {
             first_name = "Test",
             last_name = "User",
             primaryKey = PaymentId("somePaymentId"),
-            price = "£49.00",
             serviceStartDate = "21 November 2016",
             serviceEndDate = "21 December 2016"
           )

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
@@ -26,7 +26,6 @@ class EmailSendStepsTest extends AnyFlatSpec with Matchers {
             first_name = "firstNameValue",
             last_name = "lastNameValue",
             primaryKey = PaymentId("paymentId"),
-            price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
             serviceEndDate = "31 January 2017"
           )

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
@@ -52,7 +52,6 @@ class EmailSendStepsTest extends AnyFlatSpec with Matchers {
         |        "serviceEndDate": "31 January 2017",
         |        "first_name": "firstNameValue",
         |        "paymentId": "paymentId",
-        |        "price": "49.0 GBP",
         |        "serviceStartDate": "31 January 2016",
         |        "subscriber_id": "subIdValue",
         |        "card_expiry_date": "cardExpiryValue",

--- a/handlers/zuora-callout-apis/src/test/scala/manualTest/EmailSendTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/manualTest/EmailSendTest.scala
@@ -26,7 +26,6 @@ object EmailSendTest extends App with Logging {
           first_name = s"firstNameValue",
           last_name = "lastNameValue",
           primaryKey = PaymentId(UUID.randomUUID().toString),
-          price = "49.0 GBP",
           serviceStartDate = "31 January 2016",
           serviceEndDate = "31 January 2017"
         )


### PR DESCRIPTION
Previously, when a subscription had been auto-cancelled because it reached the end of the payment failure period without recovery it was left with an outstanding balance to pay on the final invoice.
In this PR, we transfer the balance of the negative invoice generated to balance the unpaid invoice to the credit account and then apply that amount to the unpaid invoice.  We call this a 'credit shuffle'.  The end result should be that all the invoices on the account have zero balances.

Tested on various accounts in Code and in the central sandbox.
