### PR TITLE
Add new POST method for bulk delete and remove DELETE method

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -204,10 +204,9 @@ Resources:
         TimeoutInMillis: 29000
         Type: "AWS"
         Uri:
-          - !Sub
+          !Sub
             - "arn:aws:apigateway:${AWS::Region}:emails-from-sf-${lowerCaseStage}.s3:path/?delete"
-            - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
-
+            - lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ]
   ApiGatewayDeployment:
     Type: "AWS::ApiGateway::Deployment"
     DependsOn:

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -157,7 +157,7 @@ Resources:
       - IAMRoleS3ReadWrite
     Properties:
       RestApiId: !Ref ApiGatewayRestApi
-      ResourceId: !Ref ApiGatewayResourceS3File
+      ResourceId: !Ref ApiGatewayResourceS3Bucket
       HttpMethod: "POST"
       AuthorizationType: "NONE"
       ApiKeyRequired: true

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -193,10 +193,10 @@ Resources:
             ResponseTemplates: { }
             SelectionPattern: "2\\d{2}"
             StatusCode: "200"
-            - SelectionPattern: "4\\d{2}"
-              StatusCode: "400"
-            - SelectionPattern: "5\\d{2}"
-              StatusCode: "500"
+          - SelectionPattern: "4\\d{2}"
+            StatusCode: "400"
+          - SelectionPattern: "5\\d{2}"
+            StatusCode: "500"
         PassthroughBehavior: "WHEN_NO_MATCH"
         RequestParameters:
           "integration.request.header.x-amz-checksum-sha1": "method.request.header.x-amz-checksum-sha1"

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -190,13 +190,13 @@ Resources:
               "method.response.header.Content-Length": "integration.response.header.Content-Length"
               "method.response.header.Content-Type": "integration.response.header.Content-Type"
               "method.response.header.Timestamp": "integration.response.header.Date"
-              ResponseTemplates: { }
-              SelectionPattern: "2\\d{2}"
-              StatusCode: "200"
-              - SelectionPattern: "4\\d{2}"
-                StatusCode: "400"
-              - SelectionPattern: "5\\d{2}"
-                StatusCode: "500"
+            ResponseTemplates: { }
+            SelectionPattern: "2\\d{2}"
+            StatusCode: "200"
+            - SelectionPattern: "4\\d{2}"
+              StatusCode: "400"
+            - SelectionPattern: "5\\d{2}"
+              StatusCode: "500"
         PassthroughBehavior: "WHEN_NO_MATCH"
         RequestParameters:
           "integration.request.header.x-amz-checksum-sha1": "method.request.header.x-amz-checksum-sha1"

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -212,7 +212,7 @@ Resources:
     Type: "AWS::ApiGateway::Deployment"
     DependsOn:
       - ApiGatewayMethodGET
-      - ApiGatewayMethodDELETE
+      - ApiGatewayMethodPOST
     Properties:
       RestApiId: !Ref ApiGatewayRestApi
 

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -46,8 +46,8 @@ Resources:
       ManagedPolicyName: !Sub "s3-emails-from-sf-${Stage}-get-delete"
       Path: "/"
       PolicyDocument: !Sub
-          - "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Action\": [\"s3:GetObject\",\"s3:DeleteObject\"],\"Resource\": \"arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*\"}]}"
-          - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
+        - "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Action\": [\"s3:GetObject\",\"s3:PutObject\",\"s3:DeleteObject\"],\"Resource\": \"arn:aws:s3:::emails-from-sf-${lowerCaseStage}/*\"}]}"
+        - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
 
   ApiGatewayRestApi:
     Type: "AWS::ApiGateway::RestApi"
@@ -151,19 +151,20 @@ Resources:
         Type: "AWS"
         Uri: !Sub "arn:aws:apigateway:${AWS::Region}:s3:path/{folder}/{item}"
 
-  ApiGatewayMethodDELETE:
+  ApiGatewayMethodPOST:
     Type: "AWS::ApiGateway::Method"
     DependsOn:
       - IAMRoleS3ReadWrite
     Properties:
       RestApiId: !Ref ApiGatewayRestApi
       ResourceId: !Ref ApiGatewayResourceS3File
-      HttpMethod: "DELETE"
+      HttpMethod: "POST"
       AuthorizationType: "NONE"
       ApiKeyRequired: true
       RequestParameters:
+        "method.request.header.x-amz-checksum-sha1": false
+        "method.request.header.x-amz-sdk-checksum-algorithm": false
         "method.request.path.bucketName": true
