### PR TITLE
update alarms so we can detect 4xx and 5xx errors better

### DIFF
--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -345,7 +345,31 @@ Resources:
         EvaluationPeriods: 1
         MetricName: 5XXError
         Namespace: AWS/ApiGateway
-        Period: 3600
+        Period: 900
         Statistic: Sum
-        Threshold: 5
+        Threshold: 6
+        TreatMissingData: notBreaching
+
+    4xxApiAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: CreateProdMonitoring
+      Properties:
+        AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+        AlarmName:
+          !Sub
+            - 4XX rate from ${ApiName}
+            - { ApiName: !FindInMap [StageMap, !Ref Stage, ApiName] }
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: ApiName
+            Value: !FindInMap [StageMap, !Ref Stage, ApiName]
+          - Name: Stage
+            Value: !Sub ${Stage}
+        EvaluationPeriods: 1
+        MetricName: 4XXError
+        Namespace: AWS/ApiGateway
+        Period: 900
+        Statistic: Sum
+        Threshold: 6
         TreatMissingData: notBreaching


### PR DESCRIPTION
If the API is modified by cloudformation, it might delete one of the routes.  This is a complex story, but we need an alarm to notice if it happens again.  As it happened this morning due to this change in riff raff causing a new tag which update every single resource. https://github.com/guardian/riff-raff/pull/687

As a side note, this will happen again if we update the sbt-riffraff-artifact plugin, so be careful everyone!

The findings of the incident were as follows:
<><><><>
so, the summary is, we originally cloudformed the Stage with one endpoint.
CFN will create the deployment at that moment.
When we added the second endpoint we had to manually Deploy, as cfn won't redeploy.
When a tag is added, CFN will refresh the deployment to what it "should" be in cfn's mind, meaaning the new deployment is rolled back.

Alhough it's fixed for now, we are still in the risky situation in case the stack is redeployed again for any reason.

The solution appears to be either not to cloudform the deployments, or to use AutoDeploy = true, which is an API Gateway V2 option. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-stage.html#cfn-apigatewayv2-stage-autodeploy