### PR TITLE
Product switching from salesforce - set case id and user id on switch record

### DIFF
--- a/handlers/product-move-api/get-secrets-as-env-vars.sh
+++ b/handlers/product-move-api/get-secrets-as-env-vars.sh
@@ -27,3 +27,19 @@ while read -r invoicingApiKey; read -r invoicingApiUrl; do
   #  https://stackoverflow.com/questions/32760584/in-intellij-how-do-i-set-default-environment-variables-for-new-test-configurati
   echo "invoicingApiUrl=$invoicingApiUrl;invoicingApiKey=$invoicingApiKey"
 done
+
+# Salesforce
+aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:eu-west-1:865473395570:secret:DEV/Salesforce/User/SupportServiceLambdas | jq -c '[.SecretString | fromjson]' | \
+jq -M -r '.[] | .url, .client_id, .client_secret, .username, .password, .token' | \
+while read -r url; read -r client_id; read -r client_secret; read -r username; read -r password; read -r token; do
+  export salesforceUrl="$url"
+  export salesforceClientId="$client_id"
+  export salesforceClientSecret="$client_secret"
+  export salesforceUsername="$username"
+  export salesforcePassword="$password"
+  export salesforceToken="$token"
+
+  # Add this into the environment variables setting in the Intellij default run configuration to enable integration tests to access the variables
+  #  https://stackoverflow.com/questions/32760584/in-intellij-how-do-i-set-default-environment-variables-for-new-test-configurati
+  echo "salesforceUrl=$url;salesforceClientId=$client_id;salesforceClientSecret=$client_secret;salesforceUsername=$username;salesforcePassword=$password;salesforceToken=$token"
+done

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Handler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Handler.scala
@@ -43,7 +43,7 @@ object Handler extends ZIOApiGatewayRequestHandler {
   def testProductMove(): Unit = super.runTest(
     "POST",
     "/product-move/A-S123",
-    Some(ProductMoveEndpointTypes.ExpectedInput(49.99, false).toJson),
+    Some(ProductMoveEndpointTypes.ExpectedInput(49.99, false, None, None).toJson),
   )
 
   @main

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Util.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Util.scala
@@ -2,5 +2,6 @@ package com.gu.productmove
 
 object Util {
   def getFromEnv(prop: String): Either[String, String] =
+
     sys.env.get(prop).toRight(s"Could not obtain $prop")
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -178,7 +178,7 @@ object ProductMoveEndpoint {
             postData.price,
             currentRatePlan,
             subscription,
-            postData.csrId,
+            postData.csrUserId,
             postData.caseId,
           )
     } yield result).fold(errorMessage => InternalServerError(errorMessage), success => success)

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -201,7 +201,7 @@ object ProductMoveEndpoint {
       price: BigDecimal,
       currentRatePlan: GetSubscription.RatePlan,
       subscription: GetSubscription.GetSubscriptionResponse,
-      csrId: Option[String],
+      csrUserId: Option[String],
       caseId: Option[String],
   ) = for {
     _ <- ZIO.log("Performing product move update")
@@ -258,7 +258,7 @@ object ProductMoveEndpoint {
           todaysDate,
           todaysDate,
           paidAmount,
-          csrId,
+          csrUserId,
           caseId,
         ),
       )

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
@@ -18,8 +18,12 @@ object ProductMoveEndpointTypes {
   case class ExpectedInput(
       @description("Price of new Supporter Plus subscription") price: BigDecimal,
       @description("Whether to preview the move or to carry it out") preview: Boolean,
-      @description("The User Id of the CSR performing the Switch. Populated only if the request comes from Salesforce") userId: String,
-      @description("The Case Id of the Salesforce Case related to the Switch. Populated only if the request comes from Salesforce") caseId: String,
+      @description(
+        "The User Id of the CSR performing the Switch. Populated only if the request comes from Salesforce",
+      ) csrId: Option[String],
+      @description(
+        "The Case Id of the Salesforce Case related to the Switch. Populated only if the request comes from Salesforce",
+      ) caseId: Option[String],
   )
 
   given JsonDecoder[ExpectedInput] = DeriveJsonDecoder.gen[ExpectedInput]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
@@ -20,7 +20,7 @@ object ProductMoveEndpointTypes {
       @description("Whether to preview the move or to carry it out") preview: Boolean,
       @description(
         "The User Id of the CSR performing the Switch. Populated only if the request comes from Salesforce",
-      ) csrId: Option[String],
+      ) csrUserId: Option[String],
       @description(
         "The Case Id of the Salesforce Case related to the Switch. Populated only if the request comes from Salesforce",
       ) caseId: Option[String],

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointTypes.scala
@@ -18,6 +18,8 @@ object ProductMoveEndpointTypes {
   case class ExpectedInput(
       @description("Price of new Supporter Plus subscription") price: BigDecimal,
       @description("Whether to preview the move or to carry it out") preview: Boolean,
+      @description("The User Id of the CSR performing the Switch. Populated only if the request comes from Salesforce") userId: String,
+      @description("The Case Id of the Salesforce Case related to the Switch. Populated only if the request comes from Salesforce") caseId: String,
   )
 
   given JsonDecoder[ExpectedInput] = DeriveJsonDecoder.gen[ExpectedInput]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/CreateRecord.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/CreateRecord.scala
@@ -43,6 +43,8 @@ object CreateRecord {
       Requested_Date__c: LocalDate,
       Effective_Date__c: LocalDate,
       Paid_Amount__c: BigDecimal,
+      CSR__c: Option[String],
+      Case__c: Option[String],
   )
   given JsonEncoder[CreateRecordRequest] = DeriveJsonEncoder.gen[CreateRecordRequest]
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
@@ -43,6 +43,7 @@ object Salesforce {
         Paid_Amount__c = paidAmount,
         CSR__c = csrUserId,
         Case__c = caseId,
+        Source__c = csrUserId.map(_ => "CSR").getOrElse("MMA")
       )
       _ <- CreateRecord.create(request)
     } yield ()

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
@@ -17,6 +17,8 @@ object Salesforce {
       requestedDate: LocalDate,
       effectiveDate: LocalDate,
       paidAmount: BigDecimal,
+      csrId: Option[String],
+      caseId: Option[String],
   )
 
   given JsonDecoder[SalesforceRecordInput] = DeriveJsonDecoder.gen[SalesforceRecordInput]
@@ -39,6 +41,8 @@ object Salesforce {
         Requested_Date__c = requestedDate,
         Effective_Date__c = effectiveDate,
         Paid_Amount__c = paidAmount,
+        CSR__c = csrId,
+        Case__c = caseId,
       )
       _ <- CreateRecord.create(request)
     } yield ()

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
@@ -17,7 +17,7 @@ object Salesforce {
       requestedDate: LocalDate,
       effectiveDate: LocalDate,
       paidAmount: BigDecimal,
-      csrId: Option[String],
+      csrUserId: Option[String],
       caseId: Option[String],
   )
 
