### PR TITLE
Adding in logging to the Zuora library 

### DIFF
--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -90,6 +90,7 @@ object SalesforceHolidayStopRequest extends Logging {
     Bulk_Suspension_Reason__c: Option[BulkSuspensionReason]
   )
   implicit val format = Json.format[HolidayStopRequest]
+  logger.info(format.toString + "test")
 
   implicit val formatIds = Json.format[RecordsWrapperCaseClass[HolidayStopRequest]]
 

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/Zuora.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/Zuora.scala
@@ -5,6 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import sttp.client3._
 import sttp.client3.circe._
+import io.circe.syntax._
 
 import scala.annotation.tailrec
 
@@ -57,7 +58,7 @@ object Zuora extends LazyLogging {
       .mapResponse(_.left.map(e => ZuoraApiFailure(e.getMessage)))
       .send(backend)
 
-    logger.info(s"subscriptionGetResponse for sub ${subscriptionName.value} is ${response.body.toString}")
+    logger.info(s"subscriptionGetResponse for sub ${subscriptionName.value} is ${response.body.asJson}")
     response.body
   }
 
@@ -78,7 +79,7 @@ object Zuora extends LazyLogging {
           else Left(ZuoraApiFailure(errMsg(status.reasons.map(_.mkString).getOrElse(""))))
       }
       .send(backend)
-      logger.info(s"response for subscriptionUpdateResponse is ${response.body.toString}")
+    logger.info(s"subscriptionUpdateResponse for sub ${subscription.subscriptionNumber} is ${response.body.asJson}")
 
       response.body.left.map(failure => ZuoraApiFailure(errMsg(failure.reason)))
   }


### PR DESCRIPTION
## What does this change?
Adding in logging to the Zuora library to log the response and request bodies when hitting the subscriptionGetResponse and subscriptionUpdateResponse. These logs will help with looking into the issue that is occurring around holiday stops and negative invoices incorrectly being created.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
We will need to check in Cloudwatch to make sure that it is logging as expected when in production

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

