### PR TITLE
Add product prop to new product api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -15,6 +15,8 @@ case class Catalog(
   voucherSundayPlus: Plan,
   voucherEveryDayPlus: Plan,
   voucherSixDayPlus: Plan,
+  monthlySupporterPlus: Plan,
+  annualSupporterPlus: Plan,
   monthlyContribution: Plan,
   annualContribution: Plan,
   homeDeliveryEveryDay: Plan,
@@ -59,6 +61,8 @@ case class Catalog(
     voucherSixDayPlus,
     monthlyContribution,
     annualContribution,
+    monthlySupporterPlus,
+    annualSupporterPlus,
     homeDeliveryEveryDay,
     homeDeliverySixDay,
     homeDeliverySunday,
@@ -92,6 +96,7 @@ case class Catalog(
   val planForId: Map[PlanId, Plan] = allPlans.map(x => x.id -> x).toMap
 }
 sealed trait VoucherPlanId
+sealed trait SupporterPlusPlanId
 sealed trait ContributionPlanId
 sealed trait HomeDeliveryPlanId
 sealed trait DigipackPlanId
@@ -101,6 +106,10 @@ sealed trait DigitalVoucherPlanId
 sealed abstract class PlanId(val name: String)
 
 object PlanId {
+  case object AnnualSupporterPlus extends PlanId("annual_supporter_plus") with SupporterPlusPlanId
+
+  case object MonthlySupporterPlus extends PlanId("monthly_supporter_plus") with SupporterPlusPlanId
+
   case object AnnualContribution extends PlanId("annual_contribution") with ContributionPlanId
 
   case object MonthlyContribution extends PlanId("monthly_contribution") with ContributionPlanId
@@ -193,10 +202,17 @@ object PlanId {
     VoucherWeekend,
     VoucherWeekendPlus
   )
+
   val enabledContributionPlans = List(
     MonthlyContribution,
     AnnualContribution
   )
+
+  val enabledSupporterPlusPlans = List(
+    MonthlySupporterPlus,
+    AnnualSupporterPlus
+  )
+
   val enabledHomeDeliveryPlans = List(
     HomeDeliveryEveryDay,
     HomeDeliveryEveryDayPlus,
@@ -241,7 +257,7 @@ object PlanId {
   )
 
   val supportedPlans: List[PlanId] =
-    enabledVoucherPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans ++ enabledDigipackPlans ++
+    enabledVoucherPlans ++ enabledSupporterPlusPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans ++ enabledDigipackPlans ++
       enabledGuardianWeeklyDomesticPlans ++ enabledGuardianWeeklyROWPlans ++ enabledDigitalVoucherPlans
 
   def fromName(name: String): Option[PlanId] = supportedPlans.find(_.name == name)
@@ -285,5 +301,6 @@ object ProductType {
   val NewspaperHomeDelivery = ProductType("Newspaper - Home Delivery")
   val DigitalPack = ProductType("Digital Pack")
   val Contribution = ProductType("Contribution")
+  val SupporterPlus = ProductType("Supporter Plus")
   val Membership = ProductType("Membership")
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
@@ -39,5 +39,16 @@ object Handler extends Logging {
   } yield Operation.noHealthcheck {
     Req: ApiGatewayRequest => ApiGatewayResponse(body = wireCatalog, statusCode = "200")
   }
+
+  def main(args: Array[String]): Unit = {
+    val result = runWithEffects(
+      null,
+      Stage("DEV"),
+      GetFromS3.fetchString,
+      LocalDate.now()
+    )
+
+    println("result:" + result);
+  }
 }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
@@ -39,6 +39,7 @@ object Handler extends Logging {
     Req: ApiGatewayRequest => ApiGatewayResponse(body = wireCatalog, statusCode = "200")
   }
 
+  // run this method with membership janus credentials, to check that the lambda is working and log the output to the console
   def main(args: Array[String]): Unit = {
     val result = runWithEffects(
       Stage("DEV"),

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
@@ -20,14 +20,13 @@ object Handler extends Logging {
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
     ApiGatewayHandler(LambdaIO(inputStream, outputStream, context)) {
       runWithEffects(
-        LambdaIO(inputStream, outputStream, context),
         RawEffects.stage,
         GetFromS3.fetchString,
         LocalDate.now()
       )
     }
 
-  def runWithEffects(lambdaIO: LambdaIO, stage: Stage, fetchString: StringFromS3, today: LocalDate): ApiGatewayOp[Operation] = for {
+  def runWithEffects(stage: Stage, fetchString: StringFromS3, today: LocalDate): ApiGatewayOp[Operation] = for {
     zuoraIds <- ZuoraIds.zuoraIdsForStage(stage)
     zuoraToPlanId = zuoraIds.rateplanIdToApiId.get _
     zuoraEnv = ZuoraEnvironment.EnvForStage(stage)
@@ -42,7 +41,6 @@ object Handler extends Logging {
 
   def main(args: Array[String]): Unit = {
     val result = runWithEffects(
-      null,
       Stage("DEV"),
       GetFromS3.fetchString,
       LocalDate.now()

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
@@ -47,8 +47,6 @@ object Handler extends Logging {
       GetFromS3.fetchString,
       LocalDate.now()
     )
-
-    println("result:" + result);
   }
 }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -14,6 +14,7 @@ object NewProductApi {
   val HomeDeliverySubscriptionStartDateWindowSize = WindowSizeDays(28)
   val GuardianWeeklySubscriptionStartDateWindowSize = WindowSizeDays(28)
   val VoucherSubscriptionStartDateWindowSize = WindowSizeDays(35)
+  val SupporterPlusStartDateWindowSize = WindowSizeDays(1)
   val ContributionStartDateWindowSize = WindowSizeDays(1)
   val DigiPackStartDateWindowSize = WindowSizeDays(90)
   val DigitalVoucherStartDateWindowSize = WindowSizeDays(1)
@@ -25,6 +26,7 @@ object NewProductApi {
   ): Catalog = {
 
     def paymentPlansFor(planId: PlanId, billingPeriod: BillingPeriod): Map[Currency, PaymentPlan] = {
+
       val pricesByCurrency: Map[Currency, AmountMinorUnits] = pricingFor(planId)
 
       val billingPeriodDescription = billingPeriod match {
@@ -90,6 +92,13 @@ object NewProductApi {
     val homeDeliverySaturdayDateRules = homeDeliveryDateRules(saturdayDays)
     val homeDeliveryWeekendRules = homeDeliveryDateRules(weekendDays)
 
+    val supporterPlusRule = StartDateRules(
+      windowRule = WindowRule(
+        startDate = today,
+        maybeSize = Some(SupporterPlusStartDateWindowSize),
+      )
+    )
+
     val contributionsRule = StartDateRules(
       windowRule = WindowRule(
         startDate = today,
@@ -143,6 +152,8 @@ object NewProductApi {
       voucherSaturdayPlus = planWithPayment(VoucherSaturdayPlus, PlanDescription("Saturday+"), voucherSaturdayDateRules, Monthly),
       voucherSunday = planWithPayment(VoucherSunday, PlanDescription("Sunday"), voucherSundayDateRules, Monthly),
       voucherSundayPlus = planWithPayment(VoucherSundayPlus, PlanDescription("Sunday+"), voucherSundayDateRules, Monthly),
+      monthlySupporterPlus = planWithPayment(MonthlySupporterPlus, PlanDescription("Monthly"), supporterPlusRule, Monthly),
+      annualSupporterPlus = planWithPayment(AnnualSupporterPlus, PlanDescription("Annual"), supporterPlusRule, Monthly),
       monthlyContribution = planWithPayment(MonthlyContribution, PlanDescription("Monthly"), contributionsRule, Monthly),
       annualContribution = planWithPayment(AnnualContribution, PlanDescription("Annual"), contributionsRule, Monthly),
       homeDeliveryEveryDay = planWithPayment(HomeDeliveryEveryDay, PlanDescription("Everyday"), homeDeliveryEveryDayRules, Monthly),

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -153,7 +153,7 @@ object NewProductApi {
       voucherSunday = planWithPayment(VoucherSunday, PlanDescription("Sunday"), voucherSundayDateRules, Monthly),
       voucherSundayPlus = planWithPayment(VoucherSundayPlus, PlanDescription("Sunday+"), voucherSundayDateRules, Monthly),
       monthlySupporterPlus = planWithPayment(MonthlySupporterPlus, PlanDescription("Monthly"), supporterPlusRule, Monthly),
-      annualSupporterPlus = planWithPayment(AnnualSupporterPlus, PlanDescription("Annual"), supporterPlusRule, Monthly),
+      annualSupporterPlus = planWithPayment(AnnualSupporterPlus, PlanDescription("Annual"), supporterPlusRule, Annual),
       monthlyContribution = planWithPayment(MonthlyContribution, PlanDescription("Monthly"), contributionsRule, Monthly),
       annualContribution = planWithPayment(AnnualContribution, PlanDescription("Annual"), contributionsRule, Monthly),
       homeDeliveryEveryDay = planWithPayment(HomeDeliveryEveryDay, PlanDescription("Everyday"), homeDeliveryEveryDayRules, Monthly),

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -135,6 +135,12 @@ object WireModel {
         enabledForDeliveryCountries = None
       )
 
+      val supporterPlusProduct = WireProduct(
+        label = "Supporter Plus",
+        plans = PlanId.enabledSupporterPlusPlans.map(wirePlanForPlanId),
+        enabledForDeliveryCountries = None
+      )
+
       val contributionProduct = WireProduct(
         label = "Contribution",
         plans = PlanId.enabledContributionPlans.map(wirePlanForPlanId),
@@ -172,7 +178,7 @@ object WireModel {
       )
 
       val availableProductsAndPlans = List(
-        contributionProduct, voucherProduct, homeDeliveryProduct, digipackProduct, guardianWeeklyDomestic,
+        supporterPlusProduct, contributionProduct, voucherProduct, homeDeliveryProduct, digipackProduct, guardianWeeklyDomestic,
         guardianWeeklyROW, digitalVoucher
       ).filterNot(_.plans.isEmpty)
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -361,7 +361,7 @@ object ZuoraIds {
       Stage("DEV") -> ZuoraIds(
         SupporterPlusZuoraIds(
           monthly = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("111"),
+            productRatePlanId = ProductRatePlanId("8ad09fc281de1ce70181de3b251736a4"),
             productRatePlanChargeId = ProductRatePlanChargeId("8ad09fc281de1ce70181de3b253e36a6")
           ),
           annual = PlanAndCharge(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -13,6 +13,14 @@ object ZuoraIds {
 
   case class PlanAndCharge(productRatePlanId: ProductRatePlanId, productRatePlanChargeId: ProductRatePlanChargeId)
 
+
+  case class SupporterPlusZuoraIds(monthly: PlanAndCharge, annual: PlanAndCharge) {
+    val planAndChargeByApiPlanId: Map[PlanId, PlanAndCharge] = Map(
+      MonthlySupporterPlus -> monthly,
+      AnnualSupporterPlus -> annual
+    )
+  }
+
   case class ContributionsZuoraIds(monthly: PlanAndCharge, annual: PlanAndCharge) {
     val planAndChargeByApiPlanId: Map[PlanId, PlanAndCharge] = Map(
       MonthlyContribution -> monthly,
@@ -162,6 +170,7 @@ object ZuoraIds {
 
 
   case class ZuoraIds(
+    supporterPlusZuoraIds: SupporterPlusZuoraIds,
     contributionsZuoraIds: ContributionsZuoraIds,
     voucherZuoraIds: VoucherZuoraIds,
     homeDeliveryZuoraIds: HomeDeliveryZuoraIds,
@@ -171,7 +180,8 @@ object ZuoraIds {
     digitalVoucher: DigitalVoucherZuoraIds
   ) {
     def apiIdToRateplanId: Map[PlanId, ProductRatePlanId] =
-      (contributionsZuoraIds.planAndChargeByApiPlanId.view.mapValues(_.productRatePlanId) ++
+      (supporterPlusZuoraIds.planAndChargeByApiPlanId.view.mapValues(_.productRatePlanId) ++
+      contributionsZuoraIds.planAndChargeByApiPlanId.view.mapValues(_.productRatePlanId) ++
       voucherZuoraIds.byApiPlanId ++
       homeDeliveryZuoraIds.byApiPlanId ++
       digitalPackIds.byApiPlanId ++
@@ -182,7 +192,8 @@ object ZuoraIds {
     val rateplanIdToApiId: Map[ProductRatePlanId, PlanId] = apiIdToRateplanId.map(_.swap)
 
     def apiIdToPlanAndCharge: Map[PlanId, PlanAndCharge] =
-      contributionsZuoraIds.planAndChargeByApiPlanId ++
+      supporterPlusZuoraIds.planAndChargeByApiPlanId ++
+        contributionsZuoraIds.planAndChargeByApiPlanId ++
         guardianWeeklyDomestic.planAndChargeByApiPlanId ++
         guardianWeeklyROW.planAndChargeByApiPlanId
 
@@ -192,6 +203,16 @@ object ZuoraIds {
     val mappings = Map(
       // todo ideally we should add an id to the fields in zuora so we don't have to hard code
       Stage("PROD") -> ZuoraIds(
+        SupporterPlusZuoraIds(
+          monthly = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("mno"),
+            productRatePlanChargeId = ProductRatePlanChargeId("pqr")
+          ),
+          annual = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("stu"),
+            productRatePlanChargeId = ProductRatePlanChargeId("vwx")
+          )
+        ),
         ContributionsZuoraIds(
           monthly = PlanAndCharge(
             ProductRatePlanId("2c92a0fc5aacfadd015ad24db4ff5e97"),
@@ -260,6 +281,16 @@ object ZuoraIds {
         )
       ),
       Stage("CODE") -> ZuoraIds(
+        SupporterPlusZuoraIds(
+          monthly = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("abc"),
+            productRatePlanChargeId = ProductRatePlanChargeId("def")
+          ),
+          annual = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("ghi"),
+            productRatePlanChargeId = ProductRatePlanChargeId("jkl")
+          )
+        ),
         ContributionsZuoraIds(
           monthly = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("2c92c0f85ab269be015acd9d014549b7"),
@@ -328,6 +359,16 @@ object ZuoraIds {
         )
       ),
       Stage("DEV") -> ZuoraIds(
+        SupporterPlusZuoraIds(
+          monthly = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("8ad09fc281de1ce70181de3b251736a4"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad09fc281de1ce70181de3b253e36a6")
+          ),
+          annual = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("8ad09fc281de1ce70181de3b28ee3783"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad09fc281de1ce70181de3b29223787")
+          )
+        ),
         ContributionsZuoraIds(
           monthly = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("2c92c0f85a6b134e015a7fcd9f0c7855"),
@@ -396,7 +437,9 @@ object ZuoraIds {
         )
       )
     )
+
     mappings.get(stage).toApiGatewayContinueProcessing(ApiGatewayResponse.internalServerError(s"missing zuora ids for stage $stage"))
+
   }
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -205,12 +205,12 @@ object ZuoraIds {
       Stage("PROD") -> ZuoraIds(
         SupporterPlusZuoraIds(
           monthly = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("mno"),
-            productRatePlanChargeId = ProductRatePlanChargeId("pqr")
+            productRatePlanId = ProductRatePlanId("8a12865b8219d9b401822106192b64dc"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b401822106194e64e3")
           ),
           annual = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("stu"),
-            productRatePlanChargeId = ProductRatePlanChargeId("vwx")
+            productRatePlanId = ProductRatePlanId("8a12865b8219d9b40182210618a464ba"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b40182210618c664c1")
           )
         ),
         ContributionsZuoraIds(
@@ -283,12 +283,12 @@ object ZuoraIds {
       Stage("CODE") -> ZuoraIds(
         SupporterPlusZuoraIds(
           monthly = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("abc"),
-            productRatePlanChargeId = ProductRatePlanChargeId("def")
+            productRatePlanId = ProductRatePlanId("8ad088718219a6b601822036a6c91f5c"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a6e21f5e")
           ),
           annual = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("ghi"),
-            productRatePlanChargeId = ProductRatePlanChargeId("jkl")
+            productRatePlanId = ProductRatePlanId("8ad088718219a6b601822036a5801f34"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a5c21f39")
           )
         ),
         ContributionsZuoraIds(
@@ -361,7 +361,7 @@ object ZuoraIds {
       Stage("DEV") -> ZuoraIds(
         SupporterPlusZuoraIds(
           monthly = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("8ad09fc281de1ce70181de3b251736a4"),
+            productRatePlanId = ProductRatePlanId("111"),
             productRatePlanChargeId = ProductRatePlanChargeId("8ad09fc281de1ce70181de3b253e36a6")
           ),
           annual = PlanAndCharge(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -1,14 +1,14 @@
 package com.gu.newproduct.api.productcatalog
 
+import java.time.DayOfWeek._
 import java.time.{DayOfWeek, LocalDate}
 
 import com.gu.i18n.Currency
 import com.gu.newproduct.api.productcatalog.PlanId._
 import com.gu.newproduct.api.productcatalog.WireModel._
-import play.api.libs.json.Json
-import java.time.DayOfWeek._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
 
 class CatalogWireTest extends AnyFlatSpec with Matchers {
   it should "serialise catalog" in {
@@ -16,6 +16,32 @@ class CatalogWireTest extends AnyFlatSpec with Matchers {
       """
         |{
         |  "products": [
+        |  {
+        |    "label" : "Supporter Plus",
+        |    "plans" : [ {
+        |      "id" : "monthly_supporter_plus",
+        |      "label" : "Monthly",
+        |      "startDateRules" : {
+        |        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        |        "selectableWindow" : {
+        |          "startDate" : "2019-12-01",
+        |          "sizeInDays" : 1
+        |        }
+        |      },
+        |      "paymentPlans": []
+        |    }, {
+        |      "id" : "annual_supporter_plus",
+        |      "label" : "Annual",
+        |      "startDateRules" : {
+        |        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        |        "selectableWindow" : {
+        |          "startDate" : "2019-12-01",
+        |          "sizeInDays" : 1
+        |        }
+        |      },
+        |      "paymentPlans": []
+        |    } ]
+        |  },
         |    {
         |      "label": "Contribution",
         |      "plans": [
@@ -1006,6 +1032,8 @@ class CatalogWireTest extends AnyFlatSpec with Matchers {
       case VoucherEveryDayPlus => gbpPrice(5196)
       case VoucherSixDay => gbpPrice(4112)
       case VoucherSixDayPlus => gbpPrice(4762)
+      case MonthlySupporterPlus => Map.empty
+      case AnnualSupporterPlus => Map.empty
       case MonthlyContribution => Map.empty
       case AnnualContribution => Map.empty
       case HomeDeliveryEveryDay => gbpPrice(123)


### PR DESCRIPTION
### Description

In Salesforce, CSRs must be able to acquire customers with an existing Billing Account onto the new Product Prop (working name: Supporter Plus)

The product catalog returned by the new-product-api lambda has been updated to include the Supporter Plus Product, its rate plans (annual, monthly) and restrictions on the available start date (today only)

_‘Supporter Plus’ product appears on the product dropdown_
![image](https://user-images.githubusercontent.com/36296660/187674607-edbf5afc-30bb-4738-b7ca-4bd3055396c4.png)

_Monthly and Annual Rate Plans are available for selection_
![image](https://user-images.githubusercontent.com/36296660/187674768-2ad7d72f-b21b-45c8-a293-9dcc6799684a.png)

_Start date restricted to today only_
![image](https://user-images.githubusercontent.com/36296660/187675230-a4d1dbde-eaa8-4d81-b1b3-cb443333e8e3.png)

### Testing 

_**Unit**_
- CatalogWireTest has been updated to verify the correct deserialisation of the product catalog with Supporter Plus product included

**_Functional_**
- Log into Salesforce and navigate to a Billing Account
- Click on 'New Subscription' button
- Click on the 'Product' drop down menu and verify 'Supporter Plus' is present
- Click on 'Rate Plan' drop down menu and verify 'Annual' and 'Monthly' options are present
- Click on the Datepicker and verify that today is the only available date for selection

### notes
- The 'Supporter Plus' name is used widely in variables throughout the changes. This name is temporary and will likely need changing before go-live. 
- A Feature Flag will be implemented in SF so that we can deploy these changes to production and ensure that CSRs are not able to use it in Salesforce until we determine it is ready for usage (see Related PRs)

### Related PRs
[#634 Add feature flag for product prop](https://github.com/guardian/salesforce/pull/634)

### Coming next

- Implement lower and upper boundaries for Amount (update schema in new-product-api lambda to contain an object representing currency-specific upper and lower boundaries. Boundaries will be stored as a file in S3)
- Implement orchestration of the acquisition when a CSR submits request for new product