### PR TITLE
Prevent Secrets Manager resolution at holiday-stop-processor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -499,7 +499,7 @@ lazy val `batch-email-sender` = lambdaProject(
 lazy val `holiday-stop-processor` = lambdaProject(
   "holiday-stop-processor",
   "Add a holiday credit amendment to a subscription.",
-  Seq(scalaLambda, awsS3, awsSecretsManager, upickle),
+  Seq(scalaLambda, awsS3),
 ).dependsOn(
   `credit-processor`,
   `holiday-stops` % "compile->compile;test->test",

--- a/build.sbt
+++ b/build.sbt
@@ -499,7 +499,7 @@ lazy val `batch-email-sender` = lambdaProject(
 lazy val `holiday-stop-processor` = lambdaProject(
   "holiday-stop-processor",
   "Add a holiday credit amendment to a subscription.",
-  Seq(scalaLambda, awsS3),
+  Seq(scalaLambda, awsS3, awsSecretsManager, upickle),
 ).dependsOn(
   `credit-processor`,
   `holiday-stops` % "compile->compile;test->test",

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -82,11 +82,6 @@ Resources:
         S3Bucket: support-service-lambdas-dist
         S3Key: !Sub membership/${Stage}/holiday-stop-processor/holiday-stop-processor.jar
       Handler: com.gu.holidaystopprocessor.Handler::handle
-      Environment:
-        Variables:
-          Stage: !Ref Stage
-          InvoicingApiUrl: !Sub '{{resolve:secretsmanager:${Stage}/InvoicingApi:SecretString:InvoicingApiUrl}}'
-          InvoicingApiKey: !Sub '{{resolve:secretsmanager:${Stage}/InvoicingApi:SecretString:InvoicingApiKey}}'
       Role:
         !GetAtt HolidayStopProcessorRole.Arn
       MemorySize: 1024

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,9 +39,6 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % "2.9.4"
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.42.0"
 
-  // upickle here is a temporary redundancy of circe while we are migrating to it
-  val upickle = "com.lihaoyi" %% "upickle" % "3.1.0"
-
   // HTTP clients
   val sttp = "com.softwaremill.sttp.client3" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbtassembly.AssemblyPlugin.autoImport.{MergeStrategy, assemblyMergeStrate
 import sbtassembly.PathList
 
 object Dependencies {
-  val awsSdkVersion = "2.18.30"
+  val awsSdkVersion = "2.20.55"
   val circeVersion = "0.13.0"
   val sttpVersion = "3.8.15"
   val http4sVersion = "0.21.34"
@@ -38,6 +38,9 @@ object Dependencies {
   val circeConfig = "io.circe" %% "circe-config" % "0.8.0"
   val playJson = "com.typesafe.play" %% "play-json" % "2.9.4"
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % "0.42.0"
+
+  // upickle here is a temporary redundancy of circe while we are migrating to it
+  val upickle = "com.lihaoyi" %% "upickle" % "3.1.0"
 
   // HTTP clients
   val sttp = "com.softwaremill.sttp.client3" %% "core" % sttpVersion


### PR DESCRIPTION
This change is the third of the ongoing effort to prevent credentials leaks from support-service-lambdas. Here we are updating holiday-stop-api.

For a full context of that change see the first PR description: https://github.com/guardian/support-service-lambdas/pull/1949

Note that in this case, there is no actual use of the retrieved values in the code, maybe that cloud formation file was copy pasted from another app when this one was made.  