### PR TITLE
zuora-rer: return error message from failed path

### DIFF
--- a/handlers/zuora-rer/cfn.yaml
+++ b/handlers/zuora-rer/cfn.yaml
@@ -55,6 +55,13 @@ Resources:
                             Action:
                             - s3:ListBucket
                             Resource: !Sub arn:aws:s3:::${RerResultsBucket}
+                - PolicyName: S3GettPolicy
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action:
+                              - s3:GetObject
+                            Resource: !Sub arn:aws:s3:::${RerResultsBucket}/zuora-results/${Stage}/*
                 - PolicyName: ReadPrivateCredentials
                   PolicyDocument:
                       Statement:

--- a/handlers/zuora-rer/src/main/scala/com/gu/zuora/rer/ZuoraRerHandler.scala
+++ b/handlers/zuora-rer/src/main/scala/com/gu/zuora/rer/ZuoraRerHandler.scala
@@ -31,7 +31,7 @@ case class ZuoraRerHandler(s3Service: S3Service, zuoraRerConfig: ZuoraRerConfig)
     s3Service.checkForResults(requestIdValue, zuoraRerConfig).map {
       case S3CompletedPathFound(resultLocations) =>
         RerStatusResponse(requestIdValue, "Success", Completed, Some(resultLocations))
-      case S3FailedPathFound() => RerStatusResponse(requestIdValue, "Failed path found", Failed)
+      case S3FailedPathFound(message) => RerStatusResponse(requestIdValue, message, Failed)
       case S3NoResultsFound() => RerStatusResponse(requestIdValue, "No results found", Pending)
     }
   }

--- a/handlers/zuora-rer/src/test/scala/com/gu/zuora/rer/S3HelperStub.scala
+++ b/handlers/zuora-rer/src/test/scala/com/gu/zuora/rer/S3HelperStub.scala
@@ -13,7 +13,7 @@ class S3HelperStub(
 
 object S3HelperStub {
   val successfulRerS3ResultResponse: Success[S3CompletedPathFound] = Success(S3CompletedPathFound(List("s3Location")))
-  val failedRerS3ResultResponse: Success[S3FailedPathFound] = Success(S3FailedPathFound())
+  val failedRerS3ResultResponse: Success[S3FailedPathFound] = Success(S3FailedPathFound("Failed path found"))
   val noS3ResultsFoundResponse: Success[S3NoResultsFound] = Success(S3NoResultsFound())
 
   val successfulWriteToS3Response = Right(S3WriteSuccess())


### PR DESCRIPTION
## What does this change?
So that we can display a relevant error message in the Baton UI, the Zuora RER lambda reads and returns the content of the first S3 object it finds in the failed path.  The object should contain the error message written by the Perform RER lambda.

https://trello.com/c/rQSXxLwu/5-assess-and-prioritise-need-to-automate-right-to-erasure-requests-for-data-within-zuora

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
To test in Baton CODE:
- deploy this branch to `zuora-rer` CODE
- populate an account with a test email and an active subscription in Zuora UAT sandbox
- run Baton https://baton.code.dev-gutools.co.uk/   
- submit an RER request including Zuora for the test email
- The request should fail and the comment field (visible in dev tools, but not in HTML) should contain the error message: 
`PreconditionCheckError("Subscription contains a non-erasable status: Active")`
 
![image](https://user-images.githubusercontent.com/46345831/219435335-7fcfdb53-24c6-4d6e-acbd-5cabdb6f4086.png)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
