### PR TITLE
use the right bucket for the lambda code

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -16,7 +16,7 @@ Parameters:
   DeployBucket:
     Description: Bucket to copy files to
     Type: String
-    Default: membership-dist
+    Default: support-service-lambdas-dist
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, "PROD" ]


### PR DESCRIPTION
I made it write to support-service-lambdas-dist but read from membership-dist.

This PR fixes it to use support-service-lambdas-dist in both places.

I will delete the erroneous artifact from membership-dist also