### PR TITLE
Add logging around Salesforce requests to isolate long-running query

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/resources/logback.xml
+++ b/handlers/soft-opt-in-consent-setter/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date %level - %message%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <!-- see https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-logging.html -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awssdk.request" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
@@ -30,10 +30,16 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
   }
 
   def updateSubs(body: String): Either[SoftOptInError, Unit] = {
-    handleCompositeUpdateResp(
+    logger.info(s"Making update request to Salesforce: $body")
+    val result = handleCompositeUpdateResp(
       sendCompositeUpdateReq(body),
       Metrics.put
     )
+    result match {
+      case Left(e) => logger.error(s"Update request failed: $body: cause $e")
+      case Right(_) => logger.info(s"Update request successful: $body")
+    }
+    result
   }
 
   private def sfHttp(url: String): HttpRequest = {


### PR DESCRIPTION
This is to isolate a query that is frequently timing out.

We've wrapped logging around all the calls to Salesforce.  The next step is to optimise the query once it's found.

Also the log was full of AWS SDK debug entries so adding logback config should minimise that.


