### PR TITLE
holiday-stop-api make it return bad request if dates are invalid

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -1,10 +1,7 @@
 package com.gu.salesforce.holiday_stops
 
-import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, ZonedDateTime}
-import java.util.UUID
-
 import ai.x.play.json.Jsonx
+import cats.implicits._
 import com.gu.salesforce.SalesforceClient.SalesforceErrorResponseBody
 import com.gu.salesforce.SalesforceConstants._
 import com.gu.salesforce.SalesforceQueryConstants.contactToWhereClausePart
@@ -19,6 +16,11 @@ import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, CustomError}
 import com.gu.util.resthttp.{HttpOp, RestRequestMaker}
 import com.gu.zuora.subscription._
 import play.api.libs.json._
+
+import java.time.format.DateTimeFormatter
+import java.time.{LocalDate, ZonedDateTime}
+import java.util.UUID
+
 
 object SalesforceHolidayStopRequest extends Logging {
 
@@ -261,9 +263,8 @@ object SalesforceHolidayStopRequest extends Logging {
       startDate: LocalDate,
       endDate: LocalDate,
       issuesData: List[IssueData],
-      existingPublicationsThatWereToBeStopped: List[HolidayStopRequestsDetail],
-      zuoraSubscription: Subscription
-    ): CompositeRequest = {
+      existingPublicationsThatWereToBeStopped: List[HolidayStopRequestsDetail]
+    ): Either[String, CompositeRequest] = {
 
       val masterRecordToBePatched = CompositePart(
         method = "PATCH",
@@ -292,26 +293,28 @@ object SalesforceHolidayStopRequest extends Logging {
             ))(Json.writes[AddHolidayStopRequestDetailBody])
           )}
 
-      val detailRecordsToBeDeleted = existingPublicationsThatWereToBeStopped
+      existingPublicationsThatWereToBeStopped
         .filterNot(holidayStopRequestDetail =>
           issuesData.map(_.issueDate).contains(holidayStopRequestDetail.Stopped_Publication_Date__c.value)
         )
         .map( holidayStopRequestDetail => {
           if(holidayStopRequestDetail.Is_Actioned__c){
-            throw new RuntimeException("actioned publications cannot be deleted")
-          }
-          CompositePart(
-            method = "DELETE",
-            url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
-            referenceId = "DELETE DETAIL : " + UUID.randomUUID().toString,
-            body = JsNull
-          )
-        })
+            Left("actioned publications cannot be deleted")
+          } else
+            Right(CompositePart(
+              method = "DELETE",
+              url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
+              referenceId = "DELETE DETAIL : " + UUID.randomUUID().toString,
+              body = JsNull
+            ))
+        }).sequence.map { detailRecordsToBeDeleted =>
 
-      CompositeRequest(
-        allOrNone = true,
-        compositeRequest = masterRecordToBePatched :: detailRecordsToBeAdded ++ detailRecordsToBeDeleted
-      )
+          CompositeRequest(
+            allOrNone = true,
+            compositeRequest = masterRecordToBePatched :: detailRecordsToBeAdded ++ detailRecordsToBeDeleted
+          )
+
+      }
     }
 
   }

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -302,17 +302,20 @@ object SalesforceHolidayStopRequest extends Logging {
             if (holidayStopRequestDetail.Is_Actioned__c)
               Left("actioned publications cannot be deleted")
             else
-              Right(CompositePart(
-                method = "DELETE",
-                url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
-                referenceId = "DELETE DETAIL : " + UUID.randomUUID().toString,
-                body = JsNull
-              ))
+              Right(
+                CompositePart(
+                  method = "DELETE",
+                  url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
+                  referenceId = "DELETE DETAIL : " + UUID.randomUUID().toString,
+                  body = JsNull
+                )
+              )
           })
-      } yield CompositeRequest(
-        allOrNone = true,
-        compositeRequest = masterRecordToBePatched :: detailRecordsToBeAdded ++ detailRecordsToBeDeleted
-      )
+      } yield
+        CompositeRequest(
+          allOrNone = true,
+          compositeRequest = masterRecordToBePatched :: detailRecordsToBeAdded ++ detailRecordsToBeDeleted
+        )
     }
 
   }


### PR DESCRIPTION
At the moment, if the user tries to shorten a holiday stop but it's too late, we return a 500 error.

This PR makes it return a 400 bad request instead.  This will prevent the alarm and be more appropriate for a REST API.

Also there is a separate change in salesforce to be done - if the CSR clicks a new date and presses the Amend button before the validate request has completed, the request will be made and cause this error.  If the CSR waits until the request has validated, the button would have been disabled.  This will be done separately to this PR.