### PR TITLE
Add schedule to run at 3am and 3:30am every day

### DIFF
--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -15,12 +15,14 @@ Parameters:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(15 minutes)'
+      Schedule1: 'rate(cron(00 03 * * ? *))'
+      Schedule2: 'rate(cron(30 03 * * ? *))'
       SalesforceUsername: EmailsToS3APIUser
       AppName: SFEmailsToS3
       ToLowerCase: prod
     DEV:
-      Schedule: 'rate(365 days)'
+      Schedule1: 'rate(365 days)'
+      Schedule2: 'rate(364 days)'
       SalesforceUsername: EmailsToS3APIUser
       AppName: AwsConnectorSandbox
       ToLowerCase: dev


### PR DESCRIPTION
## What does this change?
Schedule the Exporter Lambda to run at 3am and 3:30am every day

Each run will process 2000 records. We expect a maximum of 1500 emails per day to be surfaced for export, so the dual run will allow for up to 4000 emails per day to be exported (in the event of a sudden increase)

### Related Jobs and run times
02:00 **[Salesforce]** batch_CreateAsyncEmailExports - generates queue items for pickup by Lambda
03:00 **[AWS]** Lambda - Export Emails (this PR)
03:30 **[AWS]** Lambda - Export Emails (this PR)
04:00 **[Salesforce]** batch_genericRecordCleanup - Deletes emails that have been exported from Salesforce