### PR TITLE
Use Zio Clock instead of LocalDate in S+ Cancellation endpoint

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -148,8 +148,10 @@ object SubscriptionCancelEndpoint {
       charge <- asSingle(ratePlan.ratePlanCharges, "ratePlanCharge")
       _ <- checkProductIsSupporterPlus(charge, zuoraIds.supporterPlusZuoraIds)
 
+      today <- Clock.currentDateTime.map(_.toLocalDate)
+
       // check whether the sub is within the first 14 days of purchase - if it is then the subscriber is entitled to a refund
-      shouldBeRefunded = subIsWithinFirst14Days(LocalDate.now(), subscription.contractEffectiveDate)
+      shouldBeRefunded = subIsWithinFirst14Days(today, subscription.contractEffectiveDate)
       _ <- ZIO.log(s"Should be refunded is $shouldBeRefunded")
       cancellationDate <- ZIO
         .fromOption(


### PR DESCRIPTION
Uses Zio's Clock service instead of LocalDate. This allows us to set the time in our tests, [see here](https://github.com/guardian/support-service-lambdas/blob/main/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala#L80). I don't think we have any Zio tests for the cancellation endpoint currently.