### PR TITLE
Fix Scala Steward 'gitignore' error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-.*
-!/.gitignore
-!/.github
-!/.scala-steward.conf
+.bsp/
+.idea/
 target/
 cdk-cfn.yaml
 metals.sbt


### PR DESCRIPTION
The Guardian's [Scala Steward GitHub Action](https://github.com/guardian/scala-steward-public-repos/actions/workflows/public-repos-scala-steward.yml) job has been erroring for the past 5 days (since 9:55am GMT on Thursday 19th January 2023):

![image](https://user-images.githubusercontent.com/52038/214324817-9f108c2b-408b-4de8-bf7d-fe6effc4aae7.png)


Looking in the [logs](https://github.com/guardian/scala-steward-public-repos/actions/runs/3957277297/jobs/6777445592) we can see that Scala Steward is erroring on this repo:

```
2023-01-19 10:02:07,438 ERROR Steward guardian/support-service-lambdas failed
  java.io.IOException: 'GIT_ASKPASS=/home/runner/scala-steward/askpass.sh "SBT_OPTS=-Xmx2048m -Xss8m -XX:MaxMetaspaceSize=512m" git -c core.hooksPath=/dev/null add /home/runner/scala-steward/workspace/repos/guardian/support-service-lambdas/.git-blame-ignore-revs' exited with code 1
  The following paths are ignored by one of your .gitignore files:
  .git-blame-ignore-revs
  hint: Use -f if you really want to add them.
  hint: Turn this message off by running
  hint: "git config advice.addIgnoredFile false"
```

The error message tells us that Scala Steward is trying to commit a new file called `.git-blame-ignore-revs` to the `support-service-lambdas repo`, but the `git` command is rejecting this, because back in October 2020, https://github.com/guardian/support-service-lambdas/pull/734 added `.gitignore` configuration that rejects all files starting with a `.` ([hidden files](https://en.wikipedia.org/wiki/Hidden_file_and_hidden_directory), in UNIX).

## Why is Scala Steward trying to create a `.git-blame-ignore-revs` file?

This was a feature added to Scala Steward in July 2022 with https://github.com/scala-steward-org/scala-steward/pull/2652, fixing https://github.com/scala-steward-org/scala-steward/issues/2567: now when Scala Steward creates 'reformatting' commits with scalafmt, it adds the corresponding commit id to `.git-blame-ignore-revs`, which is a file respected by both `git` & GitHub:

* https://michaelheap.com/git-ignore-rev/
* https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

Now, when you try to `blame` a file in `git` or GitHub, the results will *leave out* reformatting commits, so long as they're listed in `.git-blame-ignore-revs`, which is nice - so it's not a bad thing that Scala Steward is trying to create this file. However, we need to change this repo's `.gitignore` file to allow Scala Steward to create the file.

## What's the fix?

The configuration added in PR #734 was '*reject* hidden files by default' - however, it now turns out that of the hidden files used in this project, _more_ of them are desired committed to the repo than not! So, it's better to switch the config to '_accept_ hidden files by default' - and just specify the 2 hidden folders we don't want to commit.
