### PR TITLE
fix config issue and local run for list of emails

### DIFF
--- a/handlers/zuora-rer/src/local/com/gu/zuora/rer/ZuoraRerLocalRun.scala
+++ b/handlers/zuora-rer/src/local/com/gu/zuora/rer/ZuoraRerLocalRun.scala
@@ -3,13 +3,17 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import com.gu.zuora.rer.circeCodecs._
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.util.config.LoadConfigModule
-import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
+import com.gu.util.zuora.{ZuoraQuery, ZuoraRestRequestMaker}
+import com.gu.zuora.baton.BatonZuoraRestConfig
+import com.gu.zuora.baton.BatonZuoraRestConfig.toZuoraRestConfig
 import com.gu.zuora.rer.BatonModels.{PerformRerRequest, RerInitiateRequest, RerRequest, RerStatusRequest}
 import io.circe.syntax._
 
 /** Run this app on your local dev machine to test the 'lambda' code against the Zuora CODE environment. Note that the
   * code runs on your machine and not in Lambda; you will need to install keys for the `membership` AWS account from
   * Janus.
+  *
+  * To target a different Zuora environment, set the `Stage` environment variable.
   *
   * Uncomment the call that you want to make at the bottom of the file.
   */
@@ -40,8 +44,8 @@ object ZuoraRerLocalRun extends App {
     val streams = requestStreams(request)
     for {
       zuoraRerConfig <- loadZuoraRerConfig[ZuoraRerConfig]
-      zuoraRestConfig <- loadZuoraRestConfig[ZuoraRestConfig]
-      requests = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
+      zuoraRestConfig <- loadZuoraRestConfig[BatonZuoraRestConfig]
+      requests = ZuoraRestRequestMaker(RawEffects.response, toZuoraRestConfig(zuoraRestConfig))
       zuoraQuerier = ZuoraQuery(requests)
       zuoraHelper = ZuoraRerService(requests, zuoraQuerier)
     } yield {
@@ -65,5 +69,24 @@ object ZuoraRerLocalRun extends App {
   // 2. emulate call to ZuoraRerLambda with `status` request
   // runTestZuoraRer(rerStatusRequest)
   // 3. emulate call to ZuoraPerformRerLambda with `initiate` request
-  runTestPerformZuoraRer(performRerInitiateRequest)
+  // runTestPerformZuoraRer(performRerInitiateRequest)
+
+  // 4. do #3 for a list of users.
+  val emails = List(
+    "andytest@example.com",
+  )
+
+  import java.util.UUID.randomUUID
+
+  emails
+    .map { e =>
+      PerformRerRequest(
+        initiationReference = "manualCleanupSREngine-" + randomUUID().toString,
+        subjectEmail = e,
+      )
+    }
+    .foreach { req =>
+      println(req.subjectEmail)
+      runTestPerformZuoraRer(req)
+    }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Used the `ZuoraRerLocalRun` test app to do some erasure cleanup for a list of email addresses.  Fixed an issue that came up with the S3-based Zuora REST configuration and left the list processing in as an example. 

