### PR TITLE
Soft Opt In config fix

### DIFF
--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -92,6 +92,14 @@ Resources:
             !Sub
             - '{{resolve:secretsmanager:${IdentityStage}/Identity/SoftOptInConsentAPI:SecretString:identityToken}}'
             - IdentityStage: !FindInMap [ StageMap, !Ref Stage, IdentityStage ]
+          mpapiUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${MpapiStage}/MobilePurchasesAPI/User/GetSubscriptions:SecretString:mpapiUrl}}'
+            - MpapiStage: !FindInMap [ StageMap, !Ref Stage, MpapiStage ]
+          mpapiToken:
+            !Sub
+            - '{{resolve:secretsmanager:${MpapiStage}/MobilePurchasesAPI/User/GetSubscriptions:SecretString:mpapiToken}}'
+            - MpapiStage: !FindInMap [ StageMap, !Ref Stage, MpapiStage ]
       Events:
         ScheduledRun:
           Type: Schedule


### PR DESCRIPTION
The lambda could not find mpapi credentials due to their absence in the cloudformation file.