### PR TITLE
only look at active rateplans when allowing product move

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala
@@ -117,8 +117,8 @@ object RecurringContributionToSupporterPlus {
       subscription <- GetSubscription.get(subscriptionName)
 
       currentRatePlan <- getSingleOrNotEligible(
-        subscription.ratePlans,
-        s"Subscription: ${subscriptionName.value} has more than one ratePlan",
+        subscription.ratePlans.filterNot(_.lastChangeType.contains("Remove")),
+        s"Subscription: ${subscriptionName.value} has more than one active ratePlan",
       )
       ratePlanCharge <- getSingleOrNotEligible(
         currentRatePlan.ratePlanCharges,


### PR DESCRIPTION
If a customer who has already switched, tries to preview or perform another switch, they will be rejected with `Subscription: ${subscriptionName.value} has more than one ratePlan`
However there is no reason to look at removed rate plans.

This PR changes it so that removed rate plans will be ignored.