### PR TITLE
give contact-us lambda more memory to avoid 30s timeout

### DIFF
--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -60,8 +60,8 @@ Resources:
       CodeUri:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/contact-us-api/contact-us-api.jar
-      Timeout: 120
-      MemorySize: 256
+      Timeout: 60
+      MemorySize: 1024
       Environment:
         Variables:
           clientID:


### PR DESCRIPTION
This PR increases the memory for the contact us lambda,.

This is needed because API gateway has a hard limit of 30s for the response - see "http api quotas" section https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html

For some reason this lambda seems to often take just over 30s to respond, meaning API gateway will return a 500 error (even though the call was completed)

I have noticed since changing from oracle java to amazon java/corretto (and to java 11) in the last year that the memory pressure is higher, which could explain why this was only a problem recently.  Also, when you give more memory, you get a faster CPU for lambda, so that should help.

This is not 100% guaranteed to fix the issue but it's worth trying as a quick fix before we start looking at the code.

----

The timeout change in this PR is only because the API gateway timeout is 30s so no point having the lambda timeout so much longer.