@@ -41,7 +41,7 @@ object Salesforce {
         Requested_Date__c = requestedDate,
         Effective_Date__c = effectiveDate,
         Paid_Amount__c = paidAmount,
-        CSR__c = csrId,
+        CSR__c = csrUserId,
         Case__c = caseId,
       )
       _ <- CreateRecord.create(request)

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -72,7 +72,7 @@ object HandlerSpec extends ZIOSpecDefault {
 
     suite("HandlerSpec")(
       test("productMove endpoint is successful for monthly sub (upsell)") {
-        val endpointJsonInputBody = ExpectedInput(15.00, false)
+        val endpointJsonInputBody = ExpectedInput(15.00, false, None, None)
         val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)
         val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse)
         val expectedOutput = ProductMoveEndpointTypes.Success("Product move completed successfully")
@@ -103,7 +103,7 @@ object HandlerSpec extends ZIOSpecDefault {
       test(
         "productMove endpoint is successful if customer neither pays nor is refunded on switch (monthly sub, upsell)",
       ) {
-        val endpointJsonInputBody = ExpectedInput(15.00, false)
+        val endpointJsonInputBody = ExpectedInput(15.00, false, None, None)
         val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)
         val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse3)
         val expectedOutput = ProductMoveEndpointTypes.Success("Product move completed successfully")
@@ -136,7 +136,7 @@ object HandlerSpec extends ZIOSpecDefault {
         }).provide(layers)
       },
       test("productMove endpoint returns 500 error if identityId does not exist") {
-        val endpointJsonInputBody = ExpectedInput(50.00, false)
+        val endpointJsonInputBody = ExpectedInput(50.00, false, None, None)
         val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)
         val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse)
         val expectedOutput = InternalServerError("identityId is null for subscription name A-S00339056")
