### PR TITLE
fix: change dataProvider to zuorasar to match baton request

### DIFF
--- a/handlers/zuora-rer/src/test/scala/com/gu/zuora/rer/CirceCodecsSpec.scala
+++ b/handlers/zuora-rer/src/test/scala/com/gu/zuora/rer/CirceCodecsSpec.scala
@@ -50,7 +50,7 @@ class CirceCodecsSpec extends AnyFreeSpec with Matchers {
       val jsonRequest =
         """{
           |"initiationReference": "someRequestId",
-          |"dataProvider" : "zuora",
+          |"dataProvider" : "zuorarer",
           |"requestType": "RER",
           |"action" : "status"
           |}

--- a/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/CirceCodecs.scala
+++ b/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/CirceCodecs.scala
@@ -27,7 +27,7 @@ object circeCodecs {
       def dataProviderIsZuora(cursor: HCursor): Boolean =
         cursor.downField("dataProvider").as[String] match {
           case Left(_) => false
-          case Right(dataProvider) => dataProvider == "zuora"
+          case Right(dataProvider) => dataProvider == "zuorasar"
         }
 
       cursor.downField("action").as[String].flatMap {
@@ -44,7 +44,7 @@ object circeCodecs {
     response
       .add("action", action.asJson)
       .add("requestType", "SAR".asJson)
-      .add("dataProvider", "zuora".asJson)
+      .add("dataProvider", "zuorasar".asJson)
       .asJson
 
   implicit val batonTaskStatusEncoder: Encoder[BatonTaskStatus] =

--- a/handlers/zuora-sar/src/test/scala/com/gu/zuora/sar/CirceCodecsSpec.scala
+++ b/handlers/zuora-sar/src/test/scala/com/gu/zuora/sar/CirceCodecsSpec.scala
@@ -30,7 +30,7 @@ class CirceCodecsSpec extends AnyFreeSpec with Matchers {
         """{
           |"subjectId": "",
           |"subjectEmail" : "testSubjectEmail",
-          |"dataProvider" : "zuora",
+          |"dataProvider" : "zuorasar",
           |"requestType": "SAR",
           |"action" : "initiate"
           |}
@@ -61,7 +61,7 @@ class CirceCodecsSpec extends AnyFreeSpec with Matchers {
       val jsonRequest =
         """{
           |"initiationReference": "someRequestId",
-          |"dataProvider" : "zuora",
+          |"dataProvider" : "zuorasar",
           |"requestType": "SAR",
           |"action" : "status"
           |}
@@ -78,7 +78,7 @@ class CirceCodecsSpec extends AnyFreeSpec with Matchers {
         """{
           |"initiationReference": "someRequestId",
           |"subjectEmail": "testSubjectEmail",
-          |"dataProvider" : "zuora",
+          |"dataProvider" : "zuorasar",
           |"requestType" : "SAR",
           |"action" : "perform"
           |}
@@ -91,7 +91,7 @@ class CirceCodecsSpec extends AnyFreeSpec with Matchers {
       val response: SarResponse = SarInitiateResponse("someRequestId")
       response.asJson.printWith(
         jsonPrinter,
-      ) shouldBe """{"initiationReference":"someRequestId","action":"initiate","requestType":"SAR","dataProvider":"zuora"}"""
+      ) shouldBe """{"initiationReference":"someRequestId","action":"initiate","requestType":"SAR","dataProvider":"zuorasar"}"""
     }
 
     "should encode completed SarStatusResponse correctly" in {
@@ -101,21 +101,21 @@ class CirceCodecsSpec extends AnyFreeSpec with Matchers {
       )
       response.asJson.printWith(
         jsonPrinter,
-      ) shouldBe """{"status":"completed","resultLocations":["locationValue"],"action":"status","requestType":"SAR","dataProvider":"zuora"}"""
+      ) shouldBe """{"status":"completed","resultLocations":["locationValue"],"action":"status","requestType":"SAR","dataProvider":"zuorasar"}"""
     }
 
     "should encode pending SarStatusResponse correctly" in {
       val response: SarResponse = SarStatusResponse(status = Pending)
       response.asJson.printWith(
         jsonPrinter,
-      ) shouldBe """{"status":"pending","action":"status","requestType":"SAR","dataProvider":"zuora"}"""
+      ) shouldBe """{"status":"pending","action":"status","requestType":"SAR","dataProvider":"zuorasar"}"""
     }
 
     "should encode failed SarStatusResponse correctly" in {
       val response: SarResponse = SarStatusResponse(status = Failed, None, Some("error making request"))
       response.asJson.printWith(
         jsonPrinter,
-      ) shouldBe """{"status":"failed","message":"error making request","action":"status","requestType":"SAR","dataProvider":"zuora"}"""
+      ) shouldBe """{"status":"failed","message":"error making request","action":"status","requestType":"SAR","dataProvider":"zuorasar"}"""
     }
   }
 }


### PR DESCRIPTION
## What does this change?
A string identifier is used to match the `dataProvider` field in requests from Baton to perform Subject Access Requests against Zuora.

Originally Baton sent `zuora`, but with the recent advent of the Zuora Right to Erasure Request (ZuoraRER) handler, Baton now sends `zuorasar`.

Since merging the Baton changes for ZuoraRER, the SAR handler has given json parsing errors:
```
{"errorMessage":"assertion failed","errorType":"java.lang.AssertionError","stackTrace":["scala.Predef$.assert(Predef.scala:264)","scala.Predef$Ensuring$.ensuring$extension(Predef.scala:357)","com.gu.zuora.sar.circeCodecs$.$anonfun$sarRequestDecoder$2(CirceCodecs.scala:35)"....}
```

Change is to expect `dataProvider="zuorasar"` in Baton requests.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
