### PR TITLE
Send supporter plus csr acquisition confirmation email 

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/QueueNames.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/QueueNames.scala
@@ -4,6 +4,7 @@ import com.gu.effects.sqs.AwsSQSSend.QueueName
 import com.gu.util.config.Stage
 
 case class EmailQueueNames(
+  supporterPlus: QueueName,
   contributions: QueueName,
   paper: QueueName,
   digipack: QueueName,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/QueueNames.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/QueueNames.scala
@@ -20,6 +20,7 @@ object EmailQueueNames {
 
     case Stage("PROD") =>
       EmailQueueNames(
+        supporterPlus = subsWelcomeProdQueue,
         contributions = contributionThanksProdQueue,
         paper = subsWelcomeProdQueue,
         digipack = subsWelcomeProdQueue,
@@ -28,6 +29,7 @@ object EmailQueueNames {
 
     case _ =>
       EmailQueueNames(
+        supporterPlus = subsWelcomeDevQueue,
         contributions = contributionThanksDevQueue,
         paper = subsWelcomeDevQueue,
         digipack = subsWelcomeDevQueue,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -38,18 +38,6 @@ object Handler extends Logging {
     ApiGatewayHandler(LambdaIO(inputStream, outputStream, context)) {
       Steps.operationForEffects(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, SqsAsync.send(SqsAsync.buildClient), RawEffects.now)
     }
-
-  def main(args: Array[String]): Unit = {
-    val result = Steps.operationForEffects(
-      RawEffects.response,
-      Stage("DEV"),
-      GetFromS3.fetchString,
-      SqsAsync.send(SqsAsync.buildClient),
-      RawEffects.now
-    )
-
-    println("result:" + result)
-  }
 }
 
 object Steps {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -115,6 +115,8 @@ object Steps {
         zuoraClient,
         isValidStartDateForPlan,
         createSubscription,
+        awsSQSSend,
+        queueNames,
         currentDate
       )
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/EmailData.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/EmailData.scala
@@ -39,6 +39,17 @@ case class DigipackEmailData(
   trialPeriod: TrialPeriod
 ) extends EmailData
 
+case class SupporterPlusEmailData(
+  accountId: ZuoraAccountId,
+  currency: Currency,
+  paymentMethod: PaymentMethod,
+  amountMinorUnits: AmountMinorUnits,
+  firstPaymentDate: LocalDate,
+  plan: Plan,
+  contacts: Contacts,
+  created: LocalDate
+) extends EmailData
+
 case class ContributionsEmailData(
   accountId: ZuoraAccountId,
   currency: Currency,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/SendConfirmationEmail.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/SendConfirmationEmail.scala
@@ -44,6 +44,7 @@ object SendConfirmationEmail extends Logging {
       case _: DigitalVoucherPlanId => "paper-subscription-card" // SV_SC_WelcomeDay0
       case _: VoucherPlanId => "paper-voucher"
       case _: DigipackPlanId => "digipack"
+      case _: SupporterPlusPlanId => "supporter-plus"
       case _: ContributionPlanId => "regular-contribution-thank-you"
       case _: HomeDeliveryPlanId => "paper-delivery"
       case _: GuardianWeeklyDomestic => "guardian-weekly"

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/supporterplus/SupporterPlusFields.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/supporterplus/SupporterPlusFields.scala
@@ -1,0 +1,53 @@
+package com.gu.newproduct.api.addsubscription.email.supporterplus
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+import com.gu.newproduct.api.addsubscription.Formatters._
+import com.gu.newproduct.api.addsubscription.email.SupporterPlusEmailData
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod}
+import com.gu.newproduct.api.productcatalog.Plan
+import com.gu.newproduct.api.productcatalog.PlanId.{AnnualSupporterPlus, MonthlySupporterPlus}
+import play.api.libs.json.{Json, Writes}
+
+object SupporterPlusEmailDataSerialiser {
+  implicit val writes: Writes[SupporterPlusEmailData] = (data: SupporterPlusEmailData) => {
+    val fields: Map[String, String] = SupporterPlusFields(data)
+    Json.toJson(fields)
+  }
+}
+
+object SupporterPlusFields {
+
+  val firstPaymentDateFormat = DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy")
+
+  def productId(plan: Plan) = plan.id match {
+    case AnnualSupporterPlus => "annual-supporter-plus"
+    case MonthlySupporterPlus => "monthly-supporter-plus"
+    case other => other.name
+  }
+
+  def paymentMethodFields(paymentMethod: PaymentMethod, firstPaymentDate: LocalDate) = paymentMethod match {
+    case DirectDebit(status, accountName, accountNumberMask, sortCode, mandateId) => Map(
+      "account number" -> accountNumberMask.value,
+      "sort code" -> sortCode.hyphenated,
+      "account name" -> accountName.value,
+      "Mandate ID" -> mandateId.value,
+      "payment method" -> "Direct Debit",
+      "first payment date" -> firstPaymentDate.format(firstPaymentDateFormat)
+    )
+    case _ => Map.empty
+
+  }
+
+  def apply(data: SupporterPlusEmailData): Map[String, String] = Map(
+    "EmailAddress" -> data.contacts.billTo.email.map(_.value).getOrElse(""),
+    "created" -> data.created.toString,
+    "amount" -> data.amountMinorUnits.formatted,
+    "currency" -> data.currency.glyph,
+    "edition" -> data.contacts.billTo.address.country.map(_.alpha2).getOrElse(""),
+    "name" -> data.contacts.billTo.firstName.value,
+    "product" -> productId(data.plan)
+  ) ++ paymentMethodFields(data.paymentMethod, data.firstPaymentDate)
+
+}

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
@@ -2,16 +2,19 @@ package com.gu.newproduct.api.addsubscription
 
 import com.gu.i18n.Currency
 import com.gu.newproduct.TestData
+import com.gu.newproduct.api.addsubscription.email.SupporterPlusEmailData
 import com.gu.newproduct.api.addsubscription.validation.supporterplus.SupporterPlusValidations.ValidatableFields
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest, ZuoraCreateSubRequestRatePlan}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlySupporterPlus
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, Plan, PlanDescription, PlanId}
 import com.gu.test.JsonMatchers.JsonMatcher
 import com.gu.util.apigateway.ApiGatewayRequest
+import com.gu.util.reader.AsyncTypes._
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import com.gu.util.resthttp.Types
 import com.gu.util.resthttp.Types.ClientSuccess
@@ -60,6 +63,10 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
       ClientSuccess(SubscriptionName("well done"))
     }
 
+    def fakeSendEmails(sfContactId: Option[SfContactId], supporterPlusEmailData: SupporterPlusEmailData) = {
+      ContinueProcessing(()).toAsync
+    }
+
     def fakeValidateRequest(fields: ValidatableFields, planId: PlanId, currency: Currency) = {
       fields.amountMinorUnits.map(Passed(_)).getOrElse(Failed("missing amount"))
     }
@@ -90,7 +97,8 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
       getPlanAndCharge,
       fakeGetCustomerData,
       fakeValidateRequest,
-      fakeCreate
+      fakeCreate,
+      fakeSendEmails
     ) _
 
     val dummySteps = (req: AddSubscriptionRequest) => {

--- a/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
@@ -9,12 +9,14 @@ import play.api.libs.json.{JsString, Json}
 object AddSubscriptionManualTest extends App {
   val requestBody =
     """{
-      |   "zuoraAccountId":"2c92c0f869330b7a01694982970a2b34",
-      |   "startDate":"2019-03-25",
-      |   "acquisitionSource":"CSR",
-      |   "createdByCSR":"someone testingsadasd",
-      |   "acquisitionCase": "caseID",
-      |   "planId": "digipack_monthly"
+      |	"zuoraAccountId":"8ad09b7d83634b880183698ea4ff27cc",
+      |	"startDate":"2022-09-23",
+      |	"productRatePlanChargeId":"monthly_supporter_plus",
+      |	"planId":"monthly_supporter_plus",
+      |	"createdByCSR":"David Pepper",
+      |	"amountMinorUnits":2000,
+      |	"acquisitionSource":"CSR",
+      |	"acquisitionCase":"5009E00000Lyy3T"
       |}
     """.stripMargin
 


### PR DESCRIPTION
### What does this change?
Send a confirmation email when Supporter Plus subscription is taken out

This has been achieved by wiring in extra steps to the Supporter Plus flow, by adding a payload to SQS, which is then picked up by membership-workflow and communicated to Braze for email send 

The changes in this PR follow the pattern established for email sends for other products.   

### Testing

**Functional**
- Log into Salesforce and navigate to a Billing Account
- Ensure the email address on the Billing Account Contact matches your own (or an account you have access to - to verify receipt of email)
- Create a Case with following fields populated:
  - Product: Supporter Plus
  - Case Type: AQ - Sale
  - Contact: same contact as Billing Account (important that these match otherwise request to create sub will fail)
- Click on 'New Subscription' button
- Click on the 'Product' drop down menu and select 'Supporter Plus'
- Click on 'Rate Plan' drop down menu and select 'Annual' or 'Monthly' 
- Click on the Datepicker and select the current date (it should be the only date available for selection)
- Enter the Case Number from step above

<img width="359" alt="image" src="https://user-images.githubusercontent.com/36296660/188150737-23f80068-411b-42f5-b4c5-ea5dd1bd7cf2.png">


- Add an amount that is within the currency-specific and payment frequency-specific boundaries
- Tick the confirmation checkboxes
- Click on submit
- Verify that a success message is displayed to the user  _<add image>_
<img width="693" alt="image" src="https://user-images.githubusercontent.com/36296660/188152411-d22c2d7a-b2a1-408d-b965-f82e6e666c09.png">

- Verify that a confirmation email is received
<img width="808" alt="image" src="https://user-images.githubusercontent.com/36296660/191953901-1ee82c56-8076-4779-a4e7-ac1c80a8666f.png">

Alternatively the logic in new-product-api\src\test\scala\manualTest\AddSubscriptionManualTest.scala can be executed (with appropriate test data) and an email should be received by the Contact on the Billing Account

```
{
      	"zuoraAccountId":"8ad09b7d83634b880183698ea4ff27cc",
      	"startDate":"2022-09-23",
      	"productRatePlanChargeId":"monthly_supporter_plus",
      	"planId":"monthly_supporter_plus",
      	"createdByCSR":"David Pepper",
      	"amountMinorUnits":2000,
      	"acquisitionSource":"CSR",
      	"acquisitionCase":"5009E00000Lyy3T"
}


```

