### PR TITLE
Sending an email message on supporter plus cancellation in product-move-api

### DIFF
--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -75,8 +75,7 @@ Resources:
                         - sqs:GetQueueUrl
                         - sqs:SendMessage
                         Resource:
-                          - Fn::ImportValue:
-                              !Sub "comms-${Stage}-EmailQueueArn"
+                          Fn::ImportValue: !Sub "comms-${Stage}-EmailQueueArn"
                 - PolicyName: ReadZuoraCatalog
                   PolicyDocument:
                     Statement:

--- a/handlers/product-move-api/riff-raff.yaml
+++ b/handlers/product-move-api/riff-raff.yaml
@@ -4,7 +4,6 @@ regions:
 - eu-west-1
 allowedStages:
 - DEV
-- CODE
 - PROD
 deployments:
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscriptionToCancel.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscriptionToCancel.scala
@@ -2,8 +2,8 @@ package com.gu.productmove.endpoint.zuora
 
 import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
-import com.gu.productmove.endpoint.zuora.GetSubscriptionToCancel.Response
-import com.gu.productmove.zuora.model.SubscriptionName
+import com.gu.productmove.endpoint.zuora.GetSubscriptionToCancel.GetSubscriptionToCancelResponse
+import com.gu.productmove.zuora.model.{AccountNumber, SubscriptionName}
 import com.gu.productmove.zuora.rest.ZuoraGet
 import sttp.capabilities.zio.ZioStreams
 import sttp.capabilities.{Effect, WebSockets}
@@ -20,21 +20,22 @@ object GetSubscriptionToCancelLive:
   val layer: URLayer[ZuoraGet, GetSubscriptionToCancel] = ZLayer.fromFunction(GetSubscriptionToCancelLive(_))
 
 private class GetSubscriptionToCancelLive(zuoraGet: ZuoraGet) extends GetSubscriptionToCancel:
-  override def get(subscriptionName: SubscriptionName): IO[String, GetSubscriptionToCancel.Response] =
-    zuoraGet.get[GetSubscriptionToCancel.Response](
+  override def get(subscriptionName: SubscriptionName): IO[String, GetSubscriptionToCancelResponse] =
+    zuoraGet.get[GetSubscriptionToCancelResponse](
       uri"subscriptions/${subscriptionName.value}?charge-detail=current-segment",
     )
 
 trait GetSubscriptionToCancel:
-  def get(subscriptionName: SubscriptionName): IO[String, GetSubscriptionToCancel.Response]
+  def get(subscriptionName: SubscriptionName): IO[String, GetSubscriptionToCancelResponse]
 
 object GetSubscriptionToCancel {
 
-  case class Response(
+  case class GetSubscriptionToCancelResponse(
       id: String,
       version: Int,
       contractEffectiveDate: LocalDate,
       accountId: String,
+      accountNumber: AccountNumber,
       ratePlans: List[RatePlan],
   )
 
@@ -58,11 +59,11 @@ object GetSubscriptionToCancel {
       effectiveEndDate: LocalDate,
   )
 
-  given JsonDecoder[Response] = DeriveJsonDecoder.gen[GetSubscriptionToCancel.Response]
+  given JsonDecoder[GetSubscriptionToCancelResponse] = DeriveJsonDecoder.gen[GetSubscriptionToCancelResponse]
   given JsonDecoder[RatePlan] = DeriveJsonDecoder.gen[RatePlan]
   given JsonDecoder[RatePlanCharge] = DeriveJsonDecoder.gen[RatePlanCharge]
 
-  def get(subscriptionName: SubscriptionName): ZIO[GetSubscriptionToCancel, String, GetSubscriptionToCancel.Response] =
+  def get(subscriptionName: SubscriptionName): ZIO[GetSubscriptionToCancel, String, GetSubscriptionToCancelResponse] =
     ZIO.serviceWithZIO[GetSubscriptionToCancel](_.get(subscriptionName))
 
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/ProductMoveEndpoint.scala
@@ -35,7 +35,7 @@ import com.gu.productmove.{
   EmailMessage,
   EmailPayload,
   EmailPayloadContactAttributes,
-  EmailPayloadSubscriberAttributes,
+  EmailPayloadProductSwitchAttributes,
   GuStageLive,
   SQS,
   SQSLive,
@@ -253,7 +253,7 @@ object ProductMoveEndpoint {
           EmailPayload(
             Address = Some(account.billToContact.workEmail),
             ContactAttributes = EmailPayloadContactAttributes(
-              SubscriberAttributes = EmailPayloadSubscriberAttributes(
+              SubscriberAttributes = EmailPayloadProductSwitchAttributes(
                 first_name = account.billToContact.firstName,
                 last_name = account.billToContact.lastName,
                 currency = account.basicInfo.currency.symbol,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetAccount.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetAccount.scala
@@ -7,6 +7,7 @@ import com.gu.productmove.endpoint.available.{Currency, TimeUnit}
 import com.gu.productmove.zuora.DefaultPaymentMethod
 import com.gu.productmove.zuora.GetAccount.{GetAccountResponse, PaymentMethodResponse}
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
+import com.gu.productmove.zuora.model.AccountNumber
 import com.gu.productmove.zuora.rest.ZuoraClientLive.ZuoraRestConfig
 import com.gu.productmove.zuora.rest.ZuoraGet
 import com.gu.productmove.zuora.rest.ZuoraRestBody.ZuoraSuccessCheck
@@ -27,14 +28,15 @@ object GetAccountLive:
   val layer: URLayer[ZuoraGet, GetAccount] = ZLayer.fromFunction(GetAccountLive(_))
 
 private class GetAccountLive(zuoraGet: ZuoraGet) extends GetAccount:
-  override def get(accountNumber: String): IO[String, GetAccountResponse] =
-    zuoraGet.get[GetAccountResponse](uri"accounts/$accountNumber/summary", ZuoraSuccessCheck.SuccessCheckLowercase)
+  override def get(accountNumber: AccountNumber): IO[String, GetAccountResponse] =
+    zuoraGet
+      .get[GetAccountResponse](uri"accounts/${accountNumber.value}/summary", ZuoraSuccessCheck.SuccessCheckLowercase)
 
   override def getPaymentMethod(paymentMethodId: String): IO[String, PaymentMethodResponse] =
     zuoraGet.get[PaymentMethodResponse](uri"object/payment-method/$paymentMethodId", ZuoraSuccessCheck.SuccessCheckSize)
 
 trait GetAccount:
-  def get(subscriptionNumber: String): ZIO[GetAccount, String, GetAccountResponse]
+  def get(subscriptionNumber: AccountNumber): ZIO[GetAccount, String, GetAccountResponse]
 
   def getPaymentMethod(paymentMethodId: String): ZIO[GetAccount, String, PaymentMethodResponse]
 
@@ -138,7 +140,7 @@ object GetAccount {
 
   given JsonDecoder[BillToContact] = DeriveJsonDecoder.gen
 
-  def get(accountNumber: String): ZIO[GetAccount, String, GetAccountResponse] =
+  def get(accountNumber: AccountNumber): ZIO[GetAccount, String, GetAccountResponse] =
     ZIO.serviceWithZIO[GetAccount](_.get(accountNumber))
 
   def getPaymentMethod(paymentMethodId: String): ZIO[GetAccount, String, PaymentMethodResponse] =

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetSubscription.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetSubscription.scala
@@ -5,7 +5,7 @@ import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
 import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
-import com.gu.productmove.zuora.model.SubscriptionName
+import com.gu.productmove.zuora.model.{AccountNumber, SubscriptionName}
 import com.gu.productmove.zuora.rest.ZuoraGet
 import sttp.capabilities.zio.ZioStreams
 import sttp.capabilities.{Effect, WebSockets}
@@ -30,7 +30,12 @@ trait GetSubscription:
 
 object GetSubscription {
 
-  case class GetSubscriptionResponse(id: String, accountId: String, accountNumber: String, ratePlans: List[RatePlan])
+  case class GetSubscriptionResponse(
+      id: String,
+      accountId: String,
+      accountNumber: AccountNumber,
+      ratePlans: List[RatePlan],
+  )
 
   case class RatePlan(
       productName: String,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/model/AccountNumber.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/model/AccountNumber.scala
@@ -1,0 +1,9 @@
+package com.gu.productmove.zuora.model
+
+import zio.json.JsonDecoder
+
+case class AccountNumber(value: String)
+
+object AccountNumber {
+  given JsonDecoder[AccountNumber] = JsonDecoder.string.map(AccountNumber(_))
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -4,15 +4,16 @@ import com.gu.newproduct.api.productcatalog.{Monthly, ZuoraIds}
 import com.gu.productmove.endpoint.available.Currency
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.PreviewResult
 import com.gu.productmove.endpoint.zuora.GetSubscriptionToCancel
+import com.gu.productmove.endpoint.zuora.GetSubscriptionToCancel.GetSubscriptionToCancelResponse
 import com.gu.productmove.refund.RefundInput
 import com.gu.productmove.salesforce.CreateRecord.CreateRecordRequest
 import com.gu.productmove.salesforce.GetSfSubscription.GetSfSubscriptionResponse
 import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.zuora.GetAccount.{AccountSubscription, BasicInfo, BillToContact, GetAccountResponse}
 import com.gu.productmove.zuora.GetSubscription.{GetSubscriptionResponse, RatePlan, RatePlanCharge}
-import com.gu.productmove.zuora.model.SubscriptionName
+import com.gu.productmove.zuora.model.{AccountNumber, SubscriptionName}
 import com.gu.productmove.zuora.*
-import com.gu.productmove.{EmailMessage, EmailPayload, EmailPayloadSubscriberAttributes}
+import com.gu.productmove.{EmailMessage, EmailPayload, EmailPayloadProductSwitchAttributes}
 import com.gu.supporterdata.model.SupporterRatePlanItem
 import com.gu.util.config.Stage
 
@@ -28,7 +29,7 @@ import java.time.LocalDate
 val getSubscriptionResponse = GetSubscriptionResponse(
   "A-S00339056",
   "zuoraAccountId",
-  "accountNumber",
+  AccountNumber("accountNumber"),
   ratePlans = List(
     RatePlan(
       id = "89ad8casd9c0asdcaj89sdc98as",
@@ -52,11 +53,12 @@ val getSubscriptionResponse = GetSubscriptionResponse(
   ),
 )
 
-val getSubscriptionForCancelResponse = GetSubscriptionToCancel.Response(
+val getSubscriptionForCancelResponse = GetSubscriptionToCancelResponse(
   id = "A-S00339056",
   version = 1,
   contractEffectiveDate = LocalDate.of(2020, 11, 29),
   accountId = "zuoraAccountId",
+  accountNumber = AccountNumber("anAccountNumber"),
   ratePlans = List(
     GetSubscriptionToCancel.RatePlan(
       id = "89ad8casd9c0asdcaj89sdc98as",
@@ -89,7 +91,7 @@ val getSubscriptionForCancelResponse = GetSubscriptionToCancel.Response(
 
 val getSubscriptionResponse2 = GetSubscriptionResponse(
   id = "8ad0823f841cf4e601841e61f6aa8923",
-  accountNumber = "A00433231",
+  accountNumber = AccountNumber("A00433231"),
   accountId = "8ad0823f841cf4e601841e61f6aads87",
   ratePlans = List(
     RatePlan(
@@ -136,7 +138,7 @@ val getSubscriptionResponse2 = GetSubscriptionResponse(
 val getSubscriptionResponseNoChargedThroughDate = GetSubscriptionResponse(
   "subscriptionName",
   "zuoraAccountId",
-  "accountNumber",
+  AccountNumber("accountNumber"),
   ratePlans = List(
     RatePlan(
       id = "R1",
@@ -237,7 +239,7 @@ val emailMessageBody = EmailMessage(
   To = EmailPayload(
     Address = Some("example@gmail.com"),
     EmailPayloadContactAttributes(
-      EmailPayloadSubscriberAttributes(
+      EmailPayloadProductSwitchAttributes(
         subscription_id = "A-S00339056",
         first_name = "John",
         last_name = "Hee",
@@ -258,7 +260,7 @@ val emailMessageBodyRefund = EmailMessage(
   To = EmailPayload(
     Address = Some("example@gmail.com"),
     EmailPayloadContactAttributes(
-      EmailPayloadSubscriberAttributes(
+      EmailPayloadProductSwitchAttributes(
         subscription_id = "A-S00339056",
         first_name = "John",
         last_name = "Hee",
@@ -279,7 +281,7 @@ val emailMessageBodyNoPaymentOrRefund = EmailMessage(
   To = EmailPayload(
     Address = Some("example@gmail.com"),
     EmailPayloadContactAttributes(
-      EmailPayloadSubscriberAttributes(
+      EmailPayloadProductSwitchAttributes(
         subscription_id = "A-S00339056",
         first_name = "John",
         last_name = "Hee",

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetAccount.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetAccount.scala
@@ -1,18 +1,19 @@
 package com.gu.productmove.zuora
 
 import com.gu.productmove.zuora.GetAccount.PaymentMethodResponse
+import com.gu.productmove.zuora.model.AccountNumber
 import zio.{IO, ZIO}
 
 class MockGetAccount(
-    accountResponse: Map[String, GetAccount.GetAccountResponse],
+    accountResponse: Map[AccountNumber, GetAccount.GetAccountResponse],
     paymentResponse: Map[String, PaymentMethodResponse],
 ) extends GetAccount {
 
-  private var mutableStore: List[String] = Nil // we need to remember the side effects
+  private var mutableStore: List[String | AccountNumber] = Nil // we need to remember the side effects
 
   def requests = mutableStore.reverse
 
-  override def get(accountNumber: String): IO[String, GetAccount.GetAccountResponse] = {
+  override def get(accountNumber: AccountNumber): IO[String, GetAccount.GetAccountResponse] = {
     mutableStore = accountNumber :: mutableStore
 
     accountResponse.get(accountNumber) match
@@ -30,5 +31,5 @@ class MockGetAccount(
 }
 
 object MockGetAccount {
-  def requests: ZIO[MockGetAccount, Nothing, List[String]] = ZIO.serviceWith[MockGetAccount](_.requests)
+  def requests: ZIO[MockGetAccount, Nothing, List[String | AccountNumber]] = ZIO.serviceWith[MockGetAccount](_.requests)
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetSubscriptionToCancel.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetSubscriptionToCancel.scala
@@ -1,16 +1,17 @@
 package com.gu.productmove.zuora
 
 import com.gu.productmove.endpoint.zuora.GetSubscriptionToCancel
+import com.gu.productmove.endpoint.zuora.GetSubscriptionToCancel.GetSubscriptionToCancelResponse
 import com.gu.productmove.zuora.model.SubscriptionName
 import zio.{IO, ZIO}
 
 import scala.collection.mutable.ArrayBuffer
 
-class MockGetSubscriptionToCancel(responses: Map[SubscriptionName, GetSubscriptionToCancel.Response])
+class MockGetSubscriptionToCancel(responses: Map[SubscriptionName, GetSubscriptionToCancelResponse])
     extends GetSubscriptionToCancel {
   val requests: ArrayBuffer[SubscriptionName] = ArrayBuffer.empty
 
-  override def get(subscriptionName: SubscriptionName): IO[String, GetSubscriptionToCancel.Response] = {
+  override def get(subscriptionName: SubscriptionName): IO[String, GetSubscriptionToCancelResponse] = {
     requests += subscriptionName
 
     responses.get(subscriptionName) match

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionCancelSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionCancelSpec.scala
@@ -37,6 +37,7 @@ object SubscriptionCancelSpec extends ZIOSpecDefault {
             AwsCredentialsLive.layer,
             ZuoraClientLive.layer,
             SttpClientLive.layer,
+            GetAccountLive.layer,
           )
       } yield assert(true)(equalTo(true))
     } @@ TestAspect.ignore)


### PR DESCRIPTION
Sending an email message on subscription cancellation in product-move-api.
Introducing case class to represent AccountNumber value (so it's typed).
Renaming GetSubscriptionToCancel.Response to GetSubscriptionToCancelResponse.

Part of:
https://trello.com/c/UWbWENtE/3942-trigger-service-comms-server-side