### PR TITLE
Avoid dependency on pre-synced subscription for Salesforce to raise cancellation case

### DIFF
--- a/handlers/cancellation-sf-cases-api/src/main/scala/com/gu/cancellation/sf_cases/RaiseCase.scala
+++ b/handlers/cancellation-sf-cases-api/src/main/scala/com/gu/cancellation/sf_cases/RaiseCase.scala
@@ -8,9 +8,9 @@ import com.gu.salesforce.SalesforceGenericIdLookup.{FieldName, LookupValue, SfOb
 import com.gu.salesforce.cases.SalesforceCase
 import com.gu.salesforce.cases.SalesforceCase.Create.WireNewCase
 import com.gu.salesforce.cases.SalesforceCase.GetMostRecentCaseByContactId.TGetMostRecentCaseByContactId
-import com.gu.salesforce.cases.SalesforceCase.{CaseId, CaseSubject, CaseWithId, ContactId, SubscriptionId}
+import com.gu.salesforce.cases.SalesforceCase.{CaseId, CaseSubject, CaseWithId, ContactId}
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
-import com.gu.util.reader.Types.{ApiGatewayOp, _}
+import com.gu.util.reader.Types.ApiGatewayOp
 import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.resthttp.{JsonHttp, Types}
 import play.api.libs.json.{JsObject, JsString, JsValue, Json}
@@ -31,8 +31,6 @@ object RaiseCase {
 
   final case class ContactIdContainer(Id: String)
   implicit val readsContactIdContainer = Json.reads[ContactIdContainer]
-  final case class SubscriptionIdContainer(Id: String)
-  implicit val readsSubscriptionIdContainer = Json.reads[SubscriptionIdContainer]
 
   case class RaiseCaseDetail(
     product: ProductName,

--- a/handlers/cancellation-sf-cases-api/src/test/scala/com/gu/cancellation/sf_cases/HandlerTest.scala
+++ b/handlers/cancellation-sf-cases-api/src/test/scala/com/gu/cancellation/sf_cases/HandlerTest.scala
@@ -2,7 +2,7 @@ package com.gu.cancellation.sf_cases
 
 import com.gu.cancellation.sf_cases.RaiseCase._
 import com.gu.salesforce.cases.SalesforceCase.Create.WireNewCase
-import com.gu.salesforce.cases.SalesforceCase.{CaseSubject, ContactId, SubscriptionId}
+import com.gu.salesforce.cases.SalesforceCase.{CaseSubject, ContactId}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,7 +10,6 @@ class HandlerTest extends AnyFlatSpec with Matchers {
 
   it should "convert the raise case post body, sub id and contact id to a WireNewCase" in {
 
-    val subId = SubscriptionIdContainer("subID")
     val contactId = ContactIdContainer("contactID")
     val product = ProductName("Membership")
     val reason = Reason("mma_editorial")
@@ -26,14 +25,14 @@ class HandlerTest extends AnyFlatSpec with Matchers {
         subName,
         gaData
       ),
-      subId,
+      subName,
       contactId
     )
 
     val expected = WireNewCase(
       ContactId = ContactId(contactId.Id),
       Product__c = product.value,
-      SF_Subscription__c = SubscriptionId(subId.Id),
+      Subscription_Name__c = subName,
       Journey__c = "SV - At Risk - MB",
       Enquiry_Type__c = reason.value,
       Case_Closure_Reason__c = gaData.value,


### PR DESCRIPTION
To raise a cancellation case in Salesforce, we depend on the subscription that is being cancelled to already exist in Salesforce so that it can be looked up and have the case associated with it.  But when the sync from Zuora hasn't run in a while the subscription won't yet exist in Salesforce.

With this change, instead of looking up the associated subscription we just pass through the name of the subscription and let Salesforce sort out what to do with it.  This should mean that it will still be possible for the case to be successfully recorded in Salesforce and for the API call from MMA to return successfully even when the subscription has yet to be synced with Zuora.

Depends on:
- [x] Code to raise the case ready in Salesforce
