### PR TITLE
Supporter Plus Cancellation & Refund

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -350,7 +350,7 @@ lazy val `new-product-api` = lambdaProject(
   .settings(
     scalacOptions += "-Ytasty-reader",
   )
-  .dependsOn(zuora, handler, `effects-sqs`, effectsDepIncludingTestFolder, testDep, `zuora-models`)
+  .dependsOn(zuora, handler, `effects-sqs`, effectsDepIncludingTestFolder, testDep, `zuora-models`, `config-core`)
 
 lazy val `zuora-retention` = lambdaProject(
   "zuora-retention",

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -62,6 +62,7 @@ Resources:
           Action: s3:GetObject
           Resource:
             - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}*.json
+            - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/invoicingApi-${Stage}*.json
       - Statement:
         - Effect: Allow
           Action: s3:GetObject

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -96,4 +96,22 @@ Resources:
               RestApiId:
                 Ref: ProductMoveApiGateway
 
-# alarms go here
+# alarms
+  ProductMovementFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: An error in the Product Move lambda. Please check the logs to diagnose
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref ProductMoveApiLambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/GuReaderRevenuePrivateS3.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/GuReaderRevenuePrivateS3.scala
@@ -1,0 +1,16 @@
+package com.gu.productmove
+
+import com.gu.productmove.GuStageLive.Stage
+
+object GuReaderRevenuePrivateS3 {
+  val bucket = "gu-reader-revenue-private"
+
+  def key(configFileName: String, stage: Stage, version: Int = 1) = {
+    val basePath = s"membership/support-service-lambdas/$stage"
+
+    val versionString = if (stage == Stage.DEV) "" else s".v${version}"
+    val relativePath = s"$configFileName-$stage$versionString.json"
+    s"$basePath/$relativePath"
+  }
+
+}

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -131,7 +131,7 @@ object SubscriptionCancelEndpoint {
       _ <- ZuoraCancel.cancel(subscriptionName, cancellationDate)
 
       _ <- ZIO.log(s"Attempting to refund sub")
-      _ <- if(shouldBeRefunded) ZIO.serviceWithZIO[InvoicingApiRefund](_.refund(subscriptionName, charge.price)) else ZIO.succeed(RefundResponse("Success"))
+      _ <- if(shouldBeRefunded) InvoicingApiRefund.refund(subscriptionName, charge.price) else ZIO.succeed(RefundResponse("Success"))
 
       _ <- ZIO.log("Sub cancelled as of: " + cancellationDate)
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -75,7 +75,7 @@ object SubscriptionCancelEndpoint {
   def asSingle[A](list: List[A], message: String): IO[String, A] =
     list match {
       case singlePlan :: Nil => ZIO.succeed(singlePlan)
-      case wrongNumber => ZIO.fail(s"subscription can't be cancelled as we didn't have a single $message: ${wrongNumber.length}: $wrongNumber")
+      case wrongNumber => ZIO.fail(s"Subscription can't be cancelled as we didn't have a single $message: ${wrongNumber.length}: $wrongNumber")
     }
 
   private def checkProductIsSupporterPlus(charge: RatePlanCharge, ids: SupporterPlusZuoraIds) = {
@@ -119,7 +119,10 @@ object SubscriptionCancelEndpoint {
           Some(subscription.contractEffectiveDate)
         else
           charge.chargedThroughDate
-      ).orElseFail(s"Cancellation date is null")
+      ).orElseFail(
+        s"Subscription charged through date is null is for supporter plus subscription $subscriptionName.\n" +
+        s"This is an error because we expect to be able to use the charged through date to work out the effective cancellation date"
+      )
       _ <- ZIO.log(s"Cancellation date is $cancellationDate")
 
       _ <- ZIO.log(s"Attempting to cancel sub")

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -42,7 +42,7 @@ object SubscriptionCancelEndpoint {
         .in(jsonBody[ExpectedInput].copy(info = EndpointIO.Info.empty[ExpectedInput].copy(description = Some("Information to describe the nature of the cancellation"))))
         .out(oneOf(
           oneOfVariant(sttp.model.StatusCode.Ok, jsonBody[Success].copy(info = EndpointIO.Info.empty.copy(description = Some("Successfully cancelled the subscription.")))),
-          oneOfVariant(sttp.model.StatusCode.NotFound, stringBody.map(NotFound.apply)(_.textResponse).copy(info = EndpointIO.Info.empty.copy(description = Some("No such subscription.")))),
+          oneOfVariant(sttp.model.StatusCode.InternalServerError, stringBody.map(InternalServerError.apply)(_.message).copy(info = EndpointIO.Info.empty.copy(description = Some("InternalServerError.")))),
         ))
         .summary("Cancels the subscription at the soonest possible date based on the subscription type.")
         .description(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointTypes.scala
@@ -22,7 +22,7 @@ object SubscriptionCancelEndpointTypes {
 
   sealed trait OutputBody
   case class Success(
-    // TBC what should the body be?
+    message: String
   ) extends OutputBody
   case class NotFound(textResponse: String) extends OutputBody
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointTypes.scala
@@ -11,7 +11,7 @@ object SubscriptionCancelEndpointTypes {
   case class ExpectedInput(
     @description("User cancellation reason - from a picklist.")
     @encodedExample("mma_other")// also "mma_value_for_money" , "mma_support_another_way" , "mma_financial_circumstances", etc
-    reason: String // TODO consider an enumeration
+    reason: String
   )
 
   given JsonDecoder[ExpectedInput] = DeriveJsonDecoder.gen[ExpectedInput]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointTypes.scala
@@ -21,15 +21,14 @@ object SubscriptionCancelEndpointTypes {
 
 
   sealed trait OutputBody
-  case class Success(
-    message: String
-  ) extends OutputBody
+  case class Success(message: String) extends OutputBody
   case class NotFound(textResponse: String) extends OutputBody
+  case class InternalServerError(message: String) extends OutputBody
 
   given Schema[Success] = inlineSchema(Schema.derived)
 
   given JsonCodec[Success] = DeriveJsonCodec.gen[Success]
-  given JsonCodec[NotFound] = DeriveJsonCodec.gen[NotFound]
+  given JsonCodec[InternalServerError] = DeriveJsonCodec.gen[InternalServerError]
   given JsonCodec[OutputBody] = DeriveJsonCodec.gen[OutputBody]
 
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscription.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscription.scala
@@ -27,7 +27,7 @@ trait GetSubscription:
 
 object GetSubscription {
 
-  case class GetSubscriptionResponse(id: String, accountId: String, ratePlans: List[RatePlan])
+  case class GetSubscriptionResponse(id: String, contractEffectiveDate: LocalDate, accountId: String, ratePlans: List[RatePlan])
 
   case class RatePlan(
     productName: String,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscription.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscription.scala
@@ -27,7 +27,13 @@ trait GetSubscription:
 
 object GetSubscription {
 
-  case class GetSubscriptionResponse(id: String, contractEffectiveDate: LocalDate, accountId: String, ratePlans: List[RatePlan])
+  case class GetSubscriptionResponse(
+    id: String,
+    version: Int,
+    contractEffectiveDate: LocalDate,
+    accountId: String,
+    ratePlans: List[RatePlan]
+  )
 
   case class RatePlan(
     productName: String,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscription.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscription.scala
@@ -40,7 +40,7 @@ object GetSubscription {
   case class RatePlanCharge(
     name: String,
     number: String,
-    price: Double,
+    price: BigDecimal,
     billingPeriod: Option[String],
     effectiveStartDate: LocalDate,
     chargedThroughDate: Option[LocalDate],

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -22,7 +22,7 @@ object InvoicingApiRefundLive {
     }
 }
 
-private class InvoicingApiRefundLive(apiKey: String, url: String, sttpClient: SttpBackend[Task, Any]) extends InvoicingApiRefund :
+private class InvoicingApiRefundLive(apiKey: String, url: String, sttpClient: SttpBackend[Task, Any]) extends InvoicingApiRefund {
   override def refund(subscriptionName: String, amount: BigDecimal): ZIO[Any, String, RefundResponse] = {
 
     val requestBody = RefundRequest(subscriptionName, amount)
@@ -33,7 +33,7 @@ private class InvoicingApiRefundLive(apiKey: String, url: String, sttpClient: St
       .post(uri"$url")
       .response(asJson[RefundResponse])
       .send(sttpClient)
-      .map{ response =>
+      .map { response =>
         response.body match {
           case Left(err) => println(s"Recieved an error from Invoicing refund endpoint: $err")
           case Right(body) => println(s"Recieved a successful response from Invoicing refund endpoint: $body")
@@ -42,6 +42,7 @@ private class InvoicingApiRefundLive(apiKey: String, url: String, sttpClient: St
       }.absolve
       .mapError(_.toString)
   }
+}
 
 trait InvoicingApiRefund {
   def refund(subscriptionName: String, amount: BigDecimal): ZIO[Any, String, RefundResponse]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -35,8 +35,8 @@ private class InvoicingApiRefundLive(apiKey: String, url: String, sttpClient: St
       .send(sttpClient)
       .map{ response =>
         response.body match {
-          case Left(err) => ZIO.logInfo(s"Recieved an error from Invoicing refund endpoint: $err")
-          case Right(body) => ZIO.logInfo(s"Recieved a successful response from Invoicing refund endpoint: $body")
+          case Left(err) => println(s"Recieved an error from Invoicing refund endpoint: $err")
+          case Right(body) => println(s"Recieved a successful response from Invoicing refund endpoint: $body")
         }
         response.body
       }.absolve
@@ -48,7 +48,7 @@ trait InvoicingApiRefund {
 }
 
 object InvoicingApiRefund {
-  case class RefundRequest(subscriptionName: String, amount: BigDecimal)
+  case class RefundRequest(subscriptionName: String, refund: BigDecimal)
   /*
   {
     "subscriptionName": "A-S00427546",

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -40,7 +40,7 @@ private class InvoicingApiRefundLive(config: InvoicingApiConfig, sttpClient: Stt
       .contentType("application/json")
       .header("x-api-key", config.apiKey)
       .body(requestBody.toJson)
-      .post(uri"$config.url")
+      .post(uri"${config.url}")
       .response(asJson[RefundResponse])
       .send(sttpClient)
       .map { response =>

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -35,8 +35,8 @@ private class InvoicingApiRefundLive(apiKey: String, url: String, sttpClient: St
       .send(sttpClient)
       .map { response =>
         response.body match {
-          case Left(err) => println(s"Recieved an error from Invoicing refund endpoint: $err")
-          case Right(body) => println(s"Recieved a successful response from Invoicing refund endpoint: $body")
+          case Left(err) => println(s"Received an error from Invoicing refund endpoint: $err")
+          case Right(body) => println(s"Received a successful response from Invoicing refund endpoint: $body")
         }
         response.body
       }.absolve
@@ -50,7 +50,7 @@ trait InvoicingApiRefund {
 
 object InvoicingApiRefund {
   case class RefundRequest(subscriptionName: String, refund: BigDecimal)
-  /*
+  /* Full response from Invoicing api is as follows:
   {
     "subscriptionName": "A-S00427546",
     "refundAmount": 30,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -1,0 +1,76 @@
+package com.gu.productmove.invoicingapi
+
+import com.gu.productmove.GuStageLive.Stage
+import com.gu.productmove.invoicingapi.InvoicingApiRefund.{RefundRequest, RefundResponse}
+import sttp.client3.Response.ExampleGet.uri
+import sttp.client3.quick.basicRequest
+import sttp.client3.ziojson.*
+import sttp.client3.*
+import zio.json.*
+import zio.{Task, ZIO, ZLayer}
+
+object InvoicingApiRefundLive {
+  val layer: ZLayer[Stage with SttpBackend[Task, Any], String, InvoicingApiRefundLive] =
+    ZLayer {
+      for {
+        stage <- ZIO.service[Stage]
+        apiKey = sys.env.getOrElse("InvoicingApiKey", throw new RuntimeException("Missing x-api-key for invoicing-api"))
+        invoicingApiUrl = s"${sys.env.getOrElse("InvoicingApiUrl", throw new RuntimeException("Missing invoicing-api url"))}/$stage/refund"
+        _ <- ZIO.logInfo(s"Invoice API url is $invoicingApiUrl")
+        sttpClient <- ZIO.service[SttpBackend[Task, Any]]
+      } yield InvoicingApiRefundLive(apiKey, invoicingApiUrl, sttpClient)
+    }
+}
+
+private class InvoicingApiRefundLive(apiKey: String, url: String, sttpClient: SttpBackend[Task, Any]) extends InvoicingApiRefund :
+  override def refund(subscriptionName: String, amount: BigDecimal): ZIO[Any, String, RefundResponse] = {
+
+    val requestBody = RefundRequest(subscriptionName, amount)
+    basicRequest
+      .contentType("application/json")
+      .header("x-api-key", apiKey)
+      .body(requestBody.toJson)
+      .post(uri"$url")
+      .response(asJson[RefundResponse])
+      .send(sttpClient)
+      .map{ response =>
+        response.body match {
+          case Left(err) => ZIO.logInfo(s"Recieved an error from Invoicing refund endpoint: $err")
+          case Right(body) => ZIO.logInfo(s"Recieved a successful response from Invoicing refund endpoint: $body")
+        }
+        response.body
+      }.absolve
+      .mapError(_.toString)
+  }
+
+trait InvoicingApiRefund {
+  def refund(subscriptionName: String, amount: BigDecimal): ZIO[Any, String, RefundResponse]
+}
+
+object InvoicingApiRefund {
+  case class RefundRequest(subscriptionName: String, amount: BigDecimal)
+  /*
+  {
+    "subscriptionName": "A-S00427546",
+    "refundAmount": 30,
+    "invoiceId": "8ad0877b8373493d018389a5f5301259",
+    "paymentId": "8ad0877b8373493d018389a5f57f1262",
+    "adjustments": [
+        {
+            "AdjustmentDate": "2022-09-29",
+            "Amount": 30,
+            "Comments": "e6282ccd-d06a-49bd-ad2e-9c362e912232",
+            "InvoiceId": "8ad0877b8373493d018389a5f5301259",
+            "Type": "Credit",
+            "SourceType": "InvoiceDetail",
+            "SourceId": "8ad0877b8373493d018389a5f539125a"
+        }
+    ],
+    "guid": "e6282ccd-d06a-49bd-ad2e-9c362e912232"
+}
+  */
+  case class RefundResponse(subscriptionName: String)
+
+  given JsonEncoder[RefundRequest] = DeriveJsonEncoder.gen[RefundRequest]
+  given JsonDecoder[RefundResponse] = DeriveJsonDecoder.gen[RefundResponse]
+}

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -49,6 +49,9 @@ trait InvoicingApiRefund {
 }
 
 object InvoicingApiRefund {
+  def refund(subscriptionName: String, amount: BigDecimal): ZIO[InvoicingApiRefund, String, RefundResponse] =
+    ZIO.serviceWithZIO[InvoicingApiRefund](_.refund(subscriptionName, amount))
+
   case class RefundRequest(subscriptionName: String, refund: BigDecimal)
   /* Full response from Invoicing api is as follows:
   {

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetAccount.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetAccount.scala
@@ -7,7 +7,7 @@ import com.gu.productmove.endpoint.available.{Currency, TimeUnit}
 import com.gu.productmove.zuora.DefaultPaymentMethod
 import com.gu.productmove.zuora.GetAccount.{GetAccountResponse, PaymentMethodResponse}
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
-import com.gu.productmove.zuora.rest.ZuoraClientLive.{ZuoraRestConfig, bucket, key}
+import com.gu.productmove.zuora.rest.ZuoraClientLive.ZuoraRestConfig
 import com.gu.productmove.zuora.rest.ZuoraGet
 import com.gu.productmove.zuora.rest.ZuoraRestBody.ZuoraSuccessCheck
 import sttp.capabilities.zio.ZioStreams

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/InvoicePreview.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/InvoicePreview.scala
@@ -4,7 +4,7 @@ import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import com.gu.productmove.zuora.InvoicePreview.ZuoraInvoiceList
-import com.gu.productmove.zuora.rest.ZuoraClientLive.{ZuoraRestConfig, bucket, key}
+import com.gu.productmove.zuora.rest.ZuoraClientLive.ZuoraRestConfig
 import com.gu.productmove.zuora.rest.ZuoraGet
 import sttp.capabilities.zio.ZioStreams
 import sttp.capabilities.{Effect, WebSockets}

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/ZuoraCancel.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/ZuoraCancel.scala
@@ -43,7 +43,7 @@ given JsonEncoder[CancellationRequest] = DeriveJsonEncoder.gen[CancellationReque
 
 case class CancellationResponse(
   subscriptionId: String,
-  cancellationDate: LocalDate
+  cancelledDate: LocalDate
 )
 
 given JsonDecoder[CancellationResponse] = DeriveJsonDecoder.gen[CancellationResponse]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/ZuoraSetCancellationReason.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/ZuoraSetCancellationReason.scala
@@ -16,22 +16,22 @@ import zio.{Clock, IO, RIO, Task, UIO, URLayer, ZIO, ZLayer}
 
 import java.time.LocalDate
 
-trait ZuoraSetCancellationReasons:
+trait ZuoraSetCancellationReason:
   def update(subscriptionNumber: String, subscriptionVersion: Int, userCancellationReason: String): ZIO[Any, String, UpdateResponse]
 
-object ZuoraSetCancellationReasonsLive:
-  val layer: URLayer[ZuoraGet, ZuoraSetCancellationReasons] = ZLayer.fromFunction(ZuoraSetCancellationReasonsLive(_))
+object ZuoraSetCancellationReasonLive:
+  val layer: URLayer[ZuoraGet, ZuoraSetCancellationReason] = ZLayer.fromFunction(ZuoraSetCancellationReasonLive(_))
 
-private class ZuoraSetCancellationReasonsLive(zuoraGet: ZuoraGet) extends ZuoraSetCancellationReasons :
+private class ZuoraSetCancellationReasonLive(zuoraGet: ZuoraGet) extends ZuoraSetCancellationReason :
   override def update(subscriptionNumber: String, subscriptionVersion: Int, userCancellationReason: String): ZIO[Any, String, UpdateResponse] = {
     val updateRequest = UpdateRequest(CustomFields(userCancellationReason))
 
     zuoraGet.put[UpdateRequest, UpdateResponse](uri"subscriptions/$subscriptionNumber/versions/$subscriptionVersion/customFields", updateRequest)
   }
 
-object ZuoraSetCancellationReasons {
-  def update(subscriptionNumber: String, subscriptionVersion: Int, userCancellationReason: String): ZIO[ZuoraSetCancellationReasons, String, UpdateResponse] =
-    ZIO.serviceWithZIO[ZuoraSetCancellationReasons](_.update(subscriptionNumber, subscriptionVersion, userCancellationReason))
+object ZuoraSetCancellationReason {
+  def update(subscriptionNumber: String, subscriptionVersion: Int, userCancellationReason: String): ZIO[ZuoraSetCancellationReason, String, UpdateResponse] =
+    ZIO.serviceWithZIO[ZuoraSetCancellationReason](_.update(subscriptionNumber, subscriptionVersion, userCancellationReason))
 }
 
 case class UpdateRequest(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/ZuoraSetCancellationReasons.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/ZuoraSetCancellationReasons.scala
@@ -1,0 +1,51 @@
+package com.gu.productmove.zuora
+
+import com.gu.productmove.AwsS3
+import com.gu.productmove.GuStageLive.Stage
+import com.gu.productmove.zuora.{CaseId, ChargeOverrides, CreateSubscriptionResponse, ProductRatePlanChargeId, ProductRatePlanId, SubscribeToRatePlans, ZuoraAccountId}
+import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
+import com.gu.productmove.zuora.rest.ZuoraGet
+import sttp.capabilities.zio.ZioStreams
+import sttp.capabilities.{Effect, WebSockets}
+import sttp.client3.*
+import sttp.client3.httpclient.zio.HttpClientZioBackend
+import sttp.client3.ziojson.*
+import sttp.model.Uri
+import zio.json.*
+import zio.{Clock, IO, RIO, Task, UIO, URLayer, ZIO, ZLayer}
+
+import java.time.LocalDate
+
+trait ZuoraSetCancellationReasons:
+  def update(subscriptionNumber: String, subscriptionVersion: Int, userCancellationReason: String): ZIO[Any, String, UpdateResponse]
+
+object ZuoraSetCancellationReasonsLive:
+  val layer: URLayer[ZuoraGet, ZuoraSetCancellationReasons] = ZLayer.fromFunction(ZuoraSetCancellationReasonsLive(_))
+
+private class ZuoraSetCancellationReasonsLive(zuoraGet: ZuoraGet) extends ZuoraSetCancellationReasons :
+  override def update(subscriptionNumber: String, subscriptionVersion: Int, userCancellationReason: String): ZIO[Any, String, UpdateResponse] = {
+    val updateRequest = UpdateRequest(CustomFields(userCancellationReason))
+
+    zuoraGet.put[UpdateRequest, UpdateResponse](uri"subscriptions/$subscriptionNumber/versions/$subscriptionVersion/customFields", updateRequest)
+  }
+
+object ZuoraSetCancellationReasons {
+  def update(subscriptionNumber: String, subscriptionVersion: Int, userCancellationReason: String): ZIO[ZuoraSetCancellationReasons, String, UpdateResponse] =
+    ZIO.serviceWithZIO[ZuoraSetCancellationReasons](_.update(subscriptionNumber, subscriptionVersion, userCancellationReason))
+}
+
+case class UpdateRequest(
+  customFields: CustomFields
+)
+
+given JsonEncoder[UpdateRequest] = DeriveJsonEncoder.gen[UpdateRequest]
+
+case class CustomFields(UserCancellationReason__c: String, CancellationReason__c: String = "Customer")
+
+given JsonEncoder[CustomFields] = DeriveJsonEncoder.gen[CustomFields]
+
+case class UpdateResponse(
+  success: Boolean
+)
+
+given JsonDecoder[UpdateResponse] = DeriveJsonDecoder.gen[UpdateResponse]


### PR DESCRIPTION
## What does this change?
This PR adds a new endpoint to the product move api to cancel and potentially refund supporter plus subscriptions.

The logic around refunds is:
- users who cancel within 14 days of the purchase of the subscription are refunded  and the cancellation date is set to the contract effective date (date of purchase)
- users who cancel after the first 14 days are not refunded and the cancellation date is set to the charged through date (end of the current period which has been paid for)

## How to test
Details are [in this document](https://docs.google.com/document/d/1pv6TSq1tONltaFxVGpCKYuWBU2BUF1X35ylzAgWHhqg/edit#)

## How can we measure success?
Cancellations and refunds work correctly for supporter plus subs
