### PR TITLE
soft-opt-in-consent-setter: add support for in-app purchases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -395,7 +395,7 @@ lazy val `sf-billing-account-remover` = lambdaProject(
 lazy val `soft-opt-in-consent-setter` = lambdaProject(
   "soft-opt-in-consent-setter",
   "sets or unsets soft opt in consents dependent on subscription product",
-  Seq(awsSecretsManager, circe, circeParser, scalatest, scalajHttp, awsS3, simpleConfig) ++ logging
+  Seq(awsSecretsManager, circe, circeParser, scalatest, scalajHttp, awsS3, simpleConfig, awsLambda, awsSQS, awsEvents) ++ logging
 ).dependsOn(`effects-s3`, `effects-cloudwatch`, `salesforce-core`)
 
 lazy val `sf-emails-to-s3-exporter` = lambdaProject(

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -16,18 +16,21 @@ Mappings:
       Schedule: 'rate(30 minutes)'
       SalesforceStage: PROD
       IdentityStage: PROD
+      MpapiStage: PROD
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: TouchpointUpdate
     CODE:
       Schedule: 'rate(365 days)'
       SalesforceStage: CODE
       IdentityStage: CODE
+      MpapiStage: CODE
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: AwsConnectorSandbox
     DEV:
       Schedule: 'rate(365 days)'
       SalesforceStage: DEV
       IdentityStage: CODE
+      MpapiStage: CODE
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: AwsConnectorSandbox
 
@@ -90,6 +93,14 @@ Resources:
             !Sub
             - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken}}'
             - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+          mpapiUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${MpapiStage}/MobilePurchasesAPI/User/asdfasdfa:SecretString:mpapiUrl}}'
+            - MpapiStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+          mpapiToken:
+            !Sub
+            - '{{resolve:secretsmanager:${MpapiStage}/MobilePurchasesAPI/User/asdfasdf:SecretString:mpapiToken}}'
+            - MpapiStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
       Events:
         ScheduledRun:
           Type: Schedule
@@ -234,13 +245,38 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to run
       AlarmDescription: >
-        Two or more runs found an error and were unable to complete.
+        Five or more runs found an error and were unable to complete.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm
         for possible causes, impacts and fixes.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
           Value: !Ref LambdaFunction
