### PR TITLE
Backfill - run lambda every 15 mins

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -323,6 +323,13 @@ Resources:
               Action: s3:GetObject
               Resource:
                 - arn:aws:s3::*:membership-dist/*
+      Events:
+        ScheduledRun:
+          Type: Schedule
+          Properties:
+            Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule ]
+            Description: Runs SF Emails to S3 Exporter
+            Enabled: True
 
   failedS3WriteFileAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -15,6 +15,7 @@ Parameters:
 Mappings:
   StageMap:
     PROD:
+      Schedule: 'rate(15 minutes)'
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
       ToLowerCase: prod

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -20,6 +20,7 @@ Mappings:
       AppName: SFEmailsToS3
       ToLowerCase: prod
     DEV:
+      Schedule: 'rate(365 days)'
       SalesforceUsername: EmailsToS3APIUser
       AppName: AwsConnectorSandbox
       ToLowerCase: dev


### PR DESCRIPTION
## What does this change?
Schedule the lambda to run every 15 minutes.

From previous performance testing, we expect the processing time to be 6-7 minutes for each set of 2000 records returned by the start query