### PR TITLE
Api spec updates to keep responses consistent with responses from members-data-api

### DIFF
--- a/handlers/product-move-api/ProductMovementAPI.yaml
+++ b/handlers/product-move-api/ProductMovementAPI.yaml
@@ -119,7 +119,7 @@ components:
         - currency
       properties:
         amount:
-          type: number
+          type: integer
           description:
             Absolute amount that will be billed in pence.
             Either this field or the percentage field will be populated.

--- a/handlers/product-move-api/ProductMovementAPI.yaml
+++ b/handlers/product-move-api/ProductMovementAPI.yaml
@@ -121,7 +121,7 @@ components:
         amount:
           type: integer
           description:
-            Absolute amount that will be billed in pence.
+            Absolute amount that will be billed in pence or cents etc.
             Either this field or the percentage field will be populated.
           example: 1199
         percentage:

--- a/handlers/product-move-api/ProductMovementAPI.yaml
+++ b/handlers/product-move-api/ProductMovementAPI.yaml
@@ -105,8 +105,9 @@ components:
       properties:
         name:
           description: Time units.
-          example: Months
+          example: month
           type: string
+          enum: [month, year]
         count:
           description: Number of time units in this time period.
           type: integer
@@ -120,9 +121,9 @@ components:
         amount:
           type: number
           description:
-            Absolute amount that will be billed.
+            Absolute amount that will be billed in pence.
             Either this field or the percentage field will be populated.
-          example: 11.99
+          example: 1199
         percentage:
           type: integer
           description:

--- a/handlers/product-move-api/ProductMovementAPI.yaml
+++ b/handlers/product-move-api/ProductMovementAPI.yaml
@@ -104,7 +104,7 @@ components:
         - count
       properties:
         name:
-          description: Time units.
+          description: Time unit.
           example: month
           type: string
           enum: [month, year]


### PR DESCRIPTION
Currently members-data-api returns amounts in pence, and intervals use "month" and "year" rather than the plural "Months" and "Years".

Example of a response from members-data-api: https://github.com/guardian/manage-frontend/blob/70fb9fe78f18b0fc4e73d3a2524e887e3be9ba1f/app/client/fixtures/productDetail.ts#L525-L531