### PR TITLE
Fix billing account remover bug

### DIFF
--- a/handlers/sf-billing-account-remover/cfn.yaml
+++ b/handlers/sf-billing-account-remover/cfn.yaml
@@ -11,7 +11,7 @@ Mappings:
     DEV:
       SalesforceUrl: https://test.salesforce.com
       SalesforceConnectedApp: AwsConnectorSandbox
-      SalesforceUser: MembersDataAPI
+      SalesforceUser: BillingAccountRemoverAPIUser
       ZuoraUrl: https://rest.apisandbox.zuora.com
       ZuoraAccount: SfSaves
     CODE:
@@ -22,8 +22,8 @@ Mappings:
       ZuoraAccount: SubscriptionsZuoraApi
     PROD:
       SalesforceUrl: https://gnmtouchpoint.my.salesforce.com
-      SalesforceConnectedApp: TouchpointUpdate
-      SalesforceUser: MembersDataAPI
+      SalesforceConnectedApp: BillingAccountRemover
+      SalesforceUser: BillingAccountRemoverAPIUser
       ZuoraUrl: https://rest.zuora.com
       ZuoraAccount: SupportServiceLambdas
 

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -11,7 +11,9 @@ import scalaj.http._
 import scala.util.Try
 
 object BillingAccountRemover extends App with LazyLogging {
-  
+
+  val salesforceApiVersion = "54.0"
+
   //Salesforce
   case class SfAuthDetails(access_token: String, instance_url: String)
 
@@ -97,28 +99,28 @@ object BillingAccountRemover extends App with LazyLogging {
       config <- optConfig.toRight(new RuntimeException("Missing config value"))
       sfAuthDetails <- decode[SfAuthDetails](auth(config.salesforceConfig))
       getCustomSettingResponse <- getSfCustomSetting(sfAuthDetails)
-      maxAttempts = getCustomSettingResponse.records.headOption
-        .getOrElse(
-          throw new RuntimeException(
-            "There should be at least one record returned for MaxAttempts"
-          )
-        )
-        .Property_Value__c
-      getBillingAccountsResponse <- getSfBillingAccounts(
-        maxAttempts,
-        sfAuthDetails
-      )
+//      maxAttempts = getCustomSettingResponse.records.headOption
+//        .getOrElse(
+//          throw new RuntimeException(
+//            "There should be at least one record returned for MaxAttempts"
+//          )
+//        )
+//        .Property_Value__c
+//      getBillingAccountsResponse <- getSfBillingAccounts(
+//        maxAttempts,
+//        sfAuthDetails
+//      )
     } yield {
-      val sfRecords = getBillingAccountsResponse.records
-      logger.info(s"Retrieved ${sfRecords.length} records from Salesforce.")
-
-      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
-
-      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
-
-      if (failedUpdates.nonEmpty) {
-        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
-      }
+//      val sfRecords = getBillingAccountsResponse.records
+//      logger.info(s"Retrieved ${sfRecords.length} records from Salesforce.")
+//
+//      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
+//
+//      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
+//
+//      if (failedUpdates.nonEmpty) {
+//        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
+//      }
     }).left
       .foreach(e => throw new RuntimeException("An error occurred: ", e))
   }
