### PR TITLE
Discard all 'module-info.class' during assembly

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -94,7 +94,7 @@ object Dependencies {
   // to resolve merge clash of 'module-info.class'
   // see https://stackoverflow.com/questions/54834125/sbt-assembly-deduplicate-module-info-class
   val assemblyMergeStrategyDiscardModuleInfo = assembly / assemblyMergeStrategy := {
-    case PathList("module-info.class") => MergeStrategy.discard
+    case PathList(ps @ _*) if ps.last == "module-info.class" => MergeStrategy.discard
     case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
     case PathList("mime.types") => MergeStrategy.filterDistinctLines
     /*


### PR DESCRIPTION
This is to fix a build failure introduced in #1467 