### PR TITLE
Update api spec

### DIFF
--- a/handlers/product-move-api/OpenAPISpec.yaml
+++ b/handlers/product-move-api/OpenAPISpec.yaml
@@ -1,0 +1,204 @@
+openapi: 3.0.3
+info:
+  title: Product Movement API
+  version: 0.0.1
+  description: |-
+    API to facilitate replacing an existing subscription
+    with another subscription for a different type of product.
+paths:
+  /available-product-moves/{subscriptionName}:
+    get:
+      summary: Gets available products that can be moved to from the given subscription.
+      description: |
+        Returns an array of eligible products that the given subscription could be moved to,
+        which will be empty if there aren't any for the given subscription.
+      operationId: getAvailable-product-movesSubscriptionname
+      parameters:
+      - name: subscriptionName
+        in: path
+        description: Name of subscription whose eligibility for movement is to be
+          checked.
+        required: true
+        schema:
+          type: string
+        example: A-S000001
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/product'
+        '404':
+          description: No such subscription.
+          content:
+            text/plain:
+              schema:
+                type: string
+  /product-move/{subscriptionName}:
+    post:
+      summary: Replaces the existing subscription with a new one.
+      description: |-
+        Cancels the existing subscription and replaces it with a new subscription
+        to a different type of product.
+        Also manages all the service comms associated with the movement.
+      operationId: postProduct-moveSubscriptionname
+      parameters:
+      - name: subscriptionName
+        in: path
+        description: Name of subscription to be moved to a different product.
+        required: true
+        schema:
+          type: string
+        example: A-S000001
+      requestBody:
+        description: Definition of required movement.
+        content:
+          application/json:
+            schema:
+              required:
+              - targetProductId
+              type: object
+              properties:
+                targetProductId:
+                  type: string
+                  description: ID of target product that new subscription will be
+                    for.
+        required: true
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                required:
+                - newSubscriptionName
+                type: object
+                properties:
+                  newSubscriptionName:
+                    type: string
+                    description: Name of new subscription.
+        '404':
+          description: No such subscription.
+          content:
+            text/plain:
+              schema:
+                type: string
+        '400':
+          description: 'Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    billing:
+      type: object
+      properties:
+        amount:
+          type: integer
+          description: |-
+            Absolute amount that will be billed in pence or cents etc.
+            Either this field or the percentage field will be populated.
+          format: int32
+          example: 1199
+        percentage:
+          type: integer
+          description: |-
+            Percentage of standard amount that will be billed.
+            This field only makes sense if the billing object is attached to an introductory offer.
+            Either this field or the amount field will be populated.
+          format: int32
+          example: 50
+        currency:
+          required:
+          - code
+          - symbol
+          type: object
+          properties:
+            code:
+              type: string
+              description: ISO 4217 alphabetic currency code.
+              example: GBP
+            symbol:
+              type: string
+              description: ISO 4217 currency symbol.
+              example: £
+        frequency:
+          $ref: '#/components/schemas/timePeriod'
+        startDate:
+          type: string
+          description: |-
+            Date on which first service period for product subscription begins.
+            This probably won't be known reliably before a subscription has actually been set up,
+            so it's an optional field.
+            In ISO 8601 format.
+          example: '2022-06-21'
+      description: Amount and frequency of billing.
+    offer:
+      required:
+      - billing
+      - duration
+      type: object
+      properties:
+        billing:
+          $ref: '#/components/schemas/billing'
+        duration:
+          $ref: '#/components/schemas/timePeriod'
+      description: |-
+        An optional special offer that begins either when a subscription begins
+        or at the end of a free trial
+        and lasts for a given period of time.
+    product:
+      required:
+      - id
+      - name
+      - billing
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID of product in Zuora product catalogue.
+        name:
+          type: string
+          description: Name of product in Zuora product catalogue.
+          example: Digital Pack
+        billing:
+          $ref: '#/components/schemas/billing'
+        trial:
+          $ref: '#/components/schemas/trial'
+        introOffer:
+          $ref: '#/components/schemas/offer'
+      description: A product that's available for subscription.
+    timePeriod:
+      required:
+      - name
+      - count
+      type: object
+      properties:
+        name:
+          type: string
+          description: Time unit.
+          example: month
+          enum:
+          - month
+          - year
+        count:
+          type: integer
+          description: Number of time units in this time period.
+          format: int32
+    trial:
+      required:
+      - dayCount
+      type: object
+      properties:
+        dayCount:
+          type: integer
+          description: Number of days that free trial lasts.
+          format: int32
+          example: 14
+      description: |-
+        An optional free trial that begins when a subscription begins
+        and lasts for a given number of days.

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/available/AvailableProductMovesEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/available/AvailableProductMovesEndpointTypes.scala
@@ -57,7 +57,7 @@ object MoveToProduct {
 
       introOffer = Offer(Billing(amount = None, percentage = Some(50), currency = None, frequency = None, startDate = Some(localDateToString.format(chargedThroughDate))), TimePeriod(TimeUnit.month, 3))
       newPlan = Billing(amount = Some(price.toInt), percentage = None, currency = Some(GBP), frequency = Some(TimePeriod(TimeUnit.fromString(billingPeriod), 1)), startDate = Some(localDateToString.format(chargedThroughDate.plusDays(90))))
-    } yield MoveToProduct(id = subscriptionName, name = "Digital Pack", trial = Some(Trial(dayCount = 14)), introOffer = Some(introOffer), billing = newPlan)
+    } yield MoveToProduct(id = productRatePlan.id, name = "Digital Pack", trial = Some(Trial(dayCount = 14)), introOffer = Some(introOffer), billing = newPlan)
 }
 
 @encodedName("product")

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -75,26 +75,5 @@ object ProductMoveEndpoint {
       _ <- ZuoraCancel.cancel(subscriptionName, chargedThroughDate)
       newSubscriptionId <- Subscribe.create(subscription.accountId, postData.targetProductId)
       _ <- ZIO.log("Sub: " + newSubscriptionId.toString)
-    } yield Success(newSubscriptionId.subscriptionId, MoveToProduct(
-      id = "123",
-      name = "Digital Pack",
-      billing = Billing(
-        amount = Some(1199),
-        percentage = None,
-        currency = Some(Currency.GBP),
-        frequency = Some(TimePeriod(TimeUnit.month, 1)),
-        startDate = Some("2022-09-21")
-      ),
-      trial = Some(Trial(14)),
-      introOffer = Some(Offer(
-        Billing(
-          amount = None,
-          percentage = Some(50),
-          currency = None,
-          frequency = None,//FIXME doesn't make sense for a percentage
-          startDate = Some("2022-09-21")
-        ),
-        duration = TimePeriod(TimeUnit.month, 3)
-      ))
-    ))
+    } yield Success(newSubscriptionId.subscriptionId)
 }


### PR DESCRIPTION
## What does this change?

 Changes the `product-move` endpoint to only return the new subscription number, removing the product detail with billing and information about the offer.

## Why?

 To return the entire product detail we would need to write some more code and make another Zuora call. [manage-frontend](https://github.com/guardian/manage-frontend) already has this product detail which is returned from the previous endpoint; `available-product-moves`. We will have to amend manage-frontend to carry the state from this endpoint between the different pages within the product-switch journey, probably via `react-router`.

## link the PR from manage-frontend when done