### PR TITLE
Supporter plus V2 product switching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,8 +50,8 @@ lazy val scalafmtSettings = Seq(
 
 // fixme this whole file needs splitting down appropriately
 
-lazy val EffectsTest = config("effectsTest") extend (Test) describedAs ("run the edge tests")
-lazy val HealthCheckTest = config("healthCheck") extend (Test) describedAs ("run the health checks against prod/code")
+lazy val EffectsTest = config("effectsTest") extend Test describedAs "run the edge tests"
+lazy val HealthCheckTest = config("healthCheck") extend Test describedAs "run the health checks against prod/code"
 val testSettings = inConfig(EffectsTest)(Defaults.testTasks) ++ inConfig(HealthCheckTest)(Defaults.testTasks) ++ Seq(
   Test / testOptions += Tests.Argument("-l", "com.gu.test.EffectsTest"),
   Test / testOptions += Tests.Argument("-l", "com.gu.test.HealthCheck"),
@@ -526,7 +526,13 @@ lazy val `product-move-api` = lambdaProject(
     "com.softwaremill.sttp.tapir" %% "tapir-aws-lambda" % tapirVersion,
     "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirVersion,
   ),
-  scala3Settings,
+  scala3Settings ++ Seq(
+    excludeDependencies ++= Seq(
+      ExclusionRule("org.typelevel", "cats-kernel_2.13"),
+      ExclusionRule("org.typelevel", "cats-core_2.13"),
+      ExclusionRule("com.typesafe.scala-logging", "scala-logging_2.13")
+    )
+  ),
 )
   .settings {
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
@@ -547,13 +553,13 @@ lazy val `product-move-api` = lambdaProject(
       val s3Bucket = "support-service-lambdas-dist"
       val s3Path = s"membership/$stage/product-move-api/product-move-api.jar"
 
-      s"aws s3 cp $jarFile s3://$s3Bucket/$s3Path --profile membership --region eu-west-1".!!
-      s"aws lambda update-function-code --function-name move-product-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
-      s"aws lambda update-function-code --function-name product-switch-refund-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
-      s"aws lambda update-function-code --function-name product-switch-salesforce-tracking-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+        s"aws s3 cp $jarFile s3://$s3Bucket/$s3Path --profile membership --region eu-west-1".!!
+        s"aws lambda update-function-code --function-name move-product-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+        s"aws lambda update-function-code --function-name product-switch-refund-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+        s"aws lambda update-function-code --function-name product-switch-salesforce-tracking-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+      }
     }
-  }
-  .dependsOn(`zuora-models`)
+    .dependsOn(`zuora-models`, `new-product-api`)
 
 lazy val `metric-push-api` =
   lambdaProject("metric-push-api", "HTTP API to push a metric to cloudwatch so we can alarm on errors")

--- a/build.sbt
+++ b/build.sbt
@@ -530,8 +530,8 @@ lazy val `product-move-api` = lambdaProject(
     excludeDependencies ++= Seq(
       ExclusionRule("org.typelevel", "cats-kernel_2.13"),
       ExclusionRule("org.typelevel", "cats-core_2.13"),
-      ExclusionRule("com.typesafe.scala-logging", "scala-logging_2.13")
-    )
+      ExclusionRule("com.typesafe.scala-logging", "scala-logging_2.13"),
+    ),
   ),
 )
   .settings {
@@ -553,13 +553,13 @@ lazy val `product-move-api` = lambdaProject(
       val s3Bucket = "support-service-lambdas-dist"
       val s3Path = s"membership/$stage/product-move-api/product-move-api.jar"
 
-        s"aws s3 cp $jarFile s3://$s3Bucket/$s3Path --profile membership --region eu-west-1".!!
-        s"aws lambda update-function-code --function-name move-product-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
-        s"aws lambda update-function-code --function-name product-switch-refund-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
-        s"aws lambda update-function-code --function-name product-switch-salesforce-tracking-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
-      }
+      s"aws s3 cp $jarFile s3://$s3Bucket/$s3Path --profile membership --region eu-west-1".!!
+      s"aws lambda update-function-code --function-name move-product-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+      s"aws lambda update-function-code --function-name product-switch-refund-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+      s"aws lambda update-function-code --function-name product-switch-salesforce-tracking-$stage --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
     }
