### PR TITLE
Stop holiday-stop processor retrying on failure

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -146,3 +146,13 @@ Resources:
     DependsOn:
       - HolidayStopProcessor
       - HolidayStopProcessorScheduleRule
+
+  # As processor runs every 20 mins anyway, there's no need to retry
+  HolidayStopProcessorRetryConfig:
+    Type: AWS::Lambda::EventInvokeConfig
+    Properties:
+      FunctionName: !Ref HolidayStopProcessor
+      MaximumRetryAttempts: 0
+      Qualifier: '$LATEST'
+    DependsOn:
+      - HolidayStopProcessor


### PR DESCRIPTION
It's possible to have two processors running concurrently if one of them was triggered by a schedule and the other was triggered by a retry.  When that happens there's a small possibility that the same credit amendment will be applied to a subscription twice.
To stop that from happening, I am disabling retry on failure in this PR.
This is has already been configured for the delivery-credit processor in #1210.