-        "method.request.path.caseNumber": true
       MethodResponses:
         - ResponseParameters:
             "method.response.header.Content-Length": false
@@ -182,27 +183,30 @@ Resources:
           StatusCode: "500"
       Integration:
         CacheNamespace: !Ref ApiGatewayResourceS3File
-        Credentials: !Sub "arn:aws:iam::${AWS::AccountId}:role/emails-to-sf-api-${Stage}-api-gateway-role"
-        IntegrationHttpMethod: "DELETE"
+        Credentials: !Sub "arn:aws:iam::${AWS::AccountId}:role/emails-to-sf-api-${ApiGatewayStage}-api-gateway-role"
+        IntegrationHttpMethod: "POST"
         IntegrationResponses:
           - ResponseParameters:
               "method.response.header.Content-Length": "integration.response.header.Content-Length"
               "method.response.header.Content-Type": "integration.response.header.Content-Type"
               "method.response.header.Timestamp": "integration.response.header.Date"
-            ResponseTemplates: { }
-            SelectionPattern: "2\\d{2}"
-            StatusCode: "200"
-          - SelectionPattern: "4\\d{2}"
-            StatusCode: "400"
-          - SelectionPattern: "5\\d{2}"
-            StatusCode: "500"
+              ResponseTemplates: { }
+              SelectionPattern: "2\\d{2}"
+              StatusCode: "200"
+              - SelectionPattern: "4\\d{2}"
+                StatusCode: "400"
+              - SelectionPattern: "5\\d{2}"
+                StatusCode: "500"
         PassthroughBehavior: "WHEN_NO_MATCH"
         RequestParameters:
-          "integration.request.path.folder": "method.request.path.bucketName"
-          "integration.request.path.item": "method.request.path.caseNumber"
+          "integration.request.header.x-amz-checksum-sha1": "method.request.header.x-amz-checksum-sha1"
+          "integration.request.header.x-amz-sdk-checksum-algorithm": "method.request.header.x-amz-sdk-checksum-algorithm"
         TimeoutInMillis: 29000
         Type: "AWS"
-        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:s3:path/{folder}/{item}"
+        Uri:
+          - !Sub
+            - "arn:aws:apigateway:${AWS::Region}:emails-from-sf-${lowerCaseStage}.s3:path/?delete"
+            - { lowerCaseStage: !FindInMap [ StageMap, !Ref Stage, ToLowerCase ] }
 
   ApiGatewayDeployment:
     Type: "AWS::ApiGateway::Deployment"

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -183,7 +183,7 @@ Resources:
           StatusCode: "500"
       Integration:
         CacheNamespace: !Ref ApiGatewayResourceS3File
-        Credentials: !Sub "arn:aws:iam::${AWS::AccountId}:role/emails-to-sf-api-${ApiGatewayStage}-api-gateway-role"
+        Credentials: !Sub "arn:aws:iam::${AWS::AccountId}:role/emails-to-sf-api-${Stage}-api-gateway-role"
         IntegrationHttpMethod: "POST"
         IntegrationResponses:
           - ResponseParameters:


### PR DESCRIPTION
## What does this change?

The functionality to perform a Delete on a single file in S3 has been replaced by an endpoint to perform a bulk delete, whereby the request body can take up to 1000 file names.

This is so that when files are being deleted due to the 18 month retention rule in Salesforce, the number of API calls is minimised. If these changes were not implemented, the number of API calls from Salesforce could be increased by up to 1500 per day.

Request Body:
```
<Delete>
	<Object>
		<Key>01564901</Key>
	</Object>
	<Object>
		<Key>01564902</Key>
	</Object>
	<Object>
		<Key>01564903</Key>
	</Object>
</Delete>
```

Example Response Body:
_where 2 deletes succeed and 1 delete fails_
```
<?xml version="1.0" encoding="UTF-8"?>
<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
	<Deleted>
   		<Key>01564901</Key>
	</Deleted>
 	<Deleted>
   		<Key>01564902</Key>
 	</Deleted>
 	<Error>
  		<Key>01564903</Key>
  		<Code>AccessDenied</Code>
  		<Message>Access Denied</Message>
 	</Error>
</DeleteResult>
```
## How to test

- make a POST callout to endpoint: _https://nun4xgqqge.execute-api.eu-west-1.amazonaws.com/DEV/emails-from-sf-dev_
- verify that a response of the structure above is returned. 
- for the Keys in the deleted nodes, verify the files have been deleted