### PR TITLE
Align the S+ contribution charge with the subscription charge

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
@@ -71,7 +71,11 @@ object AddSupporterPlus {
         .toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!"))
         .toAsync
       contributionAmount = getContributionAmount(amountMinorUnits, account.currency, plan)
-      chargeOverride = ChargeOverride(Some(contributionAmount), planAndCharge.contributionProductRatePlanChargeId, None)
+      chargeOverride = ChargeOverride(
+        Some(contributionAmount),
+        planAndCharge.contributionProductRatePlanChargeId,
+        Some(acceptanceDate),
+      )
       zuoraCreateSubRequest = ZuoraCreateSubRequest(
         request = request,
         acceptanceDate = acceptanceDate,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
@@ -50,9 +50,10 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
 
     def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
 
+    val acceptanceDate = LocalDate.of(2018, 7, 28)
     val expectedIn = ZuoraCreateSubRequest(
       ZuoraAccountId("acccc"),
-      LocalDate.of(2018, 7, 28),
+      acceptanceDate,
       CaseId("case"),
       AcquisitionSource("CSR"),
       CreatedByCSR("bob"),
@@ -63,7 +64,7 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
             ChargeOverride(
               amountMinorUnits = Some(AmountMinorUnits(1000)),
               productRatePlanChargeId = planAndCharge.contributionProductRatePlanChargeId,
-              triggerDate = None,
+              triggerDate = Some(acceptanceDate),
             ),
           ),
         ),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
There is currently a bug in the new-product-api when a user buys a supporter plus sub with Direct Debit - the subscription charge in the rate plan is set up with a customerAcceptanceDate of today + 10 days to allow for the DD to be set up before we charge it, whereas the contribution charge which is set up via a charge override with a trigger date of today. This means that the two charges are billed on different days.

There is an subscription with an example of this [here](https://www.zuora.com/platform/subscriptions/8a128be6899d0b8a0189b0a9bcc574e1)

This PR fixes this by setting the trigger date of the contribution charge to the same date as the customerAcceptanceDate.