### PR TITLE
Set toAddress and fromAddress to Option

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/EmailsFromSfResponse.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/EmailsFromSfResponse.scala
@@ -10,7 +10,7 @@ object EmailsFromSfResponse {
   case class EmailRecord(
     Id: String,
     ParentId: String,
-    FromAddress: String,
+    FromAddress: Option[String] = None,
     BccAddress: Option[String] = None,
     CcAddress: Option[String] = None,
     FirstOpenedDate: Option[String] = None,
@@ -26,7 +26,7 @@ object EmailsFromSfResponse {
     Status: String,
     Subject: Option[String] = None,
     TextBody: Option[String] = None,
-    ToAddress: String,
+    ToAddress: Option[String] = None,
     Composite_Key__c: Option[String] = None,
     Resolve_on_Send__c: Boolean
   )

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/EmailsFromSfResponse.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/EmailsFromSfResponse.scala
@@ -21,7 +21,7 @@ object EmailsFromSfResponse {
     IsExternallyVisible: Boolean,
     Incoming: Boolean,
     LastOpenedDate: Option[String] = None,
-    MessageDate: String,
+    MessageDate: Option[String] = None,
     Parent: ParentCase,
     Status: String,
     Subject: Option[String] = None,


### PR DESCRIPTION
## What does this change?
We had assumed that FromAddress and ToAddress on EmailMessages can never be null in Salesforce, however a very small set of records contain a null for one of these fields. 

Null values on these fields are causing errors when parsing json to EmailsFromSfResponse.EmailRecord in scala, so I've updated their types to Option[String] from String