### PR TITLE
dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -269,7 +269,7 @@ lazy val `zuora-core` = library(project in file("lib/zuora-core"))
 lazy val `zuora-models` = library(project in file("lib/zuora-models"), scala3Settings)
   .dependsOn(`config-core`)
   .settings(
-    libraryDependencies += "com.gu" %% "support-internationalisation" % "0.15" exclude ("com.typesafe.scala-logging", "scala-logging_2.13"),
+    libraryDependencies += "com.gu" %% "support-internationalisation" % "0.16" exclude ("com.typesafe.scala-logging", "scala-logging_2.13"),
   )
 
 lazy val `credit-processor` = library(project in file("lib/credit-processor"))
@@ -616,7 +616,7 @@ lazy val `sf-move-subscriptions-api` = lambdaProject(
     scalatest,
     diffx,
   ),
-).dependsOn(`effects-s3`, `effects-sqs`,  `config-cats`, `zuora-core`, `http4s-lambda-handler`)
+).dependsOn(`effects-s3`, `effects-sqs`, `config-cats`, `zuora-core`, `http4s-lambda-handler`)
 
 lazy val `fulfilment-date-calculator` = lambdaProject(
   "fulfilment-date-calculator",


### PR DESCRIPTION
Scala Steward attempted a PR ( https://github.com/guardian/support-service-lambdas/pull/1999 ) that is failing. Here we perform one update manually. 

- update support-internationalisation from 0.15 to 0.16

Note: It is surprising that Stewart was attempting to upgrade cats-effect from 2.5.5 to 3.5.0, considering that this is a major upgrade which is actually breaking. 
