### PR TITLE
Reduce batch size to avoid Lambda timeout

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -13,15 +13,15 @@ import com.typesafe.scalalogging.LazyLogging
 object Salesforce extends LazyLogging {
 
   /*
-   * Zuora takes ~ 2s to add each credit to a sub so this should take ~ 10 mins,
+   * Zuora takes 3-4s to add each credit to a sub so this should take ~ 10 mins,
    * which is within the 15 min max that a lambda can run.
    * As the lambda runs each hour, all should easily be processed within the
    * 24 hour window available.
    *
    * Beware! This isn't a scalable solution.  If all the products between them
-   * have > 7200 credit requests to be processed in a 24 hour window some will be missed.
+   * have > 5000 credit requests to be processed in a 24 hour window some will be missed.
    */
-  private val batchSize = 120
+  private val batchSize = 66
 
   def holidayStopRequests(sfCredentials: SFAuthConfig)(productVariant: ZuoraProductType, datesToProcess: List[LocalDate]): SalesforceApiResponse[List[HolidayStopRequestsDetail]] = {
     SalesforceClient(RawEffects.response, sfCredentials).value.flatMap { sfAuth =>


### PR DESCRIPTION
## What does this change?
On Thursdays this lambda was regularly hitting the 15 minute lambda time limit. This was due to an increase in records on Thursday morning due to Home Deliveries including three days of records rather than 1.

We are reducing the batch size down from 120 to 66 (200/3) to try and ensure the lambda runs within 15 minutes.
