### PR TITLE
Increase timeout for contact us form submissions

### DIFF
--- a/handlers/contact-us-api/src/main/scala/com/gu/contact_us_api/SalesforceConnector.scala
+++ b/handlers/contact-us-api/src/main/scala/com/gu/contact_us_api/SalesforceConnector.scala
@@ -45,6 +45,7 @@ class SalesforceConnector(runRequest: HttpRequest => Either[ContactUsError, Http
   def sendReq(env: ContactUsConfig, token: String, request: SFCompositeRequest): Either[ContactUsError, Unit] = {
     runRequest(
       Http(env.reqEndpoint)
+        .timeout(connTimeoutMs = 30000, readTimeoutMs = 30000)
         .header("Content-Type", "application/json")
         .header("Authorization", s"Bearer $token")
         .postData(request.asJson.toString())


### PR DESCRIPTION
We're seeing errors in the contact-us lambda logs because form submits are timing out waiting for a response.
They do seem to write to Salesforce cases but don't return to client quickly enough.
