### PR TITLE
Add `nextPaymentDate` to product-move-api preview endpoint

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
@@ -3,6 +3,7 @@ package com.gu.productmove.endpoint.move
 import com.gu.productmove.endpoint.available.AvailableProductMovesEndpointTypes.OutputBody
 import com.gu.productmove.framework.InlineSchema.inlineSchema
 import com.gu.productmove.endpoint.available.{Currency, MoveToProduct}
+import java.time.LocalDate
 import sttp.tapir.Schema
 import sttp.tapir.Schema.annotations.{description, encodedName}
 import sttp.tapir.generic.{Configuration, Derived}
@@ -32,6 +33,9 @@ object ProductMoveEndpointTypes {
       @description("The amount payable by the customer today") amountPayableToday: BigDecimal,
       @description("The amount refunded from the cancelled contribution") contributionRefundAmount: BigDecimal,
       @description("The cost of the new supporter plus subscription") supporterPlusPurchaseAmount: BigDecimal,
+      @description(
+        "The next payment date of the new supporter plus subscription, i.e.: the second payment date",
+      ) nextPaymentDate: LocalDate,
   ) extends OutputBody
   case class InternalServerError(message: String) extends OutputBody
   given Schema[Success] = inlineSchema(Schema.derived)

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/BuildPreviewResult.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/BuildPreviewResult.scala
@@ -15,11 +15,7 @@ object BuildPreviewResult {
       invoice.invoiceItems.partition(_.productRatePlanChargeId == ids.ratePlanChargeId)
 
     (supporterPlusInvoices.length, contributionInvoices.length) match {
-      case (0, _) =>
-        ZIO.fail(
-          s"Unexpected invoice item structure was returned from a Zuora preview call. Invoice data was: $invoice",
-        )
-      case (n1, _) if n1 > 1 =>
+      case (n1, n2) if n1 > 1 && n2 >= 1 =>
         for {
           date <- Clock.currentDateTime.map(_.toLocalDate)
           contributionRefundInvoice = contributionInvoices
@@ -36,6 +32,10 @@ object BuildPreviewResult {
           contributionRefundInvoice.totalAmount,
           supporterPlusInvoiceItems.head.totalAmount,
           supporterPlusInvoiceItems(1).serviceStartDate,
+        )
+      case (_, _) =>
+        ZIO.fail(
+          s"Unexpected invoice item structure was returned from a Zuora preview call. Invoice data was: $invoice",
         )
     }
   }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/BuildPreviewResult.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/BuildPreviewResult.scala
@@ -10,9 +10,16 @@ object BuildPreviewResult {
   def getPreviewResult(
       invoice: SubscriptionUpdateInvoice,
       ids: SupporterPlusRatePlanIds,
-  ): ZIO[Stage, String, PreviewResult] =
-    invoice.invoiceItems.partition(_.productRatePlanChargeId == ids.ratePlanChargeId) match
-      case (supporterPlusInvoice :: Nil, contributionInvoices) =>
+  ): ZIO[Stage, String, PreviewResult] = {
+    val (supporterPlusInvoices, contributionInvoices) =
+      invoice.invoiceItems.partition(_.productRatePlanChargeId == ids.ratePlanChargeId)
+
+    (supporterPlusInvoices.length, contributionInvoices.length) match {
+      case (0, _) =>
+        ZIO.fail(
+          s"Unexpected invoice item structure was returned from a Zuora preview call. Invoice data was: $invoice",
+        )
+      case (n1, _) if n1 > 1 =>
         for {
           date <- Clock.currentDateTime.map(_.toLocalDate)
           contributionRefundInvoice = contributionInvoices
@@ -21,13 +28,15 @@ object BuildPreviewResult {
                 invoiceItem.serviceStartDate == date,
             )
             .head
+          supporterPlusInvoiceItems = supporterPlusInvoices.sortWith((i1, i2) =>
+            i1.serviceStartDate.isBefore(i2.serviceStartDate),
+          )
         } yield PreviewResult(
-          supporterPlusInvoice.totalAmount - contributionRefundInvoice.totalAmount.abs,
+          supporterPlusInvoiceItems.head.totalAmount - contributionRefundInvoice.totalAmount.abs,
           contributionRefundInvoice.totalAmount,
-          supporterPlusInvoice.totalAmount,
+          supporterPlusInvoiceItems.head.totalAmount,
+          supporterPlusInvoiceItems(1).serviceStartDate,
         )
-      case _ =>
-        ZIO.fail(
-          s"Unexpected invoice item structure was returned from a Zuora preview call. Invoice data was: $invoice",
-        )
+    }
+  }
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
@@ -101,7 +101,6 @@ case class SubscriptionUpdateRequest(
     remove: List[RemoveRatePlan],
     collect: Boolean = true,
     runBilling: Boolean = true,
-    targetDate: Option[LocalDate] = None,
 )
 case class AddRatePlan(
     contractEffectiveDate: LocalDate,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
@@ -65,7 +65,9 @@ private class SubscriptionUpdateLive(zuoraGet: ZuoraGet) extends SubscriptionUpd
   ): ZIO[Stage, String, PreviewResult] = {
 
     for {
-      requestBody <- SubscriptionUpdatePreviewRequest(billingPeriod, ratePlanIdToRemove, price)
+      today <- Clock.currentDateTime.map(_.toLocalDate)
+
+      requestBody <- SubscriptionUpdatePreviewRequest(billingPeriod, ratePlanIdToRemove, price, today.plusMonths(14))
       response <- zuoraGet.put[SubscriptionUpdatePreviewRequest, SubscriptionUpdatePreviewResponse](
         uri"subscriptions/$subscriptionId",
         requestBody,
@@ -99,6 +101,7 @@ case class SubscriptionUpdateRequest(
     remove: List[RemoveRatePlan],
     collect: Boolean = true,
     runBilling: Boolean = true,
+    targetDate: Option[LocalDate] = None,
 )
 case class AddRatePlan(
     contractEffectiveDate: LocalDate,
@@ -114,6 +117,7 @@ case class SubscriptionUpdatePreviewRequest(
     add: List[AddRatePlan],
     remove: List[RemoveRatePlan],
     preview: Boolean = true,
+    targetDate: LocalDate,
 )
 case class SubscriptionUpdatePreviewResponse(invoice: SubscriptionUpdateInvoice)
 case class SubscriptionUpdateInvoiceItem(
@@ -148,9 +152,10 @@ object SubscriptionUpdatePreviewRequest {
       billingPeriod: BillingPeriod,
       ratePlanIdToRemove: String,
       price: BigDecimal,
+      targetDate: LocalDate,
   ): ZIO[Stage, String, SubscriptionUpdatePreviewRequest] =
     getRatePlans(billingPeriod, ratePlanIdToRemove, price).map { case (addRatePlan, removeRatePlan) =>
-      SubscriptionUpdatePreviewRequest(addRatePlan, removeRatePlan)
+      SubscriptionUpdatePreviewRequest(add = addRatePlan, remove = removeRatePlan, targetDate = targetDate)
     }
 }
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
@@ -67,7 +67,7 @@ private class SubscriptionUpdateLive(zuoraGet: ZuoraGet) extends SubscriptionUpd
     for {
       today <- Clock.currentDateTime.map(_.toLocalDate)
 
-      requestBody <- SubscriptionUpdatePreviewRequest(billingPeriod, ratePlanIdToRemove, price, today.plusMonths(14))
+      requestBody <- SubscriptionUpdatePreviewRequest(billingPeriod, ratePlanIdToRemove, price, today.plusMonths(13))
       response <- zuoraGet.put[SubscriptionUpdatePreviewRequest, SubscriptionUpdatePreviewResponse](
         uri"subscriptions/$subscriptionId",
         requestBody,

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -196,6 +196,7 @@ object HandlerSpec extends ZIOSpecDefault {
           amountPayableToday = 40,
           contributionRefundAmount = -10,
           supporterPlusPurchaseAmount = 50,
+          LocalDate.of(2023, 6, 10),
         )
         (for {
           _ <- TestClock.setTime(time)

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -275,7 +275,7 @@ val subscriptionUpdateResponse2 = SubscriptionUpdateResponse("A-S00339056", -4, 
 //-----------------------------------------------------
 // Stubs for SubscriptionUpdate preview service
 //-----------------------------------------------------
-val subscriptionUpdatePreviewResult = PreviewResult(40, -10, 50)
+val subscriptionUpdatePreviewResult = PreviewResult(40, -10, 50, LocalDate.of(2023, 6, 10))
 
 //-----------------------------------------------------
 // Stubs for GetSfSubscription service

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/Fixtures.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/Fixtures.scala
@@ -25,8 +25,26 @@ object Fixtures {
         0,
         contributionRatePlanChargeId,
       ),
-      SubscriptionUpdateInvoiceItem( //Supporter plus
+      SubscriptionUpdateInvoiceItem( // Supporter plus
         LocalDate.parse("2023-01-19"),
+        10,
+        0,
+        supporterPlusRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem( // Supporter plus
+        LocalDate.parse("2023-02-19"),
+        10,
+        0,
+        supporterPlusRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem( // Supporter plus
+        LocalDate.parse("2023-03-19"),
+        10,
+        0,
+        supporterPlusRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem( // Supporter plus
+        LocalDate.parse("2023-04-19"),
         10,
         0,
         supporterPlusRatePlanChargeId,
@@ -58,12 +76,18 @@ object Fixtures {
         productRatePlanChargeId = contributionRatePlanChargeId,
       ),
       SubscriptionUpdateInvoiceItem(
+        serviceStartDate = LocalDate.parse("2023-03-06"),
+        chargeAmount = 20,
+        taxAmount = 0,
+        productRatePlanChargeId = supporterPlusRatePlanChargeId,
+      ),
+      SubscriptionUpdateInvoiceItem(
         serviceStartDate = LocalDate.parse("2023-02-06"),
         chargeAmount = 9.09,
         taxAmount = 0.91,
         productRatePlanChargeId = supporterPlusRatePlanChargeId,
       ),
-    )
+    ),
   )
 
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
@@ -92,6 +92,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
           amountPayableToday = -6,
           contributionRefundAmount = -16,
           supporterPlusPurchaseAmount = 10,
+          LocalDate.of(2023, 2, 19)
         )
 
         for {
@@ -113,6 +114,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
           amountPayableToday = -10,
           contributionRefundAmount = -20,
           supporterPlusPurchaseAmount = 10,
+          LocalDate.of(2023, 3, 06)
         )
 
         for {


### PR DESCRIPTION
## What does this change?

We need to calculate the next payment date of a customer's switched subscription. By next payment date, we mean the second payment of their new supporter plus subscription (they will make the first payment on the day of the switch).

 Zuora uses the same day of each month as the billing date (e.g.: 10th of January, 10th of February, 10th of March, etc...), but what happens if a user takes out a sub on the 31st and the next month does not have that date?

 To calculate this, I'm having to query future invoices from Zuora.