### PR TITLE
Bump Salesforce API version to latest

### DIFF
--- a/handlers/contact-us-api/src/main/scala/com/gu/contact_us_api/models/ContactUsConfig.scala
+++ b/handlers/contact-us-api/src/main/scala/com/gu/contact_us_api/models/ContactUsConfig.scala
@@ -4,6 +4,8 @@ case class ContactUsConfig(clientID: String, clientSecret: String, username: Str
 
 object ContactUsConfig {
 
+  val salesforceApiVersion = "54.0"
+
   val env: Either[ContactUsError, ContactUsConfig] = {
     (for {
       clientID <- sys.env.get("clientID")
@@ -20,7 +22,7 @@ object ContactUsConfig {
       password,
       token,
       s"https://$authDomain/services/oauth2/token",
-      s"https://$reqDomain/services/data/v43.0/composite/",
+      s"https://$reqDomain/services/data/v$salesforceApiVersion/composite/",
     )).toRight(ContactUsError("Environment", "Could not obtain all environment variables."))
   }
 

--- a/handlers/contact-us-api/src/main/scala/com/gu/contact_us_api/models/SFRequestItem.scala
+++ b/handlers/contact-us-api/src/main/scala/com/gu/contact_us_api/models/SFRequestItem.scala
@@ -1,5 +1,6 @@
 package com.gu.contact_us_api.models
 
+import com.gu.contact_us_api.models.ContactUsConfig.salesforceApiVersion
 import io.circe.{Encoder, Json}
 
 trait SFRequestItem
@@ -19,8 +20,9 @@ object SFRequestItem {
 }
 
 object SFCaseRequest {
+
   val method = "POST"
-  val url = "/services/data/v20.0/sobjects/Case/"
+  val url = s"/services/data/v$salesforceApiVersion/sobjects/Case/"
   val referenceId = "newCase"
 
   implicit val encodeSFCaseRequest: Encoder[SFCaseRequest] = new Encoder[SFCaseRequest] {
@@ -51,8 +53,9 @@ object SFCaseRequest {
 }
 
 object SFAttachmentRequest {
+
   val method = "POST"
-  val url = "/services/data/v20.0/sobjects/Attachment/"
+  val url = s"/services/data/v$salesforceApiVersion/sobjects/Attachment/"
   val referenceId = "newAttachment"
 
   implicit val encodeSFAttachmentRequest: Encoder[SFAttachmentRequest] = new Encoder[SFAttachmentRequest] {

--- a/handlers/contact-us-api/src/test/scala/com/gu/contact_us_api/models/SFRequestItemTests.scala
+++ b/handlers/contact-us-api/src/test/scala/com/gu/contact_us_api/models/SFRequestItemTests.scala
@@ -1,5 +1,6 @@
 package com.gu.contact_us_api.models
 
+import com.gu.contact_us_api.models.ContactUsConfig.salesforceApiVersion
 import com.gu.contact_us_api.models.ContactUsTestVars._
 import io.circe.Json
 import io.circe.syntax._
@@ -7,11 +8,12 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
 class SFRequestItemTests extends AnyFlatSpec with should.Matchers {
+
   private val method = "POST"
-  private val caseUrl = "/services/data/v20.0/sobjects/Case/"
+  private val caseUrl = s"/services/data/v$salesforceApiVersion/sobjects/Case/"
   private val caseReferenceId = "newCase"
 
-  private val attachmentUrl = "/services/data/v20.0/sobjects/Attachment/"
+  private val attachmentUrl = s"/services/data/v$salesforceApiVersion/sobjects/Attachment/"
   private val attachmentReferenceId = "newAttachment"
 
   private val caseReqBaseJson = Json.obj(

--- a/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/SFApiCompositeCreateDeliveryProblemTest.scala
+++ b/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/SFApiCompositeCreateDeliveryProblemTest.scala
@@ -1,8 +1,8 @@
 package com.gu.delivery_records_api
 
 import java.time.{LocalDate, LocalDateTime}
-
 import com.gu.salesforce.IdentityId
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -49,7 +49,7 @@ class SFApiCompositeCreateDeliveryProblemTest extends AnyFlatSpec with Matchers 
          |    {
          |      "referenceId" : "CaseCreation",
          |      "method" : "POST",
-         |      "url" : "/services/data/v29.0/sobjects/Case",
+         |      "url" : "/services/data/v$salesforceApiVersion/sobjects/Case",
          |      "body" : {
          |        "Contact" : {
          |          "IdentityID__c" : "123456789"
@@ -73,7 +73,7 @@ class SFApiCompositeCreateDeliveryProblemTest extends AnyFlatSpec with Matchers 
          |    {
          |      "referenceId" : "LinkDeliveryRecord-deliveryRecordIdA",
          |      "method" : "PATCH",
-         |      "url" : "/services/data/v29.0/sobjects/Delivery__c/deliveryRecordIdA",
+         |      "url" : "/services/data/v$salesforceApiVersion/sobjects/Delivery__c/deliveryRecordIdA",
          |      "body" : {
          |        "Case__c" : "@{CaseCreation.id}",
          |        "Credit_Amount__c" : 1.23,
@@ -84,7 +84,7 @@ class SFApiCompositeCreateDeliveryProblemTest extends AnyFlatSpec with Matchers 
          |    {
          |      "referenceId" : "LinkDeliveryRecord-deliveryRecordIdB",
          |      "method" : "PATCH",
-         |      "url" : "/services/data/v29.0/sobjects/Delivery__c/deliveryRecordIdB",
+         |      "url" : "/services/data/v$salesforceApiVersion/sobjects/Delivery__c/deliveryRecordIdB",
          |      "body" : {
          |        "Case__c" : "@{CaseCreation.id}",
          |        "Credit_Amount__c" : 3.21,
@@ -95,7 +95,7 @@ class SFApiCompositeCreateDeliveryProblemTest extends AnyFlatSpec with Matchers 
          |    {
          |      "referenceId" : "UpdateContactPhoneNumbers",
          |      "method" : "PATCH",
-         |      "url" : "/services/data/v29.0/sobjects/Contact/id",
+         |      "url" : "/services/data/v$salesforceApiVersion/sobjects/Contact/id",
          |      "body" : {
          |        "Id" : null,
          |        "Phone" : "1234567890",

--- a/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
+++ b/handlers/digital-voucher-cancellation-processor/src/test/scala/com/gu/digital_voucher_cancellation_processor/DigitalVoucherCancellationProcessorServiceTest.scala
@@ -21,6 +21,8 @@ import scala.concurrent.ExecutionContext
 
 class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Matchers {
 
+  val salesforceApiVersion = "54.0"
+
   private implicit val contextShift = IO.contextShift(ExecutionContext.global)
 
   val authConfig = SFAuthConfig(
@@ -45,10 +47,10 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
 
   def voucherToCancelQueryResult(resultId: String) = DigitalVoucherQueryResult(
     s"digital-voucher-id-$resultId",
-    CObjectAttribues(s"/services/data/v29.0/sobjects/Digital_Voucher__c/digital-voucher-id-$resultId"),
+    CObjectAttribues(s"/services/data/v$salesforceApiVersion/sobjects/Digital_Voucher__c/digital-voucher-id-$resultId"),
     SubscriptionQueryResult(
       s"sf-subscription-id-$resultId",
-      CObjectAttribues(s"/services/data/v29.0/sobjects/SF_Subscription__c/sf-subscription-id-$resultId")
+      CObjectAttribues(s"/services/data/v$salesforceApiVersion/sobjects/SF_Subscription__c/sf-subscription-id-$resultId")
     )
   )
 
@@ -56,7 +58,7 @@ class DigitalVoucherCancellationProcessorServiceTest extends AnyFlatSpec with Ma
     SFApiCompositePart(
       s"digital-voucher-id-$resultId",
       "PATCH",
-      s"/services/data/v29.0/sobjects/Digital_Voucher__c/digital-voucher-id-$resultId",
+      s"/services/data/v$salesforceApiVersion/sobjects/Digital_Voucher__c/digital-voucher-id-$resultId",
       DigitalVoucherUpdate(now, "Deactivated")
     )
   }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/GetSFContactSyncCheckFields.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/GetSFContactSyncCheckFields.scala
@@ -3,6 +3,7 @@ package com.gu.identityBackfill.salesforce
 import com.gu.i18n.CountryGroup
 import com.gu.identityBackfill.salesforce.ContactSyncCheck.RecordTypeId
 import com.gu.identityBackfill.salesforce.GetSFContactSyncCheckFields.ContactSyncCheckFields
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.{SFAccountId, SFContactId}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types
@@ -39,7 +40,7 @@ object GetSFContactSyncCheckFields {
   def toRequest(sfAccountId: SFAccountId) =
     GetRequest(
       RelativePath(
-        s"/services/data/v43.0/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
+        s"/services/data/v$salesforceApiVersion/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
           s"WHERE AccountId = '${sfAccountId.value}'"
       )
     )

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
@@ -1,5 +1,6 @@
 package com.gu.identityBackfill.salesforce
 
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.resthttp.HttpOp
 import com.gu.util.resthttp.RestRequestMaker.{PatchRequest, RelativePath}
@@ -17,7 +18,7 @@ object UpdateSalesforceIdentityId {
 
   def toRequest(sFContactId: SFContactId, identityId: IdentityId): PatchRequest = {
     val wireRequest = WireRequest(identityId.value)
-    val relativePath = RelativePath(s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")
+    val relativePath = RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/${sFContactId.value}")
     PatchRequest(wireRequest, relativePath)
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -1,7 +1,5 @@
 package com.gu.identityBackfill
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-
 import com.gu.effects.TestingRawEffects.{BasicRequest, HTTPResponse, POSTRequest}
 import com.gu.effects.{FakeFetchString, TestingRawEffects}
 import com.gu.identity.GetByEmailTest.TestData.dummyIdentityResponse
@@ -9,13 +7,16 @@ import com.gu.identityBackfill.EndToEndData._
 import com.gu.identityBackfill.Runner._
 import com.gu.identityBackfill.salesforce.getContact.GetSFContactSyncCheckFieldsTest
 import com.gu.identityBackfill.zuora.{CountZuoraAccountsForIdentityIdData, GetZuoraAccountsForEmailData}
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.auth.SalesforceAuthenticateData
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import com.gu.util.config.Stage
 import org.scalatest.Assertion
-import play.api.libs.json.Json
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 class EndToEndHandlerTest extends AnyFlatSpec with Matchers {
 
@@ -34,7 +35,7 @@ class EndToEndHandlerTest extends AnyFlatSpec with Matchers {
     responseString jsonMatches expectedResponse
 
     requests should be(List(
-      BasicRequest("GET", ("/services/data/v43.0/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
+      BasicRequest("GET", (s"/services/data/v$salesforceApiVersion/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
         "WHERE AccountId = %27crmId%27").replace(" ", "%20"), ""),
       BasicRequest("POST", "/services/oauth2/token", "client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf" +
         "&password=passSFpasswordtokentokenSFtoken&grant_type=password"),
@@ -61,9 +62,9 @@ class EndToEndHandlerTest extends AnyFlatSpec with Matchers {
     responseString jsonMatches expectedResponse
 
     requests should be(List(
-      BasicRequest("PATCH", "/services/data/v20.0/sobjects/Contact/00110000011AABBAAB", """{"IdentityID__c":"1234"}"""),
+      BasicRequest("PATCH", s"/services/data/v$salesforceApiVersion/sobjects/Contact/00110000011AABBAAB", """{"IdentityID__c":"1234"}"""),
       BasicRequest("PUT", "/accounts/2c92a0fb4a38064e014a3f48f1663ad8", """{"IdentityId__c":"1234"}"""),
-      BasicRequest("GET", ("/services/data/v43.0/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
+      BasicRequest("GET", (s"/services/data/v$salesforceApiVersion/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
         "WHERE AccountId = %27crmId%27").replace(" ", "%20"), ""),
       BasicRequest("POST", "/services/oauth2/token", "client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf" +
         "&password=passSFpasswordtokentokenSFtoken&grant_type=password"),
@@ -112,7 +113,7 @@ object EndToEndData {
   def responsesGetSFContactSyncCheckFieldsTest: Map[String, HTTPResponse] = {
 
     Map(
-      ("/services/data/v43.0/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
+      (s"/services/data/v$salesforceApiVersion/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
         "WHERE AccountId = %27crmId%27").replace(" ", "%20") ->
         HTTPResponse(200, GetSFContactSyncCheckFieldsTest.dummyContact)
     )

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
@@ -2,6 +2,7 @@ package com.gu.identityBackfill.salesforce.getContact
 
 import com.gu.identityBackfill.salesforce.GetSFContactSyncCheckFields
 import com.gu.identityBackfill.salesforce.GetSFContactSyncCheckFields.{ContactSyncCheckFields, ContactsByAccountIdQueryResponse}
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.SFAccountId
 import com.gu.util.resthttp.RestRequestMaker.{GetRequest, RelativePath}
 import play.api.libs.json.{JsSuccess, Json}
@@ -14,7 +15,7 @@ class GetSFContactSyncCheckFieldsTest extends AnyFlatSpec with Matchers {
     val actual = GetSFContactSyncCheckFields.toRequest(SFAccountId("001g000000XrQcaAAF"))
     val expected = GetRequest(
       RelativePath(
-        "/services/data/v43.0/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
+        s"/services/data/v$salesforceApiVersion/query?q=SELECT Id, RecordTypeId, LastName, FirstName, OtherCountry, Email FROM Contact " +
           "WHERE AccountId = '001g000000XrQcaAAF'"
       )
     )
@@ -41,8 +42,10 @@ class GetSFContactSyncCheckFieldsTest extends AnyFlatSpec with Matchers {
 
 object GetSFContactSyncCheckFieldsTest {
 
+  val salesforceApiVersion = "54.0"
+
   val dummyContact: String =
-    """
+    s"""
       |{
       |    "totalSize": 1,
       |    "done": true,
@@ -50,7 +53,7 @@ object GetSFContactSyncCheckFieldsTest {
       |        {
       |            "attributes": {
       |                "type": "Contact",
-      |                "url": "/services/data/v43.0/sobjects/Contact/00110000011AABBAAB"
+      |                "url": "/services/data/v$salesforceApiVersion/sobjects/Contact/00110000011AABBAAB"
       |            },
       |            "Id": "00110000011AABBAAB",
       |            "RecordTypeId": "STANDARD_TEST_DUMMY",

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/GetSalesforceIdentityId.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/GetSalesforceIdentityId.scala
@@ -1,6 +1,7 @@
 package com.gu.identityBackfill.salesforce.updateSFIdentityId
 
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.resthttp.RestOp.HttpOpParseOp
 import com.gu.util.resthttp.RestRequestMaker.{GetRequest, RelativePath}
@@ -17,6 +18,6 @@ object GetSalesforceIdentityId {
   def apply(getOp: HttpOp[GetRequest, JsValue]): SFContactId => LazyClientFailableOp[IdentityId] =
     getOp.setupRequest(toRequest).parse[WireResult].map(_.IdentityID__c).map(IdentityId.apply).runRequestLazy
 
-  def toRequest(sfContactId: SFContactId) = GetRequest(RelativePath(s"/services/data/v43.0/sobjects/Contact/${sfContactId.value}"))
+  def toRequest(sfContactId: SFContactId) = GetRequest(RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/${sfContactId.value}"))
 
 }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
@@ -2,6 +2,7 @@ package com.gu.identityBackfill.salesforce.updateSFIdentityId
 
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.resthttp.RestRequestMaker.{PatchRequest, RelativePath}
 import play.api.libs.json.{JsObject, JsString}
@@ -14,7 +15,7 @@ class UpdateSalesforceIdentityIdTest extends AnyFlatSpec with Matchers {
 
     val actual = UpdateSalesforceIdentityId.toRequest(SFContactId("contactsf"), IdentityId("identityid"))
     val expectedJson = JsObject(Seq("IdentityID__c" -> JsString("identityid")))
-    val expected = new PatchRequest(expectedJson, RelativePath("/services/data/v20.0/sobjects/Contact/contactsf"))
+    val expected = new PatchRequest(expectedJson, RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/contactsf"))
     actual should be(expected)
 
   }

--- a/handlers/sf-api-user-credentials-setter/src/main/scala/com/gu/sfapiusercredentialsetter/Main.scala
+++ b/handlers/sf-api-user-credentials-setter/src/main/scala/com/gu/sfapiusercredentialsetter/Main.scala
@@ -12,6 +12,9 @@ import software.amazon.awssdk.services.secretsmanager.model._
 import scala.util.{Random, Try}
 
 object Main extends App with LazyLogging {
+
+  val salesforceApiVersion = "54.0"
+
   case class SfAuthDetails(access_token: String, instance_url: String)
 
   case class setPasswordResponse(message: String, errorCode: String)
@@ -155,7 +158,7 @@ object Main extends App with LazyLogging {
   }
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
-    Http(s"${sfAuthDetails.instance_url}/services/data/v20.0/query/")
+    Http(s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/query/")
       .param("q", query)
       .option(HttpOptions.readTimeout(30000))
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
@@ -219,7 +222,7 @@ object Main extends App with LazyLogging {
       setPasswordRequestBody(NewPassword = newPwd).asJson.spaces2
     Try {
       Http(
-        s"${sfAuthDetails.instance_url}/services/data/v25.0/sobjects/User/$sfUserId/password"
+        s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/sobjects/User/$sfUserId/password"
       ).option(HttpOptions.readTimeout(30000))
         .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
         .header("Content-Type", "application/json")

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -11,6 +11,9 @@ import scalaj.http._
 import scala.util.Try
 
 object BillingAccountRemover extends App with LazyLogging {
+
+  val salesforceApiVersion = "54.0"
+
   //Salesforce
   case class SfAuthDetails(access_token: String, instance_url: String)
 
@@ -169,7 +172,7 @@ object BillingAccountRemover extends App with LazyLogging {
   }
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
-    Http(s"${sfAuthDetails.instance_url}/services/data/v20.0/query/")
+    Http(s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/query/")
       .param("q", query)
       .option(HttpOptions.readTimeout(30000))
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
@@ -186,7 +189,7 @@ object BillingAccountRemover extends App with LazyLogging {
 
     Try {
       Http(
-        s"${sfAuthDetails.instance_url}/services/data/v45.0/composite/sobjects"
+        s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/composite/sobjects"
       ).header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
         .header("Content-Type", "application/json")
         .put(jsonBody)

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getsfcontacts/ToSfContactRequest.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getsfcontacts/ToSfContactRequest.scala
@@ -1,5 +1,6 @@
 package com.gu.sf_contact_merge.getsfcontacts
 
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.resthttp.RestRequestMaker.{GetRequest, RelativePath}
 import play.api.libs.json.Json
@@ -19,6 +20,6 @@ object ToSfContactRequest {
   )
   implicit val wireResultReads = Json.reads[WireResult]
 
-  def apply(sfContactId: SFContactId) = GetRequest(RelativePath(s"/services/data/v43.0/sobjects/Contact/${sfContactId.value}"))
+  def apply(sfContactId: SFContactId) = GetRequest(RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/${sfContactId.value}"))
 
 }

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSalesforceIdentityId.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSalesforceIdentityId.scala
@@ -1,5 +1,6 @@
 package com.gu.sf_contact_merge.update
 
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.sf_contact_merge.Types.IdentityId
 import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, FirstName}
@@ -59,7 +60,7 @@ object UpdateSalesforceIdentityId {
       contactUpdate.maybeOverwriteEmailAddress.map(_.value)
     )
 
-    val relativePath = RelativePath(s"/services/data/v43.0/sobjects/Contact/${sFContactId.value}")
+    val relativePath = RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/${sFContactId.value}")
     PatchRequest(wireRequest, relativePath)
   }
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -2,6 +2,7 @@ package com.gu.sf_contact_merge
 
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 import com.gu.effects.{FakeFetchString, TestingRawEffects}
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.apigateway.ResponseModels.{ApiResponse, Headers}
 import com.gu.util.config.Stage
@@ -165,8 +166,8 @@ object EndToEndTest {
 
   val mock = new TestingRawEffects(
     responses = Map(
-      "/services/data/v43.0/sobjects/Contact/newSFCont" -> HTTPResponse(200, newSFContResponse),
-      "/services/data/v43.0/sobjects/Contact/oldSFCont" -> HTTPResponse(200, oldSFContResponse)
+      s"/services/data/v$salesforceApiVersion/sobjects/Contact/newSFCont" -> HTTPResponse(200, newSFContResponse),
+      s"/services/data/v$salesforceApiVersion/sobjects/Contact/oldSFCont" -> HTTPResponse(200, oldSFContResponse)
     ),
     postResponses = Map(
       POSTRequest("/services/oauth2/token", sfAuthReq) -> HTTPResponse(200, sfAuthResponse),
@@ -174,8 +175,8 @@ object EndToEndTest {
       POSTRequest("/action/query", contactQueryRequest) -> HTTPResponse(200, contactQueryResponse),
       POSTRequest("/accounts/2c92c0f9624bbc5f016253e573970b16", updateAccountRequestBody, "PUT") -> updateAccountResponse,
       POSTRequest("/accounts/2c92c0f8644618e30164652a558c6e20", updateAccountRequestBody, "PUT") -> updateAccountResponse,
-      POSTRequest("/services/data/v43.0/sobjects/Contact/oldSFCont", removeIdentityBody, "PATCH") -> updateAccountResponse,
-      POSTRequest("/services/data/v43.0/sobjects/Contact/newSFCont", addIdentityBody, "PATCH") -> updateAccountResponse
+      POSTRequest(s"/services/data/v$salesforceApiVersion/sobjects/Contact/oldSFCont", removeIdentityBody, "PATCH") -> updateAccountResponse,
+      POSTRequest(s"/services/data/v$salesforceApiVersion/sobjects/Contact/newSFCont", addIdentityBody, "PATCH") -> updateAccountResponse
     )
   )
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getsfcontacts/ToSfContactRequestTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getsfcontacts/ToSfContactRequestTest.scala
@@ -1,5 +1,6 @@
 package com.gu.sf_contact_merge.getsfcontacts
 
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.resthttp.RestRequestMaker.{GetRequest, RelativePath}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -9,7 +10,7 @@ class ToSfContactRequestTest extends AnyFlatSpec with Matchers {
 
   "toRequest" should "compose a correct GET request" in {
     val actual = ToSfContactRequest(SFContactId("testcont"))
-    actual should be(GetRequest(RelativePath("/services/data/v43.0/sobjects/Contact/testcont")))
+    actual should be(GetRequest(RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/testcont")))
   }
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -5,6 +5,7 @@ import com.gu.salesforce.SFAuthConfig
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.salesforce.dev.SFEffectsData
 import com.gu.salesforce.SalesforceClient
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.SalesforceReads._
 import com.gu.sf_contact_merge.Types.IdentityId
 import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, FirstName}
@@ -98,6 +99,6 @@ object GetSalesforceIdentityId {
   def apply(getOp: HttpOp[GetRequest, JsValue])(sFContactId: SFContactId): ClientFailableOp[WireResult] =
     getOp.setupRequest(toRequest).parse[WireResult].runRequest(sFContactId)
 
-  def toRequest(sfContactId: SFContactId) = GetRequest(RelativePath(s"/services/data/v43.0/sobjects/Contact/${sfContactId.value}"))
+  def toRequest(sfContactId: SFContactId) = GetRequest(RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/${sfContactId.value}"))
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
@@ -1,5 +1,6 @@
 package com.gu.sf_contact_merge.update.updateSFIdentityId
 
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.sf_contact_merge.Types.IdentityId
 import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, FirstName}
@@ -43,7 +44,7 @@ class UpdateSalesforceIdentityIdTest extends AnyFlatSpec with Matchers {
       "Phone" -> JsString("phone1"),
       "Email" -> JsString("emailemail")
     ))
-    val expected = new PatchRequest(expectedJson, RelativePath("/services/data/v43.0/sobjects/Contact/contactsf"))
+    val expected = new PatchRequest(expectedJson, RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/contactsf"))
     actual should be(expected)
 
   }
@@ -63,7 +64,7 @@ class UpdateSalesforceIdentityIdTest extends AnyFlatSpec with Matchers {
       "IdentityID__c" -> JsString("identityid"),
       "FirstName" -> JsString(".")
     ))
-    val expected = new PatchRequest(expectedJson, RelativePath("/services/data/v43.0/sobjects/Contact/contactsf"))
+    val expected = new PatchRequest(expectedJson, RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/contactsf"))
     actual should be(expected)
 
   }
@@ -82,7 +83,7 @@ class UpdateSalesforceIdentityIdTest extends AnyFlatSpec with Matchers {
     val expectedJson = JsObject(Seq(
       "IdentityID__c" -> JsString("identityid")
     ))
-    val expected = new PatchRequest(expectedJson, RelativePath("/services/data/v43.0/sobjects/Contact/contactsf"))
+    val expected = new PatchRequest(expectedJson, RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/contactsf"))
     actual should be(expected)
 
   }
@@ -101,7 +102,7 @@ class UpdateSalesforceIdentityIdTest extends AnyFlatSpec with Matchers {
     val expectedJson = JsObject(Seq(
       "IdentityID__c" -> JsString("")
     ))
-    val expected = new PatchRequest(expectedJson, RelativePath("/services/data/v43.0/sobjects/Contact/contactsf"))
+    val expected = new PatchRequest(expectedJson, RelativePath(s"/services/data/v$salesforceApiVersion/sobjects/Contact/contactsf"))
     actual should be(expected)
 
   }

--- a/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
+++ b/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
@@ -19,7 +19,7 @@ object RunBatch {
   this is run to process a batch manually that's been extracted from postman
 
   run this first in postman for some suitable date range:
-  {{instance_url}}/services/data/v43.0/query?q=SELECT+Scenario_Type__c,+Recent_Contact_Creation_Date__c,+Json_For_Zuora__c+from+Duplicate_Contact__c+WHERE+Recent_Contact_Creation_Date__c+<+2016-06-16T00:00:00.000Z+AND+Scenario_Type__c+!=+null+AND+No_Of_Billing_Accounts__c+>=+2+ORDER+BY+Recent_Contact_Creation_Date__c
+  {{instance_url}}/services/data/v{{salesforce_api_version}}/query?q=SELECT+Scenario_Type__c,+Recent_Contact_Creation_Date__c,+Json_For_Zuora__c+from+Duplicate_Contact__c+WHERE+Recent_Contact_Creation_Date__c+<+2016-06-16T00:00:00.000Z+AND+Scenario_Type__c+!=+null+AND+No_Of_Billing_Accounts__c+>=+2+ORDER+BY+Recent_Contact_Creation_Date__c
 
   Then run this script with args <sf-contact-merge-apikey> <queryResultFileName>
   If you're using intellij it's easier to just run it once using the green arrow, then use the drop down at the top saying RunBatch to

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/CustomFailure.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/CustomFailure.scala
@@ -6,7 +6,7 @@ case class CustomFailure(message: String)
 
 object CustomFailure extends LazyLogging {
 
-  def toMetric(eventName: String, message:String): CustomFailure = {
+  def toMetric(eventName: String, message: String): CustomFailure = {
     logger.error(s"CustomFailure.toMetric message: $message | eventName: $eventName")
     Metrics.put(event = eventName)
     CustomFailure(message)

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Metrics.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/Metrics.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.{Failure, Success}
 
-object Metrics extends LazyLogging{
+object Metrics extends LazyLogging {
 
   private val stage = sys.env.getOrElse("Stage", "DEV")
 
@@ -20,13 +20,13 @@ object Metrics extends LazyLogging{
         1.0
       )
     ) match {
-      case Failure(exception) => {
-        logger.warn(s"Error logging Metric $event. Error:", exception)
+        case Failure(exception) => {
+          logger.warn(s"Error logging Metric $event. Error:", exception)
+        }
+        case Success(_) => {
+          logger.info(s"Metric $event logged successfully")
+        }
       }
-      case Success(_) => {
-        logger.info(s"Metric $event logged successfully")
-      }
-    }
   }
 
 }

--- a/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
+++ b/handlers/sf-emails-to-s3-exporter/src/main/scala/com/gu/sf_emails_to_s3_exporter/SFConnector.scala
@@ -11,6 +11,8 @@ import scalaj.http.{Http, HttpOptions}
 
 object SFConnector extends LazyLogging {
 
+  val salesforceApiVersion = "54.0"
+
   case class SfAuthDetails(access_token: String, instance_url: String)
 
   def getRecordsFromSF[A: Decoder](sfAuthDetails: SfAuthDetails, sfApiVersion: String, query: String, batchSize: Integer): Either[Error, A] = {
@@ -74,7 +76,7 @@ object SFConnector extends LazyLogging {
   def deleteQueueItemsInSf(sfAuthDetails: SfAuthDetails, recordIds: Seq[String]): Either[Error, Seq[WritebackToSFResponse.WritebackResponse]] = {
     logger.info("Deleting async process records from sf...")
 
-    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/v52.0/composite/sobjects")
+    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/composite/sobjects")
       .param("ids", recordIds.mkString(","))
       .param("allOrNone", "false")
       .option(HttpOptions.readTimeout(30000))
@@ -92,7 +94,7 @@ object SFConnector extends LazyLogging {
     requestType: String
   ): Either[Error, Seq[WritebackToSFResponse.WritebackResponse]] = {
 
-    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/v45.0/composite/sobjects")
+    val responseBody = Http(s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/composite/sobjects")
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
       .option(HttpOptions.readTimeout(30000))
       .header("Content-Type", "application/json")

--- a/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
@@ -4,6 +4,8 @@ import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 
 object SFTestEffects {
 
+  val salesforceApiVersion = "54.0"
+
   val authSuccessResponseBody: String =
     s"""
        |{
@@ -28,8 +30,8 @@ object SFTestEffects {
 
   def cancelSuccess(referenceId: String, price: Double) = (
     POSTRequest(
-      "/services/data/v38.0/composite/",
-      s"""{"allOrNone":true,"compositeRequest":[{"method":"PATCH","url":"/services/data/v29.0/sobjects/Holiday_Stop_Requests_Detail__c/HSD-1","referenceId":"CANCEL DETAIL : $referenceId","body":{"Actual_Price__c":$price,"Charge_Code__c":"ManualRefund_Cancellation"}}]}"""
+      s"/services/data/v$salesforceApiVersion/composite/",
+      s"""{"allOrNone":true,"compositeRequest":[{"method":"PATCH","url":"/services/data/v$salesforceApiVersion/sobjects/Holiday_Stop_Requests_Detail__c/HSD-1","referenceId":"CANCEL DETAIL : $referenceId","body":{"Actual_Price__c":$price,"Charge_Code__c":"ManualRefund_Cancellation"}}]}"""
     ),
       HTTPResponse(200, """{ "compositeResponse" : [ { "httpStatusCode": 200 } ]}""".stripMargin)
   )

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesForceHolidayStopsEffects.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesForceHolidayStopsEffects.scala
@@ -2,8 +2,8 @@ package com.gu.salesforce.holiday_stops
 
 import java.net.URLEncoder
 import java.time.LocalDate
-
 import com.gu.effects.TestingRawEffects.HTTPResponse
+import com.gu.salesforce.SalesforceConstants.salesforceApiVersion
 import com.gu.salesforce.{RecordsWrapperCaseClass, SalesforceContactId}
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest.{HolidayStopRequest, LookupByContactAndOptionalSubscriptionName}
 import com.gu.zuora.subscription.SubscriptionName
@@ -19,7 +19,7 @@ object SalesForceHolidayStopsEffects {
   val listHolidayQuery = LookupByContactAndOptionalSubscriptionName.getSOQL _
 
   def listHolidayRequestUrl(contactId: String, subscriptionName: String, optionalHistoricalCutOff: Option[LocalDate]) = {
-    s"/services/data/v29.0/query/?q=${
+    s"/services/data/v$salesforceApiVersion/query/?q=${
       escapeQueryStringValue(listHolidayQuery(
         SalesforceContactId(contactId),
         Some(SubscriptionName(subscriptionName)),

--- a/lib/salesforce/core/src/main/scala/com/gu/salesforce/SalesforceConstants.scala
+++ b/lib/salesforce/core/src/main/scala/com/gu/salesforce/SalesforceConstants.scala
@@ -2,14 +2,16 @@ package com.gu.salesforce
 
 object SalesforceConstants {
 
-  private val sfApiBaseUrl = "/services/data/v29.0"
+  val salesforceApiVersion = "54.0"
 
-  val soqlQueryBaseUrl: String = sfApiBaseUrl + "/query/"
+  private val sfApiBaseUrl = s"/services/data/v$salesforceApiVersion"
 
-  val sfObjectsBaseUrl: String = sfApiBaseUrl + "/sobjects/"
+  val soqlQueryBaseUrl: String = s"$sfApiBaseUrl/query/"
 
-  val compositeBaseUrl: String = "/services/data/v38.0/composite/"
+  val sfObjectsBaseUrl: String = s"$sfApiBaseUrl/sobjects/"
 
-  val compositeTreeBaseUrl: String = compositeBaseUrl + "tree/"
+  val compositeBaseUrl: String = s"$sfApiBaseUrl/composite/"
+
+  val compositeTreeBaseUrl: String = s"${compositeBaseUrl}tree/"
 
 }


### PR DESCRIPTION
Salesforce API v20 is about to be decommissioned so I've upgraded all references to it to the latest version, which is currently v54.0.
I've also reduced the number of references to the minimum I can without restructuring the project.
