### PR TITLE
Product move alarm

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -243,25 +243,25 @@ Resources:
 
   5xxApiAlarm:
     Type: AWS::CloudWatch::Alarm
-    #Condition: IsProd
+    Condition: IsProd
     DependsOn:
       - ProductMoveApiGateway
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName:
         !Sub The product-move-api returned a 500 response
       AlarmDescription: Check the logs for details - https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmove-product-PROD
-      ComparisonOperator: GreaterThanThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: ApiName
-          Value: product-move-api-${Stage}-ApiGateway
+          Value: !Sub product-move-api-${Stage}-ApiGateway
         - Name: Stage
           Value: !Sub ${Stage}
       EvaluationPeriods: 1
       MetricName: 5XXError
       Namespace: AWS/ApiGateway
-      Period: 900
+      Period: 60
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
@@ -273,7 +273,7 @@ Resources:
       - ProductMoveApiGateway
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub The product-move-api returned multiple 4xx responses
       AlarmDescription: Check the logs for details - https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmove-product-PROD
       ComparisonOperator: GreaterThanThreshold

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -244,6 +244,8 @@ Resources:
   5xxApiAlarm:
     Type: AWS::CloudWatch::Alarm
     #Condition: IsProd
+    DependsOn:
+      - ProductMoveApiGateway
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
@@ -268,7 +270,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
     DependsOn:
-      - ContactUsApiGateway
+      - ProductMoveApiGateway
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -243,7 +243,7 @@ Resources:
 
   5xxApiAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: IsProd
+    #Condition: IsProd
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -240,3 +240,50 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
+
+  5xxApiAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName:
+        !Sub The product-move-api returned a 500 response
+      AlarmDescription: Check the logs for details - https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmove-product-PROD
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: product-move-api-${Stage}-ApiGateway
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: 5XXError
+      Namespace: AWS/ApiGateway
+      Period: 900
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  4xxApiAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn:
+      - ContactUsApiGateway
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: !Sub The product-move-api returned multiple 4xx responses
+      AlarmDescription: Check the logs for details - https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmove-product-PROD
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub product-move-api-${Stage}-ApiGateway
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: 4XXError
+      Namespace: AWS/ApiGateway
+      Period: 3600
+      Statistic: Sum
+      Threshold: 3
+      TreatMissingData: notBreaching

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -128,16 +128,6 @@ object SubscriptionCancelEndpoint {
   private def subIsWithinFirst14Days(now: LocalDate, contractEffectiveDate: LocalDate) =
     now.isBefore(contractEffectiveDate.plusDays(15)) // This is 14 days from the day after the sub was taken out
 
-  private def getEffectiveCancellationDate(
-      shouldBeRefunded: Boolean,
-      contractEffectiveDate: LocalDate,
-      charge: RatePlanCharge,
-  ) =
-    if (shouldBeRefunded)
-      Some(contractEffectiveDate)
-    else
-      charge.chargedThroughDate
-
   private[productmove] def subscriptionCancel(subscriptionName: String, postData: ExpectedInput): ZIO[
     GetSubscription with ZuoraCancel with InvoicingApiRefund with Stage with ZuoraSetCancellationReason,
     String,


### PR DESCRIPTION
## What does this change?

This PR adds two alarms to the product move api so that we can tell when it is failing. 

They are triggered by a single 5XX Api Gateway response or multiple  4XXs over a time period - this period is quite low at the moment so we may need to tweak it if it is too noisy.

## How to test
To test this I removed the `isProd` restriction in the cloudformation template for these alarms, deployed them to dev and then triggered a 500 response by renaming a [config file in S3](s3://gu-reader-revenue-private/membership/support-service-lambdas/DEV/).
## How can we measure success?
Next time we have an issue with either the product-move api or the supporter plus cancellation api, we should receive an alarm immediately.
