### PR TITLE
Change alarm threshold for holiday stop processor

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -112,12 +112,12 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref HolidayStopProcessor
-      EvaluationPeriods: 1
+      EvaluationPeriods: 6
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: 4500
+      Period: 900
       Statistic: Sum
-      Threshold: 3
+      Threshold: 1
       TreatMissingData: notBreaching
     DependsOn:
       - HolidayStopProcessor


### PR DESCRIPTION
So that it monitors over a longer period for a smaller number of errors.

A large number of errors in a single run isn't particularly significant as history shows that almost all failures are self-healing.  But a single error that continues over several periods indicates that intervention is probably required.
