### PR TITLE
Use invoice item date in adjustments

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetRefundInvoiceDetails.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetRefundInvoiceDetails.scala
@@ -163,6 +163,7 @@ case class InvoiceItemWithTaxDetails(
     InvoiceId: String,
 ) {
   def amountWithTax = ChargeAmount + TaxDetails.map(_.amount).getOrElse(0)
+  def chargeDateAsDate = LocalDate.parse(ChargeDate, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 }
 
 object GetRefundInvoiceDetails {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
@@ -44,7 +44,6 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
       } @@ TestAspect.ignore,
       test("buildInvoiceAdjustments function ignores invoice items with zero value") {
         val adjustments = RefundSupporterPlus.buildInvoiceItemAdjustments(
-          LocalDate.now,
           List(
             InvoiceItemWithTaxDetails(
               "8ad08dc989d472290189db0888460962",

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
@@ -64,6 +64,28 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
         assert(adjustments.length)(equalTo(1)) &&
         assert(adjustments.head.Amount)(equalTo(120))
       },
+      test("buildInvoiceAdjustments function uses the correct adjustment date") {
+        val adjustments = RefundSupporterPlus.buildInvoiceItemAdjustments(
+          List(
+            InvoiceItemWithTaxDetails(
+              "8a12843289e577d00189f660966d56bd",
+              "2023-08-15T00:27:52.000+01:00",
+              33,
+              None,
+              "8a12843289e577d00189f660965f56bc",
+            ),
+            InvoiceItemWithTaxDetails(
+              "8a12843289e577d00189f660966d56be",
+              "2023-08-15T00:27:52.000+01:00",
+              15.45,
+              None,
+              "8a12843289e577d00189f660965f56bc",
+            ),
+          ),
+        )
+        assert(adjustments.length)(equalTo(2)) &&
+          assert(adjustments.head.AdjustmentDate.getDayOfMonth)(equalTo(15))
+      },
       test("Deserialisation of the invoice adjustment response works") {
         val responseJson =
           """


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This fixes a bug found with the product move refund lambda

The bug is related to a time zone issue where if we try to run an invoice adjustment in the hour after midnight (during BST) the invoice adjustment date will be before the invoice date for the invoice we are trying to adjust. 
The reason is that the code which is building the invoice item adjustments is using UTC when it builds them.

In fact we don't need to generate a date in code for these adjustments at all, we can just use the date from the invoice itself so that is what I have done in this PR.

[Cloudwatch logs are here](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Finvoicing-api-refund-PROD/log-events/2023$252F08$252F14$252F$255B$2524LATEST$255D2707ed4a3f8f46cc940db7970c305bab)