### PR TITLE
Return error message from `supporter-plus-cancel` endpoint

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointTypes.scala
@@ -28,6 +28,8 @@ object SubscriptionCancelEndpointTypes {
 
   given Schema[Success] = inlineSchema(Schema.derived)
 
+  given Schema[InternalServerError] = inlineSchema(Schema.derived)
+
   given JsonCodec[Success] = DeriveJsonCodec.gen[Success]
   given JsonCodec[InternalServerError] = DeriveJsonCodec.gen[InternalServerError]
   given JsonCodec[OutputBody] = DeriveJsonCodec.gen[OutputBody]


### PR DESCRIPTION
This keeps the design consistent with the `product-move` endpoint. It also allows us to document different error responses in the API documentation.

 This has been tested in DEV.