### PR TITLE
Increase the memory for the product-move lambda again

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -44,7 +44,7 @@ Resources:
       Runtime: java11
       Architectures: [arm64]
       Handler: com.gu.productmove.Handler::handleRequest
-      MemorySize: 3072
+      MemorySize: 6144
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
#1989 doubled the memory size for the product-move-api lambda, this has led to a significant speed up so I'm increasing it again to see if it has the same effect. 

The theory behind this is that at some point the memory will stop making a difference and the execution time will be dictated by the response times of the multiple calls to Zuora. 

Although allocating more memory to a lambda increases the execution cost, the fact that the executions are shorter offsets that cost in a linear way so if we double the memory and halve the execution time the cost remains the same. In this case it appears that doubling the memory has resulted in somewhere between a 25% & 50% reduction in the execution time, so cost increases should be minimal.