### PR TITLE
Initial spec of product movement API

### DIFF
--- a/handlers/product-move-api/ProductMovementAPI.yaml
+++ b/handlers/product-move-api/ProductMovementAPI.yaml
@@ -9,7 +9,7 @@ info:
 
 paths:
 
-  /availableProductMoves/{subscriptionName}:
+  /available-product-moves/{subscriptionName}:
     get:
       summary: Gets available products that can be moved to from the given subscription.
       description:
@@ -41,13 +41,21 @@ paths:
         504:
           description: Timeout from an upstream system.
 
-  /productMove:
+  /product-move/{subscriptionName}:
     post:
       summary: Replaces the existing subscription with a new one.
       description:
         Cancels the existing subscription and replaces it with a new subscription
         to a different type of product.
         Also manages all the service comms associated with the movement.
+      parameters:
+        - name: subscriptionName
+          in: path
+          description: Name of subscription to be moved to a different product.
+          example: A-S000001
+          required: true
+          schema:
+            type: string
       requestBody:
         description: Definition of required movement.
         required: true
@@ -56,12 +64,8 @@ paths:
             schema:
               type: object
               required:
-                - sourceSubscriptionName
                 - targetProductId
               properties:
-                sourceSubscriptionName:
-                  description: Name of source subscription that is to be cancelled.
-                  type: string
                 targetProductId:
                   description: ID of target product that new subscription will be for.
                   type: string


### PR DESCRIPTION
This is the initial spec based on early discussions.  
It's likely to change based on the journeys through MMA and presentation data required.

The easiest way to view the spec is to copy it into the [Swagger Editor](https://editor.swagger.io/)

The benefit of Open API is that it can be opened in Postman and other tools, it can be validated and potentially be used for code generation.  It's really for published APIs but I was just experimenting with it.

We could consider using [Tapir](https://tapir.softwaremill.com/en/latest/) to generate the spec from the code in future.
The code and the spec are likely to drift apart very quickly without some autosync of some kind.
