### PR TITLE
Revert "Don't run gifting lambda on 1st August 2022"

### DIFF
--- a/handlers/revenue-recogniser-job/cfn.yaml
+++ b/handlers/revenue-recogniser-job/cfn.yaml
@@ -15,7 +15,7 @@ Mappings:
   Stages:
     Schedule:
       CODE: 'rate(365 days)'
-      PROD: 'cron(0 3,15 2-31 * ? *)'
+      PROD: 'rate(12 hours)'
   Constants:
     Alarm:
       Process: See the docs at https://github.com/guardian/support-service-lambdas/tree/main/handlers/revenue-recogniser-job


### PR DESCRIPTION
Reverts guardian/support-service-lambdas#1648

The work that this enabled has completed now so we can revert the change