### PR TITLE
Better logging for product-move-api

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala
@@ -113,7 +113,7 @@ object RecurringContributionToSupporterPlus {
     OutputBody,
   ] = {
     (for {
-      _ <- ZIO.log("PostData: " + postData.toString)
+      _ <- ZIO.log("RecurringContributionToSupporterPlus PostData: " + postData.toString)
       subscription <- GetSubscription.get(subscriptionName)
 
       currentRatePlan <- getSingleOrNotEligible(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/ToRecurringContribution.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/ToRecurringContribution.scala
@@ -43,7 +43,7 @@ object ToRecurringContribution {
     OutputBody,
   ] = {
     (for {
-      _ <- ZIO.log("PostData: " + postData.toString)
+      _ <- ZIO.log("ToRecurringContribution PostData: " + postData.toString)
       subscription <- GetSubscription.get(subscriptionName)
 
       activeRatePlanAndCharge <- ZIO


### PR DESCRIPTION
There were issues in this code, but we couldn't tell if the person was attempting to move to contribtuion or S+.

Ideally we would make the framework log the full URL along with the post data, but this is a quick fix for now.