-    .dependsOn(`zuora-models`, `new-product-api`)
+  }
+  .dependsOn(`zuora-models`, `new-product-api`)
 
 lazy val `metric-push-api` =
   lambdaProject("metric-push-api", "HTTP API to push a metric to cloudwatch so we can alarm on errors")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogEffectsTest.scala
@@ -2,18 +2,19 @@ package com.gu.newproduct.api
 
 import com.gu.effects.GetFromS3
 import com.gu.newproduct.api.productcatalog.PlanId._
-import com.gu.newproduct.api.productcatalog.{PricesFromZuoraCatalog, ZuoraIds}
+import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PlanId, PricesFromZuoraCatalog, ZuoraIds}
 import com.gu.test.EffectsTest
 import com.gu.util.config.{Stage, ZuoraEnvironment}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import com.gu.i18n.Currency.GBP
 
 class PricesFromZuoraCatalogEffectsTest extends AnyFlatSpec with Matchers {
 
   it should "load catalog" taggedAs EffectsTest in {
 
     import ProductsData._
-    val expectedProducts = digital ++ voucher ++ hd ++ subsCard ++ gw
+    val expectedProducts = digital ++ voucher ++ hd ++ subsCard ++ gw ++ supporterPlus
 
     val actual = for {
       zuoraIds <- ZuoraIds.zuoraIdsForStage(Stage("DEV"))
@@ -23,6 +24,7 @@ class PricesFromZuoraCatalogEffectsTest extends AnyFlatSpec with Matchers {
         zuoraIds.rateplanIdToApiId.get,
       ).toDisjunction.left.map(_.toString)
     } yield response
+    actual.map(result => result(MonthlySupporterPlusV2).get(GBP)) shouldBe Right(Some(AmountMinorUnits(1000)))
     // the prices might change but at least we can assert that we got some price for each product
     actual.map(_.keySet) shouldBe Right(expectedProducts)
   }
@@ -82,5 +84,11 @@ object ProductsData {
     GuardianWeeklyROWAnnual,
     GuardianWeeklyDomesticQuarterly,
     GuardianWeeklyDomesticAnnual,
+  )
+  val supporterPlus = Set(
+    AnnualSupporterPlus,
+    MonthlySupporterPlus,
+    AnnualSupporterPlusV2,
+    MonthlySupporterPlusV2,
   )
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -1,6 +1,6 @@
 package com.gu.productmove.endpoint.move
 
-import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
+import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly, PricesFromZuoraCatalog}
 import com.gu.supporterdata.model.SupporterRatePlanItem
 
 import java.time.LocalDate
@@ -14,33 +14,9 @@ import com.gu.productmove.refund.RefundInput
 import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.zuora.GetSubscription.RatePlanCharge
 import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGet, ZuoraGetLive}
-import com.gu.productmove.zuora.{
-  GetAccount,
-  GetAccountLive,
-  GetSubscription,
-  GetSubscriptionLive,
-  Subscribe,
-  SubscribeLive,
-  SubscriptionUpdate,
-  getSupporterPlusRatePlanIds,
-  SubscriptionUpdateLive,
-  ZuoraCancel,
-  ZuoraCancelLive,
-}
-import com.gu.productmove.{
-  AwsCredentialsLive,
-  AwsS3Live,
-  Dynamo,
-  DynamoLive,
-  EmailMessage,
-  EmailPayload,
-  EmailPayloadContactAttributes,
-  EmailPayloadSubscriberAttributes,
-  GuStageLive,
-  SQS,
-  SQSLive,
-  SttpClientLive,
-}
+import com.gu.productmove.zuora.{GetAccount, GetAccountLive, GetSubscription, GetSubscriptionLive, Subscribe, SubscribeLive, SubscriptionUpdate, SubscriptionUpdateLive, ZuoraCancel, ZuoraCancelLive, getSupporterPlusRatePlanIds}
+import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, Dynamo, DynamoLive, EmailMessage, EmailPayload, EmailPayloadContactAttributes, EmailPayloadSubscriberAttributes, GuStageLive, SQS, SQSLive, SttpClientLive}
+import com.gu.util.config.ZuoraEnvironment
 import sttp.tapir.*
 import sttp.tapir.EndpointIO.Example
 import sttp.tapir.Schema
