### PR TITLE
Use paidAmount instead of totalDeltaMrr

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -222,8 +222,8 @@ object ProductMoveEndpoint {
                 first_name = account.billToContact.firstName,
                 last_name = account.billToContact.lastName,
                 currency = account.basicInfo.currency.symbol,
-                price = price.toString,
-                first_payment_amount = paidAmount.toString,
+                price = price.setScale(2, BigDecimal.RoundingMode.FLOOR).toString,
+                first_payment_amount = paidAmount.setScale(2, BigDecimal.RoundingMode.FLOOR).toString,
                 date_of_first_payment = todaysDate.format(DateTimeFormatter.ofPattern("d MMMM uuuu")),
                 payment_frequency = billingPeriod,
                 contribution_cancellation_date = todaysDate.format(DateTimeFormatter.ofPattern("d MMMM uuuu")),
@@ -242,7 +242,7 @@ object ProductMoveEndpoint {
       .queueSalesforceTracking(
         SalesforceRecordInput(
           subscriptionName,
-          price,
+          BigDecimal(ratePlanCharge.price),
           price,
           currentRatePlan.productName,
           currentRatePlan.ratePlanName,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -270,7 +270,10 @@ object ProductMoveEndpoint {
       )
       .fork
 
-    requests = emailFuture.zip(salesforceTrackingFuture).zip(amendSupporterProductDynamoTableFuture)
+    requests = emailFuture
+      .zip(salesforceTrackingFuture)
+      .zip(amendSupporterProductDynamoTableFuture)
+
     _ <- requests.join
 
   } yield Success("Product move completed successfully")

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -254,16 +254,6 @@ object ProductMoveEndpoint {
       )
       .fork
 
-    /*
-    refundFuture <-
-      if (updateResponse.totalDeltaMrr < 0)
-        SQS
-          .queueRefund(RefundInput(subscriptionName, updateResponse.invoiceId, updateResponse.totalDeltaMrr.abs))
-          .fork
-      else
-        ZIO.succeed(()).fork
-     */
-
     supporterPlusRatePlanIds <- ZIO.fromEither(getSupporterPlusRatePlanIds(stage, ratePlanCharge.billingPeriod))
     amendSupporterProductDynamoTableFuture <- Dynamo
       .writeItem(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -209,6 +209,9 @@ object ProductMoveEndpoint {
 
     todaysDate <- Clock.currentDateTime.map(_.toLocalDate)
     billingPeriod <- ratePlanCharge.billingPeriod.value
+
+    paidAmount = updateResponse.paidAmount.getOrElse(BigDecimal(0))
+
     emailFuture <- SQS
       .sendEmail(
         message = EmailMessage(
@@ -220,7 +223,7 @@ object ProductMoveEndpoint {
                 last_name = account.billToContact.lastName,
                 currency = account.basicInfo.currency.symbol,
                 price = price.toString,
-                first_payment_amount = updateResponse.paidAmount.toString,
+                first_payment_amount = paidAmount.toString,
                 date_of_first_payment = todaysDate.format(DateTimeFormatter.ofPattern("d MMMM uuuu")),
                 payment_frequency = billingPeriod,
                 contribution_cancellation_date = todaysDate.format(DateTimeFormatter.ofPattern("d MMMM uuuu")),
@@ -246,7 +249,7 @@ object ProductMoveEndpoint {
           "Supporter Plus",
           todaysDate,
           todaysDate,
-          updateResponse.paidAmount,
+          paidAmount,
         ),
       )
       .fork

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/CreateRecord.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/CreateRecord.scala
@@ -36,12 +36,13 @@ object CreateRecord {
       Type__c: String = "Product Switch",
       Source__c: String = "MMA",
       Previous_Amount__c: BigDecimal,
+      New_Amount__c: BigDecimal,
       Previous_Product_Name__c: String,
       Previous_Rate_Plan_Name__c: String,
       New_Rate_Plan_Name__c: String,
       Requested_Date__c: LocalDate,
       Effective_Date__c: LocalDate,
-      Refund_Amount__c: BigDecimal,
+      Paid_Amount__c: BigDecimal,
   )
   given JsonEncoder[CreateRecordRequest] = DeriveJsonEncoder.gen[CreateRecordRequest]
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
@@ -10,12 +10,13 @@ object Salesforce {
   case class SalesforceRecordInput(
       subscriptionName: String,
       previousAmount: BigDecimal,
+      newAmount: BigDecimal,
       previousProductName: String,
       previousRatePlanName: String,
       newRatePlanName: String,
       requestedDate: LocalDate,
       effectiveDate: LocalDate,
-      refundAmount: BigDecimal,
+      paidAmount: BigDecimal,
   )
 
   given JsonDecoder[SalesforceRecordInput] = DeriveJsonDecoder.gen[SalesforceRecordInput]
@@ -31,12 +32,13 @@ object Salesforce {
       request = CreateRecordRequest(
         SF_Subscription__c = sfSub.Id,
         Previous_Amount__c = previousAmount,
+        New_Amount__c = newAmount,
         Previous_Product_Name__c = previousProductName,
         Previous_Rate_Plan_Name__c = previousRatePlanName,
         New_Rate_Plan_Name__c = newRatePlanName,
         Requested_Date__c = requestedDate,
         Effective_Date__c = effectiveDate,
-        Refund_Amount__c = refundAmount,
+        Paid_Amount__c = paidAmount,
       )
       _ <- CreateRecord.create(request)
     } yield ()

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
@@ -109,7 +109,12 @@ case class RemoveRatePlan(
     contractEffectiveDate: LocalDate,
     ratePlanId: String,
 )
-case class SubscriptionUpdateResponse(subscriptionId: String, totalDeltaMrr: BigDecimal, invoiceId: String)
+case class SubscriptionUpdateResponse(
+    subscriptionId: String,
+    totalDeltaMrr: BigDecimal,
+    invoiceId: String,
+    paidAmount: BigDecimal,
+)
 case class SubscriptionUpdatePreviewRequest(
     add: List[AddRatePlan],
     remove: List[RemoveRatePlan],

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
@@ -113,7 +113,7 @@ case class SubscriptionUpdateResponse(
     subscriptionId: String,
     totalDeltaMrr: BigDecimal,
     invoiceId: String,
-    paidAmount: BigDecimal,
+    paidAmount: Option[BigDecimal],
 )
 case class SubscriptionUpdatePreviewRequest(
     add: List[AddRatePlan],

--- a/handlers/product-move-api/src/test/resources/zuoraResponses/SubscriptionUpdateResponse1.json
+++ b/handlers/product-move-api/src/test/resources/zuoraResponses/SubscriptionUpdateResponse1.json
@@ -1,0 +1,9 @@
+{
+   "success": true,
+   "subscriptionId": "8ad0823f841cf4e601841e61f6d070b8",
+   "totalDeltaMrr": 25.000000000,
+   "totalDeltaTcv": 300.000000000,
+   "invoiceId": "8ad0823f841cf4e601841e61f7b570e8",
+   "paymentId": "8ad0823f841cf4e601841e61f82870ff",
+   "paidAmount": 25.000000000
+}

--- a/handlers/product-move-api/src/test/resources/zuoraResponses/SubscriptionUpdateResponse2.json
+++ b/handlers/product-move-api/src/test/resources/zuoraResponses/SubscriptionUpdateResponse2.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "subscriptionId": "8ad08ccf844271800184528017044b36",
+  "totalDeltaMrr": -4.000000000,
+  "totalDeltaTcv": -48.000000000,
+  "invoiceId": "8ad08ccf844271800184528017b24b4b"
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -129,6 +129,11 @@ object HandlerSpec extends ZIOSpecDefault {
           ZLayer.succeed(Stage.valueOf("PROD")),
         )
       },
+
+      /*
+
+      *** Commented out until V2 ***
+
       test("productMove endpoint is successful for a refunded customer") {
         val endpointJsonInputBody = ExpectedInput(50.00, false)
         val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)
@@ -160,6 +165,8 @@ object HandlerSpec extends ZIOSpecDefault {
           ZLayer.succeed(Stage.valueOf("PROD")),
         )
       },
+       */
+
       test("productMove endpoint returns 500 error if subscription has more than one rateplan") {
         val endpointJsonInputBody = ExpectedInput(50.00, false)
         val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -164,44 +164,6 @@ object HandlerSpec extends ZIOSpecDefault {
           ZLayer.succeed(Stage.valueOf("PROD")),
         )
       },
-
-      /*
-
-      *** Commented out until V2 ***
-
-      test("productMove endpoint is successful for a refunded customer") {
-        val endpointJsonInputBody = ExpectedInput(50.00, false)
-        val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)
-        val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse2)
-        val expectedOutput = ProductMoveEndpointTypes.Success("Product move completed successfully")
-        val sqsStubs: Map[EmailMessage | RefundInput | SalesforceRecordInput, Unit] =
-          Map(emailMessageBodyRefund -> (), refundInput1 -> (), salesforceRecordInput1 -> ())
-        (for {
-          _ <- TestClock.setTime(time)
-          output <- ProductMoveEndpoint.productMove(expectedSubNameInput, endpointJsonInputBody)
-          getSubRequests <- MockGetSubscription.requests
-          subUpdateRequests <- MockSubscriptionUpdate.requests
-          getAccountRequests <- MockGetAccount.requests
-          sqsRequests <- MockSQS.requests
-          dynamoRequests <- MockDynamo.requests
-        } yield {
-          assert(output)(equalTo(expectedOutput)) &&
-          assert(getSubRequests)(equalTo(List(expectedSubNameInput))) &&
-          assert(subUpdateRequests)(equalTo(List(subscriptionUpdateInputsShouldBe))) &&
-          assert(getAccountRequests)(equalTo(List("accountNumber"))) &&
-          assert(sqsRequests)(hasSameElements(List(emailMessageBodyRefund, refundInput1, salesforceRecordInput1))) &&
-          assert(dynamoRequests)(equalTo(List(supporterRatePlanItem1)))
-        }).provide(
-          ZLayer.succeed(new MockGetSubscription(getSubscriptionStubs())),
-          ZLayer.succeed(new MockSubscriptionUpdate(subscriptionUpdatePreviewStubs, subscriptionUpdateStubs)),
-          ZLayer.succeed(new MockSQS(sqsStubs)),
-          ZLayer.succeed(new MockDynamo(dynamoStubs)),
-          ZLayer.succeed(new MockGetAccount(getAccountStubs, getPaymentMethodStubs)),
-          ZLayer.succeed(Stage.valueOf("PROD")),
-        )
-      },
-       */
-
       test("productMove endpoint returns 500 error if subscription has more than one rateplan") {
         val endpointJsonInputBody = ExpectedInput(50.00, false)
         val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -304,9 +304,11 @@ val salesforceRecordInput3 = SalesforceRecordInput(
 //-----------------------------------------------------
 // Stubs for SubscriptionUpdate service
 //-----------------------------------------------------
-val subscriptionUpdateResponse = SubscriptionUpdateResponse("A-S00339056", 28, "89ad8casd9c0asdcaj89sdc98as", Some(20))
-val subscriptionUpdateResponse2 = SubscriptionUpdateResponse("A-S00339056", -4, "80a23d9sdf9a89fs8cjjk2", Some(10))
-val subscriptionUpdateResponse3 = SubscriptionUpdateResponse("A-S00339056", 28, "89ad8casd9c0asdcaj89sdc98as", None)
+val subscriptionUpdateResponse = SubscriptionUpdateResponse("8ad0823f841cf4e601841e61f7b57mkd", 28, "89ad8casd9c0asdcaj89sdc98as", Some(20))
+val subscriptionUpdateResponse2 = SubscriptionUpdateResponse("8ad0823f841cf4e601841e61f7b57osi", -4, "80a23d9sdf9a89fs8cjjk2", Some(10))
+val subscriptionUpdateResponse3 = SubscriptionUpdateResponse("8ad0823f841cf4e601841e61f7b57jsd", 28, "89ad8casd9c0asdcaj89sdc98as", None)
+val subscriptionUpdateResponse4 = SubscriptionUpdateResponse("8ad0823f841cf4e601841e61f6d070b8", BigDecimal(25), "8ad0823f841cf4e601841e61f7b570e8", Some(25))
+val subscriptionUpdateResponse5 = SubscriptionUpdateResponse("8ad08ccf844271800184528017044b36", -4, "8ad08ccf844271800184528017b24b4b", None)
 
 //-----------------------------------------------------
 // Stubs for SubscriptionUpdate preview service

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -35,8 +35,8 @@ val getSubscriptionResponse = GetSubscriptionResponse(
       ratePlanCharges = List(
         RatePlanCharge(
           productRatePlanChargeId = "PRPC1",
-          name = "Digital Pack Monthly",
-          price = 11.11,
+          name = "Contribution",
+          price = 5.000000000,
           currency = "GBP",
           number = "number",
           effectiveStartDate = LocalDate.of(2017, 12, 15),
@@ -203,8 +203,8 @@ val emailMessageBody = EmailMessage(
         subscription_id = "A-S00339056",
         first_name = "John",
         last_name = "Hee",
-        first_payment_amount = "20",
-        price = "50.0",
+        first_payment_amount = "20.00",
+        price = "15.00",
         payment_frequency = "month",
         date_of_first_payment = "10 May 2022",
         currency = "£",
@@ -225,8 +225,30 @@ val emailMessageBodyRefund = EmailMessage(
         subscription_id = "A-S00339056",
         first_name = "John",
         last_name = "Hee",
-        first_payment_amount = "-4",
-        price = "50.0",
+        first_payment_amount = "-4.00",
+        price = "50.00",
+        payment_frequency = "month",
+        date_of_first_payment = "10 May 2022",
+        currency = "£",
+        contribution_cancellation_date = "10 May 2022",
+      ),
+    ),
+  ),
+  "SV_RCtoSP_Switch",
+  "sfContactId",
+  Some("12345"),
+)
+
+val emailMessageBodyNoPaymentOrRefund = EmailMessage(
+  To = EmailPayload(
+    Address = Some("example@gmail.com"),
+    EmailPayloadContactAttributes(
+      EmailPayloadSubscriberAttributes(
+        subscription_id = "A-S00339056",
+        first_name = "John",
+        last_name = "Hee",
+        first_payment_amount = "0.00",
+        price = "15.00",
         payment_frequency = "month",
         date_of_first_payment = "10 May 2022",
         currency = "£",
@@ -258,8 +280,8 @@ val salesforceRecordInput1 = SalesforceRecordInput(
 )
 val salesforceRecordInput2 = SalesforceRecordInput(
   "A-S00339056",
-  BigDecimal(50),
-  BigDecimal(50),
+  BigDecimal(5),
+  BigDecimal(15),
   "P1",
   "RP1",
   "Supporter Plus",
@@ -267,17 +289,29 @@ val salesforceRecordInput2 = SalesforceRecordInput(
   LocalDate.of(2022, 5, 10),
   BigDecimal(20),
 )
+val salesforceRecordInput3 = SalesforceRecordInput(
+  "A-S00339056",
+  BigDecimal(5),
+  BigDecimal(15),
+  "P1",
+  "RP1",
+  "Supporter Plus",
+  LocalDate.of(2022, 5, 10),
+  LocalDate.of(2022, 5, 10),
+  BigDecimal(0),
+)
 
 //-----------------------------------------------------
 // Stubs for SubscriptionUpdate service
 //-----------------------------------------------------
-val subscriptionUpdateResponse = SubscriptionUpdateResponse("A-S00339056", 28, "89ad8casd9c0asdcaj89sdc98as", 20)
-val subscriptionUpdateResponse2 = SubscriptionUpdateResponse("A-S00339056", -4, "80a23d9sdf9a89fs8cjjk2", 10)
+val subscriptionUpdateResponse = SubscriptionUpdateResponse("A-S00339056", 28, "89ad8casd9c0asdcaj89sdc98as", Some(20))
+val subscriptionUpdateResponse2 = SubscriptionUpdateResponse("A-S00339056", -4, "80a23d9sdf9a89fs8cjjk2", Some(10))
+val subscriptionUpdateResponse3 = SubscriptionUpdateResponse("A-S00339056", 28, "89ad8casd9c0asdcaj89sdc98as", None)
 
 //-----------------------------------------------------
 // Stubs for SubscriptionUpdate preview service
 //-----------------------------------------------------
-val subscriptionUpdatePreviewResult = PreviewResult(40, -10, 50)
+val subscriptionUpdatePreviewResult = PreviewResult(10, 0, 15)
 
 //-----------------------------------------------------
 // Stubs for GetSfSubscription service

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -203,7 +203,7 @@ val emailMessageBody = EmailMessage(
         subscription_id = "A-S00339056",
         first_name = "John",
         last_name = "Hee",
-        first_payment_amount = "28",
+        first_payment_amount = "20",
         price = "50.0",
         payment_frequency = "month",
         date_of_first_payment = "10 May 2022",
@@ -248,6 +248,7 @@ val refundInput1 = RefundInput(
 val salesforceRecordInput1 = SalesforceRecordInput(
   "A-S00339056",
   BigDecimal(50),
+  BigDecimal(50),
   "P1",
   "RP1",
   "Supporter Plus",
@@ -258,19 +259,20 @@ val salesforceRecordInput1 = SalesforceRecordInput(
 val salesforceRecordInput2 = SalesforceRecordInput(
   "A-S00339056",
   BigDecimal(50),
+  BigDecimal(50),
   "P1",
   "RP1",
   "Supporter Plus",
   LocalDate.of(2022, 5, 10),
   LocalDate.of(2022, 5, 10),
-  BigDecimal(28),
+  BigDecimal(20),
 )
 
 //-----------------------------------------------------
 // Stubs for SubscriptionUpdate service
 //-----------------------------------------------------
-val subscriptionUpdateResponse = SubscriptionUpdateResponse("A-S00339056", 28, "89ad8casd9c0asdcaj89sdc98as")
-val subscriptionUpdateResponse2 = SubscriptionUpdateResponse("A-S00339056", -4, "80a23d9sdf9a89fs8cjjk2")
+val subscriptionUpdateResponse = SubscriptionUpdateResponse("A-S00339056", 28, "89ad8casd9c0asdcaj89sdc98as", 20)
+val subscriptionUpdateResponse2 = SubscriptionUpdateResponse("A-S00339056", -4, "80a23d9sdf9a89fs8cjjk2", 10)
 
 //-----------------------------------------------------
 // Stubs for SubscriptionUpdate preview service
@@ -290,10 +292,11 @@ val sfSubscription1 = GetSfSubscriptionResponse(
 val createRecordRequest1 = CreateRecordRequest(
   SF_Subscription__c = "123456",
   Previous_Amount__c = BigDecimal(100),
+  New_Amount__c = BigDecimal(100),
   Previous_Product_Name__c = "previous product name",
   Previous_Rate_Plan_Name__c = "previous rate plan",
   New_Rate_Plan_Name__c = "new rate plan",
   Requested_Date__c = LocalDate.parse("2022-12-08"),
   Effective_Date__c = LocalDate.parse("2022-12-09"),
-  Refund_Amount__c = BigDecimal(50),
+  Paid_Amount__c = BigDecimal(50),
 )

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
@@ -37,6 +37,7 @@ object CreateRecordSpec extends ZIOSpecDefault {
               SalesforceRecordInput(
                 "A-S00102815",
                 10.0000000,
+                10.0000000,
                 "previous product name",
                 "previous rate plan",
                 "new rate plan",
@@ -64,6 +65,7 @@ object CreateRecordSpec extends ZIOSpecDefault {
           output <- Salesforce.createSfRecord(
             SalesforceRecordInput(
               "A-S00102815",
+              BigDecimal(100),
               BigDecimal(100),
               "previous product name",
               "previous rate plan",

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/JsonCodecSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/JsonCodecSpec.scala
@@ -51,15 +51,27 @@ class JsonCodecSpec extends AnyFlatSpec {
     assert(json.fromJson[GetSubscriptionResponse].getOrElse("") == getSubscriptionResponse2)
   }
 
-  it should "Correctly deocde PUT (/v1/subscriptions/$subscriptionNumber/cancel) response with a negative invoice attached" in {
+  it should "Correctly decode PUT (/v1/subscriptions/$subscriptionNumber/cancel) response with a negative invoice attached" in {
     val json = Source.fromResource("zuoraResponses/CancellationResponse1.json").mkString
 
     assert(json.fromJson[CancellationResponse].getOrElse("") == cancellationResponse1)
   }
 
-  it should "Correctly deocde PUT (/v1/subscriptions/$subscriptionNumber/cancel) response without a negative invoice attached" in {
+  it should "Correctly decode PUT (/v1/subscriptions/$subscriptionNumber/cancel) response without a negative invoice attached" in {
     val json = Source.fromResource("zuoraResponses/CancellationResponse2.json").mkString
 
     assert(json.fromJson[CancellationResponse].getOrElse("") == cancellationResponse2)
+  }
+
+  it should "Correctly decode PUT (/v1/subscriptions/$subscriptionNumber) response where user made payment on switch" in {
+    val json = Source.fromResource("zuoraResponses/SubscriptionUpdateResponse1.json").mkString
+
+    assert(json.fromJson[SubscriptionUpdateResponse].getOrElse("") == subscriptionUpdateResponse4)
+  }
+
+  it should "Correctly decode PUT (/v1/subscriptions/$subscriptionNumber) response where user made no payment on switch" in {
+    val json = Source.fromResource("zuoraResponses/SubscriptionUpdateResponse2.json").mkString
+
+    assert(json.fromJson[SubscriptionUpdateResponse].getOrElse("") == subscriptionUpdateResponse5)
   }
 }


### PR DESCRIPTION
## What does this change?

The amount paid/refunded during switch was being incorrected calculated by using the `totalDeltaMrr` property received from the subscription update response from Zuora. This is not reliable for annual subs. Instead, we use the `paidAmount` property present in the response if an amount has been paid upon switch. 

 After discussion, it appears we would have to calculate the refund amount the same way we are doing in the `preview` function, by querying a list of invoices and calculating it manually from that list. This could be done via the `billing-preview` endpoint. However, after further discussion, we have decided to remove any code related to refunds as we believe it's unlikely these will be necessary in the future. As a reminder, refunds are only possible if the customer lowers their price on switch, which is not yet possible in MMA.