### PR TITLE
Optimise soft-opt-in query

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
@@ -18,9 +18,19 @@ object SfQueries {
        |FROM
        |	SF_Subscription__c
        |WHERE
-       |	Soft_Opt_in_Status__c in ('Ready to process acquisition','Ready to process cancellation')
-       |ORDER BY
-       |  SF_Status__c, Acquisition_Date__c
+       |    Soft_Opt_in_Number_of_Attempts__c < 5 AND
+       |    Soft_Opt_in_Eligible__c = true AND
+       |    (
+       |        (
+       |            SF_Status__c = 'Active' AND
+       |            Soft_Opt_in_Last_Stage_Processed__c != 'Acquisition'
+       |        )
+       |        OR
+       |        (
+       |            SF_Status__c = 'Cancelled' AND
+       |            Soft_Opt_in_Last_Stage_Processed__c = 'Acquisition'
+       |        )
+       |    )
        |LIMIT
        |	$limit
     """.stripMargin

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
@@ -7,16 +7,16 @@ object SfQueries {
 
     s"""
        |SELECT
-       |	Id,
-       |	Name,
-       |	Product__c,
-       |	SF_Status__c,
-       |	Soft_Opt_in_Status__c,
-       |	Soft_Opt_in_Last_Stage_Processed__c,
-       |	Soft_Opt_in_Number_of_Attempts__c,
-       |	Buyer__r.IdentityID__c
+       |    Id,
+       |    Name,
+       |    Product__c,
+       |    SF_Status__c,
+       |    Soft_Opt_in_Status__c,
+       |    Soft_Opt_in_Last_Stage_Processed__c,
+       |    Soft_Opt_in_Number_of_Attempts__c,
+       |    Buyer__r.IdentityID__c
        |FROM
-       |	SF_Subscription__c
+       |    SF_Subscription__c
        |WHERE
        |    Soft_Opt_in_Number_of_Attempts__c < 5 AND
        |    Soft_Opt_in_Eligible__c = true AND


### PR DESCRIPTION
Adopting recommendation by @graham228221 to avoid read timeouts.

See https://trello.com/c/FVCC8zKC/3170-make-soft-opt-in-consent-setter-query-more-efficient
