### PR TITLE
Increase the memory for the product-move lambda

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -44,7 +44,7 @@ Resources:
       Runtime: java11
       Architectures: [arm64]
       Handler: com.gu.productmove.Handler::handleRequest
-      MemorySize: 1536
+      MemorySize: 3072
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We increased the memory of the product-move lambda in #1981 which was successful in reducing the execution time to the point where we are no longer getting timeouts. I want to increase it again to measure whether this will increase it further.