### PR TITLE
Increase RAM for Stripe Card Updater Lambda to speed it up

### DIFF
--- a/handlers/stripe-webhook-endpoints/cfn.yaml
+++ b/handlers/stripe-webhook-endpoints/cfn.yaml
@@ -69,7 +69,7 @@ Resources:
       Description: A lambda for handling customer updates
       Runtime: java11
       Handler: com.gu.stripeCardUpdated.Lambda::apply
-      MemorySize: 1356
+      MemorySize: 1536
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/stripe-webhook-endpoints/cfn.yaml
+++ b/handlers/stripe-webhook-endpoints/cfn.yaml
@@ -69,7 +69,7 @@ Resources:
       Description: A lambda for handling customer updates
       Runtime: java11
       Handler: com.gu.stripeCardUpdated.Lambda::apply
-      MemorySize: 512
+      MemorySize: 1024
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/stripe-webhook-endpoints/cfn.yaml
+++ b/handlers/stripe-webhook-endpoints/cfn.yaml
@@ -69,7 +69,7 @@ Resources:
       Description: A lambda for handling customer updates
       Runtime: java11
       Handler: com.gu.stripeCardUpdated.Lambda::apply
-      MemorySize: 1024
+      MemorySize: 1356
       Timeout: 900
       Environment:
         Variables:


### PR DESCRIPTION
## What does this change?
Increases RAM (and hence CPU power) to 1536MB to help ensure Lambda completes before 29s (API Gateway's Limit - https://stackoverflow.com/questions/54299958/how-can-i-set-the-aws-api-gateway-timeout-higher-than-30-seconds). Average maximum (green line) appears to be too close to 29s.
<img width="517" alt="Screenshot 2022-12-19 at 10 50 03" src="https://user-images.githubusercontent.com/1515970/208409406-80f68d16-5fc6-46ad-890f-a4b8e7f1beec.png">

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Deploy to CODE via RiffRaff.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Deploy via RiffRaff and observe reduction Stripe errors.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Low - increasing Lambda memory is standard stuff.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
N/A

## Accessibility

N/A