@@ -167,6 +143,12 @@ object ProductMoveEndpoint {
       ratePlanCharge <- getSingleOrNotEligible(
         currentRatePlan.ratePlanCharges,
         s"Subscription: $subscriptionName has more than one ratePlanCharge",
+      )
+      // TODO: Make this work
+      response <- PricesFromZuoraCatalog(
+        ZuoraEnvironment("DEV"),
+        GetFromS3.fetchString,
+        zuoraIds.rateplanIdToApiId.get,
       )
       result <-
         if (postData.preview)

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -1,11 +1,11 @@
 package com.gu.productmove.endpoint.move
 
-import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly, PricesFromZuoraCatalog}
+import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
 import com.gu.supporterdata.model.SupporterRatePlanItem
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
-import com.gu.productmove.endpoint.available.{Billing, Currency, MoveToProduct, Offer, TimePeriod, TimeUnit, Trial}
+import com.gu.productmove.endpoint.available.{Billing, MoveToProduct, Offer, TimePeriod, TimeUnit, Trial}
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.*
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.framework.ZIOApiGatewayRequestHandler.TIO
@@ -14,18 +14,49 @@ import com.gu.productmove.refund.RefundInput
 import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.zuora.GetSubscription.RatePlanCharge
 import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGet, ZuoraGetLive}
