### PR TITLE
Use Secrets Manager at product-move-api (part 2)

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -220,7 +220,8 @@ Resources:
             Resource:
               - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SupportServiceLambdas-729iA5"
               - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SupportServiceLambdas-417yMt"
-
+              - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Zuora/User/ZuoraApiUser-zmOGho"
+              - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Zuora/User/ZuoraApiUser-oq5ISm"
   SalesforceTrackingQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -195,30 +195,6 @@ Resources:
           App: product-move-api
           Stack: !Ref Stack
           Stage: !Ref Stage
-          salesforceUrl:
-            !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/SupportServiceLambdas:SecretString:url}}'
-            - { Stage: !Ref Stage }
-          salesforceClientId:
-            !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/SupportServiceLambdas:SecretString:client_id}}'
-            - { Stage: !Ref Stage }
-          salesforceClientSecret:
-            !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/SupportServiceLambdas:SecretString:client_secret}}'
-            - { Stage: !Ref Stage }
-          salesforceUsername:
-            !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/SupportServiceLambdas:SecretString:username}}'
-            - { Stage: !Ref Stage }
-          salesforcePassword:
-            !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/SupportServiceLambdas:SecretString:password}}'
-            - { Stage: !Ref Stage }
-          salesforceToken:
-            !Sub
-            - '{{resolve:secretsmanager:${Stage}/Salesforce/User/SupportServiceLambdas:SecretString:token}}'
-            - { Stage: !Ref Stage }
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/product-move-api/product-move-api.jar
@@ -236,6 +212,14 @@ Resources:
               - sqs:GetQueueAttributes
               - sqs:ReceiveMessage
             Resource: "*"
+        - Statement:
+            Effect: Allow
+            Action:
+              - secretsmanager:DescribeSecret
+              - secretsmanager:GetSecretValue
+            Resource:
+              - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SupportServiceLambdas-729iA5"
+              - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SupportServiceLambdas-417yMt"
 
   SalesforceTrackingQueue:
     Type: AWS::SQS::Queue

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Secrets.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Secrets.scala
@@ -74,7 +74,7 @@ object SecretsLive extends Secrets {
   }
 
   def getStage: ZIO[Any, ErrorResponse, String] =
-    ZIO.fromOption(sys.env.get("Stage")).mapError(_ => SecretsError("Failure while extracting stage from environmnt"))
+    ZIO.fromOption(sys.env.get("Stage")).mapError(_ => SecretsError("Failure while extracting stage from environment"))
 
   def parseInvoicingAPISecretsJSONString(str: String): ZIO[Any, ErrorResponse, InvoicingAPISecrets] = {
     Try(read[InvoicingAPISecrets](str)) match {

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Secrets.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Secrets.scala
@@ -118,7 +118,7 @@ object SecretsLive extends Secrets {
   def getSalesforceSSLSecrets: ZIO[Any, ErrorResponse, SalesforceSSLSecrets] = {
     for {
       stg <- getStage
-      secretId: String = s"${stg}/Zuora/User/ZuoraApiUser"
+      secretId: String = s"${stg}/Salesforce/User/SupportServiceLambdas"
       secretJsonString = getJSONString(secretId)
       secrets <- parseSalesforceSSLSecretsJSONString(secretJsonString)
     } yield secrets

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceClient.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceClient.scala
@@ -1,7 +1,7 @@
 package com.gu.productmove.salesforce
 
 import sttp.client3.quick.basicRequest
-import com.gu.productmove.AwsS3
+import com.gu.productmove.{AwsS3, Secrets}
 import com.gu.productmove.GuReaderRevenuePrivateS3.{bucket, key}
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.Util.getFromEnv
@@ -50,15 +50,17 @@ object SalesforceClient {
 
 object SalesforceClientLive {
 
-  val layer: ZLayer[SttpBackend[Task, Any], ErrorResponse, SalesforceClient] =
+  val layer: ZLayer[SttpBackend[Task, Any] with Secrets, ErrorResponse, SalesforceClient] =
     ZLayer.fromZIO(
       for {
-        url <- ZIO.fromEither(getFromEnv("salesforceUrl"))
-        clientId <- ZIO.fromEither(getFromEnv("salesforceClientId"))
-        clientSecret <- ZIO.fromEither(getFromEnv("salesforceClientSecret"))
-        username <- ZIO.fromEither(getFromEnv("salesforceUsername"))
-        password <- ZIO.fromEither(getFromEnv("salesforcePassword"))
-        token <- ZIO.fromEither(getFromEnv("salesforceToken"))
+        secrets <- ZIO.service[Secrets]
+        salesforceSSLSecrets <- secrets.getSalesforceSSLSecrets
+        url = salesforceSSLSecrets.url
+        clientId = salesforceSSLSecrets.client_id
+        clientSecret = salesforceSSLSecrets.client_secret
+        username = salesforceSSLSecrets.username
+        password = salesforceSSLSecrets.password
+        token = salesforceSSLSecrets.token
 
         _ <- ZIO.log("salesforceUrl: " + url)
         _ <- ZIO.log("salesforceUsername: " + username)

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceHandler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceHandler.scala
@@ -6,7 +6,7 @@ import com.gu.productmove.GuStageLive.Stage
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.gu.productmove.salesforce.CreateRecord.CreateRecordRequest
 import com.gu.productmove.salesforce.Salesforce.{SalesforceRecordInput, createSfRecord}
-import com.gu.productmove.{AwsCredentialsLive, AwsS3, AwsS3Live, GuStageLive, SttpClientLive}
+import com.gu.productmove.{AwsCredentialsLive, AwsS3, AwsS3Live, GuStageLive, SecretsLive, SttpClientLive}
 import sttp.client3.SttpBackend
 import zio.json.*
 import zio.{Exit, Runtime, Task, Unsafe, ZIO}
@@ -38,6 +38,7 @@ class SalesforceHandler extends RequestHandler[SQSEvent, Unit] {
             GetSfSubscriptionLive.layer,
             SalesforceClientLive.layer,
             CreateRecordLive.layer,
+            SecretsLive.layer,
           ),
       ) match
         case Exit.Success(value) => value

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
@@ -53,6 +53,7 @@ object CreateRecordSpec extends ZIOSpecDefault {
               CreateRecordLive.layer,
               GetSfSubscriptionLive.layer,
               SalesforceClientLive.layer,
+              SecretsLive.layer,
             )
         } yield assert(true)(equalTo(true))
       } @@ TestAspect.ignore,


### PR DESCRIPTION
This change is part 2 of the update of the product-move-api lambda to prevent CF secrets resolution leaks. See part 1 here: https://github.com/guardian/support-service-lambdas/pull/1957 and full context for this work here: https://github.com/guardian/support-service-lambdas/pull/1949

