### PR TITLE
Fix StripeConfigTest - update json key to pass test

### DIFF
--- a/lib/handler/src/test/scala/com/gu/util/config/StripeConfigTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/config/StripeConfigTest.scala
@@ -8,7 +8,7 @@ class StripeConfigTest extends AnyFlatSpec with Matchers {
   // Stripe specific tests
   it should "the sig verified status is on by default" in {
     val configString = """{
-                         |     "customerSourceUpdatedWebhook": {
+                         |     "customerUpdatedWebhook": {
                          |       "api.key.secret": "abc",
                          |       "au-membership.key.secret": "def"
                          |     }
@@ -23,7 +23,7 @@ class StripeConfigTest extends AnyFlatSpec with Matchers {
 
   it should "sig verifying is on if we ask for it to be on" in {
     val configString = """{
-                         |     "customerSourceUpdatedWebhook": {
+                         |     "customerUpdatedWebhook": {
                          |       "api.key.secret": "abc",
                          |       "au-membership.key.secret": "def"
                          |     },
@@ -39,7 +39,7 @@ class StripeConfigTest extends AnyFlatSpec with Matchers {
 
   it should "sig verifying is still on if we ask for sdjfkhgsdf" in {
     val configString = """{
-                         |     "customerSourceUpdatedWebhook": {
+                         |     "customerUpdatedWebhook": {
                          |       "api.key.secret": "abc",
                          |       "au-membership.key.secret": "def"
                          |     },
@@ -55,7 +55,7 @@ class StripeConfigTest extends AnyFlatSpec with Matchers {
 
   it should "sig verifying is ONLY off if we ask for false" in {
     val configString = """{
-                         |     "customerSourceUpdatedWebhook": {
+                         |     "customerUpdatedWebhook": {
                          |       "api.key.secret": "abc",
                          |       "au-membership.key.secret": "def"
                          |     },


### PR DESCRIPTION
## What does this change?
Noticed that this test was failing when developing `zuora-rer` handler (because IntelliJ runs tests in dependent projects).
Can't exactly see when it was changed, but looks to be left over from a code change that didn't update the test.

@rupertbates I've tagged you in here because it looks like you were one of the last people to make changes.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
