### PR TITLE
Recover Stage as Environment variable

### DIFF
--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -84,6 +84,9 @@ Resources:
                 S3Bucket: support-service-lambdas-dist
                 S3Key: !Sub membership/${Stage}/holiday-stop-api/holiday-stop-api.jar
             Handler: com.gu.holiday_stops.Handler::apply
+            Environment:
+              Variables:
+                Stage: !Ref Stage
             Role:
                 Fn::GetAtt:
                 - HolidayStopApiRole

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -78,6 +78,9 @@ Resources:
         S3Bucket: support-service-lambdas-dist
         S3Key: !Sub membership/${Stage}/holiday-stop-processor/holiday-stop-processor.jar
       Handler: com.gu.holidaystopprocessor.Handler::handle
+      Environment:
+        Variables:
+          Stage: !Ref Stage
       Role:
         !GetAtt HolidayStopProcessorRole.Arn
       MemorySize: 1024


### PR DESCRIPTION
### holiday-stop-processor

When I made this change https://github.com/guardian/support-service-lambdas/pull/1953 , I indicated in the PR description that the fragment of the CF I was removing is not used. That was only partially true.

`InvoicingApiUrl` and `InvoicingApiKey` are definitively not used in that Lambda and the opinion that they might have been the result of copy pasting or decommission is maybe true. 

On the other hand, the `Stage` although not used "directly" seems to be read by `com.gu.util.config.Stage` which is a dependency. 

This was not detected in CODE testing (where the default CODE value was used), but only in PROD. 

### holiday-stop-api
https://github.com/guardian/support-service-lambdas/pull/1952 suffered from the same problem, so we fixed it as well.

