### PR TITLE
Better logging

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/resources/logback.xml
+++ b/handlers/soft-opt-in-consent-setter/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date %level - %message%n%xException</pattern>
+            <pattern>%date %level - %logger{0}:%line: %replace(%message){'\n','&#xd;'} %replace(%exception){'\n','&#xd;'} %nopexception %n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
**Note:** this only affects the `soft-opt-ins-consent-setter` project. We can add this to other projects with the same problem.

## Previously

JSON was being logged incorrectly, with each new line being logged separately like so:

<img width="971" alt="Screenshot 2023-02-08 at 15 32 28" src="https://user-images.githubusercontent.com/91546670/217577555-04bde55b-ac0f-4331-b39e-cfc545421e5c.png">

## Now

JSON is logged in a single cell like so:

<img width="884" alt="Screenshot 2023-02-08 at 15 32 09" src="https://user-images.githubusercontent.com/91546670/217577678-5a30cadb-4c48-4d3f-ab52-ee70699d643c.png">

 The JSON fields can now be queried by Cloudwatch, although as this lambda logs arrays of JSON objects this can be quite difficult, but there are some threads on [stackoverflow](https://stackoverflow.com/questions/55333721/accessing-values-in-json-array).

Solution [found here](https://stackoverflow.com/questions/53961216/new-line-problem-in-cloudwatch-output-when-logging-with-slf4j-and-io-symphonia).
