### PR TITLE
Adding a unit test which both generates and validates a CAS code

### DIFF
--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
@@ -1,12 +1,12 @@
 package com.gu.digitalSubscriptionExpiry.emergencyToken
 
 import java.time.LocalDate
-
-import com.gu.cas.{PrefixedTokens, SevenDay}
+import com.gu.cas.{PrefixedTokens, SevenDay, TokenPayload}
 import com.gu.digitalSubscriptionExpiry.responses.{Expiry, ExpiryType, SuccessResponse}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import play.api.libs.json.Json
 import com.gu.util.reader.Types.ApiGatewayOp.{ReturnWithResponse, ContinueProcessing}
+import org.joda.time.{Days, Weeks}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -33,6 +33,19 @@ class GetTokenExpiryTest extends AnyFlatSpec with Matchers {
       expectedExpiryForDate(LocalDate.of(2018, 5, 21))
 
     getTokenExpiry("G99DPZBLIVIIAP").shouldBe(expectedResponse)
+  }
+
+  it should "be that a codec with same secret key should encode and decode reflexively" in {
+    // replace "secret" with the prod secret  to get a code that'll work with https://content-auth.guardian.co.uk/subs
+    val codec = PrefixedTokens(secretKey = "secret", emergencySubscriberAuthPrefix = "G99")
+    val tokenPayload = TokenPayload.apply(org.joda.time.LocalDate.now())(Weeks.weeks(51), SevenDay)
+    val encoded = codec.encode(tokenPayload)
+    // to see the generated code: println(encoded)
+    val expectedResponse = expectedExpiryForDate(LocalDate.now().plusWeeks(51).plusDays(1))
+    GetTokenExpiry(
+      EmergencyTokens("G99", codec),
+      () => LocalDate.now()
+    )(encoded).shouldBe(expectedResponse)
   }
 
   private def expectedExpiryForDate(expiryDate: LocalDate) = {


### PR DESCRIPTION
## What does this change?

Adding a unit test that can be modified by a developer to generate and print a real CAS (G99) code whenever necessary, now that subscribe.theguardian.com has closed down.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Only AWS PROD config for this app contains the PROD secret that can be used to generate a real token.
