### PR TITLE
Fix missing contentLength header from Zuora

### DIFF
--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/BlockingAquaQuery.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/BlockingAquaQuery.scala
@@ -65,6 +65,7 @@ class BlockingAquaQueryImpl(
             log(s"still pending: $pending")
             waitForResult(jobId, getJobResult)
           case c: Completed =>
+            log(s"Completed: $c")
             ClientSuccess(c.batches)
         }
       case fail: ClientFailure => fail

--- a/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/HandlerManualTest.scala
+++ b/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/HandlerManualTest.scala
@@ -63,7 +63,7 @@ object RunQueryManualTest {
   def main(args: Array[String]): Unit = {
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("PROD"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
       downloadRequests = ZuoraAquaRequestMaker(RawEffects.downloadResponse, zuoraRestConfig)
       aquaQuerier = Querier.lowLevel(downloadRequests) _
       schedules <- new RevenueSchedulesQuerier(

--- a/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/aqua/ZuoraAquaRequestMaker.scala
+++ b/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/aqua/ZuoraAquaRequestMaker.scala
@@ -25,6 +25,7 @@ object ZuoraAquaRequestMaker extends LazyLogging {
     new RestRequestMaker.Requests(
       headers = Map(
         "Authorization" -> s"Basic $encodedCredentials",
+        "Accept-Encoding" -> "identity",
       ),
       baseUrl = config.baseUrl + "/",
       getResponse = response,


### PR DESCRIPTION
## What does this change?
This fixes a bug caused by an issue described [in this PR](https://github.com/guardian/support-frontend/pull/4470)

It seems that Zuora have made a change to their response format so that they are now compressed by default. This causes an issue with some HTTP clients whereby the `Content-length` header is no longer set which in turn is causing our application code to fail.

The solution is to add an additional header `"Accept-Encoding" -> "identity"` to the request.