### PR TITLE
new-product-api lambda - Update lower boundary thresholds for supporter plus

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/supporterplus/AmountLimits.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/supporterplus/AmountLimits.scala
@@ -15,33 +15,33 @@ object AmountLimits {
   def fromMinorToMajor(value: Int) = value / 100
 
   val gbp = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 12, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 119, max = 2000)
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 95, max = 2000)
   )
 
   val aud = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 22, max = 200),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 215, max = 2400)
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 17, max = 200),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 160, max = 2400)
   )
 
   val usd = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 20, max = 800),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 119, max = 10000)
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 13, max = 800),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 120, max = 10000)
   )
 
   val nzd = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 24, max = 200),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 235, max = 2400)
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 17, max = 200),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 160, max = 2400)
   )
 
   val cad = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 22, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 219, max = 2000)
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 13, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 120, max = 2000)
   )
 
   val eur = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 15, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 149, max = 2000)
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 95, max = 2000)
   )
 
   def limitsFor(planId: PlanId, currency: Currency): AmountLimits = {


### PR DESCRIPTION
## What does this change?
Update the lower boundary thresholds for each currency for qualification to Supporter Plus product:

![image](https://user-images.githubusercontent.com/36296660/199072366-44a1f62e-d98c-4e9e-b016-1467ac0678ab.png)

### Suggested future work
These values should be stored in config that is accessible by the logic, allowing for more straightforward updates should the thresholds change in future, which they probably will (inflation etc) 