### PR TITLE
update confirmation email campaign name in product-move-api

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -229,7 +229,7 @@ object ProductMoveEndpoint {
               ),
             ),
           ),
-          "SV_RCtoDP_Switch",
+          "SV_RCtoSP_Switch",
           account.basicInfo.sfContactId__c,
           Some(identityId),
         ),

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -212,7 +212,7 @@ val emailMessageBody = EmailMessage(
       ),
     ),
   ),
-  "SV_RCtoDP_Switch",
+  "SV_RCtoSP_Switch",
   "sfContactId",
   Some("12345"),
 )
@@ -234,7 +234,7 @@ val emailMessageBodyRefund = EmailMessage(
       ),
     ),
   ),
-  "SV_RCtoDP_Switch",
+  "SV_RCtoSP_Switch",
   "sfContactId",
   Some("12345"),
 )


### PR DESCRIPTION
Braze campaign name for product switch confirmation email [has changed](https://dashboard-01.braze.eu/engagement/campaigns/6296255bdec9c61fad08a74d/5b75933b36dc781650d85641?locale=en&campaignName=SV_RCtoSP_Switch&page=-2).