@@ -148,9 +150,13 @@ object BillingAccountRemover extends App with LazyLogging {
     val query =
       "Select Id, Property_Value__c from Touch_Point_List_Property__c where name = 'Max Billing Acc GDPR Removal Attempts'"
 
-    decode[SfGetCustomSettingResponse](
+    val customSettingResponse = decode[SfGetCustomSettingResponse](
       doSfGetWithQuery(sfAuthentication, query)
     )
+
+    println("customSettingResponse:"+customSettingResponse)
+
+    customSettingResponse
   }
 
   def getSfBillingAccounts(
@@ -168,13 +174,20 @@ object BillingAccountRemover extends App with LazyLogging {
   }
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
-    Http(s"${sfAuthDetails.instance_url}/services/data/v54.0/query/")
+    val endpoint = s"${sfAuthDetails.instance_url}/services/data/v${salesforceApiVersion}/query/"
+
+    println("endpoint:"+endpoint)
+
+    val httpResponse = Http(endpoint)
       .param("q", query)
       .option(HttpOptions.readTimeout(30000))
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
       .method("GET")
       .asString
       .body
+
+    println("doSfGetWithQuery httpResponse:"+httpResponse)
+    httpResponse
   }
 
   def doSfCompositeRequest(

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -78,7 +78,7 @@ object BillingAccountRemover extends App with LazyLogging {
 
   } yield Config(
     SalesforceConfig(
-      userName = sfUserName,
+      username = sfUserName,
       clientId = sfClientId,
       clientSecret = sfClientSecret,
       password = sfPassword,
@@ -134,7 +134,7 @@ object BillingAccountRemover extends App with LazyLogging {
           "grant_type" -> "password",
           "client_id" -> salesforceConfig.clientId,
           "client_secret" -> salesforceConfig.clientSecret,
-          "username" -> salesforceConfig.userName,
+          "username" -> salesforceConfig.username,
           "password" -> s"${salesforceConfig.password}${salesforceConfig.token}"
         )
       )

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -164,7 +164,7 @@ object BillingAccountRemover extends App with LazyLogging {
     val limit = 200;
 
     val query =
-      s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts and Id=\'a029E00000OuybhQAB\' limit $limit"
+      s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts limit $limit"
 
     decode[SfGetBillingAccsResponse](doSfGetWithQuery(sfAuthentication, query))
   }

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -106,22 +106,24 @@ object BillingAccountRemover extends App with LazyLogging {
           )
         )
         .Property_Value__c
-      getBillingAccountsResponse <- getSfBillingAccounts(
-        maxAttempts,
-        sfAuthDetails
-      )
+//      getBillingAccountsResponse <- getSfBillingAccounts(
+//        maxAttempts,
+//        sfAuthDetails
+//      )
     } yield {
-      val sfRecords = getBillingAccountsResponse.records
-      println("sfRecords:" + sfRecords)
-      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
-      println("allUpdates:" + allUpdates)
-
-      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
-      println("failedUpdates:" + failedUpdates)
-
-      if (failedUpdates.nonEmpty) {
-        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
-      }
+      println("maxAttempts:" + maxAttempts)
+//
+//      val sfRecords = getBillingAccountsResponse.records
+//      println("sfRecords:" + sfRecords)
+//      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
+//      println("allUpdates:" + allUpdates)
+//
+//      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
+//      println("failedUpdates:" + failedUpdates)
+//
+//      if (failedUpdates.nonEmpty) {
+//        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
+//      }
     }).left
       .foreach(e => throw new RuntimeException("An error occurred: ", e))
   }
