### PR TITLE
Product movement API: Replace trial duration with dayCount

### DIFF
--- a/handlers/product-move-api/ProductMovementAPI.yaml
+++ b/handlers/product-move-api/ProductMovementAPI.yaml
@@ -158,13 +158,15 @@ components:
     trial:
       description:
         An optional free trial that begins when a subscription begins
-        and lasts for a given period of time.
+        and lasts for a given number of days.
       type: object
       required:
-        - duration
+        - dayCount
       properties:
-        duration:
-          $ref: '#/components/schemas/timePeriod'
+        dayCount:
+          type: integer
+          description: Number of days that free trial lasts.
+          example: 14
 
     offer:
       description:


### PR DESCRIPTION
The free trial duration is always in days so that's now modelled in the spec.