+      EvaluationPeriods: 2
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 3600
+      Statistic: Sum
+      Threshold: 5
+      TreatMissingData: notBreaching
+
+  failedRunAlarmIAP:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn:
+      - LambdaFunction
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+      AlarmName: !Sub soft-opt-in-consent-setter-IAP-${Stage} failed to run
+      AlarmDescription: >
+        Five or more runs found an error and were unable to complete.
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm
+        for possible causes, impacts and fixes.
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref LambdaFunctionIAP
       EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -191,6 +191,13 @@ Resources:
               Action: s3:GetObject
               Resource:
                 - arn:aws:s3::*:membership-dist/*
+        - Statement:
+            Effect: Allow
+            Action:
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+              - sqs:ReceiveMessage
+            Resource: "*"
 
   SoftOptInsQueue:
     Type: AWS::SQS::Queue

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -93,14 +93,6 @@ Resources:
             !Sub
             - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken}}'
             - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
-          mpapiUrl:
-            !Sub
-            - '{{resolve:secretsmanager:${MpapiStage}/MobilePurchasesAPI/User/asdfasdfa:SecretString:mpapiUrl}}'
-            - MpapiStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
-          mpapiToken:
-            !Sub
-            - '{{resolve:secretsmanager:${MpapiStage}/MobilePurchasesAPI/User/asdfasdf:SecretString:mpapiToken}}'
-            - MpapiStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
       Events:
         ScheduledRun:
           Type: Schedule
@@ -179,6 +171,14 @@ Resources:
             !Sub
             - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken}}'
             - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+          mpapiUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${MpapiStage}/MobilePurchasesAPI/User/GetSubscriptions:SecretString:mpapiUrl}}'
+            - MpapiStage: !FindInMap [ StageMap, !Ref Stage, MpapiStage ]
+          mpapiToken:
+            !Sub
+            - '{{resolve:secretsmanager:${MpapiStage}/MobilePurchasesAPI/User/GetSubscriptions:SecretString:mpapiToken}}'
+            - MpapiStage: !FindInMap [ StageMap, !Ref Stage, MpapiStage ]
       Policies:
         - Statement:
             - Effect: Allow

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -179,13 +179,6 @@ Resources:
             !Sub
             - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken}}'
             - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
-      Events:
-        ScheduledRun:
-          Type: Schedule
-          Properties:
-            Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule ]
-            Description: Runs Soft Opt-In Consent Setter
-            Enabled: True
       Policies:
         - Statement:
             - Effect: Allow

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -33,6 +33,7 @@ Mappings:
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
+  IsDev: !Equals [ !Ref Stage, DEV ]
 
 Resources:
   LambdaFunction:
@@ -112,6 +113,109 @@ Resources:
               Action: s3:GetObject
               Resource:
                 - arn:aws:s3::*:membership-dist/*
+
+  LambdaFunctionIAP:
+    Type: AWS::Serverless::Function
+    Condition: IsDev
+    Properties:
+      Description: Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation of Subscriptions in Salesforce
+      FunctionName: !Sub soft-opt-in-consent-setter-IAP-${Stage}
+      Handler: com.gu.soft_opt_in_consent_setter.HandlerIAP::handleRequest
+      CodeUri:
+        Bucket: support-service-lambdas-dist
+        Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
+      MemorySize: 512
+      Runtime: java11
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          sfApiVersion: v46.0
+          sfAuthUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+          sfClientId:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientId}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+          sfClientSecret:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:clientSecret}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              AppName: !FindInMap [ StageMap, !Ref Stage, AppName ]
+          sfPassword:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          sfToken:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          sfUsername:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          identityUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityUrl}}'
+            - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+          identityToken:
+            !Sub
+            - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken}}'
+            - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+      Events:
+        ScheduledRun:
+          Type: Schedule
+          Properties:
+            Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule ]
+            Description: Runs Soft Opt-In Consent Setter
+            Enabled: True
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action: s3:GetObject
+              Resource:
+                - !Sub arn:aws:s3:::soft-opt-in-consent-setter/${Stage}/ConsentsByProductMapping.json
+        - Statement:
+            - Effect: Allow
+              Action: cloudwatch:PutMetricData
+              Resource: "*"
+        - Statement:
+            - Sid: readDeployedArtefact
+              Effect: Allow
+              Action: s3:GetObject
+              Resource:
+                - arn:aws:s3::*:membership-dist/*
+
+  SoftOptInsQueue:
+    Type: AWS::SQS::Queue
+    Condition: IsDev
+    Properties:
+      VisibilityTimeout: 3000
+      QueueName: !Sub soft-opt-in-consent-setter-queue-${Stage}
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt SoftOptInsDeadLetterQueue.Arn
+        maxReceiveCount: 3
+
+  SoftOptInsDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Condition: IsDev
+    Properties:
+      QueueName: !Sub soft-opt-in-consent-setter-dead-letter-queue-${Stage}
+
+  SQSTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    Condition: IsDev
+    Properties:
+      BatchSize: 1
+      Enabled: true
+      EventSourceArn: !GetAtt SoftOptInsQueue.Arn
+      FunctionName: !Ref LambdaFunctionIAP
 
   failedRunAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -201,7 +201,7 @@ Resources:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
               - sqs:ReceiveMessage
-            Resource: "*"
+            Resource: !GetAtt SoftOptInsQueue.Arn
 
   SoftOptInsQueue:
     Type: AWS::SQS::Queue

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -132,7 +132,7 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-          sfApiVersion: v46.0
+          sfApiVersion: v56.0
           sfAuthUrl:
             !Sub
             - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${AppName}:SecretString:authUrl}}'

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -256,8 +256,6 @@ Resources:
   failedRunAlarmIAP:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
-    DependsOn:
-      - LambdaFunction
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
@@ -268,12 +266,12 @@ Resources:
         for possible causes, impacts and fixes.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-        - Name: FunctionName
-          Value: !Ref LambdaFunctionIAP
-      EvaluationPeriods: 2
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Period: 3600
+        - Name: QueueName
+          Value: !GetAtt SoftOptInsDeadLetterQueue.QueueName
+      Period: 300
+      EvaluationPeriods: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
       Statistic: Sum
       Threshold: 5
       TreatMissingData: notBreaching

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -121,7 +121,7 @@ Resources:
     Type: AWS::Serverless::Function
     Condition: IsDev
     Properties:
-      Description: Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation of Subscriptions in Salesforce
+      Description: Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation of Subscriptions based on a queue populated by Salesforce and the Mobile Purchases API
       FunctionName: !Sub soft-opt-in-consent-setter-IAP-${Stage}
       Handler: com.gu.soft_opt_in_consent_setter.HandlerIAP::handleRequest
       CodeUri:

--- a/handlers/soft-opt-in-consent-setter/riff-raff.yaml
+++ b/handlers/soft-opt-in-consent-setter/riff-raff.yaml
@@ -18,5 +18,5 @@ deployments:
       prefixStack: false
       functionNames:
         - soft-opt-in-consent-setter-
-        - soft-opt-in-consent-setter-iap-
+        - soft-opt-in-consent-setter-IAP-
     dependencies: [ cfn ]

--- a/handlers/soft-opt-in-consent-setter/riff-raff.yaml
+++ b/handlers/soft-opt-in-consent-setter/riff-raff.yaml
@@ -18,4 +18,5 @@ deployments:
       prefixStack: false
       functionNames:
         - soft-opt-in-consent-setter-
+        - soft-opt-in-consent-setter-iap-
     dependencies: [ cfn ]

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculator.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculator.scala
@@ -13,8 +13,7 @@ class ConsentsCalculator(consentsMappings: Map[String, Set[String]]) {
       .get(productName)
       .toRight(
         SoftOptInError(
-          "ConsentsCalculator",
-          s"getSoftOptInsByProduct couldn't find $productName in consentsMappings",
+          s"ConsentsCalculator: getSoftOptInsByProduct couldn't find $productName in consentsMappings",
         ),
       )
   }
@@ -26,8 +25,7 @@ class ConsentsCalculator(consentsMappings: Map[String, Set[String]]) {
           .get(ownedProductName)
           .toRight(
             SoftOptInError(
-              "ConsentsCalculator",
-              s"getSoftOptInsByProducts couldn't find $ownedProductName in consentsMappings",
+              s"ConsentsCalculator: getSoftOptInsByProducts couldn't find $ownedProductName in consentsMappings",
             ),
           )
           .flatMap(productConsents => acc.map(_.union(productConsents)))
@@ -44,8 +42,7 @@ class ConsentsCalculator(consentsMappings: Map[String, Set[String]]) {
           .get(ownedProductName)
           .toRight(
             SoftOptInError(
-              "ConsentsCalculator",
-              s"getCancellationConsents couldn't find $ownedProductName in consentsMappings",
+              s"ConsentsCalculator: getCancellationConsents couldn't find $ownedProductName in consentsMappings",
             ),
           )
           .flatMap(productConsents => acc.map(_.union(productConsents)))
@@ -55,8 +52,7 @@ class ConsentsCalculator(consentsMappings: Map[String, Set[String]]) {
           .get(cancelledProductName)
           .toRight(
             SoftOptInError(
-              "ConsentsCalculator",
-              s"getCancellationConsents couldn't find $cancelledProductName in consentsMappings",
+              s"ConsentsCalculator: getCancellationConsents couldn't find $cancelledProductName in consentsMappings",
             ),
           )
           .flatMap(cancelledProductConsents => Right(cancelledProductConsents.diff(ownedProductConsents)))

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -70,8 +70,8 @@ object Handler extends LazyLogging {
     } yield ()).flatten.left
       .foreach(error => {
         Metrics.put(event = "failed_run")
-        logger.error(s"${error.errorType}: ${error.errorDetails}")
-        throw new Exception(s"Run failed due to ${error.errorType}: ${error.errorDetails}")
+        logger.error(s"${error.getMessage}")
+        throw new Exception(s"Run failed due to ${error.getMessage}")
       })
   }
 
@@ -150,8 +150,7 @@ object Handler extends LazyLogging {
           ratePlanUpdates <- sub.Subscription_Rate_Plan_Updates__r
             .toRight(
               SoftOptInError(
-                "processProductSwitchSubs",
-                s"Subscription ${sub.Name} Subscription_Rate_Plan_Updates__r is null",
+                s"processProductSwitchSubs: Subscription ${sub.Name} Subscription_Rate_Plan_Updates__r is null",
               ),
             )
           consentsBody <- buildProductSwitchConsents(
@@ -231,7 +230,7 @@ object Handler extends LazyLogging {
   }
 
   def logErrors(updateResults: Either[SoftOptInError, Unit]): Unit = {
-    updateResults.left.foreach(error => logger.warn(s"${error.errorType}: ${error.errorDetails}"))
+    updateResults.left.foreach(error => logger.warn(s"${error.getMessage}"))
   }
 
   def emitIdentityMetrics(records: Seq[SFSubRecordUpdate]): Unit = {

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -11,7 +11,7 @@ import io.circe.syntax._
 
 import scala.jdk.CollectionConverters._
 
-object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
+class HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
 
   val readyToProcessAcquisitionStatus = "Ready to process acquisition"
   val readyToProcessCancellationStatus = "Ready to process cancellation"

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -227,5 +227,4 @@ class HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       case Right(_) => Metrics.put(event = "successful_consents_updates", 1)
     }
   }
-
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -1,104 +1,117 @@
 package com.gu.soft_opt_in_consent_setter
 
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.gu.soft_opt_in_consent_setter.models._
 import com.typesafe.scalalogging.LazyLogging
+import io.circe.{Decoder, ParsingFailure}
+import io.circe.parser.{decode => circeDecode}
 import io.circe.generic.auto._
 import io.circe.syntax._
 
-object HandlerIAP extends LazyLogging {
+import scala.jdk.CollectionConverters._
+
+object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
 
   val readyToProcessAcquisitionStatus = "Ready to process acquisition"
   val readyToProcessCancellationStatus = "Ready to process cancellation"
   val readyProcessSwitchStatus = "Ready to process switch"
+  case class MessageBody(
+      identityId: String,
+      eventType: String,
+      productType: String,
+      previousProductType: Option[String],
+  )
 
-  def main(args: Array[String]): Unit = {
-    handleRequest()
+  private def handleError[T <: Exception](exception: T) = {
+    Metrics.put(event = "failed_run")
+    logger.error(s"${exception.getMessage}")
+    throw exception
   }
 
-  def handleRequest(): Unit = {
-    (for {
-      config <- SoftOptInConfig()
-    } yield for {
-      sfConnector <- SalesforceConnector(config.sfConfig, config.sfApiVersion)
-
-      _ = logger.info(s"About to fetch subs to process from Salesforce")
-      allSubs <- sfConnector.getSubsToProcess()
-      _ = logger.info(
-        s"Successfully fetched ${allSubs.records.length} subs from Salesforce",
+  override def handleRequest(input: SQSEvent, context: Context): Unit = {
+    val messages =
+      input.getRecords.asScala.toList.map(message =>
+        circeDecode[MessageBody](message.getBody) match {
+          case Left(pf: ParsingFailure) =>
+            val exception = SoftOptInError(
+              s"Error '${pf.message}' when decoding JSON to MessageBody with cause :${pf.getCause} with body: ${message.getBody}",
+            )
+            handleError(exception)
+          case Left(_) =>
+            val exception =
+              SoftOptInError(s"Unknown error when decoding JSON to MessageBody with body: ${message.getBody}")
+            handleError(exception)
+          case Right(result) => result
+        },
       )
+
+    val setup = for {
+      config <- SoftOptInConfig()
+      sfConnector <- SalesforceConnector(config.sfConfig, config.sfApiVersion)
 
       identityConnector = new IdentityConnector(config.identityConfig)
       consentsCalculator = new ConsentsCalculator(config.consentsMapping)
+      mpapiConnector = new MpapiConnector(config.mpapiConfig)
+    } yield (sfConnector, identityConnector, consentsCalculator, mpapiConnector)
 
-      acqSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyToProcessAcquisitionStatus))
-      _ <- processAcquiredSubs(acqSubs, identityConnector.sendConsentsReq, sfConnector.updateSubs, consentsCalculator)
+    val (sfConnector, identityConnector, consentsCalculator, mpapiConnector) = setup match {
+      case Left(error) => handleError(error)
+      case Right(x) => x
+    }
 
-      cancelledSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyToProcessCancellationStatus))
-      cancelledSubsIdentityIds = cancelledSubs.map(sub => sub.Buyer__r.IdentityID__c)
+    messages.foreach { message =>
+      val result = message.eventType match {
+        case "Acquisition" =>
+          processAcquiredSub(
+            message,
+            identityConnector.sendConsentsReq,
+            consentsCalculator,
+          )
+        case "Cancellation" =>
+          processCancelledSub(
+            message,
+            identityConnector.sendConsentsReq,
+            mpapiConnector.getMobileSubscriptions,
+            consentsCalculator,
+            sfConnector,
+          )
+        case "Switch" =>
+          processProductSwitchSub(
+            message,
+            identityConnector.sendConsentsReq,
+            mpapiConnector.getMobileSubscriptions,
+            consentsCalculator,
+            sfConnector,
+          )
+      }
 
-      productSwitchSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyProcessSwitchStatus))
-      productSwitchSubIdentityIds = productSwitchSubs.map(sub => sub.Buyer__r.IdentityID__c)
+      result match {
+        case Left(error) => handleError(error)
+      }
+    }
 
-      _ = logger.info(s"About to fetch active subs from Salesforce")
-      activeSubs <- sfConnector.getActiveSubs((cancelledSubsIdentityIds ++ productSwitchSubIdentityIds).distinct)
-      _ = logger.info(s"Successfully fetched ${activeSubs.records.length} active subs from Salesforce")
-
-      _ <- processProductSwitchSubs(
-        productSwitchSubs,
-        activeSubs,
-        identityConnector.sendConsentsReq,
-        sfConnector.updateSubs,
-        consentsCalculator,
-      )
-
-      _ <- processCancelledSubs(
-        cancelledSubs,
-        activeSubs,
-        identityConnector.sendConsentsReq,
-        sfConnector.updateSubs,
-        consentsCalculator,
-      )
-      _ = Metrics.put(event = "successful_run")
-    } yield ()).flatten.left
-      .foreach(error => {
-        Metrics.put(event = "failed_run")
-        logger.error(s"${error.errorType}: ${error.errorDetails}")
-        throw new Exception(s"Run failed due to ${error.errorType}: ${error.errorDetails}")
-      })
+    Metrics.put(event = "successful_run")
   }
 
-  def processAcquiredSubs(
-      acquiredSubs: Seq[SFSubRecord],
+  def processAcquiredSub(
+      message: MessageBody,
       sendConsentsReq: (String, String) => Either[SoftOptInError, Unit],
-      updateSubs: String => Either[SoftOptInError, Unit],
       consentsCalculator: ConsentsCalculator,
   ): Either[SoftOptInError, Unit] = {
-    Metrics.put(event = "acquisitions_to_process", acquiredSubs.size)
+    Metrics.put(event = "acquisitions_to_process", 1)
 
-    val recordsToUpdate = acquiredSubs
-      .map(sub => {
-        val updateResult =
-          for {
-            consents <- consentsCalculator.getSoftOptInsByProduct(sub.Product__c)
-            consentsBody = consentsCalculator.buildConsentsBody(consents, state = true)
-            _ <- sendConsentsReq(sub.Buyer__r.IdentityID__c, consentsBody)
-          } yield ()
+    val updateResult =
+      for {
+        consents <- consentsCalculator.getSoftOptInsByProduct(message.productType)
+        consentsBody = consentsCalculator.buildConsentsBody(consents, state = true)
+        _ <- sendConsentsReq(message.identityId, consentsBody)
+      } yield ()
 
-        logErrors(updateResult)
+    logErrors(updateResult)
+    emitIdentityMetrics(updateResult)
 
-        SFSubRecordUpdate(
-          sub,
-          "Acquisition",
-          updateResult,
-        )
-      })
-
-    emitIdentityMetrics(recordsToUpdate)
-
-    if (recordsToUpdate.isEmpty)
-      Right(())
-    else
-      updateSubs(SFSubRecordUpdateRequest(recordsToUpdate).asJson.spaces2)
+    updateResult
   }
 
   def buildProductSwitchConsents(
@@ -124,60 +137,51 @@ object HandlerIAP extends LazyLogging {
     } yield consentsBody
   }
 
-  def processProductSwitchSubs(
-      productSwitchSubs: Seq[SFSubRecord],
-      activeSubs: SFAssociatedSubResponse,
+  def processProductSwitchSub(
+      messageBody: MessageBody,
       sendConsentsReq: (String, String) => Either[SoftOptInError, Unit],
-      updateSubs: String => Either[SoftOptInError, Unit],
+      getMobileSubscriptions: String => Either[SoftOptInError, MobileSubscriptions],
       consentsCalculator: ConsentsCalculator,
+      sfConnector: SalesforceConnector,
   ): Either[SoftOptInError, Unit] = {
-    Metrics.put(event = "product_switches_to_process", productSwitchSubs.size)
+    Metrics.put(event = "product_switches_to_process", 1)
 
-    val recordsToUpdate = productSwitchSubs
-      .map(EnhancedSub(_, activeSubs.records))
-      .map(rec => {
-        import rec._
+    val updateResult = for {
+      previousProductType <- messageBody.previousProductType.toRight(
+        SoftOptInError("Missing data: Product switch event is missing previousProductType property"),
+      )
 
-        val updateResult = for {
-          ratePlanUpdates <- sub.Subscription_Rate_Plan_Updates__r
-            .toRight(
-              SoftOptInError(
-                "processProductSwitchSubs",
-                s"Subscription ${sub.Name} Subscription_Rate_Plan_Updates__r is null",
-              ),
-            )
-          consentsBody <- buildProductSwitchConsents(
-            ratePlanUpdates.records.head.Previous_Product_Name__c,
-            sub.Product__c,
-            associatedActiveNonGiftSubs.map(_.Product__c).toSet,
-            consentsCalculator,
-          )
-          res <- sendConsentsReq(sub.Buyer__r.IdentityID__c, consentsBody)
-        } yield res
+      mobileSubscriptionsResponse <- getMobileSubscriptions(messageBody.identityId)
+      activeSubs <- sfConnector.getActiveSubs(Seq(messageBody.identityId))
 
-        logErrors(updateResult)
+      hasMobileSub = mobileSubscriptionsResponse.subscriptions
+        .filter(_.valid)
+        .headOption
+        .map(_ => "Recurring Support")
+      productTypes = activeSubs.records.map(_.Product__c) ++ hasMobileSub
 
-        SFSubRecordUpdate(
-          sub,
-          "Switch",
-          updateResult,
-        )
-      })
+      consentsBody <- buildProductSwitchConsents(
+        previousProductType,
+        messageBody.productType,
+        productTypes.toSet,
+        consentsCalculator,
+      )
 
-    emitIdentityMetrics(recordsToUpdate)
+      res <- sendConsentsReq(messageBody.identityId, consentsBody)
+    } yield res
 
-    if (recordsToUpdate.isEmpty)
-      Right(())
-    else
-      updateSubs(SFSubRecordUpdateRequest(recordsToUpdate).asJson.spaces2)
+    logErrors(updateResult)
+    emitIdentityMetrics(updateResult)
+
+    updateResult
   }
 
-  def processCancelledSubs(
-      cancelledSubs: Seq[SFSubRecord],
-      activeSubs: SFAssociatedSubResponse,
+  def processCancelledSub(
+      messageBody: MessageBody,
       sendConsentsReq: (String, String) => Either[SoftOptInError, Unit],
-      updateSubs: String => Either[SoftOptInError, Unit],
+      getMobileSubscriptions: String => Either[SoftOptInError, MobileSubscriptions],
       consentsCalculator: ConsentsCalculator,
+      sfConnector: SalesforceConnector,
   ): Either[SoftOptInError, Unit] = {
     def sendCancellationConsents(identityId: String, consents: Set[String]): Either[SoftOptInError, Unit] = {
       if (consents.nonEmpty)
@@ -189,50 +193,40 @@ object HandlerIAP extends LazyLogging {
         Right(())
     }
 
-    Metrics.put(event = "cancellations_to_process", cancelledSubs.size)
+    Metrics.put(event = "cancellations_to_process", 1)
 
-    val recordsToUpdate = cancelledSubs
-      .map(EnhancedSub(_, activeSubs.records))
-      .map(rec => {
-        import rec._
+    val updateResult = for {
+      mobileSubscriptionsResponse <- getMobileSubscriptions(messageBody.identityId)
+      activeSubs <- sfConnector.getActiveSubs(Seq(messageBody.identityId))
 
-        val updateResult =
-          for {
-            consents <- consentsCalculator.getCancellationConsents(
-              sub.Product__c,
-              associatedActiveNonGiftSubs.map(_.Product__c).toSet,
-            )
-            _ <- sendCancellationConsents(sub.Buyer__r.IdentityID__c, consents)
-          } yield ()
+      hasMobileSub = mobileSubscriptionsResponse.subscriptions
+        .filter(_.valid)
+        .headOption
+        .map(_ => "Recurring Support")
+      productTypes = activeSubs.records.map(_.Product__c) ++ hasMobileSub
 
-        logErrors(updateResult)
+      consents <- consentsCalculator.getCancellationConsents(
+        messageBody.productType,
+        productTypes.toSet,
+      )
+      _ <- sendCancellationConsents(messageBody.identityId, consents)
+    } yield ()
 
-        SFSubRecordUpdate(
-          sub,
-          "Cancellation",
-          updateResult,
-        )
-      })
+    logErrors(updateResult)
+    emitIdentityMetrics(updateResult)
 
-    emitIdentityMetrics(recordsToUpdate)
-
-    if (recordsToUpdate.isEmpty)
-      Right(())
-    else
-      updateSubs(SFSubRecordUpdateRequest(recordsToUpdate).asJson.spaces2)
+    updateResult
   }
 
   def logErrors(updateResults: Either[SoftOptInError, Unit]): Unit = {
-    updateResults.left.foreach(error => logger.warn(s"${error.errorType}: ${error.errorDetails}"))
+    updateResults.left.foreach(error => logger.warn(s"${error.getMessage}"))
   }
 
-  def emitIdentityMetrics(records: Seq[SFSubRecordUpdate]): Unit = {
-    // Soft_Opt_in_Number_of_Attempts__c == 0 means the consents were set successfully
-    val successfullyUpdated = records.count(_.Soft_Opt_in_Number_of_Attempts__c == 0)
-    val unsuccessfullyUpdated = records.count(_.Soft_Opt_in_Number_of_Attempts__c > 0)
-
-    Metrics.put(event = "successful_consents_updates", successfullyUpdated)
-    Metrics.put(event = "failed_consents_updates", unsuccessfullyUpdated)
+  def emitIdentityMetrics(updateResults: Either[SoftOptInError, Unit]): Unit = {
+    updateResults match {
+      case Left(_) => Metrics.put(event = "failed_consents_updates", 1)
+      case Right(_) => Metrics.put(event = "successful_consents_updates", 1)
+    }
   }
 
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -157,7 +157,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       hasMobileSub = mobileSubscriptionsResponse.subscriptions
         .filter(_.valid)
         .headOption
-        .map(_ => "Recurring Support")
+        .map(_ => "InAppPurchase")
       productTypes = activeSubs.records.map(_.Product__c) ++ hasMobileSub
 
       consentsBody <- buildProductSwitchConsents(
@@ -202,7 +202,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       hasMobileSub = mobileSubscriptionsResponse.subscriptions
         .filter(_.valid)
         .headOption
-        .map(_ => "Recurring Support")
+        .map(_ => "InAppPurchase")
       productTypes = activeSubs.records.map(_.Product__c) ++ hasMobileSub
 
       consents <- consentsCalculator.getCancellationConsents(

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -10,7 +10,7 @@ import io.circe.generic.auto._
 import io.circe.syntax._
 
 import scala.jdk.CollectionConverters._
-class HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
+object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
 
   val readyToProcessAcquisitionStatus = "Ready to process acquisition"
   val readyToProcessCancellationStatus = "Ready to process cancellation"

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -10,7 +10,6 @@ import io.circe.generic.auto._
 import io.circe.syntax._
 
 import scala.jdk.CollectionConverters._
-
 class HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
 
   val readyToProcessAcquisitionStatus = "Ready to process acquisition"

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -1,0 +1,238 @@
+package com.gu.soft_opt_in_consent_setter
+
+import com.gu.soft_opt_in_consent_setter.models._
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+object HandlerIAP extends LazyLogging {
+
+  val readyToProcessAcquisitionStatus = "Ready to process acquisition"
+  val readyToProcessCancellationStatus = "Ready to process cancellation"
+  val readyProcessSwitchStatus = "Ready to process switch"
+
+  def main(args: Array[String]): Unit = {
+    handleRequest()
+  }
+
+  def handleRequest(): Unit = {
+    (for {
+      config <- SoftOptInConfig()
+    } yield for {
+      sfConnector <- SalesforceConnector(config.sfConfig, config.sfApiVersion)
+
+      _ = logger.info(s"About to fetch subs to process from Salesforce")
+      allSubs <- sfConnector.getSubsToProcess()
+      _ = logger.info(
+        s"Successfully fetched ${allSubs.records.length} subs from Salesforce",
+      )
+
+      identityConnector = new IdentityConnector(config.identityConfig)
+      consentsCalculator = new ConsentsCalculator(config.consentsMapping)
+
+      acqSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyToProcessAcquisitionStatus))
+      _ <- processAcquiredSubs(acqSubs, identityConnector.sendConsentsReq, sfConnector.updateSubs, consentsCalculator)
+
+      cancelledSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyToProcessCancellationStatus))
+      cancelledSubsIdentityIds = cancelledSubs.map(sub => sub.Buyer__r.IdentityID__c)
+
+      productSwitchSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyProcessSwitchStatus))
+      productSwitchSubIdentityIds = productSwitchSubs.map(sub => sub.Buyer__r.IdentityID__c)
+
+      _ = logger.info(s"About to fetch active subs from Salesforce")
+      activeSubs <- sfConnector.getActiveSubs((cancelledSubsIdentityIds ++ productSwitchSubIdentityIds).distinct)
+      _ = logger.info(s"Successfully fetched ${activeSubs.records.length} active subs from Salesforce")
+
+      _ <- processProductSwitchSubs(
+        productSwitchSubs,
+        activeSubs,
+        identityConnector.sendConsentsReq,
+        sfConnector.updateSubs,
+        consentsCalculator,
+      )
+
+      _ <- processCancelledSubs(
+        cancelledSubs,
+        activeSubs,
+        identityConnector.sendConsentsReq,
+        sfConnector.updateSubs,
+        consentsCalculator,
+      )
+      _ = Metrics.put(event = "successful_run")
+    } yield ()).flatten.left
+      .foreach(error => {
+        Metrics.put(event = "failed_run")
+        logger.error(s"${error.errorType}: ${error.errorDetails}")
+        throw new Exception(s"Run failed due to ${error.errorType}: ${error.errorDetails}")
+      })
+  }
+
+  def processAcquiredSubs(
+      acquiredSubs: Seq[SFSubRecord],
+      sendConsentsReq: (String, String) => Either[SoftOptInError, Unit],
+      updateSubs: String => Either[SoftOptInError, Unit],
+      consentsCalculator: ConsentsCalculator,
+  ): Either[SoftOptInError, Unit] = {
+    Metrics.put(event = "acquisitions_to_process", acquiredSubs.size)
+
+    val recordsToUpdate = acquiredSubs
+      .map(sub => {
+        val updateResult =
+          for {
+            consents <- consentsCalculator.getSoftOptInsByProduct(sub.Product__c)
+            consentsBody = consentsCalculator.buildConsentsBody(consents, state = true)
+            _ <- sendConsentsReq(sub.Buyer__r.IdentityID__c, consentsBody)
+          } yield ()
+
+        logErrors(updateResult)
+
+        SFSubRecordUpdate(
+          sub,
+          "Acquisition",
+          updateResult,
+        )
+      })
+
+    emitIdentityMetrics(recordsToUpdate)
+
+    if (recordsToUpdate.isEmpty)
+      Right(())
+    else
+      updateSubs(SFSubRecordUpdateRequest(recordsToUpdate).asJson.spaces2)
+  }
+
+  def buildProductSwitchConsents(
+      oldProductName: String,
+      newProductName: String,
+      allProductsForUser: Set[String],
+      consentsCalculator: ConsentsCalculator,
+  ): Either[SoftOptInError, String] = {
+    import consentsCalculator._
+
+    for {
+      oldProductSoftOptIns <- getSoftOptInsByProduct(oldProductName)
+      newProductSoftOptIns <- getSoftOptInsByProduct(newProductName)
+      currentProductSoftOptIns <- getSoftOptInsByProducts(allProductsForUser)
+      allOtherProductSoftOptIns <- getSoftOptInsByProducts(allProductsForUser - newProductName)
+
+      toRemove = oldProductSoftOptIns.diff(currentProductSoftOptIns).map(ConsentsObject(_, false))
+      toAdd = newProductSoftOptIns
+        .filter(option => !oldProductSoftOptIns.contains(option) && !allOtherProductSoftOptIns.contains(option))
+        .map(ConsentsObject(_, true))
+
+      consentsBody = (toRemove ++ toAdd).asJson.toString()
+    } yield consentsBody
+  }
+
+  def processProductSwitchSubs(
+      productSwitchSubs: Seq[SFSubRecord],
+      activeSubs: SFAssociatedSubResponse,
+      sendConsentsReq: (String, String) => Either[SoftOptInError, Unit],
+      updateSubs: String => Either[SoftOptInError, Unit],
+      consentsCalculator: ConsentsCalculator,
+  ): Either[SoftOptInError, Unit] = {
+    Metrics.put(event = "product_switches_to_process", productSwitchSubs.size)
+
+    val recordsToUpdate = productSwitchSubs
+      .map(EnhancedSub(_, activeSubs.records))
+      .map(rec => {
+        import rec._
+
+        val updateResult = for {
+          ratePlanUpdates <- sub.Subscription_Rate_Plan_Updates__r
+            .toRight(
+              SoftOptInError(
+                "processProductSwitchSubs",
+                s"Subscription ${sub.Name} Subscription_Rate_Plan_Updates__r is null",
+              ),
+            )
+          consentsBody <- buildProductSwitchConsents(
+            ratePlanUpdates.records.head.Previous_Product_Name__c,
+            sub.Product__c,
+            associatedActiveNonGiftSubs.map(_.Product__c).toSet,
+            consentsCalculator,
+          )
+          res <- sendConsentsReq(sub.Buyer__r.IdentityID__c, consentsBody)
+        } yield res
+
+        logErrors(updateResult)
+
+        SFSubRecordUpdate(
+          sub,
+          "Switch",
+          updateResult,
+        )
+      })
+
+    emitIdentityMetrics(recordsToUpdate)
+
+    if (recordsToUpdate.isEmpty)
+      Right(())
+    else
+      updateSubs(SFSubRecordUpdateRequest(recordsToUpdate).asJson.spaces2)
+  }
+
+  def processCancelledSubs(
+      cancelledSubs: Seq[SFSubRecord],
+      activeSubs: SFAssociatedSubResponse,
+      sendConsentsReq: (String, String) => Either[SoftOptInError, Unit],
+      updateSubs: String => Either[SoftOptInError, Unit],
+      consentsCalculator: ConsentsCalculator,
+  ): Either[SoftOptInError, Unit] = {
+    def sendCancellationConsents(identityId: String, consents: Set[String]): Either[SoftOptInError, Unit] = {
+      if (consents.nonEmpty)
+        sendConsentsReq(
+          identityId,
+          consentsCalculator.buildConsentsBody(consents, state = false),
+        )
+      else
+        Right(())
+    }
+
+    Metrics.put(event = "cancellations_to_process", cancelledSubs.size)
+
+    val recordsToUpdate = cancelledSubs
+      .map(EnhancedSub(_, activeSubs.records))
+      .map(rec => {
+        import rec._
+
+        val updateResult =
+          for {
+            consents <- consentsCalculator.getCancellationConsents(
+              sub.Product__c,
+              associatedActiveNonGiftSubs.map(_.Product__c).toSet,
+            )
+            _ <- sendCancellationConsents(sub.Buyer__r.IdentityID__c, consents)
+          } yield ()
+
+        logErrors(updateResult)
+
+        SFSubRecordUpdate(
+          sub,
+          "Cancellation",
+          updateResult,
+        )
+      })
+
+    emitIdentityMetrics(recordsToUpdate)
+
+    if (recordsToUpdate.isEmpty)
+      Right(())
+    else
+      updateSubs(SFSubRecordUpdateRequest(recordsToUpdate).asJson.spaces2)
+  }
+
+  def logErrors(updateResults: Either[SoftOptInError, Unit]): Unit = {
+    updateResults.left.foreach(error => logger.warn(s"${error.errorType}: ${error.errorDetails}"))
+  }
+
+  def emitIdentityMetrics(records: Seq[SFSubRecordUpdate]): Unit = {
+    // Soft_Opt_in_Number_of_Attempts__c == 0 means the consents were set successfully
+    val successfullyUpdated = records.count(_.Soft_Opt_in_Number_of_Attempts__c == 0)
+    val unsuccessfullyUpdated = records.count(_.Soft_Opt_in_Number_of_Attempts__c > 0)
+
+    Metrics.put(event = "successful_consents_updates", successfullyUpdated)
+    Metrics.put(event = "failed_consents_updates", unsuccessfullyUpdated)
+  }
+
+}

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
@@ -29,12 +29,12 @@ class IdentityConnector(config: IdentityConfig) {
       errorDesc: String = "",
   ): Either[SoftOptInError, Unit] = {
     response.left
-      .map(i => SoftOptInError("IdentityConnector", s"Identity request failed: $i"))
+      .map(i => SoftOptInError(s"IdentityConnector: Identity request failed: $i"))
       .flatMap { response =>
         if (response.isSuccess)
           Right(())
         else
-          Left(SoftOptInError("IdentityConnector", s"$errorDesc. Status code: ${response.code}"))
+          Left(SoftOptInError(s"IdentityConnector $errorDesc. Status code: ${response.code}"))
       }
   }
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
@@ -1,0 +1,45 @@
+package com.gu.soft_opt_in_consent_setter
+
+import com.gu.soft_opt_in_consent_setter.models.{MpapiConfig, SoftOptInError}
+import io.circe.Decoder
+import io.circe.parser.decode
+import io.circe.generic.auto._
+import scalaj.http.{Http, HttpResponse}
+
+import scala.util.Try
+
+case class MobileSubscriptions(subscriptions: List[MobileSubscription])
+case class MobileSubscription(valid: Boolean)
+
+class MpapiConnector(config: MpapiConfig) {
+
+  def handleQueryResp[T: Decoder](
+      response: Either[Throwable, HttpResponse[String]],
+      errorDesc: String = "Decode error",
+  ): Either[SoftOptInError, T] = {
+    response.left
+      .map(error => SoftOptInError(s"MpapiConnector: Salesforce query request failed: $error"))
+      .flatMap { result =>
+        decode[T](result.body).left.map(decodeError =>
+          SoftOptInError(s"MpapiConnector: $errorDesc:$decodeError. String to decode ${result.body}"),
+        )
+      }
+  }
+
+  def getMobileSubscriptions(identityId: String): Either[SoftOptInError, MobileSubscriptions] = {
+    handleQueryResp[MobileSubscriptions](
+      sendReq(url = s"${config.mpapiUrl}/users/subscriptions/$identityId"),
+      errorDesc = s"Mobile purchases API (MPAPI) request failed while processing $identityId",
+    )
+  }
+
+  def sendReq(url: String): Either[Throwable, HttpResponse[String]] = {
+    Try(
+      Http(url)
+        .header("Authorization", s"Bearer ${config.mpapiToken}")
+        .method("GET")
+        .asString,
+    ).toEither
+  }
+
+}

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
@@ -18,7 +18,7 @@ class MpapiConnector(config: MpapiConfig) {
       errorDesc: String = "Decode error",
   ): Either[SoftOptInError, T] = {
     response.left
-      .map(error => SoftOptInError(s"MpapiConnector: Salesforce query request failed: $error"))
+      .map(error => SoftOptInError(s"MpapiConnector: Mobile purchases API (MPAPI) query request failed: $error"))
       .flatMap { result =>
         decode[T](result.body).left.map(decodeError =>
           SoftOptInError(s"MpapiConnector: $errorDesc:$decodeError. String to decode ${result.body}"),

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
@@ -79,10 +79,10 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
       errorDesc: String = "Decode error",
   ): Either[SoftOptInError, T] = {
     response.left
-      .map(error => SoftOptInError("SalesforceConnector", s"Salesforce query request failed: $error"))
+      .map(error => SoftOptInError(s"SalesforceConnector: Salesforce query request failed: $error"))
       .flatMap { result =>
         decode[T](result.body).left.map(decodeError =>
-          SoftOptInError("SalesforceConnector", s"$errorDesc:$decodeError. String to decode ${result.body}"),
+          SoftOptInError(s"SalesforceConnector: $errorDesc:$decodeError. String to decode ${result.body}"),
         )
       }
   }
@@ -92,7 +92,7 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
       putMetric: (String, Double) => Unit,
   ): Either[SoftOptInError, Unit] = {
     response.left
-      .map(i => SoftOptInError("SalesforceConnector", s"Salesforce composite request failed: $i"))
+      .map(i => SoftOptInError(s"SalesforceConnector: Salesforce composite request failed: $i"))
       .flatMap { result =>
         decode[List[SFResponse]](result.body) match {
           case Right(compositeResponse) =>
@@ -107,8 +107,7 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
           case Left(decodeError) =>
             Left(
               SoftOptInError(
-                "SalesforceConnector",
-                s"Could not decode SfCompositeRequest.Response: $decodeError. String to decode: ${result.body}",
+                s"SalesforceConnector: Could not decode SfCompositeRequest.Response: $decodeError. String to decode: ${result.body}",
               ),
             )
         }
@@ -147,13 +146,12 @@ object SalesforceConnector {
 
   def handleAuthResp(response: Either[Throwable, HttpResponse[String]]): Either[SoftOptInError, SalesforceAuth] = {
     response.left
-      .map(i => SoftOptInError("SalesforceConnector", s"Salesforce authentication failed: $i"))
+      .map(i => SoftOptInError(s"SalesforceConnector: Salesforce authentication failed: $i"))
       .flatMap { result =>
         decode[SalesforceAuth](result.body).left
           .map(i =>
             SoftOptInError(
-              "SalesforceConnector",
-              s"Could not decode SfAuthDetails: $i. String to decode: ${result.body}",
+              s"SalesforceConnector: Could not decode SfAuthDetails: $i. String to decode: ${result.body}",
             ),
           )
       }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SfQueries.scala
@@ -59,5 +59,4 @@ object SfQueries {
        |	buyer__r.identityId__c, product__c
     """.stripMargin
   }
-
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/SoftOptInError.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/SoftOptInError.scala
@@ -1,3 +1,3 @@
 package com.gu.soft_opt_in_consent_setter.models
 
-case class SoftOptInError(errorType: String, errorDetails: String)
+case class SoftOptInError(message: String) extends Exception(message)

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
@@ -10,11 +10,14 @@ case class SoftOptInConfig(
     sfConfig: SFAuthConfig,
     sfApiVersion: String,
     identityConfig: IdentityConfig,
+    mpapiConfig: MpapiConfig,
     consentsMapping: Map[String, Set[String]],
     stage: String,
 )
 
 case class IdentityConfig(identityUrl: String, identityToken: String)
+
+case class MpapiConfig(mpapiUrl: String, mpapiToken: String)
 
 object SoftOptInConfig {
 
@@ -29,6 +32,8 @@ object SoftOptInConfig {
       sfApiVersion <- sys.env.get("sfApiVersion")
       identityUrl <- sys.env.get("identityUrl")
       identityToken <- sys.env.get("identityToken")
+      mpapiUrl <- sys.env.get("mpapiUrl")
+      mpapiToken <- sys.env.get("mpapiToken")
       stage <- sys.env.get("Stage")
       consentsMapping <- getConsentsByProductMapping(stage)
     } yield SoftOptInConfig(
@@ -45,12 +50,15 @@ object SoftOptInConfig {
         identityUrl,
         identityToken,
       ),
+      MpapiConfig(
+        mpapiUrl,
+        mpapiToken,
+      ),
       consentsMapping,
       stage,
     )).toRight(
       SoftOptInError(
-        "SoftOptInConfig",
-        "Could not obtain all config.",
+        "SoftOptInConfig: Could not obtain all config.",
       ),
     )
   }

--- a/handlers/soft-opt-in-consent-setter/src/test/resources/mobileSubscriptions.json
+++ b/handlers/soft-opt-in-consent-setter/src/test/resources/mobileSubscriptions.json
@@ -1,0 +1,13 @@
+{
+  "subscriptions": [
+    {
+      "subscriptionId": "2000000247265063",
+      "from": "2023-01-11T11:05:20.000Z",
+      "to": "2023-01-11T12:08:02.000Z",
+      "valid": false,
+      "gracePeriod": false,
+      "autoRenewing": false,
+      "productId": "uk.co.guardian.gla.1month.2018May.withFreeTrial"
+    }
+  ]
+}

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -1,6 +1,5 @@
 package com.gu.soft_opt_in_consent_setter
 
-import com.gu.soft_opt_in_consent_setter.HandlerIAP // do not remove!
 import com.gu.soft_opt_in_consent_setter.models.SoftOptInError
 import com.gu.soft_opt_in_consent_setter.testData.ConsentsCalculatorTestData.{
   contributionMapping,

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -28,7 +28,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "ConsentsCalculator"
+    result.left.value.getMessage shouldBe "ConsentsCalculator: getSoftOptInsByProduct couldn't find nonexistentProduct in consentsMappings"
   }
 
   // getSoftOptInsByProducts success cases
@@ -44,7 +44,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "ConsentsCalculator"
+    result.left.value.getMessage shouldBe "ConsentsCalculator: getSoftOptInsByProducts couldn't find nonexistentProduct in consentsMappings"
   }
 
   // getCancellationConsents success cases
@@ -86,7 +86,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "ConsentsCalculator"
+    result.left.value.getMessage shouldBe "ConsentsCalculator: getCancellationConsents couldn't find nonexistentProduct in consentsMappings"
   }
 
   "getCancellationConsents" should "correctly return a SoftOptInError when a known product is passed and an unknown product is present in the owned products" in {
@@ -94,7 +94,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "ConsentsCalculator"
+    result.left.value.getMessage shouldBe "ConsentsCalculator: getCancellationConsents couldn't find nonexistentProduct in consentsMappings"
   }
 
   // buildConsentsBody success cases

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -1,5 +1,6 @@
 package com.gu.soft_opt_in_consent_setter
 
+import com.gu.soft_opt_in_consent_setter.HandlerIAP // do not remove!
 import com.gu.soft_opt_in_consent_setter.models.SoftOptInError
 import com.gu.soft_opt_in_consent_setter.testData.ConsentsCalculatorTestData.{
   contributionMapping,

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -123,24 +123,23 @@ class HandlerTests extends AnyFlatSpec with should.Matchers with EitherValues {
         |    "consented" : true
         |  }
         |]""".stripMargin)
+  }
 
-    "buildProductSwitchConsents - HandlerIAP" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
-      HandlerIAP.buildProductSwitchConsents(
-        "guardianweekly",
-        "newspaper",
-        Set("newspaper", "mobilesubscription"),
-        calculator,
-      ) shouldBe Right(
-        """[
-          |  {
-          |    "id" : "guardian_weekly_newsletter",
-          |    "consented" : false
-          |  },
-          |  {
-          |    "id" : "subscriber_preview",
-          |    "consented" : true
-          |  }
-          |]""".stripMargin)
+  "buildProductSwitchConsents - HandlerIAP" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
+    HandlerIAP.buildProductSwitchConsents(
+      "guardianweekly",
+      "newspaper",
+      Set("newspaper", "mobilesubscription"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "subscriber_preview",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
   }
 }
-

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -106,4 +106,22 @@ class HandlerTests extends AnyFlatSpec with should.Matchers with EitherValues {
         |  }
         |]""".stripMargin)
   }
+
+  "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
+    Handler.buildProductSwitchConsents(
+      "guardianweekly",
+      "newspaper",
+      Set("newspaper", "mobilesubscription"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "subscriber_preview",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
+  }
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -123,5 +123,24 @@ class HandlerTests extends AnyFlatSpec with should.Matchers with EitherValues {
         |    "consented" : true
         |  }
         |]""".stripMargin)
+
+    "buildProductSwitchConsents - HandlerIAP" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
+      HandlerIAP.buildProductSwitchConsents(
+        "guardianweekly",
+        "newspaper",
+        Set("newspaper", "mobilesubscription"),
+        calculator,
+      ) shouldBe Right(
+        """[
+          |  {
+          |    "id" : "guardian_weekly_newsletter",
+          |    "consented" : false
+          |  },
+          |  {
+          |    "id" : "subscriber_preview",
+          |    "consented" : true
+          |  }
+          |]""".stripMargin)
   }
 }
+

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/IdentityConnectorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/IdentityConnectorTests.scala
@@ -24,7 +24,6 @@ class IdentityConnectorTests extends AnyFlatSpec with should.Matchers with Eithe
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "IdentityConnector"
   }
 
   "handleConsentsResp" should "return a SoftOptInError if the the request was successful but a failure code was received" in {
@@ -32,6 +31,5 @@ class IdentityConnectorTests extends AnyFlatSpec with should.Matchers with Eithe
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "IdentityConnector"
   }
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/JsonCodecSpec.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/JsonCodecSpec.scala
@@ -17,4 +17,12 @@ class JsonCodecSpec extends AnyFlatSpec with should.Matchers {
 
     record shouldBe Right(SFSubRecordResponse(2, true, records = Seq(subRecord2, subRecord3)))
   }
+
+  it should "JSON Decoding: decodes Mobile Purchases API (MPAPI) response correctly" in {
+    val json = Source.fromResource("mobileSubscriptions.json").mkString
+
+    val record = decode[MobileSubscriptions](json)
+
+    record shouldBe Right(MobileSubscriptions(List(MobileSubscription(false))))
+  }
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/SFSubRecordUpdateTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/SFSubRecordUpdateTests.scala
@@ -45,7 +45,7 @@ class SFSubRecordUpdateTests extends AnyFlatSpec with should.Matchers {
   }
 
   "UpdateRecord.apply" should "return a correctly formed UpdateRecord when a failed updateResult is passed in" in {
-    val result = SFSubRecordUpdate(subRecord, softOptInStage, Left(SoftOptInError("", "")))
+    val result = SFSubRecordUpdate(subRecord, softOptInStage, Left(SoftOptInError("")))
 
     result.Id shouldBe subId
     result.Soft_Opt_in_Last_Stage_Processed__c shouldBe Some(lastProcessedStage)

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/SalesforceConnectorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/SalesforceConnectorTests.scala
@@ -30,7 +30,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.getMessage shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector: Salesforce authentication failed: java.lang.Throwable"
   }
 
   "auth" should "returns a SoftOptInError if an unexpected body is found" in {
@@ -38,7 +38,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.getMessage shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector: Could not decode SfAuthDetails: io.circe.ParsingFailure: expected json value got 'unexpe...' (line 1, column 1). String to decode: unexpected body"
   }
 
   // handleQueryResp success cases
@@ -52,7 +52,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.getMessage shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector: Salesforce query request failed: java.lang.Throwable"
   }
 
   "handleQueryResp" should "return a SoftOptInError if an unexpected body is found" in {
@@ -60,7 +60,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.getMessage shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector: Decode error:io.circe.ParsingFailure: expected json value got 'unexpe...' (line 1, column 1). String to decode unexpected body"
   }
 
   // handleCompositeUpdateResp success cases
@@ -74,7 +74,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.getMessage shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector: Salesforce composite request failed: java.lang.Throwable"
   }
 
   "handleCompositeUpdateResp" should "return a SoftOptInError if an unexpected body is found" in {
@@ -82,7 +82,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.getMessage shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector: Could not decode SfCompositeRequest.Response: io.circe.ParsingFailure: expected json value got 'unexpe...' (line 1, column 1). String to decode: unexpected body"
   }
 
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/SalesforceConnectorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/SalesforceConnectorTests.scala
@@ -30,7 +30,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector"
   }
 
   "auth" should "returns a SoftOptInError if an unexpected body is found" in {
@@ -38,7 +38,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector"
   }
 
   // handleQueryResp success cases
@@ -52,7 +52,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector"
   }
 
   "handleQueryResp" should "return a SoftOptInError if an unexpected body is found" in {
@@ -60,7 +60,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector"
   }
 
   // handleCompositeUpdateResp success cases
@@ -74,7 +74,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector"
   }
 
   "handleCompositeUpdateResp" should "return a SoftOptInError if an unexpected body is found" in {
@@ -82,7 +82,7 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SoftOptInError]
-    result.left.value.errorType shouldBe "SalesforceConnector"
+    result.left.value.getMessage shouldBe "SalesforceConnector"
   }
 
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -9,6 +9,8 @@ object ConsentsCalculatorTestData {
     Set("your_support_onboarding", "similar_guardian_products", "subscriber_preview", "supporter_newsletter")
   val guWeeklyMapping = Set("your_support_onboarding", "guardian_weekly_newsletter")
   val testProductMapping = Set("unique_consent")
+  val testMobileSubscriptionMapping =
+    Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter")
 
   val testConsentMappings = Map(
     "membership" -> membershipMapping,
@@ -17,6 +19,7 @@ object ConsentsCalculatorTestData {
     "newspaper" -> newspaperMapping,
     "guardianweekly" -> guWeeklyMapping,
     "testproduct" -> testProductMapping,
+    "mobilesubscription" -> testMobileSubscriptionMapping,
   )
 
 }


### PR DESCRIPTION
## What does this change?

Adds a [new lambda](https://github.com/guardian/support-service-lambdas/pull/1885/files#diff-e74c9f0afd9cc901a6ccb53fef2049d7eefab5f803f00c7a2ea59e0be8a0b16dR128-R204) in the cloudformation stack, with the entry point in the `HandlerIAP.scala` file. The new lambda consumes events from an [SQS queue](https://github.com/guardian/support-service-lambdas/pull/1885/files#diff-e74c9f0afd9cc901a6ccb53fef2049d7eefab5f803f00c7a2ea59e0be8a0b16dR206-R214). A [dead-letter queue](https://github.com/guardian/support-service-lambdas/pull/1885/files#diff-e74c9f0afd9cc901a6ccb53fef2049d7eefab5f803f00c7a2ea59e0be8a0b16dR216-R220) has been set up, any messages which error [3 times](https://github.com/guardian/support-service-lambdas/pull/1885/files#diff-e74c9f0afd9cc901a6ccb53fef2049d7eefab5f803f00c7a2ea59e0be8a0b16dR214) will be sent to it. `MpapiConnector.scala` is used to query any mobile subscriptions a customer may have.

 Many of the changes in this PR is due to the [change in the error class](https://github.com/guardian/support-service-lambdas/pull/1885/files#diff-ee80d3c5893b5fa3a3c22f7fe18547e63654d17058d690b872f58a58b4918af1R3).

Things to do before merging:

- [x] Mobile purchases API (MPAPI) secrets added to secrets manager
- [x] In-App Purchase soft opt-ins added to the consents mapping file in S3
- [x] Tested in DEV