### PR TITLE
Add zuora subscribe call to product-move API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ val scala2Settings = Seq(
     "-Xlint:-byname-implicit",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard"
+    "-Ywarn-value-discard",
+    "-Yretain-trees"
   ),
   Test / fork := true,
   {

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ val scala2Settings = Seq(
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",
-    "-Yretain-trees"
   ),
   Test / fork := true,
   {

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/available/AvailableProductMovesEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/available/AvailableProductMovesEndpoint.scala
@@ -84,5 +84,4 @@ object AvailableProductMovesEndpoint {
         ))
       )
     ))
-
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -19,7 +19,7 @@ object ProductMoveEndpoint {
 
   // run this to test locally via console with some hard coded data
   def main(args: Array[String]): Unit = LambdaEndpoint.runTest(
-    run("8ad0855181f72d2d0181f7c5f0116ce2", ExpectedInput("2c92c0f84bbfec8b014bc655f4852d9d"))
+    run("zuoraAccountId", ExpectedInput("targetProductId"))
   )
 
   val server: sttp.tapir.server.ServerEndpoint.Full[Unit, Unit, (String,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
@@ -1,9 +1,9 @@
 package com.gu.productmove.endpoint.move
 
 import com.gu.productmove.framework.InlineSchema.inlineSchema
-import com.gu.productmove.endpoint.available.{Currency, MoveToProduct}
+import com.gu.productmove.endpoint.available.{Currency, MoveToProduct, TimePeriod}
 import sttp.tapir.Schema
-import sttp.tapir.Schema.annotations.{description, encodedName}
+import sttp.tapir.Schema.annotations.{description, encodedExample, encodedName}
 import sttp.tapir.generic.{Configuration, Derived}
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 import sttp.tapir.Schema
@@ -39,5 +39,4 @@ object ProductMoveEndpointTypes {
   given JsonDecoder[Success] = DeriveJsonDecoder.gen[Success] // needed to keep tapir happy
   given JsonDecoder[NotFound] = DeriveJsonDecoder.gen[NotFound] // needed to keep tapir happy
   given JsonDecoder[OutputBody] = DeriveJsonDecoder.gen[OutputBody] // needed to keep tapir happy
-
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
@@ -1,9 +1,9 @@
 package com.gu.productmove.endpoint.move
 
 import com.gu.productmove.framework.InlineSchema.inlineSchema
-import com.gu.productmove.endpoint.available.{Currency, MoveToProduct, TimePeriod}
+import com.gu.productmove.endpoint.available.{Currency, MoveToProduct}
 import sttp.tapir.Schema
-import sttp.tapir.Schema.annotations.{description, encodedExample, encodedName}
+import sttp.tapir.Schema.annotations.{description, encodedName}
 import sttp.tapir.generic.{Configuration, Derived}
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 import sttp.tapir.Schema

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetSubscription.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetSubscription.scala
@@ -25,7 +25,7 @@ trait GetSubscription :
 
 object GetSubscription {
 
-  case class GetSubscriptionResponse(id: String)
+  case class GetSubscriptionResponse(id: String, accountId: String)
 
   given JsonDecoder[GetSubscriptionResponse] = DeriveJsonDecoder.gen[GetSubscriptionResponse]
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
@@ -2,7 +2,7 @@ package com.gu.productmove.zuora
 
 import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
-import com.gu.productmove.zuora.Subscribe.{CaseId, ChargeOverrides, CreateSubscriptionResponse, ProductRatePlanChargeId, ProductRatePlanId, SubscribeRequest, SubscribeToRatePlans, ZuoraAccountId}
+import com.gu.productmove.zuora.{CaseId, ChargeOverrides, CreateSubscriptionResponse, ProductRatePlanChargeId, ProductRatePlanId, SubscribeToRatePlans, ZuoraAccountId}
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import com.gu.productmove.zuora.rest.ZuoraGet
 import sttp.capabilities.zio.ZioStreams
@@ -16,86 +16,73 @@ import zio.{Clock, IO, RIO, Task, UIO, URLayer, ZIO, ZLayer}
 
 import java.time.LocalDate
 
-/*
-val subscribeRequest = SubscribeRequest(
-      accountKey = "accountkey",
-      autoRenew = true,
-      contractEffectiveDate = "2018-07-02",
-      customerAcceptanceDate = "2018-07-27",
-      termType = "TERMED",
-      renewalTerm = 12,
-      initialTerm = 12,
-      AcquisitionCase__c = "",
-      AcquisitionSource__c = "sourcesource",
-      CreatedByCSR__c = "csrcsr",
-      subscribeToRatePlans = List(SubscribeToRatePlans(productRatePlanId = "rateplanid"))
-    )
-*/
-
 trait Subscribe:
-  def create(body: String): ZIO[Any, String, CreateSubscriptionResponse]
-  def createRequestBody(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, String]
+  def create(zuoraAccountId: String, targetProductId: String): ZIO[Any, String, CreateSubscriptionResponse]
 
 object SubscribeLive :
   val layer: URLayer[ZuoraGet, Subscribe] = ZLayer.fromFunction(SubscribeLive(_))
 
 private class SubscribeLive(zuoraGet: ZuoraGet) extends Subscribe:
-  override def create(body: String): ZIO[Any, String, CreateSubscriptionResponse] = zuoraGet.post[CreateSubscriptionResponse](uri"subscriptions", body)
+  override def create(zuoraAccountId: String, targetProductId: String): ZIO[Any, String, CreateSubscriptionResponse] = {
+    for {
+      subscribeRequest <- SubscribeRequest(zuoraAccountId, targetProductId)
+      response <- zuoraGet.post[SubscribeRequest, CreateSubscriptionResponse](uri"subscriptions", subscribeRequest)
+    } yield response
+  }
 
-  override def createRequestBody(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, String] =
+object Subscribe {
+  def create(zuoraAccountId: String, targetProductId: String): ZIO[Subscribe, String, CreateSubscriptionResponse] =
+    ZIO.serviceWithZIO[Subscribe](_.create(zuoraAccountId, targetProductId))
+}
+
+case class ProductRatePlanId(value: String) extends AnyVal
+case class ProductRatePlanChargeId(value: String) extends AnyVal
+
+case class CreateSubscriptionResponse(subscriptionId: String)
+given JsonDecoder[CreateSubscriptionResponse] = DeriveJsonDecoder.gen[CreateSubscriptionResponse]
+
+case class ChargeOverrides(
+                            price: Option[Double],
+                            productRatePlanChargeId: String,
+                            triggerDate: Option[LocalDate],
+                            triggerEvent: Option[String]
+                          )
+given JsonEncoder[ChargeOverrides] = DeriveJsonEncoder.gen[ChargeOverrides]
+
+case class ZuoraAccountId(value: String) extends AnyVal
+case class CaseId(value: String) extends AnyVal
+case class AcquisitionSource(value: String) extends AnyVal
+
+case class SubscribeToRatePlans(productRatePlanId: String, chargeOverrides: List[ChargeOverrides] = List())
+given JsonEncoder[SubscribeToRatePlans] = DeriveJsonEncoder.gen[SubscribeToRatePlans]
+
+case class SubscribeRequest(
+                             accountKey: String,
+                             autoRenew: Boolean = true,
+                             contractEffectiveDate: LocalDate,
+                             customerAcceptanceDate: LocalDate,
+                             termType: String = "TERMED",
+                             renewalTerm: Int = 12,
+                             initialTerm: Int = 12,
+                             subscribeToRatePlans: List[SubscribeToRatePlans],
+                             AcquisitionCase__c: String,
+                             AcquisitionSource__c: String,
+                             CreatedByCSR__c: String
+                           )
+object SubscribeRequest {
+  given JsonEncoder[SubscribeRequest] = DeriveJsonEncoder.gen[SubscribeRequest]
+
+  def apply(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, SubscribeRequest] =
     for {
       date <- Clock.currentDateTime.map(_.toLocalDate)
     } yield SubscribeRequest(
       accountKey = zuoraAccountId,
       contractEffectiveDate = date,
-      customerAcceptanceDate = date.plusDays(16),
+      // customerAcceptanceDate = date.plusDays(14),    if there is a free trial, we simply add the 14 days onto the customerAcceptanceDate, no extra rateplans needed. To implement later on.
+      customerAcceptanceDate = date,
       subscribeToRatePlans = List(SubscribeToRatePlans(productRatePlanId = targetProductId)),
       AcquisitionCase__c = "case",
       AcquisitionSource__c = "product-movement",
       CreatedByCSR__c = "na"
-    ).toJson
-
-
-object Subscribe {
-  case class ProductRatePlanId(value: String) extends AnyVal
-  case class ProductRatePlanChargeId(value: String) extends AnyVal
-
-  case class CreateSubscriptionResponse(id: String)
-  given JsonDecoder[CreateSubscriptionResponse] = DeriveJsonDecoder.gen[CreateSubscriptionResponse]
-
-  case class ChargeOverrides(
-                              price: Option[Double],
-                              productRatePlanChargeId: String,
-                              triggerDate: Option[LocalDate],
-                              triggerEvent: Option[String]
-                            )
-  given JsonEncoder[ChargeOverrides] = DeriveJsonEncoder.gen[ChargeOverrides]
-
-  case class ZuoraAccountId(value: String) extends AnyVal
-  case class CaseId(value: String) extends AnyVal
-  case class AcquisitionSource(value: String) extends AnyVal
-
-  case class SubscribeToRatePlans(productRatePlanId: String, chargeOverrides: List[ChargeOverrides] = List())
-  given JsonEncoder[SubscribeToRatePlans] = DeriveJsonEncoder.gen[SubscribeToRatePlans]
-
-  case class SubscribeRequest(
-                               accountKey: String,
-                               autoRenew: Boolean = true,
-                               contractEffectiveDate: LocalDate,
-                               customerAcceptanceDate: LocalDate,
-                               termType: String = "TERMED",
-                               renewalTerm: Int = 12,
-                               initialTerm: Int = 12,
-                               subscribeToRatePlans: List[SubscribeToRatePlans],
-                               AcquisitionCase__c: String,
-                               AcquisitionSource__c: String,
-                               CreatedByCSR__c: String
-                             )
-
-
-  implicit val encoder: JsonEncoder[SubscribeRequest] = DeriveJsonEncoder.gen[SubscribeRequest]
-
-  def create(body: String): ZIO[Subscribe, String, CreateSubscriptionResponse] =
-    ZIO.serviceWithZIO[Subscribe](_.create(body))
-  def createRequestBody(zuoraAccountId: String, targetProductId: String): ZIO[Subscribe, Nothing, String] = ZIO.serviceWithZIO[Subscribe](_.createRequestBody(zuoraAccountId, targetProductId))
+    )
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
@@ -25,7 +25,7 @@ object SubscribeLive :
 private class SubscribeLive(zuoraGet: ZuoraGet) extends Subscribe:
   override def create(zuoraAccountId: String, targetProductId: String): ZIO[Any, String, CreateSubscriptionResponse] = {
     for {
-      subscribeRequest <- SubscribeRequest(zuoraAccountId, targetProductId)
+      subscribeRequest <- SubscribeRequest.withTodaysDate(zuoraAccountId, targetProductId)
       response <- zuoraGet.post[SubscribeRequest, CreateSubscriptionResponse](uri"subscriptions", subscribeRequest)
     } yield response
   }
@@ -72,7 +72,7 @@ case class SubscribeRequest(
 object SubscribeRequest {
   given JsonEncoder[SubscribeRequest] = DeriveJsonEncoder.gen[SubscribeRequest]
 
-  def apply(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, SubscribeRequest] =
+  def withTodaysDate(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, SubscribeRequest] =
     for {
       date <- Clock.currentDateTime.map(_.toLocalDate)
     } yield SubscribeRequest(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
@@ -1,0 +1,101 @@
+package com.gu.productmove.zuora
+
+import com.gu.productmove.AwsS3
+import com.gu.productmove.GuStageLive.Stage
+import com.gu.productmove.zuora.Subscribe.{CaseId, ChargeOverrides, CreateSubscriptionResponse, ProductRatePlanChargeId, ProductRatePlanId, SubscribeRequest, SubscribeToRatePlans, ZuoraAccountId}
+import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
+import com.gu.productmove.zuora.rest.ZuoraGet
+import sttp.capabilities.zio.ZioStreams
+import sttp.capabilities.{Effect, WebSockets}
+import sttp.client3.*
+import sttp.client3.httpclient.zio.{HttpClientZioBackend, SttpClient, send}
+import sttp.client3.ziojson.*
+import sttp.model.Uri
+import zio.json.*
+import zio.{Clock, IO, RIO, Task, UIO, URLayer, ZIO, ZLayer}
+
+import java.time.LocalDate
+
+/*
+val subscribeRequest = SubscribeRequest(
+      accountKey = "accountkey",
+      autoRenew = true,
+      contractEffectiveDate = "2018-07-02",
+      customerAcceptanceDate = "2018-07-27",
+      termType = "TERMED",
+      renewalTerm = 12,
+      initialTerm = 12,
+      AcquisitionCase__c = "",
+      AcquisitionSource__c = "sourcesource",
+      CreatedByCSR__c = "csrcsr",
+      subscribeToRatePlans = List(SubscribeToRatePlans(productRatePlanId = "rateplanid"))
+    )
+*/
+
+trait Subscribe:
+  def create(body: String): ZIO[Any, String, CreateSubscriptionResponse]
+  def createRequestBody(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, String]
+
+object SubscribeLive :
+  val layer: URLayer[ZuoraGet, Subscribe] = ZLayer.fromFunction(SubscribeLive(_))
+
+private class SubscribeLive(zuoraGet: ZuoraGet) extends Subscribe:
+  override def create(body: String): ZIO[Any, String, CreateSubscriptionResponse] = zuoraGet.post[CreateSubscriptionResponse](uri"subscriptions", body)
+
+  override def createRequestBody(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, String] =
+    for {
+      date <- Clock.currentDateTime.map(_.toLocalDate)
+    } yield SubscribeRequest(
+      accountKey = zuoraAccountId,
+      contractEffectiveDate = date,
+      customerAcceptanceDate = date.plusDays(16),
+      subscribeToRatePlans = List(SubscribeToRatePlans(productRatePlanId = targetProductId)),
+      AcquisitionCase__c = "case",
+      AcquisitionSource__c = "product-movement",
+      CreatedByCSR__c = "na"
+    ).toJson
+
+
+object Subscribe {
+  case class ProductRatePlanId(value: String) extends AnyVal
+  case class ProductRatePlanChargeId(value: String) extends AnyVal
+
+  case class CreateSubscriptionResponse(id: String)
+  given JsonDecoder[CreateSubscriptionResponse] = DeriveJsonDecoder.gen[CreateSubscriptionResponse]
+
+  case class ChargeOverrides(
+                              price: Option[Double],
+                              productRatePlanChargeId: String,
+                              triggerDate: Option[LocalDate],
+                              triggerEvent: Option[String]
+                            )
+  given JsonEncoder[ChargeOverrides] = DeriveJsonEncoder.gen[ChargeOverrides]
+
+  case class ZuoraAccountId(value: String) extends AnyVal
+  case class CaseId(value: String) extends AnyVal
+  case class AcquisitionSource(value: String) extends AnyVal
+
+  case class SubscribeToRatePlans(productRatePlanId: String, chargeOverrides: List[ChargeOverrides] = List())
+  given JsonEncoder[SubscribeToRatePlans] = DeriveJsonEncoder.gen[SubscribeToRatePlans]
+
+  case class SubscribeRequest(
+                               accountKey: String,
+                               autoRenew: Boolean = true,
+                               contractEffectiveDate: LocalDate,
+                               customerAcceptanceDate: LocalDate,
+                               termType: String = "TERMED",
+                               renewalTerm: Int = 12,
+                               initialTerm: Int = 12,
+                               subscribeToRatePlans: List[SubscribeToRatePlans],
+                               AcquisitionCase__c: String,
+                               AcquisitionSource__c: String,
+                               CreatedByCSR__c: String
+                             )
+
+
+  implicit val encoder: JsonEncoder[SubscribeRequest] = DeriveJsonEncoder.gen[SubscribeRequest]
+
+  def create(body: String): ZIO[Subscribe, String, CreateSubscriptionResponse] =
+    ZIO.serviceWithZIO[Subscribe](_.create(body))
+  def createRequestBody(zuoraAccountId: String, targetProductId: String): ZIO[Subscribe, Nothing, String] = ZIO.serviceWithZIO[Subscribe](_.createRequestBody(zuoraAccountId, targetProductId))
+}

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraGet.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraGet.scala
@@ -15,6 +15,13 @@ private class ZuoraGetLive(zuoraClient: ZuoraClient) extends ZuoraGet :
       parsedBody <- ZIO.fromEither(ZuoraRestBody.parseIfSuccessful[T](response))
     } yield parsedBody
 
+  override def post[T: JsonDecoder](relativeUrl: Uri, body: String): IO[String, T] =
+    for {
+      response <- zuoraClient.send(basicRequest.body(body).post(relativeUrl))
+      parsedBody <- ZIO.fromEither(ZuoraRestBody.parseIfSuccessful[T](response))
+    } yield parsedBody
+
 trait ZuoraGet:
   def get[T: JsonDecoder](relativeUrl: Uri): IO[String, T]
+  def post[T: JsonDecoder](relativeUrl: Uri, body: String): IO[String, T]
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraGet.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraGet.scala
@@ -2,7 +2,7 @@ package com.gu.productmove.zuora.rest
 
 import sttp.client3.basicRequest
 import sttp.model.Uri
-import zio.json.JsonDecoder
+import zio.json.*
 import zio.{IO, ULayer, URLayer, ZIO, ZLayer}
 
 object ZuoraGetLive:
@@ -15,13 +15,13 @@ private class ZuoraGetLive(zuoraClient: ZuoraClient) extends ZuoraGet :
       parsedBody <- ZIO.fromEither(ZuoraRestBody.parseIfSuccessful[T](response))
     } yield parsedBody
 
-  override def post[T: JsonDecoder](relativeUrl: Uri, body: String): IO[String, T] =
+  override def post[Request: JsonEncoder, Response: JsonDecoder](relativeUrl: Uri, input: Request): IO[String, Response] =
     for {
-      response <- zuoraClient.send(basicRequest.body(body).post(relativeUrl))
-      parsedBody <- ZIO.fromEither(ZuoraRestBody.parseIfSuccessful[T](response))
+      response <- zuoraClient.send(basicRequest.contentType("application/json").body(input.toJson).post(relativeUrl))
+      parsedBody <- ZIO.fromEither(ZuoraRestBody.parseIfSuccessful[Response](response))
     } yield parsedBody
 
 trait ZuoraGet:
   def get[T: JsonDecoder](relativeUrl: Uri): IO[String, T]
-  def post[T: JsonDecoder](relativeUrl: Uri, body: String): IO[String, T]
+  def post[Request: JsonEncoder, Response: JsonDecoder](relativeUrl: Uri, input: Request): IO[String, Response]
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -3,57 +3,58 @@ package com.gu.productmove
 import com.gu.productmove.endpoint.available.{Billing, Currency, MoveToProduct, Offer, TimePeriod, TimeUnit, Trial}
 import com.gu.productmove.endpoint.move.ProductMoveEndpoint
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ExpectedInput, OutputBody, Success}
-import com.gu.productmove.zuora.{GetSubscription, TestGetSubscription}
+import com.gu.productmove.zuora.{GetSubscription, MockSubscribe, TestGetSubscription}
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import zio.*
 import zio.test.*
 import zio.test.Assertion.*
 
 object HandlerSpec extends ZIOSpecDefault {
-  def spec = {
-    val expectedSubToLookUp = "A-S00339056"
-    suite("HandlerSpec")(
-      test("runWithEnvironment doesn't do much yet") {
-        val testInput = ExpectedInput("false")
-        val expectedOutput = Success(
-          newSubscriptionName = "asdf",
-          newProduct = MoveToProduct(
-            id = "123",
-            name = "Digital Pack",
+def spec = {
+  suite("HandlerSpec")(
+    test("runWithEnvironment doesn't do much yet") {
+      val testInput = ExpectedInput("false")
+      val expectedOutput = Success(
+        newSubscriptionName = "asdf",
+        newProduct = MoveToProduct(
+          id = "123",
+          name = "Digital Pack",
+          billing = Billing(
+            amount = Some(1199),
+            percentage = None,
+            currency = Currency.GBP,
+            frequency = Some(TimePeriod(
+              name = TimeUnit.month,
+              count = 1
+            )),
+            startDate = Some("2022-09-21")
+          ),
+          trial = Some(Trial(dayCount = 14)),
+          introOffer = Some(Offer(
             billing = Billing(
-              amount = Some(1199),
-              percentage = None,
+              amount = None,
+              percentage = Some(50),
               currency = Currency.GBP,
-              frequency = Some(TimePeriod(
-                name = TimeUnit.month,
-                count = 1
-              )),
+              frequency = None,
               startDate = Some("2022-09-21")
             ),
-            trial = Some(Trial(dayCount = 14)),
-            introOffer = Some(Offer(
-              billing = Billing(
-                amount = None,
-                percentage = Some(50),
-                currency = Currency.GBP,
-                frequency = None,
-                startDate = Some("2022-09-21")
-              ),
-              duration = TimePeriod(
-                name = TimeUnit.month,
-                count = 3
-              )
-            ))
-          )
+            duration = TimePeriod(
+              name = TimeUnit.month,
+              count = 3
+            )
+          ))
         )
-        for {
-          output <- ProductMoveEndpoint.runWithEnvironment(testInput)
-          requests <- TestGetSubscription.requests
-        } yield {
-          assert(output)(equalTo(expectedOutput)) &&
-            assert(requests)(equalTo(List(expectedSubToLookUp)))
-        }
+      )
+      for {
+        output <- ProductMoveEndpoint.productMove(testInput)
+        GetSubscriptionStubs <- TestGetSubscription.requests
+        SubscribeStubs <- MockSubscribe.requests
+      } yield {
+        assert(output)(equalTo(expectedOutput))
       }
-    ).provide(ZLayer.succeed(new TestGetSubscription(Map(expectedSubToLookUp -> "ididtest"))))
-  }
+    }
+  ).provide(ZLayer.succeed(new TestGetSubscription(Map("A-S00339056" -> "ididtest"))),
+    ZLayer.succeed(new MockSubscribe(Map("A-S00339056" -> "newSubscriptionId"))))
 }
+}
+

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -3,58 +3,74 @@ package com.gu.productmove
 import com.gu.productmove.endpoint.available.{Billing, Currency, MoveToProduct, Offer, TimePeriod, TimeUnit, Trial}
 import com.gu.productmove.endpoint.move.ProductMoveEndpoint
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ExpectedInput, OutputBody, Success}
-import com.gu.productmove.zuora.{GetSubscription, MockSubscribe, TestGetSubscription}
+import com.gu.productmove.zuora.{CreateSubscriptionResponse, GetSubscription, MockSubscribe, TestGetSubscription}
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import zio.*
 import zio.test.*
 import zio.test.Assertion.*
 
 object HandlerSpec extends ZIOSpecDefault {
-def spec = {
-  suite("HandlerSpec")(
-    test("runWithEnvironment doesn't do much yet") {
-      val testInput = ExpectedInput("false")
-      val expectedOutput = Success(
-        newSubscriptionName = "asdf",
-        newProduct = MoveToProduct(
-          id = "123",
-          name = "Digital Pack",
-          billing = Billing(
-            amount = Some(1199),
-            percentage = None,
-            currency = Currency.GBP,
-            frequency = Some(TimePeriod(
-              name = TimeUnit.month,
-              count = 1
-            )),
-            startDate = Some("2022-09-21")
-          ),
-          trial = Some(Trial(dayCount = 14)),
-          introOffer = Some(Offer(
+  def spec = {
+    suite("HandlerSpec")(
+      test("productMove endpoint") {
+        val expectedSubNameInput = "A-S00339056"
+        val testPostData = ExpectedInput("targetProductId")
+
+        val getSubscriptionResponse = GetSubscriptionResponse("subscriptionName", "zuoraAccountId")
+        val createSubscriptionResponse = CreateSubscriptionResponse("newSubscriptionName")
+
+        val GetSubscriptionStubs = Map(expectedSubNameInput -> getSubscriptionResponse)
+        val SubscribeStubs = Map(("zuoraAccountId", "targetProductId") -> createSubscriptionResponse)
+
+        val expectedOutput = Success(
+          newSubscriptionName = "newSubscriptionName",
+          newProduct = MoveToProduct(
+            id = "123",
+            name = "Digital Pack",
             billing = Billing(
-              amount = None,
-              percentage = Some(50),
+              amount = Some(1199),
+              percentage = None,
               currency = Currency.GBP,
-              frequency = None,
+              frequency = Some(
+                TimePeriod(
+                  name = TimeUnit.month,
+                  count = 1
+                )
+              ),
               startDate = Some("2022-09-21")
             ),
-            duration = TimePeriod(
-              name = TimeUnit.month,
-              count = 3
+            trial = Some(Trial(dayCount = 14)),
+            introOffer = Some(
+              Offer(
+                billing = Billing(
+                  amount = None,
+                  percentage = Some(50),
+                  currency = Currency.GBP,
+                  frequency = None,
+                  startDate = Some("2022-09-21")
+                ),
+                duration = TimePeriod(
+                  name = TimeUnit.month,
+                  count = 3
+                )
+              )
             )
-          ))
+          )
         )
-      )
-      for {
-        output <- ProductMoveEndpoint.productMove(testInput)
-        GetSubscriptionStubs <- TestGetSubscription.requests
-        SubscribeStubs <- MockSubscribe.requests
-      } yield {
-        assert(output)(equalTo(expectedOutput))
-      }
-    }
-  ).provide(ZLayer.succeed(new TestGetSubscription(Map("A-S00339056" -> "ididtest"))),
-    ZLayer.succeed(new MockSubscribe(Map("A-S00339056" -> "newSubscriptionId"))))
-}
-}
 
+        (for {
+          output <- ProductMoveEndpoint.productMove(expectedSubNameInput, testPostData)
+          testRequests <- TestGetSubscription.requests
+          subscribeRequests <- MockSubscribe.requests
+        } yield {
+          assert(output)(equalTo(expectedOutput)) &&
+          assert(testRequests)(equalTo(List(expectedSubNameInput))) &&
+          assert(subscribeRequests)(equalTo(List(("zuoraAccountId", "targetProductId"))))
+        }).provide(
+          ZLayer.succeed(new TestGetSubscription(GetSubscriptionStubs)),
+          ZLayer.succeed(new MockSubscribe(SubscribeStubs))
+        )
+      }
+    )
+  }
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -3,7 +3,7 @@ package com.gu.productmove
 import com.gu.productmove.endpoint.available.{Billing, Currency, MoveToProduct, Offer, TimePeriod, TimeUnit, Trial}
 import com.gu.productmove.endpoint.move.ProductMoveEndpoint
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ExpectedInput, OutputBody, Success}
-import com.gu.productmove.zuora.{CreateSubscriptionResponse, GetSubscription, MockSubscribe, TestGetSubscription}
+import com.gu.productmove.zuora.{CreateSubscriptionResponse, GetSubscription, MockSubscribe, MockGetSubscription}
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import zio.*
 import zio.test.*
@@ -60,14 +60,14 @@ object HandlerSpec extends ZIOSpecDefault {
 
         (for {
           output <- ProductMoveEndpoint.productMove(expectedSubNameInput, testPostData)
-          testRequests <- TestGetSubscription.requests
+          testRequests <- MockGetSubscription.requests
           subscribeRequests <- MockSubscribe.requests
         } yield {
           assert(output)(equalTo(expectedOutput)) &&
           assert(testRequests)(equalTo(List(expectedSubNameInput))) &&
           assert(subscribeRequests)(equalTo(List(("zuoraAccountId", "targetProductId"))))
         }).provide(
-          ZLayer.succeed(new TestGetSubscription(getSubscriptionStubs)),
+          ZLayer.succeed(new MockGetSubscription(getSubscriptionStubs)),
           ZLayer.succeed(new MockSubscribe(subscribeStubs))
         )
       }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -67,8 +67,8 @@ object HandlerSpec extends ZIOSpecDefault {
           assert(testRequests)(equalTo(List(expectedSubNameInput))) &&
           assert(subscribeRequests)(equalTo(List(("zuoraAccountId", "targetProductId"))))
         }).provide(
-          ZLayer.succeed(new TestGetSubscription(GetSubscriptionStubs)),
-          ZLayer.succeed(new MockSubscribe(SubscribeStubs))
+          ZLayer.succeed(new TestGetSubscription(getSubscriptionStubs)),
+          ZLayer.succeed(new MockSubscribe(subscribeStubs))
         )
       }
     )

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetSubscription.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetSubscription.scala
@@ -4,7 +4,7 @@ import com.gu.productmove.zuora.GetSubscription
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import zio.{IO, ZIO}
 
-class TestGetSubscription(responses: Map[String, GetSubscription.GetSubscriptionResponse]) extends GetSubscription {
+class MockGetSubscription(responses: Map[String, GetSubscription.GetSubscriptionResponse]) extends GetSubscription {
 
   private var mutableStore: List[String] = Nil // we need to remember the side effects
 
@@ -19,6 +19,6 @@ class TestGetSubscription(responses: Map[String, GetSubscription.GetSubscription
   }
 }
 
-object TestGetSubscription {
-  def requests: ZIO[TestGetSubscription, Nothing, List[String]] = ZIO.serviceWith[TestGetSubscription](_.requests)
+object MockGetSubscription {
+  def requests: ZIO[MockGetSubscription, Nothing, List[String]] = ZIO.serviceWith[MockGetSubscription](_.requests)
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSubscribe.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSubscribe.scala
@@ -1,0 +1,24 @@
+package com.gu.productmove.zuora
+
+import com.gu.productmove.zuora.GetSubscription
+import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
+import com.gu.productmove.zuora.Subscribe.CreateSubscriptionResponse
+import zio.{IO, ZIO}
+
+class MockSubscribe(responses: Map[String, String]) extends Subscribe {
+
+  private var mutableStore: List[String] = Nil // we need to remember the side effects
+
+  def requests = mutableStore.reverse
+
+  override def create(body: String): ZIO[Any, String, CreateSubscriptionResponse] = {
+    mutableStore = body :: mutableStore
+    ZIO.succeed(CreateSubscriptionResponse("new subscription ID"))
+  }
+
+  override def createRequestBody(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, String] = ???
+}
+
+object MockSubscribe {
+  def requests: ZIO[MockSubscribe, Nothing, List[String]] = ZIO.serviceWith[MockSubscribe](_.requests)
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSubscribe.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSubscribe.scala
@@ -2,23 +2,24 @@ package com.gu.productmove.zuora
 
 import com.gu.productmove.zuora.GetSubscription
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
-import com.gu.productmove.zuora.Subscribe.CreateSubscriptionResponse
+import com.gu.productmove.zuora.CreateSubscriptionResponse
 import zio.{IO, ZIO}
 
-class MockSubscribe(responses: Map[String, String]) extends Subscribe {
+class MockSubscribe(responses: Map[(String, String), CreateSubscriptionResponse]) extends Subscribe {
 
-  private var mutableStore: List[String] = Nil // we need to remember the side effects
+  private var mutableStore: List[(String, String)] = Nil // we need to remember the side effects
 
   def requests = mutableStore.reverse
 
-  override def create(body: String): ZIO[Any, String, CreateSubscriptionResponse] = {
-    mutableStore = body :: mutableStore
-    ZIO.succeed(CreateSubscriptionResponse("new subscription ID"))
-  }
+  override def create(zuoraAccountId: String, targetProductId: String): ZIO[Any, String, CreateSubscriptionResponse] = {
+    mutableStore = (zuoraAccountId, targetProductId) :: mutableStore
 
-  override def createRequestBody(zuoraAccountId: String, targetProductId: String): ZIO[Any, Nothing, String] = ???
+    responses.get((zuoraAccountId, targetProductId)) match
+      case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
+      case None => ZIO.fail(s"success = false")
+  }
 }
 
 object MockSubscribe {
-  def requests: ZIO[MockSubscribe, Nothing, List[String]] = ZIO.serviceWith[MockSubscribe](_.requests)
+  def requests: ZIO[MockSubscribe, Nothing, List[(String, String)]] = ZIO.serviceWith[MockSubscribe](_.requests)
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscribeSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscribeSpec.scala
@@ -1,0 +1,46 @@
+package com.gu.productmove.zuora
+
+import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, GuStageLive, SttpClientLive}
+import com.gu.productmove.endpoint.available.{Billing, Currency, MoveToProduct, Offer, TimePeriod, TimeUnit, Trial}
+import com.gu.productmove.zuora.GetSubscription
+import com.gu.productmove.zuora.Subscribe
+import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
+import com.gu.productmove.zuora.rest.{
+  ZuoraClientLive,
+  ZuoraGetLive,
+  ZuoraRatePlan,
+  ZuoraRatePlanCharge,
+  ZuoraSubscription
+}
+import zio.{IO, ZIO}
+import zio.*
+import zio.test.Assertion.*
+import zio.test.*
+
+import java.time.*
+
+object SubscribeSpec extends ZIOSpecDefault {
+  private val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 16, 10, 2), ZoneOffset.ofHours(0))
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("subscribe layer")(
+      test("createRequest function: JSON request body is created correctly") {
+        val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 10, 10, 2), ZoneOffset.ofHours(0))
+      val expectedRequestBody = "{\"accountKey\":\"zuoraAccountId\",\"autoRenew\":true,\"contractEffectiveDate\":\"2022-05-10\",\"customerAcceptanceDate\":\"2022-05-26\",\"termType\":\"TERMED\",\"renewalTerm\":12,\"initialTerm\":12,\"subscribeToRatePlans\":[{\"productRatePlanId\":\"targetProductId\",\"chargeOverrides\":[]}],\"AcquisitionCase__c\":\"case\",\"AcquisitionSource__c\":\"product-movement\",\"CreatedByCSR__c\":\"na\"}"
+
+      for {
+        _ <- TestClock.setDateTime(time)
+        createRequestBody <- Subscribe
+          .createRequestBody("zuoraAccountId", "targetProductId")
+          .provide(
+            AwsS3Live.layer,
+            AwsCredentialsLive.layer,
+            SttpClientLive.layer,
+            ZuoraClientLive.layer,
+            SubscribeLive.layer,
+            ZuoraGetLive.layer,
+            GuStageLive.layer
+          )
+      } yield assert(createRequestBody)(equalTo(expectedRequestBody))
+    })
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscribeSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscribeSpec.scala
@@ -31,7 +31,7 @@ object SubscribeSpec extends ZIOSpecDefault {
 
       for {
         _ <- TestClock.setDateTime(time)
-        createRequestBody <- SubscribeRequest("zuoraAccountId", "targetProductId")
+        createRequestBody <- SubscribeRequest.withTodaysDate("zuoraAccountId", "targetProductId")
       } yield assert(createRequestBody)(equalTo(expectedSubscribeRequest))
     })
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscribeSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscribeSpec.scala
@@ -3,15 +3,9 @@ package com.gu.productmove.zuora
 import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, GuStageLive, SttpClientLive}
 import com.gu.productmove.endpoint.available.{Billing, Currency, MoveToProduct, Offer, TimePeriod, TimeUnit, Trial}
 import com.gu.productmove.zuora.GetSubscription
-import com.gu.productmove.zuora.Subscribe
+import com.gu.productmove.zuora.Subscribe.*
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
-import com.gu.productmove.zuora.rest.{
-  ZuoraClientLive,
-  ZuoraGetLive,
-  ZuoraRatePlan,
-  ZuoraRatePlanCharge,
-  ZuoraSubscription
-}
+import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGetLive}
 import zio.{IO, ZIO}
 import zio.*
 import zio.test.Assertion.*
@@ -23,24 +17,21 @@ object SubscribeSpec extends ZIOSpecDefault {
   private val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 16, 10, 2), ZoneOffset.ofHours(0))
 
   override def spec: Spec[TestEnvironment with Scope, Any] =
-    suite("subscribe layer")(
-      test("createRequest function: JSON request body is created correctly") {
-        val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 10, 10, 2), ZoneOffset.ofHours(0))
-      val expectedRequestBody = "{\"accountKey\":\"zuoraAccountId\",\"autoRenew\":true,\"contractEffectiveDate\":\"2022-05-10\",\"customerAcceptanceDate\":\"2022-05-26\",\"termType\":\"TERMED\",\"renewalTerm\":12,\"initialTerm\":12,\"subscribeToRatePlans\":[{\"productRatePlanId\":\"targetProductId\",\"chargeOverrides\":[]}],\"AcquisitionCase__c\":\"case\",\"AcquisitionSource__c\":\"product-movement\",\"CreatedByCSR__c\":\"na\"}"
+    suite("subscribe layer")(test("createRequest function: JSON request body is created and encoded correctly") {
+      val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 10, 10, 2), ZoneOffset.ofHours(0))
+      val expectedSubscribeRequest = SubscribeRequest(
+        accountKey = "zuoraAccountId",
+        contractEffectiveDate = LocalDate.of(2022, 5, 10),
+        customerAcceptanceDate = LocalDate.of(2022, 5, 10),
+        AcquisitionCase__c = "case",
+        AcquisitionSource__c = "product-movement",
+        CreatedByCSR__c = "na",
+        subscribeToRatePlans = List(SubscribeToRatePlans(productRatePlanId = "targetProductId"))
+      )
 
       for {
         _ <- TestClock.setDateTime(time)
-        createRequestBody <- Subscribe
-          .createRequestBody("zuoraAccountId", "targetProductId")
-          .provide(
-            AwsS3Live.layer,
-            AwsCredentialsLive.layer,
-            SttpClientLive.layer,
-            ZuoraClientLive.layer,
-            SubscribeLive.layer,
-            ZuoraGetLive.layer,
-            GuStageLive.layer
-          )
-      } yield assert(createRequestBody)(equalTo(expectedRequestBody))
+        createRequestBody <- SubscribeRequest("zuoraAccountId", "targetProductId")
+      } yield assert(createRequestBody)(equalTo(expectedSubscribeRequest))
     })
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/TestGetSubscription.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/TestGetSubscription.scala
@@ -4,7 +4,7 @@ import com.gu.productmove.zuora.GetSubscription
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import zio.{IO, ZIO}
 
-class TestGetSubscription(responses: Map[String, String]) extends GetSubscription {
+class TestGetSubscription(responses: Map[String, GetSubscription.GetSubscriptionResponse]) extends GetSubscription {
 
   private var mutableStore: List[String] = Nil // we need to remember the side effects
 
@@ -12,11 +12,11 @@ class TestGetSubscription(responses: Map[String, String]) extends GetSubscriptio
 
   override def get(subscriptionNumber: String): IO[String, GetSubscription.GetSubscriptionResponse] = {
     mutableStore = subscriptionNumber :: mutableStore
+
     responses.get(subscriptionNumber) match
-      case Some(value) => ZIO.succeed(GetSubscriptionResponse(value, "accountId"))
+      case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
       case None => ZIO.fail(s"success = false, subscription not found: $subscriptionNumber")
   }
-
 }
 
 object TestGetSubscription {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/TestGetSubscription.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/TestGetSubscription.scala
@@ -5,7 +5,7 @@ import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import zio.{IO, ZIO}
 
 class TestGetSubscription(responses: Map[String, String]) extends GetSubscription {
-  
+
   private var mutableStore: List[String] = Nil // we need to remember the side effects
 
   def requests = mutableStore.reverse
@@ -13,10 +13,10 @@ class TestGetSubscription(responses: Map[String, String]) extends GetSubscriptio
   override def get(subscriptionNumber: String): IO[String, GetSubscription.GetSubscriptionResponse] = {
     mutableStore = subscriptionNumber :: mutableStore
     responses.get(subscriptionNumber) match
-      case Some(value) => ZIO.succeed(GetSubscriptionResponse(value))
+      case Some(value) => ZIO.succeed(GetSubscriptionResponse(value, "accountId"))
       case None => ZIO.fail(s"success = false, subscription not found: $subscriptionNumber")
   }
-  
+
 }
 
 object TestGetSubscription {


### PR DESCRIPTION
This is part of the product-movement-api which takes a user with a recurring contribution and switches them to a digital subscription.

 The endpoint takes in the current subscription name/Id and a targetProductId as input, which represents the ID of the product rate plan we want to subscribe the user to. We first call the `GetSubscription` service to obtain the user's `accountKey` as we need this for the subsequent subscribe call. We then call zuora's `/v1/subscriptions` ([docs here](https://www.zuora.com/developer/api-reference/#operation/POST_Subscription)) endpoint to subscribe the user to the new rateplan. 

