### PR TITLE
Fix Refund lambda secretsmanager access

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -155,6 +155,14 @@ Resources:
             - sqs:GetQueueAttributes
             - sqs:ReceiveMessage
           Resource: "*"
+      - Statement:
+        - Effect: Allow
+          Action:
+            - secretsmanager:DescribeSecret
+            - secretsmanager:GetSecretValue
+          Resource:
+            - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/InvoicingApi-qNhLQS"
+            - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/InvoicingApi-JBxYpW"
 
   RefundQueue:
     Type: AWS::SQS::Queue

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -163,6 +163,8 @@ Resources:
           Resource:
             - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/InvoicingApi-qNhLQS"
             - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/InvoicingApi-JBxYpW"
+            - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Zuora/User/ZuoraApiUser-zmOGho"
+            - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Zuora/User/ZuoraApiUser-oq5ISm"
 
   RefundQueue:
     Type: AWS::SQS::Queue

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Secrets.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Secrets.scala
@@ -40,7 +40,7 @@ import software.amazon.awssdk.auth.credentials.{
   }
  */
 
-case class InvoicingAPISecrets(invoicingApiUrl: String, invoicingApiKey: String)
+case class InvoicingAPISecrets(InvoicingApiUrl: String, InvoicingApiKey: String)
 case class ZuoraApiUserSecrets(baseUrl: String, username: String, password: String)
 case class SalesforceSSLSecrets(
     url: String,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -30,7 +30,7 @@ object InvoicingApiRefundLive {
     ZLayer {
       for {
         secrets <- ZIO.service[Secrets]
-        invoicingAPISecrets <- secrets.getInvoicingAPISecrets.tapError(_ => ZIO.fail(SecretsError("Could not")))
+        invoicingAPISecrets <- secrets.getInvoicingAPISecrets.tapError(ex => ZIO.fail(SecretsError(s"Failed to get InvoicingApi secrets because: $ex")))
         invoicingApiUrl = invoicingAPISecrets.invoicingApiUrl
         invoicingApiKey = invoicingAPISecrets.invoicingApiKey
         invoicingApiConfig = InvoicingApiConfig(invoicingApiUrl + "/refund", invoicingApiKey)

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -31,8 +31,8 @@ object InvoicingApiRefundLive {
       for {
         secrets <- ZIO.service[Secrets]
         invoicingAPISecrets <- secrets.getInvoicingAPISecrets.tapError(ex => ZIO.fail(SecretsError(s"Failed to get InvoicingApi secrets because: $ex")))
-        invoicingApiUrl = invoicingAPISecrets.invoicingApiUrl
-        invoicingApiKey = invoicingAPISecrets.invoicingApiKey
+        invoicingApiUrl = invoicingAPISecrets.InvoicingApiUrl
+        invoicingApiKey = invoicingAPISecrets.InvoicingApiKey
         invoicingApiConfig = InvoicingApiConfig(invoicingApiUrl + "/refund", invoicingApiKey)
         _ <- ZIO.logInfo(s"Invoice API url is ${invoicingApiConfig.url}")
         sttpClient <- ZIO.service[SttpBackend[Task, Any]]


### PR DESCRIPTION
Gives the product-switch-refund Lambda secrets manager access so that it can communicate with the invoicing-api

After fixing access, the Lambda would then fail with another error: `Failure while parsing json string: upickle.core.AbortException: missing keys in dictionary: invoicingApiUrl, invoicingApiKey at index 140` - This was due to the secrets manager entry having capitalised keys (`InvoicingApiUrl` and `InvoicingApiKey`).

Note that we don't have any kind of health check or automated test that would spot configuration issues such as this, so this has been missing since this PR https://github.com/guardian/support-service-lambdas/pull/1957/files#diff-5da588a0a6da3f0826731e2fd10146bf806da88d2308953ed5bb8a0346297ad2L152 - it was only spotted after a colleague complained that they didn't receive their refund