### PR TITLE
Reduce batch size for Delivery Credit Processor

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -171,7 +171,7 @@ object DeliveryCreditProcessor extends Logging {
         }
     }
 
-    // limited to 300 because each record takes ~ 2s to process and lambda has 15 min to run
+    // limited to 150 because each record takes ~ 4s to process and lambda has 15 min to run
     def deliveryRecordsQuery(productType: ZuoraProductType) =
       s"""
          |SELECT Id, SF_Subscription__r.Name, Delivery_Date__c, Charge_Code__c, Invoice_Date__c
@@ -180,7 +180,7 @@ object DeliveryCreditProcessor extends Logging {
          |AND Credit_Requested__c = true
          |AND Is_Actioned__c = false
          |ORDER BY SF_Subscription__r.Name, Delivery_Date__c
-         |LIMIT 300
+         |LIMIT 150
          |""".stripMargin
 
     val results = for {


### PR DESCRIPTION
## What does this change?
This reduces the batch size for the delivery-problem-credit-processor so that the batch can be completed within the 15 minute Lambda limit.

Reducing the batch size from 300 to 150 reduces the number of credits that can be processed in a day from 20,000 to about 10,000, assuming each batch runs successfully. This should be well within expectations.

We are currently processing a larger than usual number of delivery credits (around 2,000 due to a weather related supplier issue) and are noticing that each full batch of 300 records is failing at the 15 minute time limit.