@@ -165,7 +165,7 @@ object HandlerSpec extends ZIOSpecDefault {
         )
       },
       test("productMove endpoint returns 500 error if subscription has more than one rateplan") {
-        val endpointJsonInputBody = ExpectedInput(50.00, false)
+        val endpointJsonInputBody = ExpectedInput(50.00, false, None, None)
         val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)
         val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse)
         val expectedOutput = InternalServerError("Subscription: A-S00339056 has more than one ratePlan")
@@ -193,7 +193,7 @@ object HandlerSpec extends ZIOSpecDefault {
         )
       },
       test("preview endpoint is successful (monthly sub, upsell)") {
-        val endpointJsonInputBody = ExpectedInput(15.00, true)
+        val endpointJsonInputBody = ExpectedInput(15.00, true, None, None)
         val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdatePreviewResult)
         val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse)
         val expectedOutput = ProductMoveEndpointTypes.PreviewResult(

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -272,7 +272,7 @@ val salesforceRecordInput1 = SalesforceRecordInput(
   LocalDate.of(2022, 5, 10),
   LocalDate.of(2022, 5, 10),
   BigDecimal(4),
-  csrId = None,
+  csrUserId = None,
   caseId = None,
 )
 val salesforceRecordInput2 = SalesforceRecordInput(
@@ -285,7 +285,7 @@ val salesforceRecordInput2 = SalesforceRecordInput(
   LocalDate.of(2022, 5, 10),
   LocalDate.of(2022, 5, 10),
   BigDecimal(20),
-  csrId = None,
+  csrUserId = None,
   caseId = None,
 )
 val salesforceRecordInput3 = SalesforceRecordInput(
@@ -298,7 +298,7 @@ val salesforceRecordInput3 = SalesforceRecordInput(
   LocalDate.of(2022, 5, 10),
   LocalDate.of(2022, 5, 10),
   BigDecimal(0),
-  csrId = None,
+  csrUserId = None,
   caseId = None,
 )
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -337,6 +337,21 @@ val createRecordRequest1 = CreateRecordRequest(
   Requested_Date__c = LocalDate.parse("2022-12-08"),
   Effective_Date__c = LocalDate.parse("2022-12-09"),
   Paid_Amount__c = BigDecimal(50),
+  CSR__c = None,
+  Case__c = None,
+)
+
+val createRecordRequest2 = CreateRecordRequest(
+  SF_Subscription__c = "123456",
+  Previous_Amount__c = BigDecimal(100),
+  New_Amount__c = BigDecimal(100),
+  Previous_Product_Name__c = "previous product name",
+  Previous_Rate_Plan_Name__c = "previous rate plan",
+  New_Rate_Plan_Name__c = "new rate plan",
+  Requested_Date__c = LocalDate.parse("2022-12-08"),
+  Effective_Date__c = LocalDate.parse("2022-12-09"),
+  Paid_Amount__c = BigDecimal(50),
   CSR__c = Some("a_csr_id"),
   Case__c = Some("a_case_id"),
+  Source__c = "CSR",
 )

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -272,6 +272,8 @@ val salesforceRecordInput1 = SalesforceRecordInput(
   LocalDate.of(2022, 5, 10),
   LocalDate.of(2022, 5, 10),
   BigDecimal(4),
+  csrId = None,
+  caseId = None,
 )
 val salesforceRecordInput2 = SalesforceRecordInput(
   "A-S00339056",
@@ -283,6 +285,8 @@ val salesforceRecordInput2 = SalesforceRecordInput(
   LocalDate.of(2022, 5, 10),
   LocalDate.of(2022, 5, 10),
   BigDecimal(20),
+  csrId = None,
+  caseId = None,
 )
 val salesforceRecordInput3 = SalesforceRecordInput(
   "A-S00339056",
@@ -294,7 +298,10 @@ val salesforceRecordInput3 = SalesforceRecordInput(
   LocalDate.of(2022, 5, 10),
   LocalDate.of(2022, 5, 10),
   BigDecimal(0),
+  csrId = None,
+  caseId = None,
 )
+
 
 //-----------------------------------------------------
 // Stubs for SubscriptionUpdate service
@@ -330,4 +337,6 @@ val createRecordRequest1 = CreateRecordRequest(
   Requested_Date__c = LocalDate.parse("2022-12-08"),
   Effective_Date__c = LocalDate.parse("2022-12-09"),
   Paid_Amount__c = BigDecimal(50),
+  CSR__c = Some("a_csr_id"),
+  Case__c = Some("a_case_id"),
 )

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
@@ -35,15 +35,17 @@ object CreateRecordSpec extends ZIOSpecDefault {
           _ <- Salesforce
             .createSfRecord(
               SalesforceRecordInput(
-                "A-S00102815",
-                10.0000000,
-                10.0000000,
-                "previous product name",
-                "previous rate plan",
-                "new rate plan",
-                LocalDate.now(),
-                LocalDate.now(),
-                12.000000,
+                subscriptionName = "A-S00102815",
+                previousAmount = 10.0000000,
+                newAmount = 10.0000000,
+                previousProductName = "previous product name",
+                previousRatePlanName = "previous rate plan",
+                newRatePlanName = "new rate plan",
+                requestedDate = LocalDate.now(),
+                effectiveDate = LocalDate.now(),
+                paidAmount = 12.000000,
+                csrId = Some("a_csr_id"),
+                caseId = Some("a_case_id"),
               ),
             )
             .provide(
@@ -61,15 +63,17 @@ object CreateRecordSpec extends ZIOSpecDefault {
         (for {
           output <- Salesforce.createSfRecord(
             SalesforceRecordInput(
-              "A-S00102815",
-              BigDecimal(100),
-              BigDecimal(100),
-              "previous product name",
-              "previous rate plan",
-              "new rate plan",
-              LocalDate.parse("2022-12-08"),
-              LocalDate.parse("2022-12-09"),
-              BigDecimal(50),
+              subscriptionName = "A-S00102815",
+              previousAmount = BigDecimal(100),
+              newAmount = BigDecimal(100),
+              previousProductName = "previous product name",
+              previousRatePlanName = "previous rate plan",
+              newRatePlanName = "new rate plan",
+              requestedDate = LocalDate.parse("2022-12-08"),
+              effectiveDate = LocalDate.parse("2022-12-09"),
+              paidAmount = BigDecimal(50),
+              csrId = Some("a_csr_id"),
+              caseId = Some("a_case_id"),
             ),
           )
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
@@ -44,8 +44,8 @@ object CreateRecordSpec extends ZIOSpecDefault {
                 requestedDate = LocalDate.now(),
                 effectiveDate = LocalDate.now(),
                 paidAmount = 12.000000,
-                csrId = Some("a_csr_id"),
-                caseId = Some("a_case_id"),
+                csrUserId = Some("0050J000005ZDPfQAO"),
+                caseId = Some("5009E00000Mph1qQAB"),
               ),
             )
             .provide(
@@ -72,7 +72,7 @@ object CreateRecordSpec extends ZIOSpecDefault {
               requestedDate = LocalDate.parse("2022-12-08"),
               effectiveDate = LocalDate.parse("2022-12-09"),
               paidAmount = BigDecimal(50),
-              csrId = Some("a_csr_id"),
+              csrUserId = Some("a_csr_id"),
               caseId = Some("a_case_id"),
             ),
           )


### PR DESCRIPTION
## What does this change?

When switching a recurring contributor to supporter plus through Salesforce, we want to record the CSR user id and case id in the 'Subscription Rate Plan Update' record which we write to SF at the end of the process.

## [Trello card](https://trello.com/c/8WMWYrGO/3944-csr-product-switch-wizard-receive-and-store-csr-name-and-case-number-on-switch)