### PR TITLE
Emails to s3   fix datetime bug on writeback to sf

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
@@ -18,6 +18,6 @@ object ConfirmationWriteBackToSF {
   case class Attributes(`type`: String)
 
   def getCurrentDateTimeForWriteback(): String = {
-    DateTimeFormatter.ofPattern("YYYY-MM-DD'T'HH:mm:SS'Z'").format(LocalDateTime.now)
+    DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:SS'Z'").format(LocalDateTime.now)
   }
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/ConfirmationWriteBackToSF.scala
@@ -18,6 +18,6 @@ object ConfirmationWriteBackToSF {
   case class Attributes(`type`: String)
 
   def getCurrentDateTimeForWriteback(): String = {
-    DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:SS'Z'").format(LocalDateTime.now)
+    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:SS'Z'").format(LocalDateTime.now)
   }
 }


### PR DESCRIPTION
## What does this change?
For our writeback to Salesforce, we should be using:


- day of month (dd) instead of day of year (DD)
- year of era (yyyy) instead of week-based year (YYYY)

This should fix incorrect dates being written upon successful export.


## How to test
Export an email from Salesforce and verify that the correct datetime is written back to the EmailMessage.Most_Recent_Export__c field