### PR TITLE
update all lambdas to amazon java 11

### DIFF
--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -119,7 +119,7 @@ Resources:
         - "LogAndWriteToEmailQueueRole"
         - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 300
     DependsOn:
     - "LogAndWriteToEmailQueueRole"

--- a/handlers/cancellation-sf-cases-api/cfn.yaml
+++ b/handlers/cancellation-sf-cases-api/cfn.yaml
@@ -77,7 +77,7 @@ Resources:
           - CancellationSFCasesApiRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 300
     DependsOn:
       - CancellationSFCasesApiRole

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -84,7 +84,7 @@ Resources:
             Role:
                 !GetAtt CatalogServiceRole.Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - CatalogServiceRole
@@ -106,7 +106,7 @@ Resources:
             Role:
                 !GetAtt CatalogServiceRole.Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - CatalogServiceRole
@@ -175,7 +175,7 @@ Resources:
             Role:
                 !GetAtt CatalogServiceRole.Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - CatalogServiceRole

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -56,7 +56,7 @@ Resources:
     Properties:
       FunctionName: !Sub contact-us-api-${Stage}
       Handler: com.gu.contact_us_api.Handler
-      Runtime: java8.al2
+      Runtime: java11
       CodeUri:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/contact-us-api/contact-us-api.jar

--- a/handlers/delivery-problem-credit-processor/cfn.yaml
+++ b/handlers/delivery-problem-credit-processor/cfn.yaml
@@ -77,7 +77,7 @@ Resources:
       Role:
         !GetAtt DeliveryProblemCreditProcessorRole.Arn
       MemorySize: 512
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - DeliveryProblemCreditProcessorRole

--- a/handlers/delivery-records-api/cfn.yaml
+++ b/handlers/delivery-records-api/cfn.yaml
@@ -86,7 +86,7 @@ Resources:
                 - DeliveryRecordsApiRole
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - DeliveryRecordsApiRole

--- a/handlers/dev-env-cleaner/cfn.yaml
+++ b/handlers/dev-env-cleaner/cfn.yaml
@@ -35,7 +35,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/dev-env-cleaner/dev-env-cleaner.jar
       MemorySize: 2048
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -61,7 +61,7 @@ Resources:
                 - "DigitalSubscriptionExpiryRole"
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - DigitalSubscriptionExpiryRole

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -102,7 +102,7 @@ Resources:
                 - DigitalVoucherApiRole
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - DigitalVoucherApiRole

--- a/handlers/digital-voucher-cancellation-processor/cfn.yaml
+++ b/handlers/digital-voucher-cancellation-processor/cfn.yaml
@@ -106,7 +106,7 @@ Resources:
         Fn::GetAtt:
           - DigitalVoucherCancellationProcessorFnRole9BC677A8
           - Arn
-      Runtime: java8.al2
+      Runtime: java11
       Environment:
         Variables:
           App: digital-voucher-cancellation-processor

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -38,7 +38,7 @@ Resources:
       Description: >
         Suspends fulfilment of digital voucher subscriptions.
         Source: https://github.com/guardian/support-service-lambdas/tree/main/handlers/digital-voucher-suspension-processor.
-      Runtime: java8.al2
+      Runtime: java11
       MemorySize: 1536
       Timeout: 900
       CodeUri:

--- a/handlers/fulfilment-date-calculator/cfn.yaml
+++ b/handlers/fulfilment-date-calculator/cfn.yaml
@@ -97,7 +97,7 @@ Resources:
           Stage: !Ref Stage
       Role: !GetAtt FulfilmentDateCalculatorLambdaRole.Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - FulfilmentDateCalculatorLambdaRole

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -98,7 +98,7 @@ Resources:
                 - HolidayStopApiRole
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - HolidayStopApiRole

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -90,7 +90,7 @@ Resources:
       Role:
         !GetAtt HolidayStopProcessorRole.Arn
       MemorySize: 1024
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - HolidayStopProcessorRole

