### PR TITLE
add api key for product movement api

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -70,7 +70,7 @@ Resources:
         ProductMovement:
           Type: Api
           Properties:
-              Path: '/move-product'
+              Path: '/product-move'
               Method: post
               RestApiId:
                 Ref: ProductMoveApiGateway

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -21,11 +21,21 @@ Parameters:
 Conditions:
   IsProd: !Equals [ !Ref Stage, "PROD" ]
 
-Globals:
-  Api:
-    OpenApiVersion: 3.0.1
-
 Resources:
+
+  ProductMoveApiGateway:
+    Type: AWS::Serverless::Api
+    Properties:
+      OpenApiVersion: 3.0.1
+      Name: !Sub product-move-api-${Stage}-ApiGateway
+      StageName: !Sub ${Stage}
+      Auth:
+        ApiKeyRequired: true
+        UsagePlan:
+          CreateUsagePlan: PER_API
+          UsagePlanName: !Sub product-move-api-${Stage}-UsagePlan
+          Description: !Sub Usage plan for product-move-api-${Stage}
+
   ProductMoveApiLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -58,9 +68,11 @@ Resources:
             - arn:aws:s3::*:membership-dist/*
       Events:
         ProductMovement:
-            Type: Api
-            Properties:
-                Path: '/move-product'
-                Method: post
+          Type: Api
+          Properties:
+              Path: '/move-product'
+              Method: post
+              RestApiId:
+                Ref: ProductMoveApiGateway
 
 # alarms go here


### PR DESCRIPTION
This PR adds an API key to the product movement api
We based this on the existing example at https://github.com/guardian/support-service-lambdas/blob/6e5523ce911d7daff621106c94bf24ed5b3c9f8d/handlers/contact-us-api/cfn.yaml#L41-L52

This is needed for manage frontend to access the API securely https://github.com/guardian/manage-frontend/blob/14c9e48b8c9a816800a4cd69c432e9351fe8dced/app/server/apiGatewayDiscovery.ts#L50-L91

It seemed to create all the right things in CODE, so we will do the work to integrate manage frontend once this is out in PROD.

One small caveat is that it changed the API gateway URL when we deployed.  This isn't a problem here as PROD isn't used, but if we were to do it when it's in use, it would require a manage-frontend redelploy.
