### PR TITLE
Add dead letter queue to refund lambda

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -183,7 +183,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       VisibilityTimeout: 3000
-      QueueName: !Sub product-switch-refund-queue-${Stage}
+      QueueName: !Sub product-switch-refund-${Stage}
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt RefundDeadLetterQueue.Arn
         maxReceiveCount: 2
@@ -191,7 +191,7 @@ Resources:
   RefundDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub product-switch-refund-dead-letter-queue-${Stage}
+      QueueName: !Sub product-switch-refund-dead-letter-${Stage}
 
   SQSTrigger:
     Type: AWS::Lambda::EventSourceMapping
@@ -294,18 +294,18 @@ Resources:
 
   RefundLambdaFailureAlarm:
     Type: AWS::CloudWatch::Alarm
-    # Condition: IsProd
+    Condition: IsProd
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub An error in the refund lambda. Please check the logs to diagnose and redrive the product-switch-refund-dead-letter-${Stage} SQS queue when ready.
+      AlarmName: !Sub An error in the refund lambda ${Stage}. Please check the logs to diagnose and redrive the product-switch-refund-dead-letter-${Stage} SQS queue when ready.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: QueueName
-          Value: !Ref RefundDeadLetterQueue
-      Period: 60
+          Value: !GetAtt RefundDeadLetterQueue.QueueName
+      Period: 300
       EvaluationPeriods: 1
-      MetricName: NumberOfMessagesReceived
+      MetricName: ApproximateNumberOfMessagesVisible
       Namespace: AWS/SQS
       Statistic: Sum
       Threshold: 1

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -184,6 +184,14 @@ Resources:
     Properties:
       VisibilityTimeout: 3000
       QueueName: !Sub product-switch-refund-${Stage}
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt RefundDeadLetterQueue.Arn
+        maxReceiveCount: 2
+
+  RefundDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub product-switch-refund-dead-letter-${Stage}
 
   SQSTrigger:
     Type: AWS::Lambda::EventSourceMapping
@@ -289,16 +297,16 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub An error in the Refund lambda ${Stage}. Please check the logs to diagnose
+      AlarmName: !Sub An error in the Refund lambda ${Stage} - Dead Letter Queue. Please check the logs to diagnose
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-        - Name: FunctionName
-          Value: !Ref RefundLambda
+        - Name: QueueName
+          Value: !Ref RefundDeadLetterQueue
+      Period: 60
       EvaluationPeriods: 1
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Period: 300
-      Statistic: Sum
+      MetricName: NumberOfMessagesReceived
+      Namespace: AWS/SQS
+      Statistic: Minimum
       Threshold: 1
       TreatMissingData: notBreaching
 

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -306,7 +306,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: NumberOfMessagesReceived
       Namespace: AWS/SQS
-      Statistic: Minimum
+      Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
 

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -271,6 +271,7 @@ Resources:
       EventSourceArn: !GetAtt SalesforceTrackingQueue.Arn
       FunctionName: !Ref SalesforceTrackingLambda
 
+
   # alarms
   ProductMovementFailureAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -183,7 +183,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       VisibilityTimeout: 3000
-      QueueName: !Sub product-switch-refund-${Stage}
+      QueueName: !Sub product-switch-refund-queue-${Stage}
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt RefundDeadLetterQueue.Arn
         maxReceiveCount: 2
@@ -191,7 +191,7 @@ Resources:
   RefundDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub product-switch-refund-dead-letter-${Stage}
+      QueueName: !Sub product-switch-refund-dead-letter-queue-${Stage}
 
   SQSTrigger:
     Type: AWS::Lambda::EventSourceMapping
@@ -293,11 +293,11 @@ Resources:
 
   RefundLambdaFailureAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: IsProd
+    # Condition: IsProd
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub An error in the Refund lambda ${Stage} - Dead Letter Queue. Please check the logs to diagnose
+      AlarmName: !Sub An error in the refund lambda. Please check the logs to diagnose and redrive the product-switch-refund-dead-letter-${Stage} SQS queue when ready.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: QueueName


### PR DESCRIPTION
Adds a dead letter queue to the refund lambda, after the message has been tried and failed twice it will be put in this queue. An alarm will be triggered when a message is added to the queue.