### PR TITLE
Handle product moves for subscriptions with multiple invoice items

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/BuildPreviewResult.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/BuildPreviewResult.scala
@@ -1,0 +1,33 @@
+package com.gu.productmove.zuora
+
+import zio.{IO, ZIO}
+import zio.*
+import zio.Clock
+import com.gu.productmove.GuStageLive.Stage
+import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.PreviewResult
+
+object BuildPreviewResult {
+  def getPreviewResult(
+      invoice: SubscriptionUpdateInvoice,
+      ids: SupporterPlusRatePlanIds,
+  ): ZIO[Stage, String, PreviewResult] =
+    invoice.invoiceItems.partition(_.productRatePlanChargeId == ids.ratePlanChargeId) match
+      case (supporterPlusInvoice :: Nil, contributionInvoices) =>
+        for {
+          date <- Clock.currentDateTime.map(_.toLocalDate)
+          contributionRefundInvoice = contributionInvoices
+            .filter(invoiceItem =>
+              invoiceItem.totalAmount < 0 &&
+                invoiceItem.serviceStartDate == date,
+            )
+            .head
+        } yield PreviewResult(
+          supporterPlusInvoice.totalAmount - contributionRefundInvoice.totalAmount.abs,
+          contributionRefundInvoice.totalAmount,
+          supporterPlusInvoice.totalAmount,
+        )
+      case _ =>
+        ZIO.fail(
+          s"Unexpected invoice item structure was returned from a Zuora preview call. Invoice data was: $invoice",
+        )
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/Fixtures.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/Fixtures.scala
@@ -1,0 +1,69 @@
+package com.gu.productmove.zuora
+
+import com.gu.productmove.zuora.SubscriptionUpdateSpec.test
+
+import java.time.LocalDate
+
+object Fixtures {
+  val supporterPlusRatePlanChargeId = "8ad09fc281de1ce70181de3b253e36a6"
+  val contributionRatePlanChargeId = "2c92c0f85a6b1352015a7fcf35ab397c"
+
+  val invoiceWithMultipleInvoiceItems = SubscriptionUpdateInvoice(
+    amount = 42,
+    amountWithoutTax = 42,
+    taxAmount = 0,
+    invoiceItems = List(
+      SubscriptionUpdateInvoiceItem(
+        LocalDate.parse("2022-11-19"),
+        16,
+        0,
+        contributionRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem(
+        LocalDate.parse("2022-12-19"),
+        16,
+        0,
+        contributionRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem( //Supporter plus
+        LocalDate.parse("2023-01-19"),
+        10,
+        0,
+        supporterPlusRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem(
+        LocalDate.parse("2023-01-19"),
+        -16,
+        0,
+        contributionRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem(
+        LocalDate.parse("2023-01-19"),
+        16,
+        0,
+        contributionRatePlanChargeId,
+      ),
+    ),
+  )
+
+  val invoiceWithTax = SubscriptionUpdateInvoice(
+    amount = -10,
+    amountWithoutTax = -10.91,
+    taxAmount = 0.91,
+    invoiceItems = List(
+      SubscriptionUpdateInvoiceItem(
+        serviceStartDate = LocalDate.parse("2023-02-06"),
+        chargeAmount = -20,
+        taxAmount = -0,
+        productRatePlanChargeId = contributionRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem(
+        serviceStartDate = LocalDate.parse("2023-02-06"),
+        chargeAmount = 9.09,
+        taxAmount = 0.91,
+        productRatePlanChargeId = supporterPlusRatePlanChargeId,
+      ),
+    )
+  )
+
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
@@ -12,6 +12,8 @@ import zio.{IO, ZIO}
 import zio.*
 import zio.test.Assertion.*
 import zio.test.*
+import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.PreviewResult
+import Fixtures.*
 
 import java.time.*
 
@@ -82,6 +84,48 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
             ZLayer.succeed(Stage.valueOf("PROD")),
           )
         } yield assert(createRequestBody)(equalTo(expectedRequestBody))
+      },
+      test("SubscriptionUpdateRequest preview response is correct for invoice with multiple invoice items") {
+        val time = LocalDateTime.parse("2023-01-19T00:00:00").toInstant(ZoneOffset.ofHours(0))
+
+        val expectedResponse = PreviewResult(
+          amountPayableToday = -6,
+          contributionRefundAmount = -16,
+          supporterPlusPurchaseAmount = 10,
+        )
+
+        for {
+          _ <- TestClock.setTime(time)
+          response <- BuildPreviewResult
+            .getPreviewResult(
+              invoiceWithMultipleInvoiceItems,
+              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6"),
+            )
+            .provideLayer(
+              ZLayer.succeed(Stage.valueOf("DEV")),
+            )
+        } yield assert(response)(equalTo(expectedResponse))
+      },
+      test("SubscriptionUpdateRequest preview response is correct for invoice with tax") {
+        val time = LocalDateTime.parse("2023-02-06T00:00:00").toInstant(ZoneOffset.ofHours(0))
+
+        val expectedResponse = PreviewResult(
+          amountPayableToday = -10,
+          contributionRefundAmount = -20,
+          supporterPlusPurchaseAmount = 10,
+        )
+
+        for {
+          _ <- TestClock.setTime(time)
+          response <- BuildPreviewResult
+            .getPreviewResult(
+              invoiceWithTax,
+              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6"),
+            )
+            .provideLayer(
+              ZLayer.succeed(Stage.valueOf("DEV")),
+            )
+        } yield assert(response)(equalTo(expectedResponse))
       },
     )
 


### PR DESCRIPTION
## What does this change?

The product move api preview endpoint currently fails if a subscription has multiple invoice items. This PR fixes that and adds two tests for how we handle the response from Zuora.