### PR TITLE
Update scala-steward.yml

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     name: Test of Scala Steward PR
         
-    if: github.actor == 'gu-scala-steward-public-repos'
+    if: github.actor == 'gu-scala-steward-public-repos[bot]'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## What does this change?

This is still skipping `gu-scala-steward-public-repos` PRs, it looks like we need to append "[bot]" to the username for it to run on these PRs.