### PR TITLE
[WIP] add basic shell product-move lambda using zio and scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -408,6 +408,22 @@ lazy val `delivery-problem-credit-processor` = lambdaProject(
   )
 ).dependsOn(`credit-processor`, `salesforce-sttp-client`, effects)
 
+lazy val `product-move-api` = lambdaProject(
+  "product-move-api",
+  "moves a reader from one subscription to another.",
+  Seq(
+    zio,
+    awsEvents,
+    awsLambda,
+    "com.softwaremill.sttp.client3" %% "httpclient-backend-zio1" % "3.5.1"  exclude("org.scala-lang.modules","scala-collection-compat_2.13"),
+    "dev.zio" %% "zio-s3" % "0.3.7"  exclude("org.scala-lang.modules","scala-collection-compat_2.13"),
+    "com.softwaremill.sttp.client3" %% "zio1-json" % "3.5.1",
+    "dev.zio" %% "zio-logging-slf4j" % "0.5.14"
+  )
+)
+  .settings(scalaVersion := "3.1.1")
+  .dependsOn()
+
 lazy val `metric-push-api` = lambdaProject(
   "metric-push-api",
   "HTTP API to push a metric to cloudwatch so we can alarm on errors")

--- a/handlers/product-move-api/README.md
+++ b/handlers/product-move-api/README.md
@@ -1,0 +1,11 @@
+# Product move api
+This is a lambda API to take a subscription ID for a contribution
+and move the subscription to be a digital subscription.
+It would be called from the backend, either manage-frontend or
+possibly support-frontend for acquisition channel based switches.
+
+The intention is to cancel the existing sub in zuora and replace it
+with a fresh one in the same account.  There will also be a confirmation
+email sent via membership-workflow.
+
+Working doc here: https://docs.google.com/document/d/17_es85x-rVrS-ONmHUrX5lVS0bCcgk6ZxOkwvyCQ3xY/edit#heading=h.4hjwot4q08ip

