### PR TITLE
Fix `nextPaymentDate` not being calculated for annual subs

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
@@ -122,6 +122,8 @@ case class SubscriptionUpdatePreviewRequest(
     remove: List[RemoveRatePlan],
     preview: Boolean = true,
     targetDate: LocalDate,
+    currentTerm: String = "24",
+    currentTermPeriodType: String = "Month",
 )
 case class SubscriptionUpdatePreviewResponse(invoice: SubscriptionUpdateInvoice)
 case class SubscriptionUpdateInvoiceItem(


### PR DESCRIPTION
## What does this change?

When attempting to calculate the `nextPaymentDate` for annual subscriptions, an error occurs because only the invoice item for the current term (12 months) is obtained. As a result, we are unable to access the next invoice needed to determine the `nextPaymentDate`. To address this issue, we have developed a workaround by adjusting the `currentTerm` property in the API call to 24 months. This enables us to retrieve two invoices for annual subscriptions that span two years, providing us with the necessary information to accurately calculate the `nextPaymentDate`.

Tested in DEV.