--- a/handlers/identity-backfill/cfn.yaml
+++ b/handlers/identity-backfill/cfn.yaml
@@ -72,7 +72,7 @@ Resources:
                 - "IdentityBackfillRole"
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - "IdentityBackfillRole"

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -77,7 +77,7 @@ Resources:
                 - "IdentityRetentionRole"
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - "IdentityRetentionRole"

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -143,7 +143,7 @@ Resources:
                 - "NewSubscriptionRole"
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - "NewSubscriptionRole"
@@ -198,7 +198,7 @@ Resources:
           - "ProductCatalogRole"
           - Arn
         MemorySize: 1536
-        Runtime: java8.al2
+        Runtime: java11
         Timeout: 300
       DependsOn:
       - "ProductCatalogRole"

--- a/handlers/revenue-recogniser-job/cfn.yaml
+++ b/handlers/revenue-recogniser-job/cfn.yaml
@@ -35,7 +35,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/revenue-recogniser-job/revenue-recogniser-job.jar
       MemorySize: 2048
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/sf-api-user-credentials-setter/cfn.yaml
+++ b/handlers/sf-api-user-credentials-setter/cfn.yaml
@@ -96,7 +96,7 @@ Resources:
       Role:
         !GetAtt SfApiUserCredentialsSetterRole.Arn
       MemorySize: 512
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - SfApiUserCredentialsSetterRole

--- a/handlers/sf-billing-account-remover/cfn.yaml
+++ b/handlers/sf-billing-account-remover/cfn.yaml
@@ -99,7 +99,7 @@ Resources:
       Role:
         !GetAtt SFBillingAccountRemoverRole.Arn
       MemorySize: 512
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - SFBillingAccountRemoverRole

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -73,7 +73,7 @@ Resources:
             Role:
                 !GetAtt SfContactMergeRole.Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - "SfContactMergeRole"

--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -80,7 +80,7 @@ Resources:
       Role:
         !GetAtt StartJobRole.Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 300
     DependsOn:
     - StartJobRole
@@ -129,7 +129,7 @@ Resources:
       Role:
         !GetAtt BatchStateRole.Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 300
     DependsOn:
     - BatchStateRole
@@ -223,7 +223,7 @@ Resources:
       Role:
         !GetAtt DownloadBatchRole.Arn
       MemorySize: 1792
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
     DependsOn:
     - DownloadBatchRole
@@ -280,7 +280,7 @@ Resources:
       Role:
         !GetAtt CleanBucketRole.Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - CleanBucketRole
@@ -300,7 +300,7 @@ Resources:
       Role:
         !GetAtt EndJobRole.Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 300
     DependsOn:
     - EndJobRole

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -248,7 +248,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/sf-emails-to-s3-exporter/sf-emails-to-s3-exporter.jar
       MemorySize: 512
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/sf-gocardless-sync/cfn.yaml
+++ b/handlers/sf-gocardless-sync/cfn.yaml
@@ -80,7 +80,7 @@ Resources:
         - "GoCardlessSalesForceSyncRole"
         - Arn
       MemorySize: 1536 # TODO review this amount of memory is required
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 240 # kills if still running after 4mins to avoid clashes with next run
 
 

--- a/handlers/sf-move-subscriptions-api/cfn.yaml
+++ b/handlers/sf-move-subscriptions-api/cfn.yaml
@@ -98,7 +98,7 @@ Resources:
         Fn::GetAtt:
           - sfMoveSubscriptionsFnRole6D1AF23F
           - Arn
-      Runtime: java8.al2
+      Runtime: java11
       Environment:
         Variables:
           App: sf-move-subscriptions-api

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -54,7 +54,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
       MemorySize: 512
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/stripe-webhook-endpoints/cfn.yaml
+++ b/handlers/stripe-webhook-endpoints/cfn.yaml
@@ -31,7 +31,7 @@ Resources:
     Properties:
       FunctionName: !Sub payment-intent-issues-${Stage}
       Description: A lambda for handling payment intent issues (cancellation, failure, action required)
