### PR TITLE
Improve error messages in the product-move-api for CSRs

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
@@ -33,13 +33,16 @@ object ProductMoveEndpointTypes {
       @description("The amount refunded from the cancelled contribution") contributionRefundAmount: BigDecimal,
       @description("The cost of the new supporter plus subscription") supporterPlusPurchaseAmount: BigDecimal,
   ) extends OutputBody
-  case class InternalServerError(message: String) extends OutputBody
+  case class InternalServerError(@description("Error message.") message: String) extends OutputBody
   given Schema[Success] = inlineSchema(Schema.derived)
   given Schema[PreviewResult] = inlineSchema(Schema.derived)
+  given Schema[InternalServerError] = inlineSchema(Schema.derived)
   given JsonEncoder[Success] = DeriveJsonEncoder.gen[Success]
   given JsonDecoder[Success] = DeriveJsonDecoder.gen[Success] // needed to keep tapir happy
   given JsonEncoder[PreviewResult] = DeriveJsonEncoder.gen[PreviewResult]
   given JsonDecoder[PreviewResult] = DeriveJsonDecoder.gen // needed to keep tapir happy
   given JsonEncoder[OutputBody] = DeriveJsonEncoder.gen[OutputBody]
   given JsonDecoder[OutputBody] = DeriveJsonDecoder.gen[OutputBody] // needed to keep tapir happy
+  given JsonEncoder[InternalServerError] = DeriveJsonEncoder.gen[InternalServerError]
+  given JsonDecoder[InternalServerError] = DeriveJsonDecoder.gen[InternalServerError] // needed to keep tapir happy
 }


### PR DESCRIPTION
## Before

No JSON was being returned on failure.

<img width="600" alt="image (4)" src="https://user-images.githubusercontent.com/91546670/217898667-9f05aa33-5fe2-49ce-b4ae-11f51ee8d63e.png">

## Now

As part of the new OKR (product switches done from Salesforce), we've been asked to provide useful error messages to the CSRs. a JSON body with a message is now returned:

<img width="987" alt="Screenshot 2023-02-09 at 18 02 15" src="https://user-images.githubusercontent.com/91546670/217899124-dc903f84-281c-4f84-b8de-9ecabb05f289.png">

