### PR TITLE
fix: Baton/Zuora Right to Erasure unhandled cases

### DIFF
--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -57,7 +57,6 @@ object BillingAccountRemover extends App with LazyLogging {
   // Zuora
   case class BillingAccountsForRemoval(
       CrmId: String = "",
-      Status: String = "Canceled",
   )
   case class Errors(Code: String, Message: String)
   case class ZuoraResponse(Success: Boolean, Errors: Seq[Errors])

--- a/handlers/zuora-rer/src/main/scala/com/gu/zuora/rer/S3Helper.scala
+++ b/handlers/zuora-rer/src/main/scala/com/gu/zuora/rer/S3Helper.scala
@@ -2,8 +2,7 @@ package com.gu.zuora.rer
 
 import java.util.UUID.randomUUID
 import com.typesafe.scalalogging.LazyLogging
-import com.gu.effects.{BucketName, CopyS3Objects, GetFromS3, Key, ListS3Objects, S3Location, S3Path, UploadToS3}
-import cats.syntax.traverse._
+import com.gu.effects.{BucketName, GetFromS3, Key, ListS3Objects, S3Location, S3Path, UploadToS3}
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 
 import scala.util.{Failure, Success, Try}

--- a/handlers/zuora-rer/src/main/scala/com/gu/zuora/rer/ZuoraRerService.scala
+++ b/handlers/zuora-rer/src/main/scala/com/gu/zuora/rer/ZuoraRerService.scala
@@ -63,7 +63,9 @@ case class ZuoraRerService(zuoraClient: Requests, zuoraQuerier: ZuoraQuerier) ex
         "crmId" -> "",
         "sfContactId__c" -> "",
         "IdentityId__c" -> "",
-        "autoPay" -> false
+        "autoPay" -> false,
+        "invoiceDeliveryPrefsEmail" -> false,
+        "invoiceDeliveryPrefsPrint" -> false,
       ),
       RelativePath(s"accounts/$accountId")
     )

--- a/handlers/zuora-rer/src/test/scala/com/gu/zuora/rer/ZuoraRerServiceSpec.scala
+++ b/handlers/zuora-rer/src/test/scala/com/gu/zuora/rer/ZuoraRerServiceSpec.scala
@@ -48,8 +48,10 @@ class ZuoraRerServiceSpec extends AnyFlatSpec with Matchers {
   val accountResponseZeroBalances = "/accounts/1234567" -> HTTPResponse(
     200,
     """{"success": true,
-      | "basicInfo": {"accountNumber": "abc-123"},
-      | "metrics": {"balance": "0.00", "creditBalance": "0.00", "totalInvoiceBalance": "0.00"}
+      | "basicInfo": {"accountNumber": "abc-123", "status": "Active", "id": "1234567"},
+      | "metrics": {"balance": "0.00", "creditBalance": "0.00", "totalInvoiceBalance": "0.00"},
+      | "billToContact": {"id": "2345678"},
+      | "soldToContact": {"id": "3456789"}
       |}""".stripMargin
   )
 
@@ -66,8 +68,10 @@ class ZuoraRerServiceSpec extends AnyFlatSpec with Matchers {
   val accountResponseOutstandingBalances = "/accounts/1234567" -> HTTPResponse(
     200,
     """{"success": true,
-      | "basicInfo": {"accountNumber": "abc-123"},
-      | "metrics": {"balance": "10.37", "creditBalance": "0.00", "totalInvoiceBalance": "-3.45"}
+      | "basicInfo": {"accountNumber": "abc-123", "status": "Active", "id": "1234567"},
+      | "metrics": {"balance": "10.37", "creditBalance": "0.00", "totalInvoiceBalance": "-3.45"},
+      | "billToContact": {"id": "2345678"},
+      | "soldToContact": {"id": "3456789"}
       |}""".stripMargin
   )
 


### PR DESCRIPTION
## What does this change?
The Zuora erasure process called from Lambda has recently been introduced and this PR adds support for some unhandled cases that were causing the process to fail:
1) the Zuora Customer Account has been left in a Cancelled state (by the Salesforce erasure process).  This meant that the API update to scrub the personal data failed.
2) email billing contact preference has been set.  This meant that the removal of the contact email address failed.

This change includes:
- zuora-rer: a new step to check that the account is Active and re-activate if not.
- zuora-rer: scrubAccount resets the billing contact preferences.
- sf-billing-account-remover: don't cancel the Zuora account.

https://trello.com/c/PUrodiki/114-baton-zuora-erasure-handle-cancelled-customer-account

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Test successfully as below:
- Deploy the branch to CODE.
- In Zuora UAT sandbox, add an account with a dummy email address
- Set email invoice setting to true in billing settings
- Cancel the account
- Go into Baton and create an RER for the email
- The Zuora erasure should run successfully, scrub the account and leave it in an Active state

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
