### PR TITLE
Return Zuora error code as well as reason

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraClient.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraClient.scala
@@ -111,7 +111,7 @@ object ZuoraRestBody {
             else
               zuoraResponse.reasons match {
                 case None => Left(s"success = false, body: $body")
-                case Some(reasons) => Left(reasons.map(_.message).mkString(" "))
+                case Some(reasons) => Left(reasons.map(r => s"${r.message} (code: ${r.code})").mkString(" "))
               }
         } yield ()
 
@@ -123,7 +123,7 @@ object ZuoraRestBody {
             else
               zuoraResponse.reasons match {
                 case None => Left(s"Success = false, body: $body")
-                case Some(reasons) => Left(reasons.map(_.message).mkString(" "))
+                case Some(reasons) => Left(reasons.map(r => s"${r.message} (code: ${r.code})").mkString(" "))
               }
         } yield ()
       case ZuoraSuccessCheck.None => Right(())


### PR DESCRIPTION
Returns the `code` property from Zuora's API response as well as the `reason` property. This gives us better insight into what `code` numbers we need to add more specific error handling for.