### PR TITLE
Allow the cancel and refund api to handle supporter plus v2

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
@@ -1,7 +1,6 @@
 package com.gu.newproduct.api.addsubscription
 
 import java.time.LocalDate
-
 import com.gu.effects.sqs.AwsSQSSend
 import com.gu.effects.sqs.AwsSQSSend.QueueName
 import com.gu.i18n.Currency
@@ -31,7 +30,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetCont
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod, PaymentMethodWire}
 import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetAccountSubscriptions, GetContacts, GetPaymentMethod}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
-import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanId, ZuoraIds}
+import com.gu.newproduct.api.productcatalog.ZuoraIds.{HasPlanAndChargeIds, PlanAndCharge, ProductRatePlanId, ZuoraIds}
 import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, Catalog, Plan, PlanId}
 import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
 import com.gu.util.reader.AsyncTypes.{AsyncApiGatewayOp, _}
@@ -46,7 +45,7 @@ object AddContribution {
   def steps(
       getPlan: PlanId => Plan,
       getCurrentDate: () => LocalDate,
-      getPlanAndCharge: PlanId => Option[PlanAndCharge],
+      getPlanAndCharge: PlanId => Option[HasPlanAndChargeIds],
       getCustomerData: ZuoraAccountId => ApiGatewayOp[ContributionCustomerData],
       contributionValidations: (ValidatableFields, PlanId, Currency) => ValidationResult[AmountMinorUnits],
       createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
@@ -1,7 +1,6 @@
 package com.gu.newproduct.api.addsubscription
 
 import java.time.LocalDate
-
 import com.gu.effects.sqs.AwsSQSSend
 import com.gu.effects.sqs.AwsSQSSend.QueueName
 import com.gu.newproduct.api.EmailQueueNames
@@ -27,7 +26,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetContacts.{BillToAddress, S
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetContactsResponse
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.PaymentMethodWire
 import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetContacts, GetPaymentMethod}
-import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanId, ZuoraIds}
+import com.gu.newproduct.api.productcatalog.ZuoraIds.{HasPlanAndChargeIds, PlanAndCharge, ProductRatePlanId, ZuoraIds}
 import com.gu.newproduct.api.productcatalog.{Catalog, Plan, PlanId}
 import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
 import com.gu.util.reader.AsyncTypes.{AsyncApiGatewayOp, _}
@@ -41,7 +40,7 @@ object AddGuardianWeeklySub {
   def steps(
       getPlan: PlanId => Plan,
       getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
-      getPlanAndCharge: PlanId => Option[PlanAndCharge],
+      getPlanAndCharge: PlanId => Option[HasPlanAndChargeIds],
       getCustomerData: ZuoraAccountId => ApiGatewayOp[GuardianWeeklyCustomerData],
       validateStartDate: (PlanId, LocalDate) => ValidationResult[Unit],
       validateAddress: (BillToAddress, SoldToAddress) => ValidationResult[Unit],
@@ -133,7 +132,7 @@ object AddGuardianWeeklySub {
       sixForSixPlanId: PlanId,
       quarterlyPlanId: PlanId,
       getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
-      getPlanAndCharge: PlanId => Option[PlanAndCharge],
+      getPlanAndCharge: PlanId => Option[HasPlanAndChargeIds],
   ): ApiGatewayOp[ZuoraCreateSubRequest] = {
     if (request.planId == sixForSixPlanId) {
       for {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
@@ -11,11 +11,11 @@ import com.gu.newproduct.api.addsubscription.validation._
 import com.gu.newproduct.api.addsubscription.validation.supporterplus
 import com.gu.newproduct.api.addsubscription.validation.supporterplus.SupporterPlusValidations.ValidatableFields
 import com.gu.newproduct.api.addsubscription.validation.supporterplus.{
+  AmountLimits,
   GetSupporterPlusCustomerData,
   SupporterPlusAccountValidation,
   SupporterPlusCustomerData,
   SupporterPlusValidations,
-  AmountLimits,
 }
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
   ChargeOverride,
@@ -31,7 +31,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetCont
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod, PaymentMethodWire}
 import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetAccountSubscriptions, GetContacts, GetPaymentMethod}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlySupporterPlus
-import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanId, ZuoraIds}
+import com.gu.newproduct.api.productcatalog.ZuoraIds.{HasPlanAndChargeIds, PlanAndCharge, ProductRatePlanId, ZuoraIds}
 import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, Catalog, Plan, PlanId}
 import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
 import com.gu.util.reader.AsyncTypes.{AsyncApiGatewayOp, _}
@@ -47,7 +47,7 @@ object AddSupporterPlus {
   def steps(
       getPlan: PlanId => Plan,
       getCurrentDate: () => LocalDate,
-      getPlanAndCharge: PlanId => Option[PlanAndCharge],
+      getPlanAndCharge: PlanId => Option[HasPlanAndChargeIds],
       getCustomerData: ZuoraAccountId => ApiGatewayOp[SupporterPlusCustomerData],
       supporterPlusValidations: (
           SupporterPlusValidations.ValidatableFields,

--- a/handlers/product-move-api/get-secrets-as-env-vars.sh
+++ b/handlers/product-move-api/get-secrets-as-env-vars.sh
@@ -1,9 +1,17 @@
+# Private config is now provided to the lambdas via environment variables from secrets manager, this means
+# that to run code which relies on that config locally we need to retrieve the values into local environment variables.
+# This script will do that and also output a string representation which can be used to make the values available in
+# Intellij test configurations
+
 # Zuora secrets
 aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:eu-west-1:865473395570:secret:DEV/Zuora/User/ZuoraApiUser-kxm7mq | jq -c '[.SecretString | fromjson]' | \
 jq -M -r '.[] | .baseUrl, .username, .password' | \
 while read -r baseUrl; read -r username; read -r password; do
-  echo "baseUrl = $baseUrl"
   export zuoraBaseUrl="$baseUrl"
   export zuoraUsername="$username"
   export zuoraPassword="$password"
+
+  # Add this into the environment variables setting in the Intellij default run configuration to enable integration tests to access the variables
+  #  https://stackoverflow.com/questions/32760584/in-intellij-how-do-i-set-default-environment-variables-for-new-test-configurati
+  echo "zuoraBaseUrl=$baseUrl;zuoraUsername=$username;zuoraPassword=$password"
 done

--- a/handlers/product-move-api/get-secrets-as-env-vars.sh
+++ b/handlers/product-move-api/get-secrets-as-env-vars.sh
@@ -1,0 +1,9 @@
+# Zuora secrets
+aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:eu-west-1:865473395570:secret:DEV/Zuora/User/ZuoraApiUser-kxm7mq | jq -c '[.SecretString | fromjson]' | \
+jq -M -r '.[] | .baseUrl, .username, .password' | \
+while read -r baseUrl; read -r username; read -r password; do
+  echo "baseUrl = $baseUrl"
+  export zuoraBaseUrl="$baseUrl"
+  export zuoraUsername="$username"
+  export zuoraPassword="$password"
+done

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
@@ -47,10 +47,7 @@ object CreateRecordSpec extends ZIOSpecDefault {
               ),
             )
             .provide(
-              AwsS3Live.layer,
-              AwsCredentialsLive.layer,
               SttpClientLive.layer,
-              ZLayer.succeed(Stage.valueOf("DEV")),
               CreateRecordLive.layer,
               GetSfSubscriptionLive.layer,
               SalesforceClientLive.layer,

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionCancelSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionCancelSpec.scala
@@ -1,0 +1,40 @@
+package com.gu.productmove.zuora
+
+import com.gu.productmove.endpoint.cancel.SubscriptionCancelEndpoint
+import com.gu.productmove.endpoint.cancel.zuora.GetSubscriptionLive
+import com.gu.productmove.endpoint.cancel.SubscriptionCancelEndpointTypes.ExpectedInput
+import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, GuStageLive, SQSLive, SttpClientLive}
+import com.gu.productmove.invoicingapi.InvoicingApiRefundLive
+import com.gu.productmove.refund.{Refund, RefundInput}
+import com.gu.productmove.zuora.RefundSpec.{suite, test}
+import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGetLive}
+import zio.Scope
+import zio.test.Assertion.equalTo
+import zio.test.{Spec, TestAspect, TestEnvironment, ZIOSpecDefault, assert}
+
+
+object SubscriptionCancelSpec extends ZIOSpecDefault{
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("Cancel")(test("Run cancellation lambda locally") {
+      /*
+           Test suite used to run the cancellation lambda locally
+       */
+
+      for {
+        _ <- SubscriptionCancelEndpoint.subscriptionCancel("A-S00496717", ExpectedInput("mma_other"))
+          .provide(
+            GetSubscriptionLive.layer,
+            ZuoraCancelLive.layer,
+            SQSLive.layer,
+            ZuoraSetCancellationReasonLive.layer,
+            AwsCredentialsLive.layer,
+            SttpClientLive.layer,
+            ZuoraClientLive.layer,
+            ZuoraGetLive.layer,
+            GuStageLive.layer,
+          )
+      } yield assert(true)(equalTo(true))
+    }) // @@ TestAspect.ignore)
+
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionCancelSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionCancelSpec.scala
@@ -22,7 +22,7 @@ object SubscriptionCancelSpec extends ZIOSpecDefault{
        */
 
       for {
-        _ <- SubscriptionCancelEndpoint.subscriptionCancel("A-S00496717", ExpectedInput("mma_other"))
+        _ <- SubscriptionCancelEndpoint.subscriptionCancel("A-S00497184", ExpectedInput("mma_other"))
           .provide(
             GetSubscriptionLive.layer,
             ZuoraCancelLive.layer,
@@ -35,6 +35,6 @@ object SubscriptionCancelSpec extends ZIOSpecDefault{
             GuStageLive.layer,
           )
       } yield assert(true)(equalTo(true))
-    }) // @@ TestAspect.ignore)
+    } @@ TestAspect.ignore)
 
 }

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -108,6 +108,8 @@ sealed abstract class PlanId(val name: String)
 object PlanId {
   case object AnnualSupporterPlus extends PlanId("annual_supporter_plus") with SupporterPlusPlanId
 
+  case object AnnualSupporterPlusV2 extends PlanId("annual_supporter_plus_v2") with SupporterPlusPlanId
+
   case object MonthlySupporterPlus extends PlanId("monthly_supporter_plus") with SupporterPlusPlanId
 
   case object MonthlySupporterPlusV2 extends PlanId("monthly_supporter_plus_v2") with SupporterPlusPlanId

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -110,6 +110,8 @@ object PlanId {
 
   case object MonthlySupporterPlus extends PlanId("monthly_supporter_plus") with SupporterPlusPlanId
 
+  case object MonthlySupporterPlusV2 extends PlanId("monthly_supporter_plus_v2") with SupporterPlusPlanId
+
   case object AnnualContribution extends PlanId("annual_contribution") with ContributionPlanId
 
   case object MonthlyContribution extends PlanId("monthly_contribution") with ContributionPlanId

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -11,9 +11,10 @@ object ZuoraIds {
 
   case class PlanAndCharge(productRatePlanId: ProductRatePlanId, productRatePlanChargeId: ProductRatePlanChargeId)
 
-  case class SupporterPlusZuoraIds(monthly: PlanAndCharge, annual: PlanAndCharge) {
+  case class SupporterPlusZuoraIds(monthly: PlanAndCharge, monthlyV2: PlanAndCharge, annual: PlanAndCharge) {
     val planAndChargeByApiPlanId: Map[PlanId, PlanAndCharge] = Map(
       MonthlySupporterPlus -> monthly,
+      MonthlySupporterPlusV2 -> monthlyV2,
       AnnualSupporterPlus -> annual,
     )
   }
@@ -214,7 +215,13 @@ object ZuoraIds {
         SupporterPlusZuoraIds(
           monthly = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8a12865b8219d9b401822106192b64dc"),
-            productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b401822106194e64e3"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b401822106194e64e3")
+          ),
+          // TODO these ids are wrong (just copied from monthly)
+          // TODO annualV2
+          monthlyV2 = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("8a12865b8219d9b401822106192b64dc"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b401822106194e64e3")
           ),
           annual = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8a12865b8219d9b40182210618a464ba"),
@@ -292,7 +299,13 @@ object ZuoraIds {
         SupporterPlusZuoraIds(
           monthly = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8ad088718219a6b601822036a6c91f5c"),
-            productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a6e21f5e"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a6e21f5e")
+          ),
+          // TODO these ids are wrong (just copied from monthly)
+          // TODO annualV2
+          monthlyV2 = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("8ad088718219a6b601822036a6c91f5c"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a6e21f5e")
           ),
           annual = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8ad088718219a6b601822036a5801f34"),
@@ -371,6 +384,11 @@ object ZuoraIds {
           monthly = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8ad09fc281de1ce70181de3b251736a4"),
             productRatePlanChargeId = ProductRatePlanChargeId("8ad09fc281de1ce70181de3b253e36a6"),
+          ),
+          // TODO annualV2
+          monthlyV2 = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("8ad08e018499b108018499f163ac32e3"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad08e018499b108018499f163e132ef")
           ),
           annual = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8ad09fc281de1ce70181de3b28ee3783"),

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -9,13 +9,31 @@ object ZuoraIds {
 
   case class ProductRatePlanChargeId(value: String) extends AnyVal
 
-  case class PlanAndCharge(productRatePlanId: ProductRatePlanId, productRatePlanChargeId: ProductRatePlanChargeId)
+  trait HasPlanAndChargeIds {
+    val productRatePlanId: ProductRatePlanId
+    val productRatePlanChargeId: ProductRatePlanChargeId
+  }
 
-  case class SupporterPlusZuoraIds(monthly: PlanAndCharge, monthlyV2: PlanAndCharge, annual: PlanAndCharge) {
-    val planAndChargeByApiPlanId: Map[PlanId, PlanAndCharge] = Map(
+  case class PlanAndCharge(productRatePlanId: ProductRatePlanId, productRatePlanChargeId: ProductRatePlanChargeId)
+      extends HasPlanAndChargeIds
+
+  case class PlanAndCharges(
+      productRatePlanId: ProductRatePlanId,
+      productRatePlanChargeId: ProductRatePlanChargeId,
+      contributionProductRatePlanChargeId: ProductRatePlanChargeId,
+  ) extends HasPlanAndChargeIds
+
+  case class SupporterPlusZuoraIds(
+      monthly: PlanAndCharge,
+      monthlyV2: PlanAndCharges,
+      annual: PlanAndCharge,
+      annualV2: PlanAndCharges,
+  ) {
+    val planAndChargeByApiPlanId: Map[PlanId, HasPlanAndChargeIds] = Map(
       MonthlySupporterPlus -> monthly,
       MonthlySupporterPlusV2 -> monthlyV2,
       AnnualSupporterPlus -> annual,
+      AnnualSupporterPlusV2 -> annualV2,
     )
   }
 
@@ -200,7 +218,7 @@ object ZuoraIds {
 
     val rateplanIdToApiId: Map[ProductRatePlanId, PlanId] = apiIdToRateplanId.map(_.swap)
 
-    def apiIdToPlanAndCharge: Map[PlanId, PlanAndCharge] =
+    def apiIdToPlanAndCharge: Map[PlanId, HasPlanAndChargeIds] =
       supporterPlusZuoraIds.planAndChargeByApiPlanId ++
         contributionsZuoraIds.planAndChargeByApiPlanId ++
         guardianWeeklyDomestic.planAndChargeByApiPlanId ++
@@ -215,17 +233,21 @@ object ZuoraIds {
         SupporterPlusZuoraIds(
           monthly = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8a12865b8219d9b401822106192b64dc"),
-            productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b401822106194e64e3")
+            productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b401822106194e64e3"),
           ),
-          // TODO these ids are wrong (just copied from monthly)
-          // TODO annualV2
-          monthlyV2 = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("8a12865b8219d9b401822106192b64dc"),
-            productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b401822106194e64e3")
+          monthlyV2 = PlanAndCharges(
+            productRatePlanId = ProductRatePlanId("8a128ed885fc6ded018602296ace3eb8"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8a128ed885fc6ded018602296af13eba"),
+            contributionProductRatePlanChargeId = ProductRatePlanChargeId("8a128d7085fc6dec01860234cd075270"),
           ),
           annual = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8a12865b8219d9b40182210618a464ba"),
             productRatePlanChargeId = ProductRatePlanChargeId("8a12865b8219d9b40182210618c664c1"),
+          ),
+          annualV2 = PlanAndCharges(
+            productRatePlanId = ProductRatePlanId("8a128ed885fc6ded01860228f77e3d5a"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8a128ed885fc6ded01860228f7cb3d5f"),
+            contributionProductRatePlanChargeId = ProductRatePlanChargeId("8a12892d85fc6df4018602451322287f"),
           ),
         ),
         ContributionsZuoraIds(
@@ -299,17 +321,21 @@ object ZuoraIds {
         SupporterPlusZuoraIds(
           monthly = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8ad088718219a6b601822036a6c91f5c"),
-            productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a6e21f5e")
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a6e21f5e"),
           ),
-          // TODO these ids are wrong (just copied from monthly)
-          // TODO annualV2
-          monthlyV2 = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("8ad088718219a6b601822036a6c91f5c"),
-            productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a6e21f5e")
+          monthlyV2 = PlanAndCharges(
+            productRatePlanId = ProductRatePlanId("8ad0940885f8901f0186024838f844a1"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad0940885f8901f01860248397b44d7"),
+            contributionProductRatePlanChargeId = ProductRatePlanChargeId("8ad08e1a86023f520186024dd62d4aa2"),
           ),
           annual = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8ad088718219a6b601822036a5801f34"),
             productRatePlanChargeId = ProductRatePlanChargeId("8ad088718219a6b601822036a5c21f39"),
+          ),
+          annualV2 = PlanAndCharges(
+            productRatePlanId = ProductRatePlanId("8ad094b985f8901601860248d751315c"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad094b985f8901601860248d7ba3176"),
+            contributionProductRatePlanChargeId = ProductRatePlanChargeId("8ad08e1a86023f520186024d08801ad6"),
           ),
         ),
         ContributionsZuoraIds(
@@ -385,14 +411,19 @@ object ZuoraIds {
             productRatePlanId = ProductRatePlanId("8ad09fc281de1ce70181de3b251736a4"),
             productRatePlanChargeId = ProductRatePlanChargeId("8ad09fc281de1ce70181de3b253e36a6"),
           ),
-          // TODO annualV2
-          monthlyV2 = PlanAndCharge(
-            productRatePlanId = ProductRatePlanId("8ad08e018499b108018499f163ac32e3"),
-            productRatePlanChargeId = ProductRatePlanChargeId("8ad08e018499b108018499f163e132ef")
+          monthlyV2 = PlanAndCharges(
+            productRatePlanId = ProductRatePlanId("8ad08cbd8586721c01858804e3275376"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad08cbd8586721c01858804e3715378"),
+            contributionProductRatePlanChargeId = ProductRatePlanChargeId("8ad09ea0858682bb0185880ac57f4c4c"),
           ),
           annual = PlanAndCharge(
             productRatePlanId = ProductRatePlanId("8ad09fc281de1ce70181de3b28ee3783"),
             productRatePlanChargeId = ProductRatePlanChargeId("8ad09fc281de1ce70181de3b29223787"),
+          ),
+          annualV2 = PlanAndCharges(
+            productRatePlanId = ProductRatePlanId("8ad08e1a8586721801858805663f6fab"),
+            productRatePlanChargeId = ProductRatePlanChargeId("8ad08e1a858672180185880566606fad"),
+            contributionProductRatePlanChargeId = ProductRatePlanChargeId("8ad096ca858682bb0185881568385d73"),
           ),
         ),
         ContributionsZuoraIds(


### PR DESCRIPTION
## What does this change?
This PR updates the cancel and refund lambdas to handle Supporter Plus V2, it will still handle V1 correctly so can be released immediately.

[Spike doc](https://docs.google.com/document/d/1WeI2uPMX3UpB5BxYXtKu_CVX9sQnMou7DNAmzM91yCc/edit#)
[More detailed info](https://docs.google.com/document/d/1bZfMtPZBGmtk-IBm941xsrg79UmZ5T_4ajrHkMwP5is/edit#)