### PR TITLE
switch to cdk-provisioned DNS etc. and point to new infrastructure

### DIFF
--- a/cdk/lib/__snapshots__/new-product-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/new-product-api.test.ts.snap
@@ -559,47 +559,28 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
       "Type": "AWS::ApiGateway::Stage",
     },
     "NewProductBasePathMapping": {
-      "DependsOn": [
-        "NewProductApi",
-        "NewProductApiStage",
-        "NewProductDomainName",
-      ],
       "Properties": {
         "DomainName": {
           "Ref": "NewProductDomainName",
         },
         "RestApiId": {
-          "Ref": "NewProductApi",
+          "Ref": "RestApi0C43BF4B",
         },
         "Stage": {
-          "Fn::Sub": "\${Stage}",
+          "Ref": "RestApiDeploymentStageprod3855DE66",
         },
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
     "NewProductDNSRecord": {
       "Properties": {
-        "Comment": {
-          "Fn::Sub": "CNAME for new product API \${Stage}",
-        },
-        "HostedZoneName": "membership.guardianapis.com.",
-        "Name": {
-          "Fn::FindInMap": [
-            "StageMap",
-            {
-              "Ref": "Stage",
-            },
-            "DomainName",
-          ],
-        },
+        "HostedZoneId": "Z1E4V12LQGXFEC",
+        "Name": "new-product-api-code.membership.guardianapis.com",
         "ResourceRecords": [
           {
-            "Fn::FindInMap": [
-              "StageMap",
-              {
-                "Ref": "Stage",
-              },
-              "ApiGatewayTargetDomainName",
+            "Fn::GetAtt": [
+              "NewProductDomainName",
+              "RegionalDomainName",
             ],
           },
         ],
@@ -610,22 +591,27 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
     },
     "NewProductDomainName": {
       "Properties": {
-        "DomainName": {
-          "Fn::FindInMap": [
-            "StageMap",
-            {
-              "Ref": "Stage",
-            },
-            "DomainName",
-          ],
-        },
+        "DomainName": "new-product-api-code.membership.guardianapis.com",
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL",
           ],
         },
         "RegionalCertificateArn": {
-          "Fn::Sub": "arn:aws:acm:\${AWS::Region}:\${AWS::AccountId}:certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2",
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:acm:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2",
+            ],
+          ],
         },
         "Tags": [
           {
@@ -2719,47 +2705,28 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
       "Type": "AWS::ApiGateway::Stage",
     },
     "NewProductBasePathMapping": {
-      "DependsOn": [
-        "NewProductApi",
-        "NewProductApiStage",
-        "NewProductDomainName",
-      ],
       "Properties": {
         "DomainName": {
           "Ref": "NewProductDomainName",
         },
         "RestApiId": {
-          "Ref": "NewProductApi",
+          "Ref": "RestApi0C43BF4B",
         },
         "Stage": {
-          "Fn::Sub": "\${Stage}",
+          "Ref": "RestApiDeploymentStageprod3855DE66",
         },
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
     "NewProductDNSRecord": {
       "Properties": {
-        "Comment": {
-          "Fn::Sub": "CNAME for new product API \${Stage}",
-        },
-        "HostedZoneName": "membership.guardianapis.com.",
-        "Name": {
-          "Fn::FindInMap": [
-            "StageMap",
-            {
-              "Ref": "Stage",
-            },
-            "DomainName",
-          ],
-        },
+        "HostedZoneId": "Z1E4V12LQGXFEC",
+        "Name": "new-product-api-prod.membership.guardianapis.com",
         "ResourceRecords": [
           {
-            "Fn::FindInMap": [
-              "StageMap",
-              {
-                "Ref": "Stage",
-              },
-              "ApiGatewayTargetDomainName",
+            "Fn::GetAtt": [
+              "NewProductDomainName",
+              "RegionalDomainName",
             ],
           },
         ],
@@ -2770,22 +2737,27 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
     },
     "NewProductDomainName": {
       "Properties": {
-        "DomainName": {
-          "Fn::FindInMap": [
-            "StageMap",
-            {
-              "Ref": "Stage",
-            },
-            "DomainName",
-          ],
-        },
+        "DomainName": "new-product-api-prod.membership.guardianapis.com",
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL",
           ],
         },
         "RegionalCertificateArn": {
-          "Fn::Sub": "arn:aws:acm:\${AWS::Region}:\${AWS::AccountId}:certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2",
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:acm:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2",
+            ],
+          ],
         },
         "Tags": [
           {

--- a/cdk/lib/new-product-api.ts
+++ b/cdk/lib/new-product-api.ts
@@ -121,31 +121,31 @@ export class NewProductApi extends GuStack {
 
 
     // ---- DNS ---- //
-    // const certificateArn = `arn:aws:acm:${this.region}:${this.account}:certificate/${props.certificateId}`;
-    //
-    // const cfnDomainName = new CfnDomainName(this, "NewProductDomainName", {
-    //   domainName: props.domainName,
-    //   regionalCertificateArn: certificateArn,
-    //   endpointConfiguration: {
-    //     types: ["REGIONAL"]
-    //   }
-    // });
-    //
-    // new CfnBasePathMapping(this, "NewProductBasePathMapping", {
-    //   domainName: cfnDomainName.ref,
-    //   restApiId: newProductApi.api.restApiId,
-    //   stage: newProductApi.api.deploymentStage.stageName,
-    // });
-    //
-    // new CfnRecordSet(this, "NewProductDNSRecord", {
-    //   name: props.domainName,
-    //   type: "CNAME",
-    //   hostedZoneId: props.hostedZoneId,
-    //   ttl: "120",
-    //   resourceRecords: [
-    //     cfnDomainName.attrRegionalDomainName
-    //   ],
-    // });
+    const certificateArn = `arn:aws:acm:${this.region}:${this.account}:certificate/${props.certificateId}`;
+
+    const cfnDomainName = new CfnDomainName(this, "NewProductDomainName", {
+      domainName: props.domainName,
+      regionalCertificateArn: certificateArn,
+      endpointConfiguration: {
+        types: ["REGIONAL"]
+      }
+    });
+
+    new CfnBasePathMapping(this, "NewProductBasePathMapping", {
+      domainName: cfnDomainName.ref,
+      restApiId: newProductApi.api.restApiId,
+      stage: newProductApi.api.deploymentStage.stageName,
+    });
+
+    new CfnRecordSet(this, "NewProductDNSRecord", {
+      name: props.domainName,
+      type: "CNAME",
+      hostedZoneId: props.hostedZoneId,
+      ttl: "120",
+      resourceRecords: [
+        cfnDomainName.attrRegionalDomainName
+      ],
+    });
 
 
     // ---- Apply policies ---- //

--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -286,37 +286,37 @@ Resources:
       - NewProductApiKey
       - NewProductUsagePlan
 
-    NewProductDomainName:
-      Type: "AWS::ApiGateway::DomainName"
-      Properties:
-        RegionalCertificateArn: # only for *.membership.guardianapis.com
-          !Sub arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2
-        DomainName: !FindInMap [ StageMap, !Ref Stage, DomainName ]
-        EndpointConfiguration:
-          Types:
-            - REGIONAL
+#    NewProductDomainName:
+#      Type: "AWS::ApiGateway::DomainName"
+#      Properties:
+#        RegionalCertificateArn: # only for *.membership.guardianapis.com
+#          !Sub arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2
+#        DomainName: !FindInMap [ StageMap, !Ref Stage, DomainName ]
+#        EndpointConfiguration:
+#          Types:
+#            - REGIONAL
 
-    NewProductBasePathMapping:
-      Type: "AWS::ApiGateway::BasePathMapping"
-      Properties:
-        RestApiId: !Ref NewProductApi
-        DomainName: !Ref NewProductDomainName
-        Stage: !Sub ${Stage}
-      DependsOn:
-      - NewProductApi
-      - NewProductDomainName
-      - NewProductApiStage
+#    NewProductBasePathMapping:
+#      Type: "AWS::ApiGateway::BasePathMapping"
+#      Properties:
+#        RestApiId: !Ref NewProductApi
+#        DomainName: !Ref NewProductDomainName
+#        Stage: !Sub ${Stage}
+#      DependsOn:
+#      - NewProductApi
+#      - NewProductDomainName
+#      - NewProductApiStage
 
-    NewProductDNSRecord:
-      Type: AWS::Route53::RecordSet
-      Properties:
-        HostedZoneName: membership.guardianapis.com.
-        Name: !FindInMap [ StageMap, !Ref Stage, DomainName ]
-        Comment: !Sub CNAME for new product API ${Stage}
-        Type: CNAME
-        TTL: '120'
-        ResourceRecords:
-        - !FindInMap [ StageMap, !Ref Stage, ApiGatewayTargetDomainName ]
+#    NewProductDNSRecord:
+#      Type: AWS::Route53::RecordSet
+#      Properties:
+#        HostedZoneName: membership.guardianapis.com.
+#        Name: !FindInMap [ StageMap, !Ref Stage, DomainName ]
+#        Comment: !Sub CNAME for new product API ${Stage}
+#        Type: CNAME
+#        TTL: '120'
+#        ResourceRecords:
+#        - !FindInMap [ StageMap, !Ref Stage, ApiGatewayTargetDomainName ]
 
     5xxApiAlarm:
       Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
This PR switches from the old `cfn.yaml` provisioned CloudFormation resources to the new, GuCDK managed ones.