### PR TITLE
Include old and new Guardian Weekly rate plan names in Supported Products list

### DIFF
--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -22,6 +22,7 @@ object SupportedProduct {
       productType = GuardianWeekly,
       annualIssueLimitPerEdition = 6,
       ratePlans = List(
+        // Old names for GW gift subs
         SupportedRatePlan(
           "GW Oct 18 - 1 Year - Domestic",
           List(SupportedRatePlanCharge("GW Oct 18 - 1 Year - Domestic", DayOfWeek.FRIDAY)),
@@ -29,6 +30,15 @@ object SupportedProduct {
         SupportedRatePlan(
           "GW Oct 18 - 3 Month - Domestic",
           List(SupportedRatePlanCharge("GW Oct 18 - 3 Month - Domestic", DayOfWeek.FRIDAY)),
+        ),
+        // New names for GW gift subs
+        SupportedRatePlan(
+          "GW GIFT Oct 18 - 1 Year - Domestic",
+          List(SupportedRatePlanCharge("GW GIFT Oct 18 - 1 Year - Domestic", DayOfWeek.FRIDAY)),
+        ),
+        SupportedRatePlan(
+          "GW GIFT Oct 18 - 3 Month - Domestic",
+          List(SupportedRatePlanCharge("GW GIFT Oct 18 - 3 Month - Domestic", DayOfWeek.FRIDAY)),
         ),
         SupportedRatePlan(
           "GW Oct 18 - Annual - Domestic",
@@ -53,6 +63,7 @@ object SupportedProduct {
       productType = GuardianWeekly,
       annualIssueLimitPerEdition = 6,
       ratePlans = List(
+        // Old names for GW Gift rate plans
         SupportedRatePlan(
           "GW Oct 18 - 1 Year - ROW",
           List(SupportedRatePlanCharge("GW Oct 18 - 1 Year - ROW", DayOfWeek.FRIDAY)),
@@ -60,6 +71,15 @@ object SupportedProduct {
         SupportedRatePlan(
           "GW Oct 18 - 3 Month - ROW",
           List(SupportedRatePlanCharge("GW Oct 18 - 3 Month - ROW", DayOfWeek.FRIDAY)),
+        ),
+        // New names for GW Gift rate plans
+        SupportedRatePlan(
+          "GW GIFT Oct 18 - 1 Year - ROW",
+          List(SupportedRatePlanCharge("GW GIFT Oct 18 - 1 Year - ROW", DayOfWeek.FRIDAY)),
+        ),
+        SupportedRatePlan(
+          "GW GIFT Oct 18 - 3 Month - ROW",
+          List(SupportedRatePlanCharge("GW GIFT Oct 18 - 3 Month - ROW", DayOfWeek.FRIDAY)),
         ),
         SupportedRatePlan(
           "GW Oct 18 - Annual - ROW",


### PR DESCRIPTION
## What does this change?
It adds new rate plan names after we renamed the GW Gift rate plans.  The old ones stay in place for matching against older subscriptions.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