@@ -172,8 +174,12 @@ object BillingAccountRemover extends App with LazyLogging {
 
     val query =
       s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts and Id=\'a029E00000OuybhQAB\' limit $limit"
+    println("query:"+query)
 
-    decode[SfGetBillingAccsResponse](doSfGetWithQuery(sfAuthentication, query))
+    val queryResponse = doSfGetWithQuery(sfAuthentication, query)
+    println("queryResponse:"+queryResponse)
+
+    decode[SfGetBillingAccsResponse](queryResponse)
   }
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -112,10 +112,12 @@ object BillingAccountRemover extends App with LazyLogging {
       )
     } yield {
       val sfRecords = getBillingAccountsResponse.records
-
+      println("sfRecords:" + sfRecords)
       val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
+      println("allUpdates:" + allUpdates)
 
       val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
+      println("failedUpdates:" + failedUpdates)
 
       if (failedUpdates.nonEmpty) {
         writeErrorsBackToSf(sfAuthDetails, failedUpdates)
@@ -166,7 +168,7 @@ object BillingAccountRemover extends App with LazyLogging {
     val limit = 200;
 
     val query =
-      s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts limit $limit"
+      s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts and Id=\'a029E00000OuybhQAB\' limit $limit"
 
     decode[SfGetBillingAccsResponse](doSfGetWithQuery(sfAuthentication, query))
   }

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -11,9 +11,7 @@ import scalaj.http._
 import scala.util.Try
 
 object BillingAccountRemover extends App with LazyLogging {
-
-  val salesforceApiVersion = "54.0"
-
+  
   //Salesforce
   case class SfAuthDetails(access_token: String, instance_url: String)
 
@@ -114,13 +112,13 @@ object BillingAccountRemover extends App with LazyLogging {
       val sfRecords = getBillingAccountsResponse.records
       logger.info(s"Retrieved ${sfRecords.length} records from Salesforce.")
 
-      //      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
-      //
-      //      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
-      //
-      //      if (failedUpdates.nonEmpty) {
-      //        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
-      //      }
+      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
+
+      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
+
+      if (failedUpdates.nonEmpty) {
+        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
+      }
     }).left
       .foreach(e => throw new RuntimeException("An error occurred: ", e))
   }
@@ -170,9 +168,7 @@ object BillingAccountRemover extends App with LazyLogging {
   }
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
-    val url = s"${sfAuthDetails.instance_url}/services/data/v${salesforceApiVersion}/query/"
-    println("url:" + url)
-    Http(url)
+    Http(s"${sfAuthDetails.instance_url}/services/data/v54.0/query/")
       .param("q", query)
       .option(HttpOptions.readTimeout(30000))
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
@@ -189,7 +185,7 @@ object BillingAccountRemover extends App with LazyLogging {
 
     Try {
       Http(
-        s"${sfAuthDetails.instance_url}/services/data/v${salesforceApiVersion}/composite/sobjects"
+        s"${sfAuthDetails.instance_url}/services/data/v54.0/composite/sobjects"
       ).header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
         .header("Content-Type", "application/json")
         .put(jsonBody)

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -157,9 +157,10 @@ object BillingAccountRemover extends App with LazyLogging {
 
     val query =
       "Select Id, Property_Value__c from Touch_Point_List_Property__c where name = \'Max Billing Acc GDPR Removal Attempts\'"
-    println("custom setting query:"+query)
+    println("custom setting query:" + query)
+    println("sfAuthentication:" + sfAuthentication)
     val customSettingQueryResponse = doSfGetWithQuery(sfAuthentication, query)
-    println("customSettingQueryResponse:"+customSettingQueryResponse)
+    println("customSettingQueryResponse:" + customSettingQueryResponse)
 
     decode[SfGetCustomSettingResponse](customSettingQueryResponse)
   }
@@ -184,13 +185,20 @@ object BillingAccountRemover extends App with LazyLogging {
   }
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
-    Http(s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/query/")
+
+    val url = s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/query/"
+
+    println("url:" + url)
+    val abc = Http(url)
       .param("q", query)
       .option(HttpOptions.readTimeout(30000))
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
       .method("GET")
       .asString
       .body
+
+    println("abc:" + abc)
+    abc
   }
 
   def doSfCompositeRequest(

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -11,7 +11,9 @@ import scalaj.http._
 import scala.util.Try
 
 object BillingAccountRemover extends App with LazyLogging {
-  
+
+  val salesforceApiVersion = "54.0"
+
   //Salesforce
   case class SfAuthDetails(access_token: String, instance_url: String)
 
@@ -168,7 +170,7 @@ object BillingAccountRemover extends App with LazyLogging {
   }
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
-    Http(s"${sfAuthDetails.instance_url}/services/data/v54.0/query/")
+    Http(s"${sfAuthDetails.instance_url}/services/data/v${salesforceApiVersion}/query/")
       .param("q", query)
       .option(HttpOptions.readTimeout(30000))
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
@@ -185,7 +187,7 @@ object BillingAccountRemover extends App with LazyLogging {
 
     Try {
       Http(
-        s"${sfAuthDetails.instance_url}/services/data/v54.0/composite/sobjects"
+        s"${sfAuthDetails.instance_url}/services/data/v${salesforceApiVersion}/composite/sobjects"
       ).header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
         .header("Content-Type", "application/json")
         .put(jsonBody)

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -11,9 +11,7 @@ import scalaj.http._
 import scala.util.Try
 
 object BillingAccountRemover extends App with LazyLogging {
-
-  val salesforceApiVersion = "54.0"
-
+  
   //Salesforce
   case class SfAuthDetails(access_token: String, instance_url: String)
 

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -114,13 +114,13 @@ object BillingAccountRemover extends App with LazyLogging {
       val sfRecords = getBillingAccountsResponse.records
       logger.info(s"Retrieved ${sfRecords.length} records from Salesforce.")
 
-      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
-
-      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
-
-      if (failedUpdates.nonEmpty) {
-        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
-      }
+      //      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
+      //
+      //      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
+      //
+      //      if (failedUpdates.nonEmpty) {
+      //        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
+      //      }
     }).left
       .foreach(e => throw new RuntimeException("An error occurred: ", e))
   }
@@ -170,7 +170,9 @@ object BillingAccountRemover extends App with LazyLogging {
   }
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
-    Http(s"${sfAuthDetails.instance_url}/services/data/v${salesforceApiVersion}/query/")
+    val url = s"${sfAuthDetails.instance_url}/services/data/v${salesforceApiVersion}/query/"
+    println("url:" + url)
+    Http(url)
       .param("q", query)
       .option(HttpOptions.readTimeout(30000))
       .header("Authorization", s"Bearer ${sfAuthDetails.access_token}")

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -159,6 +159,8 @@ object BillingAccountRemover extends App with LazyLogging {
       "Select Id, Property_Value__c from Touch_Point_List_Property__c where name = \'Max Billing Acc GDPR Removal Attempts\'"
     println("custom setting query:"+query)
     val customSettingQueryResponse = doSfGetWithQuery(sfAuthentication, query)
+    println("customSettingQueryResponse:"+customSettingQueryResponse)
+
     decode[SfGetCustomSettingResponse](customSettingQueryResponse)
   }
 

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -128,7 +128,8 @@ object BillingAccountRemover extends App with LazyLogging {
 
   def auth(salesforceConfig: SalesforceConfig): String = {
     logger.info("Authenticating with Salesforce...")
-    Http(s"${System.getenv("authUrl")}/services/oauth2/token")
+    logger.info("Auth URL:"+s"${System.getenv("authUrl")}")
+    val authResponse = Http(s"${System.getenv("authUrl")}/services/oauth2/token")
       .postForm(
         Seq(
           "grant_type" -> "password",
@@ -141,6 +142,8 @@ object BillingAccountRemover extends App with LazyLogging {
       .asString
       .body
 
+    println("authResponse:"+authResponse)
+    authResponse
   }
 
   def getSfCustomSetting(

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -106,31 +106,31 @@ object BillingAccountRemover extends App with LazyLogging {
           )
         )
         .Property_Value__c
-//      getBillingAccountsResponse <- getSfBillingAccounts(
-//        maxAttempts,
-//        sfAuthDetails
-//      )
+      //      getBillingAccountsResponse <- getSfBillingAccounts(
+      //        maxAttempts,
+      //        sfAuthDetails
+      //      )
     } yield {
       println("maxAttempts:" + maxAttempts)
-//
-//      val sfRecords = getBillingAccountsResponse.records
-//      println("sfRecords:" + sfRecords)
-//      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
-//      println("allUpdates:" + allUpdates)
-//
-//      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
-//      println("failedUpdates:" + failedUpdates)
-//
-//      if (failedUpdates.nonEmpty) {
-//        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
-//      }
+      //
+      //      val sfRecords = getBillingAccountsResponse.records
+      //      println("sfRecords:" + sfRecords)
+      //      val allUpdates = updateRecordsInZuora(config.zuoraConfig, sfRecords)
+      //      println("allUpdates:" + allUpdates)
+      //
+      //      val failedUpdates = allUpdates.filter(_.ErrorCode.isDefined)
+      //      println("failedUpdates:" + failedUpdates)
+      //
+      //      if (failedUpdates.nonEmpty) {
+      //        writeErrorsBackToSf(sfAuthDetails, failedUpdates)
+      //      }
     }).left
       .foreach(e => throw new RuntimeException("An error occurred: ", e))
   }
 
   def auth(salesforceConfig: SalesforceConfig): String = {
     logger.info("Authenticating with Salesforce...")
-    logger.info("Auth URL:"+s"${System.getenv("authUrl")}")
+    logger.info("Auth URL:" + s"${System.getenv("authUrl")}")
     val authResponse = Http(s"${System.getenv("authUrl")}/services/oauth2/token")
       .postForm(
         Seq(
@@ -144,7 +144,7 @@ object BillingAccountRemover extends App with LazyLogging {
       .asString
       .body
 
-    println("authResponse:"+authResponse)
+    println("authResponse:" + authResponse)
     authResponse
   }
 
@@ -156,11 +156,10 @@ object BillingAccountRemover extends App with LazyLogging {
     )
 
     val query =
-      "Select Id, Property_Value__c from Touch_Point_List_Property__c where name = 'Max Billing Acc GDPR Removal Attempts'"
-
-    decode[SfGetCustomSettingResponse](
-      doSfGetWithQuery(sfAuthentication, query)
-    )
+      "Select Id, Property_Value__c from Touch_Point_List_Property__c where name = \'Max Billing Acc GDPR Removal Attempts\'"
+    println("custom setting query:"+query)
+    val customSettingQueryResponse = doSfGetWithQuery(sfAuthentication, query)
+    decode[SfGetCustomSettingResponse](customSettingQueryResponse)
   }
 
   def getSfBillingAccounts(
@@ -174,10 +173,10 @@ object BillingAccountRemover extends App with LazyLogging {
 
     val query =
       s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts and Id=\'a029E00000OuybhQAB\' limit $limit"
-    println("query:"+query)
+    println("query:" + query)
 
     val queryResponse = doSfGetWithQuery(sfAuthentication, query)
-    println("queryResponse:"+queryResponse)
+    println("queryResponse:" + queryResponse)
 
     decode[SfGetBillingAccsResponse](queryResponse)
   }

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -186,7 +186,7 @@ object BillingAccountRemover extends App with LazyLogging {
 
   def doSfGetWithQuery(sfAuthDetails: SfAuthDetails, query: String): String = {
 
-    val url = s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/query/"
+    val url = s"${sfAuthDetails.instance_url}/services/data/v54.0/query/"
 
     println("url:" + url)
     val abc = Http(url)
@@ -209,7 +209,7 @@ object BillingAccountRemover extends App with LazyLogging {
 
     Try {
       Http(
-        s"${sfAuthDetails.instance_url}/services/data/v$salesforceApiVersion/composite/sobjects"
+        s"${sfAuthDetails.instance_url}/services/data/v54.0/composite/sobjects"
       ).header("Authorization", s"Bearer ${sfAuthDetails.access_token}")
         .header("Content-Type", "application/json")
         .put(jsonBody)

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/Config.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/Config.scala
@@ -12,7 +12,7 @@ case class SalesforceConfig(
   authUrl: String,
   clientId: String,
   clientSecret: String,
-  userName: String,
+  username: String,
   password: String,
   token: String
 )


### PR DESCRIPTION
### Context
There is an error occurring when the Billing Account Remover Lambda executes in DEV

**What is the Billing Account Remover Lambda?**
This lambda is intended to:

- run daily
- grab billing accounts from Salesforce that are marked for removal
- sever the link between the Account in Salesforce and the Billing Account in Zuora (i.e. remove the foreign Id from the Billing Account in Zuora, and set its status to 'Cancelled')
- Write back any errors to Salesforce

**Error**

```
{
  "errorMessage": "An error occurred: ",
  "errorType": "java.lang.RuntimeException",
  "stackTrace": [
    "com.gu.sf_billing_account_remover.BillingAccountRemover$.$anonfun$processBillingAccounts$10(BillingAccountRemover.scala:121)",
    "scala.util.Either$LeftProjection.foreach(Either.scala:549)",
    "com.gu.sf_billing_account_remover.BillingAccountRemover$.processBillingAccounts(BillingAccountRemover.scala:121)",
    "com.gu.sf_billing_account_remover.BillingAccountRemover$.lambda(BillingAccountRemover.scala:347)",
    "com.gu.sf_billing_account_remover.BillingAccountRemover.lambda(BillingAccountRemover.scala)",
    "sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)",
    "sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)",
    "sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)",
    "java.lang.reflect.Method.invoke(Method.java:498)"
  ],
  "cause": {
    "errorMessage": "Attempt to decode value on failed cursor: DownField(access_token)",
    "errorType": "io.circe.DecodingFailure$$anon$2",
    "stackTrace": []
  }
}
```

**Root Cause**
The global variable salesforceApiVersion was not permeating throughout the code, resulting in the following endpoint being generated:

```
https://gnmtouchpoint--dev1.sandbox.my.salesforce.com/services/data/vnull/query/
```
This is because the solution extends App which extends DelayedInit which which means that fields of the object will not have been initialized before the main method has been executed.

**Fix**
I have hardcoded the API version into the endpoint to resolve the issue

**Comments**
Ideally, the api version would be stored in a piece of config in one location, where it would be accessed by every application that uses the Salesforce REST API. There is a decision to be made about how we should go about this. Until we get to a decision and an implementation plan, hardcoding the value here is good enough.

### Notes
This is a good opportunity to update our authentication process to align with our security policy for integrations with Salesforce to have 1 user and 1 Connected App per integration.

I've created a new [User](https://gnmtouchpoint.my.salesforce.com/0055I000004BZRE?noredirect=1&isUserEntityOverride=1) in Salesforce, as well as a new [Connected App](https://gnmtouchpoint.my.salesforce.com/app/mgmt/forceconnectedapps/forceAppDetail.apexp?applicationId=06P5I000000c71v&id=0Ci5I000000PBtb)

The User Credentials and Connected App secrets have been added to secrets in AWS Secrets Manager:

**Users**
[DEV/Salesforce/User/BillingAccountRemoverAPIUser](https://eu-west-1.console.aws.amazon.com/secretsmanager/secret?name=DEV%2FSalesforce%2FUser%2FBillingAccountRemoverAPIUser&region=eu-west-1)
[PROD/Salesforce/User/BillingAccountRemoverAPIUser](https://eu-west-1.console.aws.amazon.com/secretsmanager/secret?name=PROD%2FSalesforce%2FUser%2FBillingAccountRemoverAPIUser&region=eu-west-1)

**Connected App**
[PROD/Salesforce/ConnectedApp/BillingAccountRemover](https://eu-west-1.console.aws.amazon.com/secretsmanager/secret?name=PROD%2FSalesforce%2FConnectedApp%2FBillingAccountRemover&region=eu-west-1) 