### PR TITLE
add DEV to product-move-api

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -11,6 +11,7 @@ Parameters:
     Description: Set by RiffRaff on each deploy
     Type: String
     AllowedValues:
+      - DEV
       - CODE
       - PROD
   DeployBucket:

--- a/handlers/product-move-api/riff-raff.yaml
+++ b/handlers/product-move-api/riff-raff.yaml
@@ -3,6 +3,7 @@ stacks:
 regions:
 - eu-west-1
 allowedStages:
+- DEV
 - CODE
 - PROD
 deployments:


### PR DESCRIPTION
Manage-frontend uses the "DEV" stacks when you run it locally.  So this adds the possibility to deploy to DEV via riffraff.