--- a/handlers/product-move-api/src/main/resources/logback.xml
+++ b/handlers/product-move-api/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date %level - %message%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Handler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Handler.scala
@@ -1,0 +1,165 @@
+package com.gu.productmove
+
+import com.amazonaws.services.lambda.runtime.*
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayV2HTTPEvent, APIGatewayV2HTTPResponse}
+import software.amazon.awssdk.auth.credentials.*
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.model.S3Exception
+import software.amazon.awssdk.utils.SdkAutoCloseable
+import sttp.capabilities.WebSockets
+import sttp.capabilities.zio.ZioStreams
+import sttp.client3.httpclient.zio.{HttpClientZioBackend, SttpClient, send}
+import sttp.client3.*
+import sttp.model.*
+import zio.blocking.*
+import zio.json.*
+import zio.s3.*
+import zio.s3.providers.*
+import zio.stream.ZTransducer
+import zio.{Has, *}
+import zio.logging._
+
+object Handler extends RequestHandler[APIGatewayV2HTTPEvent, APIGatewayV2HTTPResponse] {
+
+  val testInput: String = """{ "dummy": false }"""
+
+  // for testing
+  def main(args: Array[String]): Unit = {
+    val input = new APIGatewayV2HTTPEvent(
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      testInput,
+      false,
+      null
+    )
+    val context = new Context {
+      override def getAwsRequestId: String = ???
+
+      override def getLogGroupName: String = ???
+
+      override def getLogStreamName: String = ???
+
+      override def getFunctionName: String = ???
+
+      override def getFunctionVersion: String = ???
+
+      override def getInvokedFunctionArn: String = ???
+
+      override def getIdentity: CognitoIdentity = ???
+
+      override def getClientContext: ClientContext = ???
+
+      override def getRemainingTimeInMillis: Int = ???
+
+      override def getMemoryLimitInMB: Int = ???
+
+      override def getLogger: LambdaLogger = ???
+    }
+    val response = handleRequest(input, context)
+    println("response: " + response)
+  }
+
+  // this is the main lambda entry point.  It is referenced in the cloudformation.
+  override def handleRequest(input: APIGatewayV2HTTPEvent, context: Context): APIGatewayV2HTTPResponse =
+    Runtime.default.unsafeRun(
+      run(input)
+        .provideCustomLayer(AwsS3.live ++ SttpLayer.live ++ LoggingLayer.live)
+    )
+
+  case class ExpectedInput(dummy: Boolean)
+
+  object ExpectedInput {
+    implicit val decoder: JsonDecoder[ExpectedInput] =
+      DeriveJsonDecoder.gen[ExpectedInput]
+  }
+
+  case class ZuoraRestConfig(
+    baseUrl: String,
+    username: String,
+    password: String,
+  )
+  object ZuoraRestConfig {
+    implicit val decoder: JsonDecoder[ZuoraRestConfig] = DeriveJsonDecoder.gen[ZuoraRestConfig]
+  }
+
+  val bucket = "gu-reader-revenue-private"
+
+  def key(stage: String, version: Int = 1) = {
+    val basePath = s"membership/support-service-lambdas/$stage"
+
+    val versionString = if (stage == "DEV") "" else s".v${version}"
+    val relativePath = s"zuoraRest-$stage$versionString.json"
+    s"$basePath/$relativePath"
+  }
+
+  def run(input: APIGatewayV2HTTPEvent): ZIO[Logging with S3 with Blocking with SttpClient, Nothing, APIGatewayV2HTTPResponse] = {
+    (for {
+      stage <- ZIO.effect(sys.env.getOrElse("Stage", "DEV")).mapError(_.toString)
+      postData <- ZIO.fromEither(input.getBody.fromJson[ExpectedInput])
+      zuoraConfig <- getConfig(stage)
+      subscriptionNumber = "A-S00339056"//DEV - for testing locally
+      sub <- send(
+        basicRequest
+          .get(uri"${zuoraConfig.baseUrl}/subscriptions/$subscriptionNumber")
+          .headers(Map(
+            "apiSecretAccessKey" -> zuoraConfig.password,
+            "apiAccessKeyId" -> zuoraConfig.username
+          ))
+      ).mapError(_.toString)
+      _ <- log.info("PostData: " + postData.toString)
+      _ <- log.info("ZuoraConfig: " + zuoraConfig.toString)
+      _ <- log.info("Sub: " + sub.toString)
+    } yield APIGatewayV2HTTPResponse.builder().withStatusCode(200).build())
+      .catchAll { message =>
+        for {
+          _ <- log.info(message)
+        } yield APIGatewayV2HTTPResponse.builder().withStatusCode(500).build()
+
+      }
+  }
+
+  private def getConfig(stage: String): ZIO[Blocking with S3 with Logging, String, ZuoraRestConfig] = {
+    getObject(bucket, key(stage))
+      .transduce(ZTransducer.utf8Decode.mapChunks(_.flatMap(s => Chunk.fromArray(s.toCharArray))))
+      .transduce(summon[JsonDecoder[ZuoraRestConfig]].decodeJsonTransducer(JsonStreamDelimiter.Newline))
+      .runCollect.map(_.head)
+      .mapError(_.toString)
+  }
+}
+
+object AwsS3 {
+
+  private val ProfileName = "membership"
+
+  private val membershipProfile: ZManaged[Blocking, InvalidCredentials, ProfileCredentialsProvider] =
+    ZManaged
+      .fromAutoCloseable(IO.succeed(ProfileCredentialsProvider.create(ProfileName)))
+      .tapM(c =>
+        effectBlocking(c.resolveCredentials())
+          .mapError(err => InvalidCredentials(err.getMessage)))
+
+  private val managedCredentials: RManaged[Blocking, AwsCredentialsProvider] = membershipProfile <> instanceProfile
+  val live: ZLayer[Blocking, S3Exception, S3] = liveM[Blocking](Region.EU_WEST_1, managedCredentials)
+
+}
+
+object SttpLayer {
+
+  val live: ZLayer[Any, Throwable, SttpClient] = HttpClientZioBackend.managed().toLayer
+
+}
+
+object LoggingLayer {
+  val live =
+    Logging.console(
+      logLevel = LogLevel.Info,
+      format = LogFormat.ColoredLogFormat()
+    ) >>> Logging.withRootLoggerName("my-component")//TODO
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val contentAuthCommon = "com.gu" %% "content-authorisation-common" % "0.6"
 
   // Other
-  val zio = "dev.zio" %% "zio" % "1.0.7"
+  val zio = "dev.zio" %% "zio" % "1.0.13"
   val enumeratum = "com.beachape" %% "enumeratum" % "1.7.0"
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.0.1"
   val stripe = "com.stripe" % "stripe-java" % "20.105.0"


### PR DESCRIPTION
This PR adds a basic shell lambda for the new product-move API.

So far it uses Scala 3 and ZIO v1 (sttp, zio-logging, zio-json)

I have added code to read config from S3, and make an HTTP call to zuora.  It will then output the results to the logs.

It is WIP but just to get an idea of the direction I have been learning and request for comments on which approaches should be abandoned and any others I should be pusuing.
