### PR TITLE
Update supporter product data from move subscription fix lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -616,7 +616,7 @@ lazy val `sf-move-subscriptions-api` = lambdaProject(
     scalatest,
     diffx,
   ),
-).dependsOn(`effects-s3`, `config-cats`, `zuora-core`, `http4s-lambda-handler`)
+).dependsOn(`effects-s3`, `effects-sqs`,  `config-cats`, `zuora-core`, `http4s-lambda-handler`)
 
 lazy val `fulfilment-date-calculator` = lambdaProject(
   "fulfilment-date-calculator",

--- a/handlers/sf-move-subscriptions-api/cfn.yaml
+++ b/handlers/sf-move-subscriptions-api/cfn.yaml
@@ -32,6 +32,19 @@ Resources:
     Properties:
       PolicyDocument:
         Statement:
+          - Action:
+              - sqs:GetQueueUrl
+              - sqs:SendMessage
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:aws:sqs:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - ":supporter-product-data-"
+                  - Ref: stage
           - Action: ssm:GetParametersByPath
             Effect: Allow
             Resource:

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Handler.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Handler.scala
@@ -10,6 +10,12 @@ object Handler
       SFMoveSubscriptionsApiApp(
         AppIdentity.whoAmI(defaultAppName = "sf-move-subscriptions-api"),
         HttpURLConnectionBackend(),
+        UpdateSupporterProductDataService(
+          sys.env.getOrElse(
+            "Stage",
+            throw new RuntimeException("Stage parameter is missing from the lambda environment variables"),
+          ),
+        ),
       ).value
         .unsafeRunSync()
         .valueOr((error: MoveSubscriptionApiError) => throw new RuntimeException(error.toString)),

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/Model.scala
@@ -1,5 +1,10 @@
 package com.gu.sf.move.subscriptions.api
 
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+
+import java.time.LocalDate
+
 final case class MoveSubscriptionReqBody(
     zuoraSubscriptionId: String,
     sfAccountId: String,
@@ -23,3 +28,16 @@ final case class ExampleReqDoc(
     path: String,
     body: MoveSubscriptionReqBody,
 )
+
+final case class SupporterRatePlanItem(
+    subscriptionName: String,
+    identityId: String,
+    productRatePlanId: String,
+    productRatePlanName: String,
+    termEndDate: LocalDate,
+    contractEffectiveDate: LocalDate,
+)
+
+object SupporterRatePlanItem {
+  implicit val encoder: Encoder[SupporterRatePlanItem] = deriveEncoder[SupporterRatePlanItem]
+}

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiApp.scala
@@ -1,7 +1,7 @@
 package com.gu.sf.move.subscriptions.api
 
 import cats.data.EitherT
-import cats.effect.{ContextShift, IO}
+import cats.effect.{IO, ContextShift}
 import cats.syntax.all._
 import com.gu.AppIdentity
 import com.gu.util.config.ConfigLoader
@@ -23,12 +23,17 @@ object SFMoveSubscriptionsApiApp extends LazyLogging {
   def apply(
       appIdentity: AppIdentity,
       backend: SttpBackend[Identity, Any],
+      updateSupporterProductData: UpdateSupporterProductData,
   ): EitherT[IO, MoveSubscriptionApiError, HttpRoutes[IO]] = {
     for {
       apiConfig <- ConfigLoader
         .loadConfig[IO, MoveSubscriptionApiConfig](appIdentity)
         .leftMap(error => MoveSubscriptionApiError(error.toString))
-      routes <- createLogging()(SFMoveSubscriptionsApiRoutes(SFMoveSubscriptionsService(apiConfig, backend)))
+      routes <- createLogging()(
+        SFMoveSubscriptionsApiRoutes(
+          SFMoveSubscriptionsService(apiConfig, backend, updateSupporterProductData),
+        ),
+      )
         .asRight[MoveSubscriptionApiError]
         .toEitherT[IO]
     } yield routes

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/UpdateSupporterProductDataService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/UpdateSupporterProductDataService.scala
@@ -13,20 +13,8 @@ trait UpdateSupporterProductData {
 class UpdateSupporterProductDataService(queueName: QueueName) extends UpdateSupporterProductData with LazyLogging {
 
   def combineErrorsOrUnit(list: List[Either[String, Unit]]): Either[String, Unit] = {
-    list.foldLeft[Either[String, Unit]](Right(())) { (acc, either) =>
-      acc match {
-        case Left(errors) =>
-          either match {
-            case Left(error) => Left(s"$errors, $error")
-            case Right(_) => acc
-          }
-        case Right(_) =>
-          either match {
-            case Left(error) => Left(s"$error")
-            case Right(_) => acc
-          }
-      }
-    }
+    val errors = list.collect { case Left(error) => error }
+    if (errors.isEmpty) Right(()) else Left(errors.mkString(", "))
   }
   override def update(
       subscription: Subscription,

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/UpdateSupporterProductDataService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/UpdateSupporterProductDataService.scala
@@ -13,7 +13,9 @@ trait UpdateSupporterProductData {
 class UpdateSupporterProductDataService(queueName: QueueName) extends UpdateSupporterProductData with LazyLogging {
 
   def combineErrorsOrUnit(list: List[Either[String, Unit]]): Either[String, Unit] = {
-    val errors = list.collect { case Left(error) => error }
+    val errors = list.zipWithIndex.collect { case (Left(error), index) =>
+      s"Error writing item $index to SQS: $error"
+    }
     if (errors.isEmpty) Right(()) else Left(errors.mkString(", "))
   }
   override def update(

--- a/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/UpdateSupporterProductDataService.scala
+++ b/handlers/sf-move-subscriptions-api/src/main/scala/com/gu/sf/move/subscriptions/api/UpdateSupporterProductDataService.scala
@@ -1,0 +1,59 @@
+package com.gu.sf.move.subscriptions.api
+import cats.implicits.toTraverseOps
+import com.gu.effects.sqs.AwsSQSSend.{Payload, QueueName}
+import com.gu.effects.sqs.{AwsSQSSend, SqsSync}
+import com.gu.zuora.subscription.Subscription
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.syntax.EncoderOps
+
+trait UpdateSupporterProductData {
+  def update(subscription: Subscription, identityId: String): Either[String, Unit]
+}
+
+class UpdateSupporterProductDataService(queueName: QueueName) extends UpdateSupporterProductData with LazyLogging {
+
+  def combineErrorsOrUnit(list: List[Either[String, Unit]]): Either[String, Unit] = {
+    list.foldLeft[Either[String, Unit]](Right(())) { (acc, either) =>
+      acc match {
+        case Left(errors) =>
+          either match {
+            case Left(error) => Left(s"$errors, $error")
+            case Right(_) => acc
+          }
+        case Right(_) =>
+          either match {
+            case Left(error) => Left(s"$error")
+            case Right(_) => acc
+          }
+      }
+    }
+  }
+  override def update(
+      subscription: Subscription,
+      identityId: String,
+  ): Either[String, Unit] = {
+    val sqsSync = SqsSync.send(SqsSync.buildClient)(queueName) _
+    logger.info(s"Attempting to write to SQS ${queueName.value}, events: ${subscription.ratePlans}")
+    val events = subscription.ratePlans
+      .map(ratePlan =>
+        SupporterRatePlanItem(
+          subscription.subscriptionNumber,
+          identityId,
+          ratePlan.productRatePlanId,
+          ratePlan.ratePlanName,
+          subscription.termEndDate,
+          subscription.contractEffectiveDate,
+        ),
+      )
+      .map(item => Payload(item.asJson.noSpaces))
+      .map(payload => sqsSync(payload).toEither.left.map(_.getMessage))
+
+    combineErrorsOrUnit(events)
+  }
+}
+object UpdateSupporterProductDataService extends LazyLogging {
+  def apply(stage: String): UpdateSupporterProductDataService = {
+    logger.info(s"Creating UpdateSupporterProductDataService in environment $stage")
+    new UpdateSupporterProductDataService(QueueName(s"supporter-product-data-$stage"))
+  }
+}

--- a/handlers/sf-move-subscriptions-api/src/test/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiTest.scala
+++ b/handlers/sf-move-subscriptions-api/src/test/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiTest.scala
@@ -177,7 +177,11 @@ class SFMoveSubscriptionsApiTest extends AnyFlatSpec with should.Matchers with D
   }
 
   private def createApp(backendStub: SttpBackendStub[Identity, Any]) = {
-    SFMoveSubscriptionsApiApp(DevIdentity("sf-move-subscriptions-api"), backendStub).value
+    SFMoveSubscriptionsApiApp(
+      DevIdentity("sf-move-subscriptions-api"),
+      backendStub,
+      new UpdateSupporterProductDataStub(),
+    ).value
       .unsafeRunSync()
       .getOrElse(throw new RuntimeException)
   }

--- a/handlers/sf-move-subscriptions-api/src/test/scala/com/gu/sf/move/subscriptions/api/ZuoraTestBackendMixin.scala
+++ b/handlers/sf-move-subscriptions-api/src/test/scala/com/gu/sf/move/subscriptions/api/ZuoraTestBackendMixin.scala
@@ -1,9 +1,9 @@
 package com.gu.sf.move.subscriptions.api
 
-import com.gu.zuora.subscription.{Subscription, ZuoraApiFailure}
+import com.gu.zuora.subscription.{ZuoraApiFailure, Subscription}
 import com.gu.zuora.{AccessToken, MoveSubscriptionAtZuoraAccountResponse}
 import sttp.client3.testing.SttpBackendStub
-import sttp.client3.{Identity, Response}
+import sttp.client3.{Response, Identity}
 import sttp.model.StatusCode
 
 import java.time.LocalDate
@@ -43,6 +43,10 @@ trait ZuoraTestBackendMixin {
 
   protected val updateAccountFailedRes: Response[Either[ZuoraApiFailure, MoveSubscriptionAtZuoraAccountResponse]] =
     Response(Left(ZuoraApiFailure("update ZuoraAccount failure")), StatusCode.InternalServerError)
+
+  class UpdateSupporterProductDataStub extends UpdateSupporterProductData {
+    override def update(subscription: Subscription, identityId: String): Either[String, Unit] = Right(())
+  }
 
   def createZuoraBackendStub(
       oauthResponse: Response[Either[ZuoraApiFailure, AccessToken]],


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Currently the sf-move-subscription lambda, which reassigns subscriptions from one identity account to another, does not update the SupporterProductData dynamo table which drives the members-data-api attribute service. This means that even though a subscription has been reassigned the new user does not get the benefit of it.

This PR fixes that issue by adding a new record into SupporterProductData when the switch occurs. The way it  does this is by adding an item to the supporter-product-data SQS queue which is then processed by a lambda in the support-frontend repository. 

Currently we do not delete the old record on switch, I don't think this is a problem as the fact that the user is asking to switch is usually because they do not use the other account and even if they do end up using digital benefits on two accounts this is not a huge problem and will anyway only be until the next renewal date. 

If we do decide that we should remove the old record we can do this in a future PR