### PR TITLE
Renewal error fix

### DIFF
--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -79,7 +79,7 @@ object HandlerSpec extends ZIOSpecDefault {
   def spec = {
     val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 10, 10, 2), ZoneOffset.ofHours(0)).toInstant
     val time2 = OffsetDateTime.of(LocalDateTime.of(2023, 2, 6, 10, 2), ZoneOffset.ofHours(0)).toInstant
-    val time3 = OffsetDateTime.of(LocalDateTime.of(2021, 2, 5, 5, 2), ZoneOffset.ofHours(0)).toInstant
+    val time3 = OffsetDateTime.of(LocalDateTime.of(2021, 2, 15, 5, 2), ZoneOffset.ofHours(0)).toInstant
     val subscriptionName = SubscriptionName("A-S00339056")
 
     def getSubscriptionStubs(subscriptionResponse: GetSubscriptionResponse = getSubscriptionResponse) = {
@@ -99,6 +99,40 @@ object HandlerSpec extends ZIOSpecDefault {
     val getPaymentMethodStubs = Map("paymentMethodId" -> getPaymentMethodResponse)
 
     suite("HandlerSpec")(
+      /*
+        Term renewal for many subs happens during the billing run on the renewal day which is scheduled for around 6am BST.
+        During this billing run, Zuora does not return the contribution invoice item, only supporter plus invoice items.
+        This tests this scenario.
+       */
+
+      test("productMove endpoint completes if subscription is being switched early in morning on renewal date") {
+        val endpointJsonInputBody = ExpectedInput(15.00, true, None, None)
+        val subscriptionUpdateInputsShouldBe: (SubscriptionName, SubscriptionUpdateRequest) =
+          (subscriptionName, expectedRequestBodyPreview2)
+        val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> previewResponse2)
+
+        (for {
+          _ <- TestClock.setTime(time3)
+          output <- RecurringContributionToSupporterPlus(subscriptionName, endpointJsonInputBody)
+          getSubRequests <- MockGetSubscription.requests
+          subUpdateRequests <- MockSubscriptionUpdate.requests
+          sqsRequests <- MockSQS.requests
+          dynamoRequests <- MockDynamo.requests
+        } yield {
+          assert(output)(equalTo(subscriptionUpdatePreviewResult2)) &&
+          assert(getSubRequests)(equalTo(List(subscriptionName))) &&
+          assert(subUpdateRequests)(equalTo(List(subscriptionUpdateInputsShouldBe))) &&
+          assert(sqsRequests)(equalTo(Nil)) &&
+          assert(dynamoRequests)(equalTo(Nil))
+        }).provide(
+          ZLayer.succeed(new MockGetSubscription(getSubscriptionStubs(getSubscriptionResponse3))),
+          ZLayer.succeed(new MockSubscriptionUpdate(subscriptionUpdatePreviewStubs)),
+          ZLayer.succeed(new MockSQS(sqsStubs)),
+          ZLayer.succeed(new MockDynamo(dynamoStubs)),
+          ZLayer.succeed(new MockGetAccount(getAccountStubs, getPaymentMethodStubs)),
+          ZLayer.succeed(Stage.valueOf("CODE")),
+        )
+      },
       test("productMove endpoint is successful for monthly sub (upsell)") {
         val endpointJsonInputBody = ExpectedInput(15.00, false, None, None)
         val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse)
@@ -164,40 +198,6 @@ object HandlerSpec extends ZIOSpecDefault {
           assert(sqsRequests)(hasSameElements(List(emailMessageBodyNoPaymentOrRefund, salesforceRecordInput3))) &&
           assert(dynamoRequests)(equalTo(List(supporterRatePlanItem1)))
         }).provide(layers)
-      },
-      /*
-        Term renewal for many subs happens during the billing run on the renewal day which is scheduled for around 6am BST.
-        During this billing run, Zuora does not return the contribution invoice item, only supporter plus invoice items.
-        This tests this scenario.
-       */
-
-      test("productMove endpoint completes if subscription is being switched early in morning on renewal date") {
-        val endpointJsonInputBody = ExpectedInput(15.00, true, None, None)
-        val subscriptionUpdateInputsShouldBe: (SubscriptionName, SubscriptionUpdateRequest) =
-          (subscriptionName, expectedRequestBodyPreview2)
-        val subscriptionUpdatePreviewStubs = Map(subscriptionUpdateInputsShouldBe -> previewResponse2)
-
-        (for {
-          _ <- TestClock.setTime(time3)
-          output <- RecurringContributionToSupporterPlus(subscriptionName, endpointJsonInputBody)
-          getSubRequests <- MockGetSubscription.requests
-          subUpdateRequests <- MockSubscriptionUpdate.requests
-          sqsRequests <- MockSQS.requests
-          dynamoRequests <- MockDynamo.requests
-        } yield {
-          assert(output)(equalTo(subscriptionUpdatePreviewResult2)) &&
-          assert(getSubRequests)(equalTo(List(subscriptionName))) &&
-          assert(subUpdateRequests)(equalTo(List(subscriptionUpdateInputsShouldBe))) &&
-          assert(sqsRequests)(equalTo(Nil)) &&
-          assert(dynamoRequests)(equalTo(Nil))
-        }).provide(
-          ZLayer.succeed(new MockGetSubscription(getSubscriptionStubs(getSubscriptionResponse3))),
-          ZLayer.succeed(new MockSubscriptionUpdate(subscriptionUpdatePreviewStubs)),
-          ZLayer.succeed(new MockSQS(sqsStubs)),
-          ZLayer.succeed(new MockDynamo(dynamoStubs)),
-          ZLayer.succeed(new MockGetAccount(getAccountStubs, getPaymentMethodStubs)),
-          ZLayer.succeed(Stage.valueOf("CODE")),
-        )
       },
       test(
         "(MembershipToRecurringContribution) productMove endpoint is successful",

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -50,9 +50,9 @@ val ratePlanCharge2 = RatePlanCharge(
   price = Some(5.000000000),
   currency = "GBP",
   number = "number",
-  effectiveStartDate = LocalDate.of(2021, 2, 5),
-  effectiveEndDate = LocalDate.of(2021, 3, 5),
-  chargedThroughDate = Some(LocalDate.of(2021, 3, 5)),
+  effectiveStartDate = LocalDate.of(2021, 1, 15),
+  effectiveEndDate = LocalDate.of(2022, 1, 15),
+  chargedThroughDate = Some(LocalDate.of(2021, 2, 15)),
   billingPeriod = Monthly,
 )
 
@@ -418,7 +418,7 @@ val subscriptionUpdateResponse5 =
 val timeLocalDate = LocalDate.of(2022, 5, 10)
 val timeLocalDate2 = LocalDate.of(2023, 2, 6)
 val timeLocalDate3 = LocalDate.of(2022, 9, 29)
-val timeLocalDate4 = LocalDate.of(2021, 2, 5)
+val timeLocalDate4 = LocalDate.of(2021, 2, 15)
 
 // RecurringContributionToSupporterPlus
 val expectedRequestBody = SubscriptionUpdateRequest(
@@ -517,7 +517,7 @@ val expectedRequestBodyPreview2 = SubscriptionUpdateRequest(
     ),
   ),
   preview = Some(true),
-  targetDate = Some(LocalDate.of(2022, 3, 5)),
+  targetDate = Some(LocalDate.of(2022, 3, 15)),
   currentTerm = Some("24"),
   currentTermPeriodType = Some("Month"),
 )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
