### PR TITLE
Add dynamo logging to soft-opt-in-consent-setter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -434,6 +434,7 @@ lazy val `soft-opt-in-consent-setter` = lambdaProject(
     scalatest,
     scalajHttp,
     awsS3,
+    awsDynamo,
     simpleConfig,
     awsLambda,
     awsSQS,

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -295,10 +295,6 @@ Resources:
       Tags:
         - Key: Stage
           Value: !Ref Stage
-        - Key: Stack
-          Value: !Ref Stack
-        - Key: App
-          Value: !Ref App
 
   failedRunAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -240,6 +240,8 @@ Resources:
                   - sqs:GetQueueAttributes
                 Resource: !GetAtt SoftOptInsQueue.Arn
 
+
+
   SoftOptInsQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -261,6 +263,42 @@ Resources:
       Enabled: true
       EventSourceArn: !GetAtt SoftOptInsQueue.Arn
       FunctionName: !Ref LambdaFunctionIAP
+
+  SoftOptInsLoggingTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${App}-${Stage}-soft-opt-ins-logging
+      AttributeDefinitions:
+        - AttributeName: timestamp
+          AttributeType: N
+        - AttributeName: identityId
+          AttributeType: S
+        - AttributeName: subscriptionId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: identityId
+          KeyType: HASH
+        - AttributeName: timestamp
+          KeyType: RANGE
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+      GlobalSecondaryIndexes:
+        - IndexName: subscriptionId-index
+          KeySchema:
+            - AttributeName: subscriptionId
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
 
   failedRunAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -195,6 +195,12 @@ Resources:
         - AWSLambdaBasicExecutionRole
         - Statement:
             - Effect: Allow
+              Action:
+                - "dynamodb:PutItem"
+              Resource:
+                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/soft-opt-in-consent-setter-${Stage}-logging
+        - Statement:
+            - Effect: Allow
               Action: s3:GetObject
               Resource:
                 - !Sub arn:aws:s3:::soft-opt-in-consent-setter/${Stage}/ConsentsByProductMapping.json
@@ -321,13 +327,38 @@ Resources:
       Threshold: 5
       TreatMissingData: notBreaching
 
-  failedRunAlarmIAP:
+  exceptionsAlarmIAP:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn:
+      - LambdaFunctionIAP
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+      AlarmName: !Sub soft-opt-in-consent-setter-IAP-${Stage} threw an exception
+      AlarmDescription: >
+        Five or more runs found an error and were unable to complete.
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm
+        for possible causes, impacts and fixes.
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref LambdaFunctionIAP
+      EvaluationPeriods: 2
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 3600
+      Statistic: Sum
+      Threshold: 5
+      TreatMissingData: notBreaching
+
+  deadLetterBuildUpAlarmIAP:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
-      AlarmName: !Sub soft-opt-in-consent-setter-IAP-${Stage} failed to run
+      AlarmName: !Sub soft-opt-in-consent-setter-IAP-${Stage} failed to run and sent the message to the dead letter queue.
       AlarmDescription: >
         Five or more runs found an error and were unable to complete.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -267,7 +267,7 @@ Resources:
   SoftOptInsLoggingTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${App}-${Stage}-soft-opt-ins-logging
+      TableName: !Sub soft-opt-in-consent-setter-${Stage}-logging
       AttributeDefinitions:
         - AttributeName: timestamp
           AttributeType: N

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -334,3 +334,28 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
+
+  failedDynamoUpdateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn:
+      - LambdaFunction
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update the Dynamo logging table.
+      AlarmDescription: >
+        A run failed to update (some) records in Salesforce in the last hour.
+        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedUpdateAlarm
+        for possible causes, impacts and fixes.
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: failed_dynamo_update
+      Namespace: soft-opt-in-consent-setter
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/AwsCredentialsBuilder.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/AwsCredentialsBuilder.scala
@@ -1,0 +1,33 @@
+package com.gu.soft_opt_in_consent_setter
+
+import com.gu.soft_opt_in_consent_setter.models.SoftOptInError
+import com.typesafe.scalalogging.LazyLogging
+import software.amazon.awssdk.auth.credentials.{
+  AwsCredentialsProvider,
+  AwsCredentialsProviderChain,
+  EnvironmentVariableCredentialsProvider,
+  ProfileCredentialsProvider,
+}
+
+import scala.util.{Failure, Success, Try}
+
+object AwsCredentialsBuilder extends LazyLogging {
+  private val ProfileName = "membership"
+
+  def buildCredentials: Either[SoftOptInError, AwsCredentialsProvider] = {
+    Try(
+      AwsCredentialsProviderChain
+        .builder()
+        .credentialsProviders(
+          ProfileCredentialsProvider.create(ProfileName),
+          EnvironmentVariableCredentialsProvider.create(),
+        )
+        .build(),
+    ) match {
+      case Success(credentialsProvider) => Right(credentialsProvider)
+      case Failure(e) =>
+        logger.error("Failed to build AWS credentials", e)
+        Left(SoftOptInError("Failed to build AWS credentials"))
+    }
+  }
+}

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
@@ -11,9 +11,8 @@ import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 class DynamoConnector(dynamoDbClient: DynamoDbClient) extends LazyLogging {
-  private val app = "membership"
   private val stage = sys.env.getOrElse("Stage", "DEV")
-  private val tableName = s"$app-$stage-soft-opt-ins-logging"
+  private val tableName = s"soft-opt-in-consent-setter-$stage-logging"
 
   def putItem(putReq: PutItemRequest): Try[Unit] = Try(dynamoDbClient.putItem(putReq)).map(_ => ())
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
@@ -21,9 +21,9 @@ class DynamoConnector private (dynamoDbClient: DynamoDbClient) extends LazyLoggi
   val app = "mobile"
   private val stage = sys.env.getOrElse("Stage", "DEV")
 
-  def updateLoggingTable(subscriptionId: String, identityId: String): Unit = {
+  def updateLoggingTable(subscriptionNumber: String, identityId: String): Unit = {
     val timestamp = System.currentTimeMillis()
-    val record = SoftOptInLog(identityId, subscriptionId, timestamp, "Soft opt-ins processed for acquisition")
+    val record = SoftOptInLog(identityId, subscriptionNumber, timestamp, "Soft opt-ins processed for acquisition")
 
     val itemValues = Map(
       "userId" -> AttributeValue.builder().s(record.userId).build(),

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
@@ -1,0 +1,68 @@
+package com.gu.soft_opt_in_consent_setter
+
+import com.gu.soft_opt_in_consent_setter.models.SoftOptInError
+import com.typesafe.scalalogging.LazyLogging
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, PutItemRequest}
+
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
+
+case class SoftOptInLog(userId: String, subscriptionId: String, timestamp: Long, logMessage: String)
+
+object SoftOptInLog {
+  val app = "mobile"
+
+  def tableName(app: String, stage: String): String = s"${app}-${stage}-soft-opt-ins-logging-v2"
+}
+
+class DynamoConnector private (dynamoDbClient: DynamoDbClient) extends LazyLogging {
+  val app = "mobile"
+  private val stage = sys.env.getOrElse("Stage", "DEV")
+
+  def updateLoggingTable(subscriptionId: String, identityId: String): Unit = {
+    val timestamp = System.currentTimeMillis()
+    val record = SoftOptInLog(identityId, subscriptionId, timestamp, "Soft opt-ins processed for acquisition")
+
+    val itemValues = Map(
+      "userId" -> AttributeValue.builder().s(record.userId).build(),
+      "subscriptionId" -> AttributeValue.builder().s(record.subscriptionId).build(),
+      "timestamp" -> AttributeValue.builder().n(record.timestamp.toString).build(),
+      "logMessage" -> AttributeValue.builder().s(record.logMessage).build(),
+    )
+
+    val putReq = PutItemRequest
+      .builder()
+      .tableName(SoftOptInLog.tableName(app, stage))
+      .item(itemValues.asJava)
+      .build()
+
+    Try(dynamoDbClient.putItem(putReq)) match {
+      case Success(_) =>
+        logger.info("Logged soft opt-in setting to Dynamo")
+      case Failure(exception) =>
+        logger.error(s"Dynamo write failed for record: $record")
+        logger.error(s"Exception: $exception")
+        Metrics.put("failed_dynamo_update")
+    }
+  }
+}
+
+object DynamoConnector extends LazyLogging {
+  def apply(): Either[SoftOptInError, DynamoConnector] =
+    AwsCredentialsBuilder.buildCredentials.flatMap { credentialsProvider =>
+      Try(
+        DynamoDbClient
+          .builder()
+          .region(Region.EU_WEST_1)
+          .credentialsProvider(credentialsProvider)
+          .build(),
+      ) match {
+        case Success(dynamoDbClient) => Right(new DynamoConnector(dynamoDbClient))
+        case Failure(e) =>
+          logger.error("Failed to build DynamoDB client", e)
+          Left(SoftOptInError("Failed to build DynamoDB client"))
+      }
+    }
+}

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
@@ -18,7 +18,7 @@ class DynamoConnector(dynamoDbClient: DynamoDbClient) extends LazyLogging {
   def putItem(putReq: PutItemRequest): Try[Unit] = Try(dynamoDbClient.putItem(putReq)).map(_ => ())
 
   def updateLoggingTable(
-      subscriptionNumber: String,
+      subscriptionId: String,
       identityId: String,
       eventType: EventType,
       putItem: PutItemRequest => Try[Unit] = putItem,
@@ -32,7 +32,7 @@ class DynamoConnector(dynamoDbClient: DynamoDbClient) extends LazyLogging {
 
     val itemValues = Map(
       "identityId" -> AttributeValue.builder().s(identityId).build(),
-      "subscriptionId" -> AttributeValue.builder().s(subscriptionNumber).build(),
+      "subscriptionId" -> AttributeValue.builder().s(subscriptionId).build(),
       "timestamp" -> AttributeValue.builder().n(timestamp.toString).build(),
       "logMessage" -> AttributeValue.builder().s(logMessage).build(),
     )

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -46,6 +46,8 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
     throw exception
   }
 
+  private val dynamoLoggingFeatureFlag = false
+
   override def handleRequest(input: SQSEvent, context: Context): Unit = {
     logger.info("Handling request")
 
@@ -123,14 +125,15 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       result match {
         case Left(e) => handleError(e)
         case Right(_) =>
-          dynamoConnector.updateLoggingTable(message.subscriptionId, message.identityId, message.eventType) match {
-            case Success(_) =>
-              logger.info("Logged soft opt-in setting to Dynamo")
-            case Failure(exception) =>
-              logger.error(s"Dynamo write failed for identityId: ${message.identityId}")
-              logger.error(s"Exception: $exception")
-              Metrics.put("failed_dynamo_update")
-          }
+          if (dynamoLoggingFeatureFlag)
+            dynamoConnector.updateLoggingTable(message.subscriptionId, message.identityId, message.eventType) match {
+              case Success(_) =>
+                logger.info("Logged soft opt-in setting to Dynamo")
+              case Failure(exception) =>
+                logger.error(s"Dynamo write failed for identityId: ${message.identityId}")
+                logger.error(s"Exception: $exception")
+                Metrics.put("failed_dynamo_update")
+            }
       }
     }
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -16,6 +16,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
   val readyToProcessCancellationStatus = "Ready to process cancellation"
   val readyProcessSwitchStatus = "Ready to process switch"
   case class MessageBody(
+      subscriptionNumber: String,
       identityId: String,
       eventType: String,
       productName: String,
@@ -105,7 +106,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       result match {
         case Left(e) => handleError(e)
         case Right(_) =>
-          dynamoConnector.updateLoggingTable(message.identityId, "")
+          dynamoConnector.updateLoggingTable(message.subscriptionNumber, message.identityId)
       }
     }
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.gu.soft_opt_in_consent_setter.models._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.ParsingFailure
+import io.circe.{Decoder, DecodingFailure}
 import io.circe.generic.auto._
 import io.circe.parser.{decode => circeDecode}
 import io.circe.syntax._
@@ -21,6 +22,15 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
   case object Acquisition extends EventType
   case object Cancellation extends EventType
   case object Switch extends EventType
+
+  object EventType {
+    implicit val eventTypeDecoder: Decoder[EventType] = Decoder.decodeString.emap {
+      case "Acquisition" => Right(Acquisition)
+      case "Cancellation" => Right(Cancellation)
+      case "Switch" => Right(Switch)
+      case unknown => Left(s"Invalid EventType: $unknown")
+    }
+  }
 
   case class MessageBody(
       subscriptionId: String,

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/DynamoConnectorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/DynamoConnectorTests.scala
@@ -15,13 +15,13 @@ class DynamoConnectorTests extends AnyFunSuite with Matchers with MockFactory {
   val dynamoConnector = new DynamoConnector(mockDbClient)
 
   val identityId = "someIdentityId"
-  val subscriptionNumber = "A-S12345678"
+  val subscriptionId = "A-S12345678"
 
   val switchLogMessage = "Soft opt-ins processed for product-switch"
 
   val itemValues1 = Map(
     "identityId" -> AttributeValue.builder().s(identityId).build(),
-    "subscriptionId" -> AttributeValue.builder().s(subscriptionNumber).build(),
+    "subscriptionId" -> AttributeValue.builder().s(subscriptionId).build(),
     "timestamp" -> AttributeValue.builder().n("timestamp not tested").build(),
     "logMessage" -> AttributeValue.builder().s(switchLogMessage).build(),
   )
@@ -45,6 +45,6 @@ class DynamoConnectorTests extends AnyFunSuite with Matchers with MockFactory {
     }
 
     val dynamoConnector = new DynamoConnector(mockDbClient)
-    dynamoConnector.updateLoggingTable(subscriptionNumber, identityId, Switch, mockPutItem)
+    dynamoConnector.updateLoggingTable(subscriptionId, identityId, Switch, mockPutItem)
   }
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/DynamoConnectorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/DynamoConnectorTests.scala
@@ -1,0 +1,50 @@
+package com.gu.soft_opt_in_consent_setter
+
+import com.gu.soft_opt_in_consent_setter.HandlerIAP.Switch
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, PutItemRequest}
+
+import scala.jdk.CollectionConverters._
+import scala.util.{Success, Try}
+
+class DynamoConnectorTests extends AnyFunSuite with Matchers with MockFactory {
+  val mockDbClient = mock[DynamoDbClient]
+  val dynamoConnector = new DynamoConnector(mockDbClient)
+
+  val identityId = "someIdentityId"
+  val subscriptionNumber = "A-S12345678"
+
+  val switchLogMessage = "Soft opt-ins processed for product-switch"
+
+  val itemValues1 = Map(
+    "identityId" -> AttributeValue.builder().s(identityId).build(),
+    "subscriptionId" -> AttributeValue.builder().s(subscriptionNumber).build(),
+    "timestamp" -> AttributeValue.builder().n("timestamp not tested").build(),
+    "logMessage" -> AttributeValue.builder().s(switchLogMessage).build(),
+  )
+
+  test(testName = "updateLoggingTable builds request correctly") {
+    val putReq = PutItemRequest
+      .builder()
+      .tableName("membership-DEV-soft-opt-ins-logging")
+      .item(itemValues1.asJava)
+      .build()
+
+    val mockPutItem: PutItemRequest => Try[Unit] = (req: PutItemRequest) => {
+      // Check if the items in the request match the expected items (ignoring timestamp)
+      assert(
+        req.tableName() == putReq.tableName() &&
+          req.item().get("identityId") == itemValues1("identityId") &&
+          req.item().get("subscriptionId") == itemValues1("subscriptionId") &&
+          req.item().get("logMessage") == itemValues1("logMessage"),
+      )
+      Success(())
+    }
+
+    val dynamoConnector = new DynamoConnector(mockDbClient)
+    dynamoConnector.updateLoggingTable(subscriptionNumber, identityId, Switch, mockPutItem)
+  }
+}

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/DynamoConnectorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/DynamoConnectorTests.scala
@@ -29,7 +29,7 @@ class DynamoConnectorTests extends AnyFunSuite with Matchers with MockFactory {
   test(testName = "updateLoggingTable builds request correctly") {
     val putReq = PutItemRequest
       .builder()
-      .tableName("membership-DEV-soft-opt-ins-logging")
+      .tableName("soft-opt-in-consent-setter-DEV-logging")
       .item(itemValues1.asJava)
       .build()
 

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -1,17 +1,7 @@
-import com.gu.soft_opt_in_consent_setter.{
-  ConsentsCalculator,
-  MobileSubscription,
-  MobileSubscriptions,
-  SalesforceConnector,
-}
-import com.gu.soft_opt_in_consent_setter.HandlerIAP.{
-  MessageBody,
-  processAcquiredSub,
-  processCancelledSub,
-  processProductSwitchSub,
-}
+import com.gu.soft_opt_in_consent_setter.HandlerIAP._
 import com.gu.soft_opt_in_consent_setter.models.{SFAssociatedSubRecord, SFAssociatedSubResponse, SoftOptInError}
 import com.gu.soft_opt_in_consent_setter.testData.ConsentsCalculatorTestData.testConsentMappings
+import com.gu.soft_opt_in_consent_setter.{ConsentsCalculator, MobileSubscription, MobileSubscriptions, SalesforceConnector}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -25,6 +15,9 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
   val mockGetMobileSubscriptions = mockFunction[String, Either[SoftOptInError, MobileSubscriptions]]
   val mockSfConnector = mock[SalesforceConnector]
 
+  val identityId = "someIdentityId"
+  val subscriptionNumber = "A-S12345678"
+
   test(testName = "processProductSwitchSub should handle product switch event correctly") {
     val mobileSubscriptions = MobileSubscriptions(
       List(
@@ -34,7 +27,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     mockSendConsentsReq
       .expects(
-        "someIdentityId",
+        identityId,
         "[\n  {\n    \"id\" : \"digital_subscriber_preview\",\n    \"consented\" : true\n  }\n]",
       )
       .returning(Right(()))
@@ -46,7 +39,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
         records = Seq(
           SFAssociatedSubRecord(
             "contributions",
-            "someIdentityId",
+            identityId,
           ),
         ),
       ),
@@ -56,7 +49,8 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       identityId = "someIdentityId",
       productName = "supporterPlus",
       previousProductName = Some("contributions"),
-      eventType = "Switch",
+      eventType = Switch,
+      subscriptionNumber = "A-S12345678",
     )
 
     val result = processProductSwitchSub(
@@ -88,7 +82,8 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       identityId = "someIdentityId",
       productName = "supporterPlus",
       previousProductName = None,
-      eventType = "Acquisition",
+      eventType = Acquisition,
+      subscriptionNumber = "A-S12345678",
     )
 
     val result = processAcquiredSub(
@@ -126,7 +121,8 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       identityId = "someIdentityId",
       productName = "supporterPlus",
       previousProductName = None,
-      eventType = "Cancellation",
+      eventType = Cancellation,
+      subscriptionNumber = "A-S12345678",
     )
 
     val result = processCancelledSub(
@@ -162,7 +158,8 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       identityId = "someIdentityId",
       productName = "supporterPlus",
       previousProductName = None,
-      eventType = "Cancellation",
+      eventType = Cancellation,
+      subscriptionNumber = "A-S12345678",
     )
 
     val result = processCancelledSub(

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -16,7 +16,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
   val mockSfConnector = mock[SalesforceConnector]
 
   val identityId = "someIdentityId"
-  val subscriptionNumber = "A-S12345678"
+  val subscriptionId = "A-S12345678"
 
   test(testName = "processProductSwitchSub should handle product switch event correctly") {
     val mobileSubscriptions = MobileSubscriptions(
@@ -50,7 +50,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       productName = "supporterPlus",
       previousProductName = Some("contributions"),
       eventType = Switch,
-      subscriptionNumber = "A-S12345678",
+      subscriptionId = "A-S12345678",
     )
 
     val result = processProductSwitchSub(
@@ -83,7 +83,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       productName = "supporterPlus",
       previousProductName = None,
       eventType = Acquisition,
-      subscriptionNumber = "A-S12345678",
+      subscriptionId = "A-S12345678",
     )
 
     val result = processAcquiredSub(
@@ -122,7 +122,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       productName = "supporterPlus",
       previousProductName = None,
       eventType = Cancellation,
-      subscriptionNumber = "A-S12345678",
+      subscriptionId = "A-S12345678",
     )
 
     val result = processCancelledSub(
@@ -159,7 +159,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       productName = "supporterPlus",
       previousProductName = None,
       eventType = Cancellation,
-      subscriptionNumber = "A-S12345678",
+      subscriptionId = "A-S12345678",
     )
 
     val result = processCancelledSub(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
   val awsSecretsManager = "software.amazon.awssdk" % "secretsmanager" % awsSdkVersion
   val awsSQS = "software.amazon.awssdk" % "sqs" % awsSdkVersion
   val awsS3 = "software.amazon.awssdk" % "s3" % awsSdkVersion
+  val awsDynamo = "software.amazon.awssdk" % "dynamodb" % awsSdkVersion
 
   val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.2"
   val awsEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.11.1"


### PR DESCRIPTION
This PR involves important revisions for the 'Soft Opt-ins for In-App Purchase' (SOI's for IAP) project. As part of the IAP project we wanted to set up a system to capture any changes we make to a user's soft opt-ins, so we created a logging table located in the Mobile AWS account. The table's cloudformation is here in the [mobile-purchases API](https://github.com/guardian/mobile-purchases). This setup was logical during the project's initial phase since the SOI's were directly set via the mobile-purchases API.

As we transition into version 1.5 of the project, the `soft-opt-in-consent-setter` lambda (IAP) will now handle the SOI's. As such, we have decided to centralize the logging capabilities within this lambda function, which means moving the logging table to the Membership AWS profile.

This PR contains modifications to create the logging table within the Membership AWS account and to adjust the lambda to write records to this relocated table.

I will be running a Python script to migrate the small amount of data to the new table in the membership profile.

This PR also adds a new property to the message body `subscriptionId`, as this is necessary for the logging. It also converts the `eventType` from a String to an enum.

 [PR to remove SOI V1 and writing to the logging table from MPAPI](https://github.com/guardian/mobile-purchases/pull/1038).

- [x] Test in CODE