### PR TITLE
Handle cancellation of switched supporter+ subs 

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -153,7 +153,7 @@ object SubscriptionCancelEndpoint {
       // should look at the relevant charge, members data api looks for the Paid Plan.
       // initially this will only apply to new prop which won't have multiple plans or charges.
       zuoraIds <- ZIO.fromEither(ZuoraIds.zuoraIdsForStage(config.Stage(stage.toString)))
-      ratePlan <- asSingle(subscription.ratePlans, "ratePlan")
+      ratePlan <- asSingle(subscription.ratePlans.filterNot(_.lastChangeType.contains("Remove")), "ratePlan")
       charges <- asNonEmptyList(ratePlan.ratePlanCharges, "ratePlanCharge")
       _ <- checkProductIsSupporterPlus(charges, zuoraIds.supporterPlusZuoraIds)
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscription.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscription.scala
@@ -38,6 +38,7 @@ object GetSubscription {
   case class RatePlan(
       productName: String,
       ratePlanName: String,
+      lastChangeType: Option[String],
       ratePlanCharges: List[RatePlanCharge],
       productRatePlanId: String,
       id: String,


### PR DESCRIPTION
## What does this change?
The cancellation lambda currently fails for subscriptions which have been switched to Supporter plus via the MMA product switch functionality because the `GetSubscription` response from Zuora returns the removed rate plan as well as the added rate plan.

Eg.
```json
{
    "success": true,
    "id": "8ad09e20867e02df01867f52b703460e",
    "accountId": "8ad09408867e02d901867f517f566102",
    ...
    "ratePlans": [
        {
            "id": "8ad09e20867e02df01867f52b6c64603",
            "lastChangeType": "Remove",
            "productId": "2c92c0f85a6b134e015a7fcc183e756f",
            "productName": "Contributor",
            "productSku": "SKU-00000049",
            "productRatePlanId": "2c92c0f85a6b134e015a7fcd9f0c7855",
            "ratePlanName": "Monthly Contribution",
            "ratePlanCharges": [
                {
                    "id": "8ad09e20867e02df01867f52b6c64604",
                    "originalChargeId": "8ad09408867e02d901867f518001610d",
                    "productRatePlanChargeId": "2c92c0f85a6b1352015a7fcf35ab397c",
                    "number": "C-00827314",
                    "name": "Contribution",
                    "type": "Recurring",
                    "model": "FlatFee",
                    ...
                }
            ],
            "subscriptionProductFeatures": [],
            "externallyManagedPlanId": null
        },
        {
            "id": "8ad09e20867e02df01867f52b70c4610",
            "lastChangeType": "Add",
            "productId": "8ad09fc281de1ce70181de3b23b2363d",
            "productName": "Supporter Plus",
            "productSku": "SKU-00000072",
            "productRatePlanId": "8ad09fc281de1ce70181de3b251736a4",
            "ratePlanName": "Supporter Plus Monthly",
            "ratePlanCharges": [
                {
                    "id": "8ad09e20867e02df01867f52b70f4612",
                    "originalChargeId": "8ad09e20867e02df01867f52b56f45ed",
                    "productRatePlanChargeId": "8ad09fc281de1ce70181de3b253e36a6",
                    "number": "C-00827315",
                    "name": "Supporter Plus Monthly",
                    "type": "Recurring",
                    "model": "FlatFee",
                    ...
                }
            ],
            "subscriptionProductFeatures": [],
            "externallyManagedPlanId": null
        }
    ],
    "orderNumber": "O-00069849",
    "externallyManagedBy": null,
    "statusHistory": [
        {
            "startDate": "2023-02-23",
            "endDate": "2024-02-23",
            "status": "Active"
        },
        {
            "startDate": "2024-02-23",
            "endDate": null,
            "status": "OutOfTerm"
        }
    ]
}
```

This didn't work with the existing logic was expecting a single rate plan to cancel, so I have updated the logic to filter out removed rate plans.