### PR TITLE
chore(deps): Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# See the documentation for all configuration options https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: "chore(deps): "
+  
+  - package-ecosystem: 'npm'
+    directory: '/cdk'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: "chore(deps): "
+    # The version of AWS CDK libraries must match those from @guardian/cdk.
+    # We'd never be able to update them here independently, so just ignore them.
+    ignore:
+      - dependency-name: "aws-cdk"
+      - dependency-name: "aws-cdk-lib"
+      - dependency-name: "constructs"


### PR DESCRIPTION
Following #2007, this change configures Depenabot in the repository, running monthly to update the GitHub Actions being used, and NPM packages. We're ignoring `aws-cdk`, `aws-cdk-lib` and `constructs` as they must always align with the peerDependencies of GuCDK.

The recommend way to update them is using:

```
npm info @guardian/cdk@latest peerDependencies version
```