-      Runtime: java8.al2
+      Runtime: java11
       Handler: com.gu.paymentIntentIssues.Lambda::handler
       MemorySize: 512
       Timeout: 300

--- a/handlers/zuora-callout-apis/cloudformation.yaml
+++ b/handlers/zuora-callout-apis/cloudformation.yaml
@@ -88,7 +88,7 @@ Resources:
                 - ZuoraAutoCancelRole
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - ZuoraAutoCancelRole
@@ -111,7 +111,7 @@ Resources:
                 - ZuoraAutoCancelRole
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - ZuoraAutoCancelRole
@@ -205,7 +205,7 @@ Resources:
                 - ZuoraAutoCancelRole
                 - Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - ZuoraAutoCancelRole

--- a/handlers/zuora-datalake-export/cfn.yaml
+++ b/handlers/zuora-datalake-export/cfn.yaml
@@ -71,7 +71,7 @@ Resources:
                   Stage: !Ref Stage
             Role: !GetAtt ExportLambdaRole.Arn
             MemorySize: 3008
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 900
         DependsOn:
         - ExportLambdaRole

--- a/handlers/zuora-retention/cfn.yaml
+++ b/handlers/zuora-retention/cfn.yaml
@@ -238,7 +238,7 @@ Resources:
             Role:
                 !GetAtt ZuoraQuerierRole.Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - ZuoraQuerierRole
@@ -258,7 +258,7 @@ Resources:
             Role:
                 !GetAtt ZuoraResultsRole.Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - ZuoraResultsRole
@@ -278,7 +278,7 @@ Resources:
             Role:
                 !GetAtt ZuoraFileFetcherRole.Arn
             MemorySize: 1536
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 300
         DependsOn:
         - ZuoraFileFetcherRole
@@ -298,7 +298,7 @@ Resources:
                 Role:
                     !GetAtt FilterRole.Arn
                 MemorySize: 1536
-                Runtime: java8.al2
+                Runtime: java11
                 Timeout: 300
             DependsOn:
             - FilterRole
@@ -318,7 +318,7 @@ Resources:
                 Role:
                     !GetAtt UpdaterRole.Arn
                 MemorySize: 1536
-                Runtime: java8.al2
+                Runtime: java11
                 Timeout: 300
             DependsOn:
             - UpdaterRole

--- a/handlers/zuora-sar/cfn.yaml
+++ b/handlers/zuora-sar/cfn.yaml
@@ -176,7 +176,7 @@ Resources:
                 Variables:
                   Stage: !Ref Stage
             MemorySize: 384
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 120
             VpcConfig:
                 SecurityGroupIds:
@@ -199,7 +199,7 @@ Resources:
                 Variables:
                     Stage: !Ref Stage
             MemorySize: 1024
-            Runtime: java8.al2
+            Runtime: java11
             Timeout: 900
             VpcConfig:
                 SecurityGroupIds:


### PR DESCRIPTION
This PR updates all lambdas to use java11 runtime.  This is needed because Zio/scala3/sttp uses the built in java11 http client,  so it won't build on java 8.  If we flip the build over to java 11 there may be a class compatibility issue.

There are other solutions, for example adding a separate build for the product-move-api (which could even be a github action rather than a TC build)
Or switching sttp to use a non java11 backend.
Or even moving product-move-api to another repo.

I picked this approach because java8 is a legacy runtime and java11 is the current one according to AWS docs.  Also I think this is the quickest way to get this working, as I don't expect any other changes needed other than the runtime and build.

Once this is shipped, I can change TC to build for Java11:
> you can simply update the parameters in the config of the build by setting:
>
> env.JAVA_HOME to %env.JDK_11_0%

From https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit#heading=h.2c51544oeq0b