### PR TITLE
Apply Zuora API version at call level

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -32,9 +32,7 @@ object AutoCancelHandler extends App with Logging {
   ): ApiGatewayOp[ApiGatewayHandler.Operation] = {
     val loadConfigModule = LoadConfigModule(stage, fetchString)
     for {
-      zuoraRestConfig <- loadConfigModule[ZuoraRestConfig]
-        .toApiGatewayOp("load zuora config")
-        .map(_.copy(apiMinorVersion = Some("315.0")))
+      zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
     } yield {
       val zuoraRequest = ZuoraRestRequestMaker(response, zuoraRestConfig)
 

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraCancelSubscription.scala
@@ -9,6 +9,8 @@ import play.api.libs.json.{JsSuccess, Json, Reads, Writes}
 
 object ZuoraCancelSubscription extends LazyLogging {
 
+  private val zuoraApiMinorVersion = "315.0"
+
   case class SubscriptionCancellation(cancellationEffectiveDate: LocalDate)
 
   implicit val subscriptionCancellationWrites = new Writes[SubscriptionCancellation] {
@@ -28,7 +30,7 @@ object ZuoraCancelSubscription extends LazyLogging {
 
   def apply(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[Unit] = {
     val (body, path) = toBodyAndPath(subscription, cancellationDate)
-    requests.put(body, path)
+    requests.put(body, path, "zuora-version" -> zuoraApiMinorVersion)
   }
 
   def dryRun(requests: Requests)(subscription: SubscriptionNumber, cancellationDate: LocalDate): ClientFailableOp[Unit] = {


### PR DESCRIPTION
This implements #1424 taking advantage of the method introduced in #1425.