-import com.gu.productmove.zuora.{GetAccount, GetAccountLive, GetSubscription, GetSubscriptionLive, Subscribe, SubscribeLive, SubscriptionUpdate, SubscriptionUpdateLive, ZuoraCancel, ZuoraCancelLive, getSupporterPlusRatePlanIds}
-import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, Dynamo, DynamoLive, EmailMessage, EmailPayload, EmailPayloadContactAttributes, EmailPayloadSubscriberAttributes, GuStageLive, SQS, SQSLive, SttpClientLive}
-import com.gu.util.config.ZuoraEnvironment
+import com.gu.productmove.zuora.{
+  GetAccount,
+  GetAccountLive,
+  GetSubscription,
+  GetSubscriptionLive,
+  Subscribe,
+  SubscribeLive,
+  SubscriptionUpdate,
+  SubscriptionUpdateLive,
+  ZuoraCancel,
+  ZuoraCancelLive,
+  getSupporterPlusRatePlanIds,
+}
+import com.gu.productmove.{
+  AwsCredentialsLive,
+  AwsS3Live,
+  Dynamo,
+  DynamoLive,
+  EmailMessage,
+  EmailPayload,
+  EmailPayloadContactAttributes,
+  EmailPayloadSubscriberAttributes,
+  GuStageLive,
+  SQS,
+  SQSLive,
+  SttpClientLive,
+}
 import sttp.tapir.*
 import sttp.tapir.EndpointIO.Example
 import sttp.tapir.Schema
 import sttp.tapir.json.zio.jsonBody
 import zio.{Clock, IO, URIO, ZIO}
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
+import zio.ThreadLocalBridge.trace
+
+import com.gu.newproduct.api.productcatalog.PricesFromZuoraCatalog
+import com.gu.util.config.ZuoraEnvironment
+import com.gu.effects.GetFromS3
+import com.gu.newproduct.api.productcatalog.ZuoraIds.ZuoraIds
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import com.gu.i18n.Currency
 
 // this is the description for just the one endpoint
 object ProductMoveEndpoint {
@@ -144,20 +175,21 @@ object ProductMoveEndpoint {
         currentRatePlan.ratePlanCharges,
         s"Subscription: $subscriptionName has more than one ratePlanCharge",
       )
-      // TODO: Make this work
-      response <- PricesFromZuoraCatalog(
-        ZuoraEnvironment("DEV"),
-        GetFromS3.fetchString,
-        zuoraIds.rateplanIdToApiId.get,
-      )
+      currency <- ZIO
+        .fromOption(ratePlanCharge.currencyObject)
+        .orElseFail(
+          s"Missing or unknown currency ${ratePlanCharge.currency} on rate plan charge in rate plan ${currentRatePlan.id} ",
+        )
       result <-
         if (postData.preview)
-          doPreview(subscription.id, postData.price, ratePlanCharge.billingPeriod, currentRatePlan.id)
+          doPreview(subscription.id, postData.price, ratePlanCharge.billingPeriod, currency, currentRatePlan.id)
         else
           doUpdate(
             subscriptionName,
-            ratePlanCharge,
             postData.price,
+            BigDecimal(ratePlanCharge.price),
+            ratePlanCharge.billingPeriod,
+            currency,
             currentRatePlan,
             subscription,
             postData.csrUserId,
@@ -169,18 +201,21 @@ object ProductMoveEndpoint {
       subscriptionId: String,
       price: BigDecimal,
       billingPeriod: BillingPeriod,
+      currency: Currency,
       currentRatePlanId: String,
   ): ZIO[SubscriptionUpdate with Stage, String, OutputBody] = for {
     _ <- ZIO.log("Fetching Preview from Zuora")
     previewResponse <- SubscriptionUpdate
-      .preview(subscriptionId, billingPeriod, price, currentRatePlanId)
+      .preview(subscriptionId, billingPeriod, price, currency, currentRatePlanId)
       .addLogMessage("SubscriptionUpdate")
   } yield previewResponse
 
   def doUpdate(
       subscriptionName: String,
-      ratePlanCharge: RatePlanCharge,
       price: BigDecimal,
+      previousAmount: BigDecimal,
+      billingPeriod: BillingPeriod,
+      currency: Currency,
       currentRatePlan: GetSubscription.RatePlan,
       subscription: GetSubscription.GetSubscriptionResponse,
       csrUserId: Option[String],
@@ -195,11 +230,11 @@ object ProductMoveEndpoint {
       .orElseFail(s"identityId is null for subscription name $subscriptionName")
 
     updateResponse <- SubscriptionUpdate
-      .update(subscription.id, ratePlanCharge.billingPeriod, price, currentRatePlan.id)
+      .update(subscription.id, billingPeriod, price, currency, currentRatePlan.id)
       .addLogMessage("SubscriptionUpdate")
 
     todaysDate <- Clock.currentDateTime.map(_.toLocalDate)
-    billingPeriod <- ratePlanCharge.billingPeriod.value
+    billingPeriodValue <- billingPeriod.value
 
     paidAmount = updateResponse.paidAmount.getOrElse(BigDecimal(0))
 
@@ -216,7 +251,7 @@ object ProductMoveEndpoint {
                 price = price.setScale(2, BigDecimal.RoundingMode.FLOOR).toString,
                 first_payment_amount = paidAmount.setScale(2, BigDecimal.RoundingMode.FLOOR).toString,
                 date_of_first_payment = todaysDate.format(DateTimeFormatter.ofPattern("d MMMM uuuu")),
-                payment_frequency = billingPeriod + "ly",
+                payment_frequency = billingPeriodValue + "ly",
                 subscription_id = subscriptionName,
               ),
             ),
@@ -232,7 +267,7 @@ object ProductMoveEndpoint {
       .queueSalesforceTracking(
         SalesforceRecordInput(
           subscriptionName,
-          BigDecimal(ratePlanCharge.price),
+          previousAmount,
           price,
           currentRatePlan.productName,
           currentRatePlan.ratePlanName,
@@ -246,7 +281,7 @@ object ProductMoveEndpoint {
       )
       .fork
 
-    supporterPlusRatePlanIds <- ZIO.fromEither(getSupporterPlusRatePlanIds(stage, ratePlanCharge.billingPeriod))
+    supporterPlusRatePlanIds <- ZIO.fromEither(getSupporterPlusRatePlanIds(stage, billingPeriod))
     amendSupporterProductDynamoTableFuture <- Dynamo
       .writeItem(
         SupporterRatePlanItem(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/BuildPreviewResult.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/BuildPreviewResult.scala
@@ -12,7 +12,7 @@ object BuildPreviewResult {
       ids: SupporterPlusRatePlanIds,
   ): ZIO[Stage, String, PreviewResult] = {
     val (supporterPlusInvoices, contributionInvoices) =
-      invoice.invoiceItems.partition(_.productRatePlanChargeId == ids.ratePlanChargeId)
+      invoice.invoiceItems.partition(_.productRatePlanChargeId == ids.subscriptionRatePlanChargeId)
 
     (supporterPlusInvoices.length, contributionInvoices.length) match {
       case (n1, n2) if n1 > 1 && n2 >= 1 =>

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetSubscription.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetSubscription.scala
@@ -1,6 +1,7 @@
 package com.gu.productmove.zuora
 
-import com.gu.newproduct.api.productcatalog.{BillingPeriod, Monthly, Annual}
+import com.gu.i18n.Currency
+import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
 import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
@@ -51,18 +52,18 @@ object GetSubscription {
       billingPeriod: BillingPeriod,
       effectiveStartDate: LocalDate,
       chargedThroughDate: Option[LocalDate],
-  )
+  ){
+    def currencyObject = Currency.fromString(currency)
+  }
   object RatePlanCharge {
     given JsonDecoder[RatePlanCharge] = DeriveJsonDecoder.gen
   }
 
-  given JsonDecoder[BillingPeriod] = JsonDecoder[String].mapOrFail(x =>
-    x match {
-      case "Month" => Right(Monthly)
-      case "Annual" => Right(Annual)
-      case _ => Left(s"No such billing period ${x.toString}")
-    },
-  )
+  given JsonDecoder[BillingPeriod] = JsonDecoder[String].mapOrFail {
+    case "Month" => Right(Monthly)
+    case "Annual" => Right(Annual)
+    case x => Left(s"No such billing period $x")
+  }
 
   given JsonDecoder[GetSubscriptionResponse] = DeriveJsonDecoder.gen[GetSubscriptionResponse]
   given JsonDecoder[RatePlan] = DeriveJsonDecoder.gen[RatePlan]

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSubscriptionUpdate.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSubscriptionUpdate.scala
@@ -7,6 +7,7 @@ import com.gu.productmove.zuora.GetSubscription
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import com.gu.productmove.zuora.CreateSubscriptionResponse
 import zio.{IO, ZIO}
+import com.gu.i18n.Currency
 
 class MockSubscriptionUpdate(
     previewResponse: Map[(String, BillingPeriod, BigDecimal, String), PreviewResult],
@@ -22,6 +23,7 @@ class MockSubscriptionUpdate(
       subscriptionId: String,
       billingPeriod: BillingPeriod,
       price: BigDecimal,
+      currency: Currency,
       ratePlanIdToRemove: String,
   ): ZIO[Any, String, SubscriptionUpdateResponse] = {
     mutableStore = (subscriptionId, billingPeriod, price, ratePlanIdToRemove) :: mutableStore
@@ -35,6 +37,7 @@ class MockSubscriptionUpdate(
       subscriptionId: String,
       billingPeriod: BillingPeriod,
       price: BigDecimal,
+      currency: Currency,
       ratePlanIdToRemove: String,
   ): ZIO[GuStageLive.Stage, String, PreviewResult] = {
     mutableStore = (subscriptionId, billingPeriod, price, ratePlanIdToRemove) :: mutableStore

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
@@ -38,6 +38,6 @@ object ProductMoveSpec extends ZIOSpecDefault {
 
         assert(true)(equalTo(true))
       }
-    })
+    } @@ TestAspect.ignore)
 
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
@@ -21,7 +21,7 @@ object ProductMoveSpec extends ZIOSpecDefault {
 
       for {
         _ <- TestClock.setTime(Instant.now())
-        result <- ProductMoveEndpoint.productMove("A-S00500486", ExpectedInput(20, false))
+        result <- ProductMoveEndpoint.productMove("A-S00500486", ExpectedInput(20, false, None, None))
           .provide(
             GetSubscriptionLive.layer,
             AwsCredentialsLive.layer,

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
@@ -14,14 +14,14 @@ import zio.test.{Spec, TestAspect, TestEnvironment, ZIOSpecDefault}
 object ProductMoveSpec extends ZIOSpecDefault {
 
   override def spec: Spec[TestEnvironment with Scope, Any] =
-    suite("Cancel")(test("Run cancellation lambda locally") {
+    suite("Switch")(test("Run product switch lambda locally") {
       /*
            Test suite used to run the cancellation lambda locally
        */
 
       for {
         _ <- TestClock.setTime(Instant.now())
-        result <- ProductMoveEndpoint.productMove("A-S00500486", ExpectedInput(20, false, None, None))
+        _ <- ProductMoveEndpoint.productMove("A-S00487531", ExpectedInput(20, false, None, None))
           .provide(
             GetSubscriptionLive.layer,
             AwsCredentialsLive.layer,

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
@@ -15,10 +15,6 @@ object ProductMoveSpec extends ZIOSpecDefault {
 
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("Switch")(test("Run product switch lambda locally") {
-      /*
-           Test suite used to run the cancellation lambda locally
-       */
-
       for {
         _ <- TestClock.setTime(Instant.now())
         _ <- ProductMoveEndpoint.productMove("A-S00487531", ExpectedInput(20, false, None, None))

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ProductMoveSpec.scala
@@ -1,0 +1,43 @@
+package com.gu.productmove.zuora
+
+import com.gu.productmove.{AwsCredentialsLive, DynamoLive, GuStageLive, SQSLive, SttpClientLive}
+import com.gu.productmove.endpoint.move.ProductMoveEndpoint
+import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.ExpectedInput
+import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGetLive}
+import java.time.*
+import zio.Scope
+import zio.*
+import zio.test.Assertion.*
+import zio.test.*
+import zio.test.{Spec, TestAspect, TestEnvironment, ZIOSpecDefault}
+
+object ProductMoveSpec extends ZIOSpecDefault {
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("Cancel")(test("Run cancellation lambda locally") {
+      /*
+           Test suite used to run the cancellation lambda locally
+       */
+
+      for {
+        _ <- TestClock.setTime(Instant.now())
+        result <- ProductMoveEndpoint.productMove("A-S00500486", ExpectedInput(20, false))
+          .provide(
+            GetSubscriptionLive.layer,
+            AwsCredentialsLive.layer,
+            SttpClientLive.layer,
+            ZuoraClientLive.layer,
+            ZuoraGetLive.layer,
+            SubscriptionUpdateLive.layer,
+            SQSLive.layer,
+            GetAccountLive.layer,
+            GuStageLive.layer,
+            DynamoLive.layer,
+          )
+      } yield {
+
+        assert(true)(equalTo(true))
+      }
+    })
+
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
@@ -14,6 +14,8 @@ import zio.test.Assertion.*
 import zio.test.*
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.PreviewResult
 import Fixtures.*
+import com.gu.newproduct.api.productcatalog.PlanId.MonthlySupporterPlus
+import com.gu.i18n.Currency.GBP
 
 import java.time.*
 import scala.None
@@ -49,7 +51,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
 
         for {
           _ <- TestClock.setTime(time)
-          createRequestBody <- SubscriptionUpdateRequest(Monthly, "8ad03sdfa1312f3123", 50.00).provideLayer(
+          createRequestBody <- SubscriptionUpdateRequest(Monthly, GBP, "8ad03sdfa1312f3123", 50.00).provideLayer(
             ZLayer.succeed(Stage.valueOf("DEV")),
           )
         } yield assert(createRequestBody)(equalTo(expectedRequestBody))
@@ -81,7 +83,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
 
         for {
           _ <- TestClock.setTime(time)
-          createRequestBody <- SubscriptionUpdateRequest(Monthly, "8ad03sdfa1312f3123", 50.00).provideLayer(
+          createRequestBody <- SubscriptionUpdateRequest(Monthly, GBP, "8ad03sdfa1312f3123", 50.00).provideLayer(
             ZLayer.succeed(Stage.valueOf("PROD")),
           )
         } yield assert(createRequestBody)(equalTo(expectedRequestBody))
@@ -101,7 +103,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
           response <- BuildPreviewResult
             .getPreviewResult(
               invoiceWithMultipleInvoiceItems,
-              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
+              SupporterPlusRatePlanIds(MonthlySupporterPlus, "8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
             )
             .provideLayer(
               ZLayer.succeed(Stage.valueOf("DEV")),
@@ -123,7 +125,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
           response <- BuildPreviewResult
             .getPreviewResult(
               invoiceWithTax,
-              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
+              SupporterPlusRatePlanIds(MonthlySupporterPlus, "8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
             )
             .provideLayer(
               ZLayer.succeed(Stage.valueOf("DEV")),

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
@@ -16,6 +16,7 @@ import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.PreviewResult
 import Fixtures.*
 
 import java.time.*
+import scala.None
 
 object SubscriptionUpdateSpec extends ZIOSpecDefault {
 
@@ -100,7 +101,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
           response <- BuildPreviewResult
             .getPreviewResult(
               invoiceWithMultipleInvoiceItems,
-              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6"),
+              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
             )
             .provideLayer(
               ZLayer.succeed(Stage.valueOf("DEV")),
@@ -122,7 +123,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
           response <- BuildPreviewResult
             .getPreviewResult(
               invoiceWithTax,
-              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6"),
+              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
             )
             .provideLayer(
               ZLayer.succeed(Stage.valueOf("DEV")),

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
@@ -103,7 +103,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
           response <- BuildPreviewResult
             .getPreviewResult(
               invoiceWithMultipleInvoiceItems,
-              SupporterPlusRatePlanIds(MonthlySupporterPlus, "8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
+              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
             )
             .provideLayer(
               ZLayer.succeed(Stage.valueOf("DEV")),
@@ -125,7 +125,7 @@ object SubscriptionUpdateSpec extends ZIOSpecDefault {
           response <- BuildPreviewResult
             .getPreviewResult(
               invoiceWithTax,
-              SupporterPlusRatePlanIds(MonthlySupporterPlus, "8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
+              SupporterPlusRatePlanIds("8ad09fc281de1ce70181de3b251736a4", "8ad09fc281de1ce70181de3b253e36a6", None),
             )
             .provideLayer(
               ZLayer.succeed(Stage.valueOf("DEV")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -114,6 +114,7 @@ object Dependencies {
     case PathList(ps @ _*) if ps.last == "deriving.conf" => MergeStrategy.filterDistinctLines
     case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
     case PathList("mime.types") => MergeStrategy.filterDistinctLines
+    case PathList("logback.xml") => MergeStrategy.preferProject
     /*
      * AWS SDK v2 includes a codegen-resources directory in each jar, with conflicting names.
      * This appears to be for generating clients from HTTP services.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR  enables product switching from a recurring contribution onto supporter plus V2. 

V2 changes the original supporter plus product by adding two separate charges to the product rate plan, one for the cost of the subscription which is fixed and an additional contribution charge which is variable and may be zero.

For product switching from a recurring contribution, this means that we need to work out how much of the amount which the user has chosen to pay is above the threshold so that we can treat that as a contribution (add it to the contribution charge in Zuora)

There is a new boolean flag added `SubscriptionUpdate.SwitchToV2SupporterPlus` which determines whether to switch to V1 or V2, this is currently set to false so that we can merge these changes without making the code active.