### PR TITLE
Enable holiday stop operations that were broken by API upgrade

### DIFF
--- a/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
@@ -31,7 +31,7 @@ object SFTestEffects {
   def cancelSuccess(referenceId: String, price: Double) = (
     POSTRequest(
       s"/services/data/v$salesforceApiVersion/composite/",
-      s"""{"allOrNone":true,"compositeRequest":[{"method":"PATCH","url":"/services/data/v$salesforceApiVersion/sobjects/Holiday_Stop_Requests_Detail__c/HSD-1","referenceId":"CANCEL DETAIL : $referenceId","body":{"Actual_Price__c":$price,"Charge_Code__c":"ManualRefund_Cancellation"}}]}"""
+      s"""{"allOrNone":true,"compositeRequest":[{"method":"PATCH","url":"/services/data/v$salesforceApiVersion/sobjects/Holiday_Stop_Requests_Detail__c/HSD-1","referenceId":"CANCEL_DETAIL : $referenceId","body":{"Actual_Price__c":$price,"Charge_Code__c":"ManualRefund_Cancellation"}}]}"""
     ),
       HTTPResponse(200, """{ "compositeResponse" : [ { "httpStatusCode": 200 } ]}""".stripMargin)
   )

--- a/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/SFTestEffects.scala
@@ -31,7 +31,7 @@ object SFTestEffects {
   def cancelSuccess(referenceId: String, price: Double) = (
     POSTRequest(
       s"/services/data/v$salesforceApiVersion/composite/",
-      s"""{"allOrNone":true,"compositeRequest":[{"method":"PATCH","url":"/services/data/v$salesforceApiVersion/sobjects/Holiday_Stop_Requests_Detail__c/HSD-1","referenceId":"CANCEL_DETAIL : $referenceId","body":{"Actual_Price__c":$price,"Charge_Code__c":"ManualRefund_Cancellation"}}]}"""
+      s"""{"allOrNone":true,"compositeRequest":[{"method":"PATCH","url":"/services/data/v$salesforceApiVersion/sobjects/Holiday_Stop_Requests_Detail__c/HSD-1","referenceId":"CANCEL_DETAIL_$referenceId","body":{"Actual_Price__c":$price,"Charge_Code__c":"ManualRefund_Cancellation"}}]}"""
     ),
       HTTPResponse(200, """{ "compositeResponse" : [ { "httpStatusCode": 200 } ]}""".stripMargin)
   )

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -284,7 +284,7 @@ object SalesforceHolidayStopRequest extends Logging {
           CompositePart(
             method = "POST",
             url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef",
-            referenceId = "CREATE DETAIL : " + UUID.randomUUID().toString,
+            referenceId = "CREATE_DETAIL : " + UUID.randomUUID().toString,
             body = Json.toJson(AddHolidayStopRequestDetailBody(
               Holiday_Stop_Request__c = holidayStopRequestId,
               Stopped_Publication_Date__c = issueData.issueDate,

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -341,10 +341,10 @@ object SalesforceHolidayStopRequest extends Logging {
       val requestDetailParts = holidayStopRequestsDetails
         .map { requestDetail =>
           CompositePart(
-            "PATCH",
-            s"$holidayStopRequestsDetailSfObjectsBaseUrl/${requestDetail.Id.value}",
-            "CANCEL DETAIL : " + idGenerator,
-            Json.toJson(CancelHolidayStopRequestDetailBody(requestDetail.Actual_Price__c, requestDetail.Charge_Code__c))
+            method = "PATCH",
+            url = s"$holidayStopRequestsDetailSfObjectsBaseUrl/${requestDetail.Id.value}",
+            referenceId = "CANCEL_DETAIL : " + idGenerator,
+            body = Json.toJson(CancelHolidayStopRequestDetailBody(requestDetail.Actual_Price__c, requestDetail.Charge_Code__c))
           )
         }
       CompositeRequest(

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -306,7 +306,7 @@ object SalesforceHolidayStopRequest extends Logging {
                 CompositePart(
                   method = "DELETE",
                   url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
-                  referenceId = "DELETE DETAIL : " + UUID.randomUUID().toString,
+                  referenceId = "DELETE_DETAIL : " + UUID.randomUUID().toString,
                   body = JsNull
                 )
               )

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -284,7 +284,7 @@ object SalesforceHolidayStopRequest extends Logging {
           CompositePart(
             method = "POST",
             url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef",
-            referenceId = "CREATE_DETAIL : " + UUID.randomUUID().toString,
+            referenceId = s"CREATE_DETAIL_${UUID.randomUUID().toString}",
             body = Json.toJson(AddHolidayStopRequestDetailBody(
               Holiday_Stop_Request__c = holidayStopRequestId,
               Stopped_Publication_Date__c = issueData.issueDate,
@@ -306,7 +306,7 @@ object SalesforceHolidayStopRequest extends Logging {
                 CompositePart(
                   method = "DELETE",
                   url = s"$sfObjectsBaseUrl$HolidayStopRequestsDetailSfObjectRef/${holidayStopRequestDetail.Id.value}",
-                  referenceId = "DELETE_DETAIL : " + UUID.randomUUID().toString,
+                  referenceId = s"DELETE_DETAIL_${UUID.randomUUID().toString}",
                   body = JsNull
                 )
               )
@@ -343,7 +343,7 @@ object SalesforceHolidayStopRequest extends Logging {
           CompositePart(
             method = "PATCH",
             url = s"$holidayStopRequestsDetailSfObjectsBaseUrl/${requestDetail.Id.value}",
-            referenceId = "CANCEL_DETAIL : " + idGenerator,
+            referenceId = s"CANCEL_DETAIL_$idGenerator",
             body = Json.toJson(CancelHolidayStopRequestDetailBody(requestDetail.Actual_Price__c, requestDetail.Charge_Code__c))
           )
         }


### PR DESCRIPTION
This is another bug introduced by #1509 
The solution is the same as #1512, ie. in a composite request ensure that reference IDs are well-formed.
In this case, these aren't referenced anywhere so they can be arbitrary.