### PR TITLE
Increase available memory for delivery credit processor

### DIFF
--- a/handlers/delivery-problem-credit-processor/cfn.yaml
+++ b/handlers/delivery-problem-credit-processor/cfn.yaml
@@ -76,7 +76,7 @@ Resources:
           Stage: !Ref Stage
       Role:
         !GetAtt DeliveryProblemCreditProcessorRole.Arn
-      MemorySize: 512
+      MemorySize: 1024
       Runtime: java11
       Timeout: 900
     DependsOn:


### PR DESCRIPTION
We're seeing metaspace capacity errors in the log on every run, which we've also seen in other lambdas recently.
So increasing memory available from 512 MB to 1024 MB.
