### PR TITLE
Don't run gifting lambda on 1st August 2022

### DIFF
--- a/handlers/revenue-recogniser-job/cfn.yaml
+++ b/handlers/revenue-recogniser-job/cfn.yaml
@@ -15,7 +15,7 @@ Mappings:
   Stages:
     Schedule:
       CODE: 'rate(365 days)'
-      PROD: 'rate(12 hours)'
+      PROD: 'cron(0 3,15 2-31 * *)'
   Constants:
     Alarm:
       Process: See the docs at https://github.com/guardian/support-service-lambdas/tree/main/handlers/revenue-recogniser-job

--- a/handlers/revenue-recogniser-job/cfn.yaml
+++ b/handlers/revenue-recogniser-job/cfn.yaml
@@ -15,7 +15,7 @@ Mappings:
   Stages:
     Schedule:
       CODE: 'rate(365 days)'
-      PROD: 'cron(0 3,15 2-31 * *)'
+      PROD: 'cron(0 3,15 2-31 * * *)'
   Constants:
     Alarm:
       Process: See the docs at https://github.com/guardian/support-service-lambdas/tree/main/handlers/revenue-recogniser-job

--- a/handlers/revenue-recogniser-job/cfn.yaml
+++ b/handlers/revenue-recogniser-job/cfn.yaml
@@ -15,7 +15,7 @@ Mappings:
   Stages:
     Schedule:
       CODE: 'rate(365 days)'
-      PROD: 'cron(0 3,15 2-31 * * *)'
+      PROD: 'cron(0 3,15 2-31 * ? *)'
   Constants:
     Alarm:
       Process: See the docs at https://github.com/guardian/support-service-lambdas/tree/main/handlers/revenue-recogniser-job


### PR DESCRIPTION
## What does this change?
Updating the gifting lambda to run exactly at 3am and 3pm UTC, and for now, exclude 1st day of month due to Finance project change happening 12am-2pm on 1 August.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Release today and see that it runs at 3pm just fine.

## Have we considered potential risks?
Lambda does not deploy. Rollback PR will be merged and deployed. On 2nd August the 2-31 bit of the cron will be replaced with a *.
