### PR TITLE
Resolve reference ID format error introduced by Salesforce API v 54

### DIFF
--- a/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryProblemCase.scala
+++ b/handlers/delivery-records-api/src/main/scala/com/gu/delivery_records_api/SFApiDeliveryProblemCase.scala
@@ -116,7 +116,7 @@ object SFApiCompositeCreateDeliveryProblem {
         Priority = detail.priority
       )
     )) ++ detail.deliveryRecords.map(deliveryRecord => SFApiCompositePart[SFApiCompositePartBody](
-      referenceId = s"LinkDeliveryRecord-${deliveryRecord.id}",
+      referenceId = s"LinkDeliveryRecord_${deliveryRecord.id}",
       method = "PATCH",
       url = s"${sfObjectsBaseUrl}Delivery__c/${deliveryRecord.id}",
       body = SFApiLinkDeliveryRecord(

--- a/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/SFApiCompositeCreateDeliveryProblemTest.scala
+++ b/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/SFApiCompositeCreateDeliveryProblemTest.scala
@@ -71,7 +71,7 @@ class SFApiCompositeCreateDeliveryProblemTest extends AnyFlatSpec with Matchers 
          |      }
          |    },
          |    {
-         |      "referenceId" : "LinkDeliveryRecord-deliveryRecordIdA",
+         |      "referenceId" : "LinkDeliveryRecord_deliveryRecordIdA",
          |      "method" : "PATCH",
          |      "url" : "/services/data/v$salesforceApiVersion/sobjects/Delivery__c/deliveryRecordIdA",
          |      "body" : {
@@ -82,7 +82,7 @@ class SFApiCompositeCreateDeliveryProblemTest extends AnyFlatSpec with Matchers 
          |      }
          |    },
          |    {
-         |      "referenceId" : "LinkDeliveryRecord-deliveryRecordIdB",
+         |      "referenceId" : "LinkDeliveryRecord_deliveryRecordIdB",
          |      "method" : "PATCH",
          |      "url" : "/services/data/v$salesforceApiVersion/sobjects/Delivery__c/deliveryRecordIdB",
          |      "body" : {


### PR DESCRIPTION
Since upgrading the Salesforce API to v 54, we see error entries in the log like this:
> Provided referenceId ('LinkDeliveryRecord-xyz') must start with a letter or a number, and it can contain only letters, numbers and underscores ('_').

This behaviour is documented in the [API developer guide](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_subrequest_result.htm).

To fix it. I've modified the name of the offending reference ID.  These IDs aren't referred to in subsequent parts of the composite request so this seems safe to do.
