### PR TITLE
Optionally add version header to Zuora API calls

### DIFF
--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestConfig.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestConfig.scala
@@ -6,7 +6,8 @@ import play.api.libs.json.Json
 case class ZuoraRestConfig(
   baseUrl: String,
   username: String,
-  password: String
+  password: String,
+  apiMinorVersion: Option[String] = None,
 )
 
 object ZuoraRestConfig {

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -11,11 +11,15 @@ import play.api.libs.json._
 object ZuoraRestRequestMaker extends LazyLogging {
 
   def apply(response: Request => Response, config: ZuoraRestConfig): RestRequestMaker.Requests = {
+    val apiVersionHeader = config.apiMinorVersion match {
+      case None => Map()
+      case Some(version) => Map("zuora-version" -> version)
+    }
     new RestRequestMaker.Requests(
       headers = Map(
         "apiSecretAccessKey" -> config.password,
         "apiAccessKeyId" -> config.username
-      ),
+      ) ++ apiVersionHeader,
       baseUrl = config.baseUrl + "/", //TODO shouldn't have to add it
       getResponse = response,
       jsonIsSuccessful = zuoraIsSuccessful


### PR DESCRIPTION
Some of our calls depend on minimum versions of the Zuora API.  But the API appears to be non-backward compatible so it isn't safe to assume we can use the latest version everywhere.
This change allows calling code to use a specific version of the API if it pleases.

Tested in Code.
