### PR TITLE
Add higher level unit tests for `soft-opt-in-consent-setter` lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -423,7 +423,19 @@ lazy val `sf-billing-account-remover` = lambdaProject(
 lazy val `soft-opt-in-consent-setter` = lambdaProject(
   "soft-opt-in-consent-setter",
   "sets or unsets soft opt in consents dependent on subscription product",
-  Seq(awsSecretsManager, circe, circeParser, scalatest, scalajHttp, awsS3, simpleConfig, awsLambda, awsSQS, awsEvents) ++ logging
+  Seq(
+    awsSecretsManager,
+    circe,
+    circeParser,
+    scalatest,
+    scalajHttp,
+    awsS3,
+    simpleConfig,
+    awsLambda,
+    awsSQS,
+    awsEvents,
+    scalaMock,
+  ) ++ logging,
 ).dependsOn(`effects-s3`, `effects-cloudwatch`, `salesforce-core`)
 
 lazy val `sf-emails-to-s3-exporter` = lambdaProject(

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -130,6 +130,136 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
     |]""".stripMargin)
   }
 
+  "buildProductSwitchConsents" should "return the correct consents when switching from a Recurring Contribution to Guardian Weekly subscription" in {
+    Handler.buildProductSwitchConsents(
+      "contributions",
+      "guardianweekly",
+      Set("guardianweekly"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "similar_guardian_products",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "supporter_newsletter",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
+  }
+
+  "buildProductSwitchConsents" should "return the correct consents when switching from a Recurring Contribution to a Guardian Weekly subscription whilst the user also owns a Newspaper subscription" in {
+    Handler.buildProductSwitchConsents(
+      "contributions",
+      "guardianweekly",
+      Set("guardianweekly", "newspaper"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
+  }
+
+  "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription" in {
+    Handler.buildProductSwitchConsents(
+      "guardianweekly",
+      "newspaper",
+      Set("newspaper"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "similar_guardian_products",
+        |    "consented" : true
+        |  },
+        |  {
+        |    "id" : "subscriber_preview",
+        |    "consented" : true
+        |  },
+        |  {
+        |    "id" : "supporter_newsletter",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
+  }
+
+  "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Recurring Contribution whilst also owning a Newspaper subscription" in {
+    Handler.buildProductSwitchConsents(
+      "guardianweekly",
+      "contributions",
+      Set("newspaper", "contributions"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : false
+        |  }
+        |]""".stripMargin)
+  }
+
+  "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Recurring Contribution" in {
+    Handler.buildProductSwitchConsents(
+      "guardianweekly",
+      "newspaper",
+      Set("newspaper", "contributions"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "subscriber_preview",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
+  }
+
+  "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
+    Handler.buildProductSwitchConsents(
+      "guardianweekly",
+      "newspaper",
+      Set("newspaper", "mobilesubscription"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "subscriber_preview",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
+  }
+
+  "buildProductSwitchConsents - HandlerIAP" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
+    HandlerIAP.buildProductSwitchConsents(
+      "guardianweekly",
+      "newspaper",
+      Set("newspaper", "mobilesubscription"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "subscriber_preview",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
+  }
+
   def removeWhitespace(stringToRemoveWhitespaceFrom: String): String = {
     stringToRemoveWhitespaceFrom.replaceAll("\\s", "")
   }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -15,6 +15,7 @@ object ConsentsCalculatorTestData {
   val testConsentMappings = Map(
     "membership" -> membershipMapping,
     "contributions" -> contributionMapping,
+    "InAppPurchase" -> contributionMapping,
     "supporterPlus" -> supporterPlusMapping,
     "newspaper" -> newspaperMapping,
     "guardianweekly" -> guWeeklyMapping,


### PR DESCRIPTION
We recently introduced additional complexity in [this PR](https://github.com/guardian/support-service-lambdas/pull/1885), which fetches any mobile subscriptions a customer may have from the mobile-purchase API. I've added some new unit tests to cover more of the code.