### PR TITLE
Remove redundant config for Zuora API version

### DIFF
--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestConfig.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestConfig.scala
@@ -7,7 +7,6 @@ case class ZuoraRestConfig(
   baseUrl: String,
   username: String,
   password: String,
-  apiMinorVersion: Option[String] = None,
 )
 
 object ZuoraRestConfig {

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -11,15 +11,11 @@ import play.api.libs.json._
 object ZuoraRestRequestMaker extends LazyLogging {
 
   def apply(response: Request => Response, config: ZuoraRestConfig): RestRequestMaker.Requests = {
-    val apiVersionHeader = config.apiMinorVersion match {
-      case None => Map()
-      case Some(version) => Map("zuora-version" -> version)
-    }
     new RestRequestMaker.Requests(
       headers = Map(
         "apiSecretAccessKey" -> config.password,
         "apiAccessKeyId" -> config.username
-      ) ++ apiVersionHeader,
+      ),
       baseUrl = config.baseUrl + "/", //TODO shouldn't have to add it
       getResponse = response,
       jsonIsSuccessful = zuoraIsSuccessful


### PR DESCRIPTION
Now that we're applying the Zuora API version at the call level in #1426, there's no more need for the extra config field to hold it.

