### PR TITLE
Set up salesforce tracking lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -497,6 +497,7 @@ lazy val `product-move-api` = lambdaProject(
       s"aws s3 cp $jarFile s3://$s3Bucket/$s3Path --profile membership --region eu-west-1".!!
       s"aws lambda update-function-code --function-name move-product-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
       s"aws lambda update-function-code --function-name product-switch-refund-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+      s"aws lambda update-function-code --function-name product-switch-salesforce-tracking-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
     }
   }
   .dependsOn(`zuora-models`)

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -153,6 +153,54 @@ Resources:
       EventSourceArn: !GetAtt RefundQueue.Arn
       FunctionName: !Ref RefundLambda
 
+  SalesforceTrackingLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub product-switch-salesforce-tracking-${Stage}
+      Description: An SQS-triggered lambda that refunds customer's going through product-switching
+      Runtime: java11
+      Handler: com.gu.productmove.salesforce.SalesforceHandler::handleRequest
+      MemorySize: 1024
+      Timeout: 300
+      Environment:
+        Variables:
+          App: product-move-api
+          Stack: !Ref Stack
+          Stage: !Ref Stage
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/product-move-api/product-move-api.jar
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Statement:
+            Effect: Allow
+            Action: s3:GetObject
+            Resource:
+              - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}*.json
+              - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/invoicingApi-${Stage}*.json
+              - arn:aws:s3::*:membership-dist/*
+        - Statement:
+            Effect: Allow
+            Action:
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+              - sqs:ReceiveMessage
+            Resource: "*"
+
+  SalesforceTrackingQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout: 3000
+      QueueName: !Sub product-switch-salesforce-tracking-${Stage}
+
+  SQSTriggerSF:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: 1
+      Enabled: true
+      EventSourceArn: !GetAtt SalesforceTrackingQueue.Arn
+      FunctionName: !Ref SalesforceTrackingLambda
+
   # alarms
   ProductMovementFailureAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -64,6 +64,8 @@ Resources:
           Resource:
             - arn:aws:sqs:eu-west-1:865473395570:contributions-thanks
             - arn:aws:sqs:eu-west-1:865473395570:contributions-thanks-dev
+            - !GetAtt RefundQueue.Arn
+            - !GetAtt SalesforceTrackingQueue.Arn
       - AWSLambdaBasicExecutionRole
       - Statement:
           Effect: Allow

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -178,8 +178,7 @@ Resources:
             Effect: Allow
             Action: s3:GetObject
             Resource:
-              - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}*.json
-              - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/invoicingApi-${Stage}*.json
+              - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/sfAuth-${Stage}*.json
               - arn:aws:s3::*:membership-dist/*
         - Statement:
             Effect: Allow

--- a/handlers/product-move-api/riff-raff.yaml
+++ b/handlers/product-move-api/riff-raff.yaml
@@ -23,4 +23,5 @@ deployments:
       functionNames:
       - move-product-
       - product-switch-refund-
+      - product-switch-salesforce-tracking-
     dependencies: [cfn]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/SQS.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/SQS.scala
@@ -2,6 +2,7 @@ package com.gu.productmove
 
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.refund.RefundInput
+import com.gu.productmove.salesforce.SalesforceHandler.SalesforceRecordInput
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
@@ -14,6 +15,8 @@ trait SQS {
   def sendEmail(message: EmailMessage): ZIO[Any, String, Unit]
 
   def queueRefund(refundInput: RefundInput): ZIO[Any, String, Unit]
+
+  def queueSalesforceTracking(salesforceRecordInput: SalesforceRecordInput): ZIO[Any, String, Unit]
 }
 
 object SQS {
@@ -24,6 +27,10 @@ object SQS {
   def queueRefund(refundInput: RefundInput): ZIO[SQS, String, Unit] = {
     ZIO.environmentWithZIO(_.get.queueRefund(refundInput))
   }
+
+  def queueSalesforceTracking(salesforceRecordInput: SalesforceRecordInput): ZIO[SQS, String, Unit] = {
+    ZIO.environmentWithZIO(_.get.queueSalesforceTracking(salesforceRecordInput))
+  }
 }
 
 object SQSLive {
@@ -31,8 +38,9 @@ object SQSLive {
     ZLayer.scoped(for {
       stage <- ZIO.service[Stage]
       sqsClient <- initializeSQSClient().mapError(ex => s"Failed to initialize SQS Client with error: $ex")
-      emailQueueUrlResponse <- getEmailQueue(stage, sqsClient)
-      refundQueueUrlResponse <- getRefundQueue(stage, sqsClient)
+      emailQueueUrlResponse <- getQueue(if (stage == Stage.PROD) "contributions-thanks" else "contributions-thanks-dev", sqsClient)
+      refundQueueUrlResponse <- getQueue(s"product-switch-refund-${stage.toString}", sqsClient)
+      salesforceTrackingQueueUrlResponse <- getQueue(s"product-switch-salesforce-tracking-${stage.toString}", sqsClient)
     } yield new SQS {
       override def sendEmail(message: EmailMessage): ZIO[Any, String, Unit] =
         for {
@@ -71,6 +79,25 @@ object SQSLive {
             s"Successfully sent refund message for subscription number: ${refundInput.subscriptionName}",
           )
         } yield ()
+
+      override def queueSalesforceTracking(salesforceRecordInput: SalesforceRecordInput): ZIO[Any, String, Unit] =
+        for {
+          _ <- ZIO
+            .fromCompletableFuture {
+              sqsClient.sendMessage(
+                SendMessageRequest.builder
+                  .queueUrl(salesforceTrackingQueueUrlResponse.queueUrl)
+                  .messageBody(salesforceRecordInput.toJson)
+                  .build(),
+              )
+            }
+            .mapError { ex =>
+              s"Failed to send sqs salesforce tracking message with subscription Number: ${salesforceRecordInput.subscriptionName} with error: ${ex.toString}"
+            }
+          _ <- ZIO.log(
+            s"Successfully sent salesforce tracking message for subscription number: ${salesforceRecordInput.subscriptionName}",
+          )
+        } yield ()
     })
 
   private def initializeSQSClient(): ZIO[AwsCredentialsProvider with Scope, Throwable, SqsAsyncClient] =
@@ -79,19 +106,7 @@ object SQSLive {
       sqsClient <- ZIO.fromAutoCloseable(ZIO.attempt(impl(creds)))
     } yield sqsClient
 
-  private def getEmailQueue(stage: Stage, sqsAsyncClient: SqsAsyncClient): ZIO[Any, String, GetQueueUrlResponse] =
-    // choose existing SQS queue to test for now, create another queue for this.
-    val queueName = if (stage == Stage.PROD) "contributions-thanks" else "contributions-thanks-dev"
-    val queueUrl = GetQueueUrlRequest.builder.queueName(queueName).build()
-
-    ZIO
-      .fromCompletableFuture(
-        sqsAsyncClient.getQueueUrl(queueUrl),
-      )
-      .mapError { ex => s"Failed to get sqs queue url: ${ex.getMessage}" }
-
-  private def getRefundQueue(stage: Stage, sqsAsyncClient: SqsAsyncClient): ZIO[Any, String, GetQueueUrlResponse] =
-    val queueName = s"product-switch-refund-${stage.toString}"
+  private def getQueue(queueName: String, sqsAsyncClient: SqsAsyncClient): ZIO[Any, String, GetQueueUrlResponse] =
     val queueUrl = GetQueueUrlRequest.builder.queueName(queueName).build()
 
     ZIO

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/SQS.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/SQS.scala
@@ -2,7 +2,7 @@ package com.gu.productmove
 
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.refund.RefundInput
-import com.gu.productmove.salesforce.SalesforceHandler.SalesforceRecordInput
+import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -1,39 +1,16 @@
 package com.gu.productmove.endpoint.move
 
-import com.gu.newproduct.api.productcatalog.{BillingPeriod, Annual, Monthly}
+import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
 import com.gu.productmove.endpoint.available.{Billing, Currency, MoveToProduct, Offer, TimePeriod, TimeUnit, Trial}
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.*
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.framework.ZIOApiGatewayRequestHandler.TIO
 import com.gu.productmove.framework.{LambdaEndpoint, ZIOApiGatewayRequestHandler}
 import com.gu.productmove.refund.RefundInput
+import com.gu.productmove.salesforce.SalesforceHandler.SalesforceRecordInput
 import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGet, ZuoraGetLive}
-import com.gu.productmove.zuora.{
-  GetAccount,
-  GetAccountLive,
-  GetSubscription,
-  GetSubscriptionLive,
-  InvoicePreview,
-  InvoicePreviewLive,
-  Subscribe,
-  SubscribeLive,
-  SubscriptionUpdate,
-  SubscriptionUpdateLive,
-  ZuoraCancel,
-  ZuoraCancelLive,
-}
-import com.gu.productmove.{
-  AwsCredentialsLive,
-  AwsS3Live,
-  EmailMessage,
-  EmailPayload,
-  EmailPayloadContactAttributes,
-  EmailPayloadSubscriberAttributes,
-  GuStageLive,
-  SQS,
-  SQSLive,
-  SttpClientLive,
-}
+import com.gu.productmove.zuora.{GetAccount, GetAccountLive, GetSubscription, GetSubscriptionLive, InvoicePreview, InvoicePreviewLive, Subscribe, SubscribeLive, SubscriptionUpdate, SubscriptionUpdateLive, ZuoraCancel, ZuoraCancelLive}
+import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, EmailMessage, EmailPayload, EmailPayloadContactAttributes, EmailPayloadSubscriberAttributes, GuStageLive, SQS, SQSLive, SttpClientLive}
 import sttp.tapir.*
 import sttp.tapir.EndpointIO.Example
 import sttp.tapir.Schema
@@ -197,6 +174,16 @@ object ProductMoveEndpoint {
         .addLogMessage("SQS sendEmail()")
         .fork
 
+      salesforceTrackingFuture <- SQS.queueSalesforceTracking(SalesforceRecordInput(
+        subscriptionName,
+        postData.price,
+        currentRatePlan.ratePlanName,
+        "Supporter Plus",
+        date,
+        date,
+        updateResponse.totalDeltaMrr.abs
+      )).fork
+
       refundFuture <-
         if (updateResponse.totalDeltaMrr < 0)
           SQS
@@ -206,7 +193,7 @@ object ProductMoveEndpoint {
         else
           ZIO.succeed(()).fork
 
-      sqsRequests = emailFuture.zip(refundFuture)
+      sqsRequests = emailFuture.zip(refundFuture).zip(salesforceTrackingFuture)
       _ <- sqsRequests.join
 
     } yield Success("Product move completed successfully")

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -7,7 +7,7 @@ import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.framework.ZIOApiGatewayRequestHandler.TIO
 import com.gu.productmove.framework.{LambdaEndpoint, ZIOApiGatewayRequestHandler}
 import com.gu.productmove.refund.RefundInput
-import com.gu.productmove.salesforce.SalesforceHandler.SalesforceRecordInput
+import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGet, ZuoraGetLive}
 import com.gu.productmove.zuora.{GetAccount, GetAccountLive, GetSubscription, GetSubscriptionLive, InvoicePreview, InvoicePreviewLive, Subscribe, SubscribeLive, SubscriptionUpdate, SubscriptionUpdateLive, ZuoraCancel, ZuoraCancelLive}
 import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, EmailMessage, EmailPayload, EmailPayloadContactAttributes, EmailPayloadSubscriberAttributes, GuStageLive, SQS, SQSLive, SttpClientLive}

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundHandler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundHandler.scala
@@ -13,11 +13,7 @@ import zio.{Exit, Runtime, Unsafe, ZIO}
 
 import scala.jdk.CollectionConverters.*
 
-object RefundHandler extends RefundHandler {
-  type TIO[+A] = ZIO[Any, Any, A] // Succeed with an `A`, may fail with anything`, no requirements.
-}
-
-trait RefundHandler extends RequestHandler[SQSEvent, Unit] {
+class RefundHandler extends RequestHandler[SQSEvent, Unit] {
 
   override def handleRequest(input: SQSEvent, context: Context): Unit = {
     val records: List[SQSEvent.SQSMessage] = input.getRecords.asScala.toList

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
@@ -1,0 +1,42 @@
+package com.gu.productmove.salesforce
+
+import com.gu.productmove.salesforce.CreateRecord.CreateRecordRequest
+import zio.ZIO
+import zio.json.*
+import java.time.LocalDate
+
+object Salesforce {
+
+
+  case class SalesforceRecordInput(
+                                    subscriptionName: String,
+                                    previousAmount: BigDecimal,
+                                    previousRatePlanName: String,
+                                    newRatePlanName: String,
+                                    requestedDate: LocalDate,
+                                    effectiveDate: LocalDate,
+                                    refundAmount: BigDecimal,
+                                  )
+
+  given JsonDecoder[SalesforceRecordInput] = DeriveJsonDecoder.gen[SalesforceRecordInput]
+  given JsonEncoder[SalesforceRecordInput] = DeriveJsonEncoder.gen[SalesforceRecordInput]
+
+  def createSfRecord(
+                      salesforceRecordInput: SalesforceRecordInput,
+                    ): ZIO[CreateRecord with GetSfSubscription, String, Unit] =
+    import salesforceRecordInput.*
+
+    for {
+      sfSub <- GetSfSubscription.get(subscriptionName)
+      request = CreateRecordRequest(
+        SF_Subscription__c = sfSub.Id,
+        Previous_Amount__c = previousAmount,
+        Previous_Rate_Plan_Name__c = previousRatePlanName,
+        New_Rate_Plan_Name__c = newRatePlanName,
+        Requested_Date__c = requestedDate,
+        Effective_Date__c = effectiveDate,
+        Refund_Amount__c = refundAmount,
+      )
+      _ <- CreateRecord.create(request)
+    } yield ()
+}

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceHandler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceHandler.scala
@@ -5,18 +5,16 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import com.gu.productmove.GuStageLive.Stage
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.gu.productmove.salesforce.CreateRecord.CreateRecordRequest
+import com.gu.productmove.salesforce.Salesforce.{SalesforceRecordInput, createSfRecord}
 import com.gu.productmove.{AwsCredentialsLive, AwsS3, AwsS3Live, GuStageLive, SttpClientLive}
 import sttp.client3.SttpBackend
 import zio.json.*
 import zio.{Exit, Runtime, Task, Unsafe, ZIO}
 
-import java.time.LocalDate
 import scala.jdk.CollectionConverters.*
 
-object SalesforceHandler extends SalesforceHandler {
-  type TIO[+A] = ZIO[Any, Any, A] // Succeed with an `A`, may fail with anything`, no requirements.
-}
-trait SalesforceHandler extends RequestHandler[SQSEvent, Unit] {
+
+class SalesforceHandler extends RequestHandler[SQSEvent, Unit] {
   override def handleRequest(input: SQSEvent, context: Context): Unit = {
     val records: List[SQSEvent.SQSMessage] = input.getRecords.asScala.toList
 
@@ -31,36 +29,6 @@ trait SalesforceHandler extends RequestHandler[SQSEvent, Unit] {
     }
   }
 
-  case class SalesforceRecordInput(
-      subscriptionName: String,
-      previousAmount: BigDecimal,
-      previousRatePlanName: String,
-      newRatePlanName: String,
-      requestedDate: LocalDate,
-      effectiveDate: LocalDate,
-      refundAmount: BigDecimal,
-  )
-  given JsonDecoder[SalesforceRecordInput] = DeriveJsonDecoder.gen[SalesforceRecordInput]
-  given JsonEncoder[SalesforceRecordInput] = DeriveJsonEncoder.gen[SalesforceRecordInput]
-
-  def createSfRecord(
-      salesforceRecordInput: SalesforceRecordInput,
-  ): ZIO[CreateRecord with GetSfSubscription, String, Unit] =
-    import salesforceRecordInput.*
-
-    for {
-      sfSub <- GetSfSubscription.get(subscriptionName)
-      request = CreateRecordRequest(
-        SF_Subscription__c = sfSub.Id,
-        Previous_Amount__c = previousAmount,
-        Previous_Rate_Plan_Name__c = previousRatePlanName,
-        New_Rate_Plan_Name__c = newRatePlanName,
-        Requested_Date__c = requestedDate,
-        Effective_Date__c = effectiveDate,
-        Refund_Amount__c = refundAmount,
-      )
-      _ <- CreateRecord.create(request)
-    } yield ()
 
   def runZio(salesforceRecordInput: SalesforceRecordInput, context: Context) =
     val runtime = Runtime.default

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -5,6 +5,7 @@ import com.gu.productmove.endpoint.available.Currency
 import com.gu.productmove.refund.RefundInput
 import com.gu.productmove.salesforce.CreateRecord.CreateRecordRequest
 import com.gu.productmove.salesforce.GetSfSubscription.GetSfSubscriptionResponse
+import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.{EmailMessage, EmailPayload, EmailPayloadSubscriberAttributes}
 import com.gu.productmove.zuora.{DefaultPaymentMethod, InvoicePreview, SubscriptionUpdateResponse}
 import com.gu.productmove.zuora.GetAccount.{AccountSubscription, BasicInfo, BillToContact, GetAccountResponse}
@@ -199,6 +200,9 @@ val refundInput1 = RefundInput(
   invoiceId = "80a23d9sdf9a89fs8cjjk2",
   refundAmount = 4,
 )
+
+val salesforceRecordInput1 = SalesforceRecordInput("A-S00339056", BigDecimal(50), "RP1", "Supporter Plus", LocalDate.of(2022, 5, 10), LocalDate.of(2022, 5, 10), BigDecimal(4))
+val salesforceRecordInput2 = SalesforceRecordInput("A-S00339056", BigDecimal(50), "RP1", "Supporter Plus", LocalDate.of(2022, 5, 10), LocalDate.of(2022, 5, 10), BigDecimal(28))
 
 //-----------------------------------------------------
 // Stubs for InvoicePreview service

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
@@ -6,17 +6,10 @@ import com.gu.productmove.endpoint.move.ProductMoveEndpoint
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.ExpectedInput
 import com.gu.productmove.invoicingapi.InvoicingApiRefundLive
 import com.gu.productmove.refund.*
-import com.gu.productmove.salesforce.SalesforceHandler.SalesforceRecordInput
-import com.gu.productmove.salesforce.{
-  CreateRecordLive,
-  GetSfSubscription,
-  GetSfSubscriptionLive,
-  MockCreateRecord,
-  SalesforceClientLive,
-  SalesforceHandler,
-}
+import com.gu.productmove.salesforce.{CreateRecordLive, GetSfSubscription, GetSfSubscriptionLive, MockCreateRecord, SalesforceClientLive, SalesforceHandler}
 import com.gu.productmove.*
 import com.gu.productmove.salesforce.CreateRecord.CreateRecordResponse
+import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import zio.test.*
 import zio.test.Assertion.*
 import zio.*
@@ -32,8 +25,7 @@ object CreateRecordSpec extends ZIOSpecDefault {
          */
 
         for {
-          _ <- SalesforceHandler
-            .createSfRecord(
+          _ <- Salesforce.createSfRecord(
               SalesforceRecordInput(
                 "A-S00102815",
                 10.0000000,
@@ -60,7 +52,7 @@ object CreateRecordSpec extends ZIOSpecDefault {
         val createRecordStubs = Map(createRecordRequest1 -> CreateRecordResponse("a0s9E00000ehvxUQAQ"))
 
         (for {
-          output <- SalesforceHandler.createSfRecord(
+          output <- Salesforce.createSfRecord(
             SalesforceRecordInput(
               "A-S00102815",
               BigDecimal(100),

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSQS.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSQS.scala
@@ -1,6 +1,7 @@
 package com.gu.productmove.zuora
 
 import com.gu.productmove.refund.RefundInput
+import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.{EmailMessage, SQS}
 import com.gu.productmove.zuora.GetSubscription
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
@@ -8,9 +9,9 @@ import com.gu.productmove.zuora.CreateSubscriptionResponse
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import zio.{IO, ZIO}
 
-class MockSQS(responses: Map[EmailMessage | RefundInput, Unit]) extends SQS {
+class MockSQS(responses: Map[EmailMessage | RefundInput | SalesforceRecordInput, Unit]) extends SQS {
 
-  private var mutableStore: List[EmailMessage | RefundInput] = Nil // we need to remember the side effects
+  private var mutableStore: List[EmailMessage | RefundInput | SalesforceRecordInput] = Nil // we need to remember the side effects
 
   def requests = mutableStore.reverse
 
@@ -29,8 +30,16 @@ class MockSQS(responses: Map[EmailMessage | RefundInput, Unit]) extends SQS {
       case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
       case None => ZIO.fail(s"wrong input, refund input was $refundInput")
   }
+
+  override def queueSalesforceTracking(salesforceRecordInput: SalesforceRecordInput): ZIO[Any, String, Unit] = {
+    mutableStore = salesforceRecordInput :: mutableStore
+
+    responses.get(salesforceRecordInput) match
+      case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
+      case None => ZIO.fail(s"wrong input, salesforce record input was $salesforceRecordInput")
+  }
 }
 
 object MockSQS {
-  def requests: ZIO[MockSQS, Nothing, List[EmailMessage | RefundInput]] = ZIO.serviceWith[MockSQS](_.requests)
+  def requests: ZIO[MockSQS, Nothing, List[EmailMessage | RefundInput | SalesforceRecordInput]] = ZIO.serviceWith[MockSQS](_.requests)
 }


### PR DESCRIPTION
 Create a lambda and SQS queue to handle the tracking of product-switches in Salesforce. The lambda is triggered by a new message on the queue.