### PR TITLE
Add schedule to  Billing Account Remover

### DIFF
--- a/handlers/sf-billing-account-remover/cfn.yaml
+++ b/handlers/sf-billing-account-remover/cfn.yaml
@@ -14,6 +14,7 @@ Mappings:
       SalesforceUser: BillingAccountRemoverAPIUser
       ZuoraUrl: https://rest.apisandbox.zuora.com
       ZuoraAccount: SfSaves
+      Schedule: 'cron(00 07,08,09,10 * * ? *)'
     CODE:
       SalesforceUrl: https://test.salesforce.com
       SalesforceConnectedApp: AwsConnectorSandbox
@@ -96,6 +97,13 @@ Resources:
             - User: !FindInMap [StageMap, !Ref Stage, SalesforceUser]
           zuoraInstanceUrl: !FindInMap [StageMap, !Ref Stage, ZuoraUrl]
 
+      Events:
+        ScheduledRun:
+          Type: Schedule
+          Properties:
+            Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule ]
+            Description: Runs BillingAccountRemover
+            Enabled: True
       Role:
         !GetAtt SFBillingAccountRemoverRole.Arn
       MemorySize: 512


### PR DESCRIPTION
### What does this change?
Run Billing Account Remover 4 times per day at:

- 7am
- 8am
- 9am
- 10am

### Context
BillingAccountRemover is a component of the implementation of the Salesforce Retention Policy, and works by severing the link between Salesforce Accounts and Zuora Billing Accounts, so that the records in Salesforce can be deleted safely and Zuora will not try to recreate them. 