### PR TITLE
Add two extra runs each morning to sf-billing-account-remover schedule

### DIFF
--- a/handlers/sf-billing-account-remover/cfn.yaml
+++ b/handlers/sf-billing-account-remover/cfn.yaml
@@ -21,7 +21,7 @@ Mappings:
       SalesforceUser: BillingAccountRemoverAPIUser
       ZuoraUrl: https://rest.zuora.com
       ZuoraAccount: SupportServiceLambdas
-      Schedule: 'cron(00 07,08,09,10 * * ? *)'
+      Schedule: 'cron(00 04,05,06,07,08,09,10 * * ? *)'
 
 Resources:
   SFBillingAccountRemoverRole:


### PR DESCRIPTION
## What does this change?

Adds two extra runs to the sf-billing-account-remover schedule

The runs are earlier in the morning to avoid conflicting with any billing/payment runs in Zuora (when the Z360 sync tends to get very slow due to "Turbo Sync" mode)

### Why would we want to do that?

This Lambda picks up 200 records at a time and was set to run 4 times each day. In the past few weeks, this has not been sufficient to clear the backlog of records in Salesforce that need processing.

Note here that since April the Lambda has been running the maximum 800 Billing Account updates every day (i.e. 4 x 200 record runs). If it were clearing the backlog, it should be picking up less than the maximum on some days.

<img width="984" alt="Screenshot 2023-08-21 at 14 01 11" src="https://github.com/guardian/support-service-lambdas/assets/23298731/55a5a5d9-59e6-4765-af0a-0a1a28933408">

Today in Salesforce there were only 417 records awaiting processing by this Lambda, so presumably the amount of Billing Accounts per day that are falling outside the retention period is not _massively_ higher than the current maximum of 800. Adding two extra runs increases this maximum to 1,200 per day.

### Why not increase the batch size?

We probably wanted to keep this fairly low as the Zuora API can be a little slow.

## How to test

N/A - this is just a change to the schedule.

## How can we measure success?

The backlog starts to get cleared over a couple of days.