### PR TITLE
run emails to s3 backfill lambda every 10 mins

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -15,7 +15,7 @@ Parameters:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(15 minutes)'
+      Schedule: 'rate(10 minutes)'
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
       ToLowerCase: prod


### PR DESCRIPTION
## What does this change?
Increase the frequency of the Lambda backfill from every 15 minutes to every 10 minutes

Over the last 24 hours we have observed that the lambda takes between 4mins (minimum) and 6mins 30s (maximum) to export batches of 2000 emails in salesforce to S3. Increasing the frequency of the Lambda to run every 10 mins will enable the Lambda to process the remaining 280,000 records in 24 hours rather than 35 hours, enabling us to complete post-backfill actions tomorrow