### PR TITLE
Increase threshold for no-requests alarm

### DIFF
--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -169,7 +169,7 @@ Resources:
         Or it could mean our users are happy and don't need to contact us. :)
       ComparisonOperator: LessThanThreshold
       Threshold: 1
-      EvaluationPeriods: 6
+      EvaluationPeriods: 12
       Metrics:
         - Id: actualCount
           Expression: "FILL(rawCount, 0)"


### PR DESCRIPTION
Increase threshold to trigger alarm when no requests for 12 hours, rather than 6.
Number of submissions has fallen significantly since live chat became available.