### PR TITLE
Generate a balancing invoice when auto-cancelling a subscription: Attempt 2

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -23,8 +23,6 @@ import scala.util.Try
 
 object AutoCancelHandler extends App with Logging {
 
-  private val zuoraApiMinorVersion = "315.0"
-
   def operationForEffects(
     stage: Stage,
     fetchString: StringFromS3,
@@ -36,7 +34,7 @@ object AutoCancelHandler extends App with Logging {
     for {
       zuoraRestConfig <- loadConfigModule[ZuoraRestConfig]
         .toApiGatewayOp("load zuora config")
-        .map(_.copy(apiMinorVersion = Some(zuoraApiMinorVersion)))
+        .map(_.copy(apiMinorVersion = Some("315.0")))
     } yield {
       val zuoraRequest = ZuoraRestRequestMaker(response, zuoraRestConfig)
 

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -23,6 +23,8 @@ import scala.util.Try
 
 object AutoCancelHandler extends App with Logging {
 
+  private val zuoraApiMinorVersion = "315.0"
+
   def operationForEffects(
     stage: Stage,
     fetchString: StringFromS3,
@@ -32,7 +34,9 @@ object AutoCancelHandler extends App with Logging {
   ): ApiGatewayOp[ApiGatewayHandler.Operation] = {
     val loadConfigModule = LoadConfigModule(stage, fetchString)
     for {
-      zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+      zuoraRestConfig <- loadConfigModule[ZuoraRestConfig]
+        .toApiGatewayOp("load zuora config")
+        .map(_.copy(apiMinorVersion = Some(zuoraApiMinorVersion)))
     } yield {
       val zuoraRequest = ZuoraRestRequestMaker(response, zuoraRestConfig)
 

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -15,7 +15,8 @@ object ZuoraCancelSubscription extends LazyLogging {
     def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(
       "cancellationEffectiveDate" -> subscriptionCancellation.cancellationEffectiveDate,
       "cancellationPolicy" -> "SpecificDate",
-      "invoiceCollect" -> false
+      "runBilling" -> true,
+      "collect" -> false
     )
   }
 


### PR DESCRIPTION
Previously, the auto-cancel process wouldn't generate a balancing invoice. This made it impossible to do credit transfers to zero the last invoice for the cancelled subscription until a balancing invoice was generated on the next bill run.

Now, the balancing invoice will be generated immediately following the cancellation of the subscription. So this will enable us to zero the last invoice on the account for the cancelled subscription in another PR.

See https://www.zuora.com/developer/api-reference/#operation/PUT_CancelSubscription

The call to Zuora depends on a minimum version of the Zuora API, which has now been localised to the auto-cancelling lambda.

See also:
#1406
#1416 
#1421 
 