### PR TITLE
Soft opt-in alarm on 5 errors in 2 hours

### DIFF
--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -147,12 +147,12 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref LambdaFunction
-      EvaluationPeriods: 1
+      EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda
       Period: 3600
       Statistic: Sum
-      Threshold: 2
+      Threshold: 5
       TreatMissingData: notBreaching
 
   failedUpdateAlarm:


### PR DESCRIPTION
This slightly raises the threshold for the alarm from 2 errors per hour to 5 over 2 hours to ensure it isn't an ongoing problem before alarming.

All recent errors have been timeouts from query modified in #1530

----------------------------------------
|         bin(1h)         | errorCount |
|-------------------------|------------|
| 2022-05-19 00:00:00.000 | 3          |
| 2022-05-18 23:00:00.000 | 1          |
| 2022-05-18 22:00:00.000 | 3          |
| 2022-05-18 17:00:00.000 | 1          |
| 2022-05-17 22:00:00.000 | 2          |
| 2022-05-17 17:00:00.000 | 1          |
| 2022-05-17 16:00:00.000 | 1          |
| 2022-05-16 23:00:00.000 | 1          |
| 2022-05-16 22:00:00.000 | 1          |
| 2022-05-16 16:00:00.000 | 1          |
| 2022-05-15 00:00:00.000 | 1          |
| 2022-05-14 23:00:00.000 | 1          |
----------------------------------------
