### PR TITLE
new product api refactor

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
@@ -16,7 +16,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAcc
 import com.gu.newproduct.api.addsubscription.zuora.GetAccountSubscriptions.WireModel.ZuoraSubscriptionsResponse
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.Contacts
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetContactsResponse
-import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod, PaymentMethodWire}
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{PaymentMethod, PaymentMethodWire}
 import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetAccountSubscriptions, GetContacts, GetPaymentMethod}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{HasPlanAndChargeIds, ProductRatePlanId, ZuoraIds}
@@ -49,7 +49,7 @@ object AddContribution {
         request.planId,
         account.currency,
       ).toApiGatewayOp.toAsync
-      acceptanceDate = request.startDate.plusDays(paymentDelayFor(paymentMethod))
+      acceptanceDate = request.startDate
       planAndCharge <- getPlanAndCharge(request.planId)
         .toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!"))
         .toAsync
@@ -115,11 +115,6 @@ object AddContribution {
       sendConfirmationEmail = sendConfirmationEmail,
     ) _
 
-  }
-
-  def paymentDelayFor(paymentMethod: PaymentMethod): Long = paymentMethod match {
-    case d: DirectDebit => 10L
-    case _ => 0L
   }
 
   def toContributionEmailData(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
@@ -16,7 +16,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAcc
 import com.gu.newproduct.api.addsubscription.zuora.GetAccountSubscriptions.WireModel.ZuoraSubscriptionsResponse
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.Contacts
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetContactsResponse
-import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod, PaymentMethodWire}
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{PaymentMethod, PaymentMethodWire}
 import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetAccountSubscriptions, GetContacts, GetPaymentMethod}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlySupporterPlus
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharges, ProductRatePlanId, ZuoraIds}
@@ -53,7 +53,7 @@ object AddSupporterPlus {
         request.planId,
         account.currency,
       ).toApiGatewayOp.toAsync
-      acceptanceDate = request.startDate.plusDays(paymentDelayFor(paymentMethod))
+      acceptanceDate = request.startDate
       plan = getPlan(request.planId)
       planAndCharge <- getPlanAndCharge(request.planId)
         .toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!"))
@@ -121,11 +121,6 @@ object AddSupporterPlus {
       sendConfirmationEmail = sendConfirmationEmail,
     ) _
 
-  }
-
-  def paymentDelayFor(paymentMethod: PaymentMethod): Long = paymentMethod match {
-    case d: DirectDebit => 10L
-    case _ => 0L
   }
 
   def toSupporterPlusEmailData(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/paper/PaperAddressValidator.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/paper/PaperAddressValidator.scala
@@ -9,29 +9,31 @@ import com.gu.newproduct.api.productcatalog.{HomeDeliveryPlanId, PlanId}
 object PaperAddressValidator {
   def apply(planId: PlanId, soldToAddress: SoldToAddress): ValidationResult[Unit] =
     for {
-      _ <-
-        (soldToAddress.country == Country.UK) orFailWith s"Invalid country: ${soldToAddress.country.name}, only UK addresses are allowed"
-      - <- postCodeValidationFor(planId)(soldToAddress.postcode)
+      _ <- (soldToAddress.country == Country.UK) orFailWith cantDeliverOutsideUK(soldToAddress)
+      _ <- postCodeValidationFor(planId)(soldToAddress.postcode)
     } yield ()
 
-  def postCodeValidationFor(planId: PlanId): Option[Postcode] => ValidationResult[Any] = planId match {
+  private def cantDeliverOutsideUK(soldToAddress: SoldToAddress): String =
+    s"Invalid country: ${soldToAddress.country.name}, only UK addresses are allowed"
+
+  private def postCodeValidationFor(planId: PlanId): Option[Postcode] => ValidationResult[Any] = planId match {
     case _: HomeDeliveryPlanId => validatePostCodeForHomeDelivery _
     case _ => (postCode: Option[Postcode]) => Passed(())
   }
 
-  def validatePostCodeForHomeDelivery(postcode: Option[Postcode]): ValidationResult[Postcode] = for {
+  private def validatePostCodeForHomeDelivery(postcode: Option[Postcode]): ValidationResult[Postcode] = for {
     deliveryPostcode <- postcode getOrFailWith ("delivery postcode is required")
     _ <- isWithinM25(
       deliveryPostcode,
     ) orFailWith (s"Invalid postcode ${deliveryPostcode.value}: postcode must be within M25")
   } yield (deliveryPostcode)
 
-  def isWithinM25(postcode: Postcode): Boolean = {
+  private def isWithinM25(postcode: Postcode): Boolean = {
     val normalisedPostCode = postcode.value.toUpperCase.filterNot(_.isWhitespace)
     M25_POSTCODE_PREFIXES.exists(normalisedPostCode.startsWith(_))
   }
 
-  val M25_POSTCODE_PREFIXES = List(
+  private val M25_POSTCODE_PREFIXES = List(
     "BR1",
     "BR2",
     "BR3",

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/ContributionsPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/ContributionsPlans.scala
@@ -7,18 +7,16 @@ import java.time.LocalDate
 
 class ContributionsPlans(today: LocalDate) {
 
-  private val ContributionStartDateWindowSize = WindowSizeDays(1)
-
-  private val contributionsRule = StartDateRules(
+  private val rule = StartDateRules(
     windowRule = WindowRule(
       startDate = today,
-      maybeSize = Some(ContributionStartDateWindowSize),
+      maybeSize = Some(WindowSizeDays(1)),
     ),
   )
 
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
-    (MonthlyContribution, PlanDescription("Monthly"), contributionsRule, Monthly),
-    (AnnualContribution, PlanDescription("Annual"), contributionsRule, Monthly),
+    (MonthlyContribution, PlanDescription("Monthly"), rule, Monthly),
+    (AnnualContribution, PlanDescription("Annual"), rule, Monthly),
   )
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/DigitalPackPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/DigitalPackPlans.scala
@@ -7,21 +7,18 @@ import java.time.LocalDate
 
 class DigitalPackPlans(today: LocalDate) {
 
-  private val DigiPackFreeTrialPeriodDays = 14
-  private val DigiPackStartDateWindowSize = WindowSizeDays(90)
+  private val FreeTrialPeriodDays = 14
 
-  private val digiPackWindowRule = WindowRule(
-    startDate = today.plusDays(DigiPackFreeTrialPeriodDays.toLong),
-    maybeSize = Some(DigiPackStartDateWindowSize),
-  )
-
-  private val digipackStartRules = StartDateRules(
-    windowRule = digiPackWindowRule,
+  private val startRules = StartDateRules(
+    windowRule = WindowRule(
+      startDate = today.plusDays(FreeTrialPeriodDays.toLong),
+      maybeSize = Some(WindowSizeDays(90)),
+    ),
   )
 
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
-    (DigipackAnnual, PlanDescription("Annual"), digipackStartRules, Annual),
-    (DigipackMonthly, PlanDescription("Monthly"), digipackStartRules, Monthly),
+    (DigipackAnnual, PlanDescription("Annual"), startRules, Annual),
+    (DigipackMonthly, PlanDescription("Monthly"), startRules, Monthly),
   )
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/DigitalVoucherPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/DigitalVoucherPlans.scala
@@ -5,19 +5,15 @@ import com.gu.newproduct.api.productcatalog._
 
 import java.time.{DayOfWeek, LocalDate}
 
-class DigitalVoucherPlans(
-  getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate
-) {
+class DigitalVoucherPlans(getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate) {
 
   import PaperDays._
-  private val DigitalVoucherStartDateWindowSize = WindowSizeDays(1)
-
-  private def digitalVoucherStartDateRule(daysOfWeek: List[DayOfWeek]) =
+  private def startDateRule(daysOfWeek: List[DayOfWeek]) =
     StartDateRules(
       daysOfWeekRule = Some(DaysOfWeekRule(daysOfWeek)),
       windowRule = WindowRule(
         startDate = getStartDateFromFulfilmentFiles(ProductType.NewspaperDigitalVoucher, daysOfWeek),
-        maybeSize = Some(DigitalVoucherStartDateWindowSize),
+        maybeSize = Some(WindowSizeDays(1)),
       ),
     )
 
@@ -25,61 +21,61 @@ class DigitalVoucherPlans(
     (
       DigitalVoucherWeekend,
       PlanDescription("Weekend"),
-      digitalVoucherStartDateRule(weekendDays),
+      startDateRule(weekendDays),
       Monthly,
     ),
     (
       DigitalVoucherWeekendPlus,
       PlanDescription("Weekend+"),
-      digitalVoucherStartDateRule(weekendDays),
+      startDateRule(weekendDays),
       Monthly,
     ),
     (
       DigitalVoucherEveryday,
       PlanDescription("Everyday"),
-      digitalVoucherStartDateRule(everyDayDays),
+      startDateRule(everyDayDays),
       Monthly,
     ),
     (
       DigitalVoucherEverydayPlus,
       PlanDescription("Everyday+"),
-      digitalVoucherStartDateRule(everyDayDays),
+      startDateRule(everyDayDays),
       Monthly,
     ),
     (
       DigitalVoucherSaturday,
       PlanDescription("Saturday"),
-      digitalVoucherStartDateRule(saturdayDays),
+      startDateRule(saturdayDays),
       Monthly,
     ),
     (
       DigitalVoucherSaturdayPlus,
       PlanDescription("Saturday+"),
-      digitalVoucherStartDateRule(saturdayDays),
+      startDateRule(saturdayDays),
       Monthly,
     ),
     (
       DigitalVoucherSunday,
       PlanDescription("Sunday"),
-      digitalVoucherStartDateRule(sundayDays),
+      startDateRule(sundayDays),
       Monthly,
     ),
     (
       DigitalVoucherSundayPlus,
       PlanDescription("Sunday+"),
-      digitalVoucherStartDateRule(sundayDays),
+      startDateRule(sundayDays),
       Monthly,
     ),
     (
       DigitalVoucherSixday,
       PlanDescription("Sixday"),
-      digitalVoucherStartDateRule(sixDayDays),
+      startDateRule(sixDayDays),
       Monthly,
     ),
     (
       DigitalVoucherSixdayPlus,
       PlanDescription("Sixday+"),
-      digitalVoucherStartDateRule(sixDayDays),
+      startDateRule(sixDayDays),
       Monthly,
     ),
   )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/GuardianWeeklyPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/GuardianWeeklyPlans.scala
@@ -5,19 +5,15 @@ import com.gu.newproduct.api.productcatalog._
 
 import java.time.{DayOfWeek, LocalDate}
 
-class GuardianWeeklyPlans(
-    getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate,
-) {
+class GuardianWeeklyPlans(getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate) {
 
-  private val GuardianWeeklySubscriptionStartDateWindowSize = WindowSizeDays(28)
-
-  private val guardianWeeklyIssueDays = List(DayOfWeek.FRIDAY)
-  private val guardianWeeklyStartDateRules =
+  private val issueDays = List(DayOfWeek.FRIDAY)
+  private val startDateRules =
     StartDateRules(
-      daysOfWeekRule = Some(DaysOfWeekRule(guardianWeeklyIssueDays)),
+      daysOfWeekRule = Some(DaysOfWeekRule(issueDays)),
       windowRule = WindowRule(
-        startDate = getStartDateFromFulfilmentFiles(ProductType.GuardianWeekly, guardianWeeklyIssueDays),
-        maybeSize = Some(GuardianWeeklySubscriptionStartDateWindowSize),
+        startDate = getStartDateFromFulfilmentFiles(ProductType.GuardianWeekly, issueDays),
+        maybeSize = Some(WindowSizeDays(28)),
       ),
     )
 
@@ -25,37 +21,37 @@ class GuardianWeeklyPlans(
     (
       GuardianWeeklyDomestic6for6,
       PlanDescription("GW Oct 18 - Six for Six - Domestic"),
-      guardianWeeklyStartDateRules,
+      startDateRules,
       SixWeeks,
     ),
     (
       GuardianWeeklyDomesticQuarterly,
       PlanDescription("GW Oct 18 - Quarterly - Domestic"),
-      guardianWeeklyStartDateRules,
+      startDateRules,
       Quarterly,
     ),
     (
       GuardianWeeklyDomesticAnnual,
       PlanDescription("GW Oct 18 - Annual - Domestic"),
-      guardianWeeklyStartDateRules,
+      startDateRules,
       Annual,
     ),
     (
       GuardianWeeklyROW6for6,
       PlanDescription("GW Oct 18 - Six for Six - ROW"),
-      guardianWeeklyStartDateRules,
+      startDateRules,
       SixWeeks,
     ),
     (
       GuardianWeeklyROWQuarterly,
       PlanDescription("GW Oct 18 - Quarterly - ROW"),
-      guardianWeeklyStartDateRules,
+      startDateRules,
       Quarterly,
     ),
     (
       GuardianWeeklyROWAnnual,
       PlanDescription("GW Oct 18 - Annual - ROW"),
-      guardianWeeklyStartDateRules,
+      startDateRules,
       Annual,
     ),
   )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/HomeDeliveryPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/HomeDeliveryPlans.scala
@@ -5,43 +5,39 @@ import com.gu.newproduct.api.productcatalog._
 
 import java.time.{DayOfWeek, LocalDate}
 
-class HomeDeliveryPlans(
-    getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate,
-) {
+class HomeDeliveryPlans(getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate) {
 
   import PaperDays._
-  private val HomeDeliverySubscriptionStartDateWindowSize = WindowSizeDays(28)
-
-  private def homeDeliveryWindowRule(issueDays: List[DayOfWeek]) = WindowRule(
+  private def windowRule(issueDays: List[DayOfWeek]) = WindowRule(
     startDate = getStartDateFromFulfilmentFiles(ProductType.NewspaperHomeDelivery, issueDays),
-    maybeSize = Some(HomeDeliverySubscriptionStartDateWindowSize),
+    maybeSize = Some(WindowSizeDays(28)),
   )
 
-  private def homeDeliveryDateRules(allowedDays: List[DayOfWeek]) = StartDateRules(
+  private def dateRules(allowedDays: List[DayOfWeek]) = StartDateRules(
     Some(DaysOfWeekRule(allowedDays)),
-    homeDeliveryWindowRule(allowedDays),
+    windowRule(allowedDays),
   )
 
-  private val homeDeliveryEveryDayRules = homeDeliveryDateRules(
+  private val everyDayRules = dateRules(
     everyDayDays,
   )
 
-  private val homeDeliverySixDayRules = homeDeliveryDateRules(sixDayDays)
-  private val homeDeliverySundayDateRules = homeDeliveryDateRules(sundayDays)
-  private val homeDeliverySaturdayDateRules = homeDeliveryDateRules(saturdayDays)
-  private val homeDeliveryWeekendRules = homeDeliveryDateRules(weekendDays)
+  private val sixDayRules = dateRules(sixDayDays)
+  private val sundayDateRules = dateRules(sundayDays)
+  private val saturdayDateRules = dateRules(saturdayDays)
+  private val weekendRules = dateRules(weekendDays)
 
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
-    (HomeDeliveryEveryDay, PlanDescription("Everyday"), homeDeliveryEveryDayRules, Monthly),
-    (HomeDeliverySixDay, PlanDescription("Sixday"), homeDeliverySixDayRules, Monthly),
-    (HomeDeliveryWeekend, PlanDescription("Weekend"), homeDeliveryWeekendRules, Monthly),
-    (HomeDeliverySunday, PlanDescription("Sunday"), homeDeliverySundayDateRules, Monthly),
-    (HomeDeliverySaturday, PlanDescription("Saturday"), homeDeliverySaturdayDateRules, Monthly),
-    (HomeDeliveryEveryDayPlus, PlanDescription("Everyday+"), homeDeliveryEveryDayRules, Monthly),
-    (HomeDeliverySixDayPlus, PlanDescription("Sixday+"), homeDeliverySixDayRules, Monthly),
-    (HomeDeliveryWeekendPlus, PlanDescription("Weekend+"), homeDeliveryWeekendRules, Monthly),
-    (HomeDeliverySundayPlus, PlanDescription("Sunday+"), homeDeliverySundayDateRules, Monthly),
-    (HomeDeliverySaturdayPlus, PlanDescription("Saturday+"), homeDeliverySaturdayDateRules, Monthly),
+    (HomeDeliveryEveryDay, PlanDescription("Everyday"), everyDayRules, Monthly),
+    (HomeDeliverySixDay, PlanDescription("Sixday"), sixDayRules, Monthly),
+    (HomeDeliveryWeekend, PlanDescription("Weekend"), weekendRules, Monthly),
+    (HomeDeliverySunday, PlanDescription("Sunday"), sundayDateRules, Monthly),
+    (HomeDeliverySaturday, PlanDescription("Saturday"), saturdayDateRules, Monthly),
+    (HomeDeliveryEveryDayPlus, PlanDescription("Everyday+"), everyDayRules, Monthly),
+    (HomeDeliverySixDayPlus, PlanDescription("Sixday+"), sixDayRules, Monthly),
+    (HomeDeliveryWeekendPlus, PlanDescription("Weekend+"), weekendRules, Monthly),
+    (HomeDeliverySundayPlus, PlanDescription("Sunday+"), sundayDateRules, Monthly),
+    (HomeDeliverySaturdayPlus, PlanDescription("Saturday+"), saturdayDateRules, Monthly),
   )
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/NationalDeliveryPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/NationalDeliveryPlans.scala
@@ -5,9 +5,7 @@ import com.gu.newproduct.api.productcatalog._
 
 import java.time.{DayOfWeek, LocalDate}
 
-class NationalDeliveryPlans(
-    getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate,
-) {
+class NationalDeliveryPlans(getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate) {
 
   import PaperDays._
   private val SubscriptionStartDateWindowSize = WindowSizeDays(28)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/SupporterPlusPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/SupporterPlusPlans.scala
@@ -7,18 +7,16 @@ import java.time.LocalDate
 
 class SupporterPlusPlans(today: LocalDate) {
 
-  private val SupporterPlusStartDateWindowSize = WindowSizeDays(1)
-
-  private val supporterPlusRule = StartDateRules(
+  private val rule = StartDateRules(
     windowRule = WindowRule(
       startDate = today,
-      maybeSize = Some(SupporterPlusStartDateWindowSize),
+      maybeSize = Some(WindowSizeDays(1)),
     ),
   )
 
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
-    (MonthlySupporterPlus, PlanDescription("Monthly"), supporterPlusRule, Monthly),
-    (AnnualSupporterPlus, PlanDescription("Annual"), supporterPlusRule, Annual),
+    (MonthlySupporterPlus, PlanDescription("Monthly"), rule, Monthly),
+    (AnnualSupporterPlus, PlanDescription("Annual"), rule, Annual),
   )
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/VoucherPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/VoucherPlans.scala
@@ -6,41 +6,37 @@ import com.gu.newproduct.api.productcatalog._
 import java.time.DayOfWeek.MONDAY
 import java.time.{DayOfWeek, LocalDate}
 
-class VoucherPlans(
-    getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate,
-) {
+class VoucherPlans(getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate) {
 
   import PaperDays._
 
-  private val VoucherSubscriptionStartDateWindowSize = WindowSizeDays(35)
-
-  private def voucherWindowRule(issueDays: List[DayOfWeek]) = {
+  private def windowRule(issueDays: List[DayOfWeek]) = {
     WindowRule(
       startDate = getStartDateFromFulfilmentFiles(ProductType.NewspaperVoucherBook, issueDays),
-      maybeSize = Some(VoucherSubscriptionStartDateWindowSize),
+      maybeSize = Some(WindowSizeDays(35)),
     )
   }
 
-  private def voucherDateRules(allowedDays: List[DayOfWeek]) = StartDateRules(
+  private def dateRules(allowedDays: List[DayOfWeek]) = StartDateRules(
     Some(DaysOfWeekRule(allowedDays)),
-    voucherWindowRule(allowedDays),
+    windowRule(allowedDays),
   )
 
-  private val voucherMondayRules = voucherDateRules(List(MONDAY))
-  private val voucherSundayDateRules = voucherDateRules(sundayDays)
-  private val voucherSaturdayDateRules = voucherDateRules(saturdayDays)
+  private val mondayRules = dateRules(List(MONDAY))
+  private val sundayDateRules = dateRules(sundayDays)
+  private val saturdayDateRules = dateRules(saturdayDays)
 
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
-    (VoucherWeekend, PlanDescription("Weekend"), voucherSaturdayDateRules, Monthly),
-    (VoucherSaturday, PlanDescription("Saturday"), voucherSaturdayDateRules, Monthly),
-    (VoucherSunday, PlanDescription("Sunday"), voucherSundayDateRules, Monthly),
-    (VoucherEveryDay, PlanDescription("Everyday"), voucherMondayRules, Monthly),
-    (VoucherSixDay, PlanDescription("Sixday"), voucherMondayRules, Monthly),
-    (VoucherWeekendPlus, PlanDescription("Weekend+"), voucherSaturdayDateRules, Monthly),
-    (VoucherSaturdayPlus, PlanDescription("Saturday+"), voucherSaturdayDateRules, Monthly),
-    (VoucherSundayPlus, PlanDescription("Sunday+"), voucherSundayDateRules, Monthly),
-    (VoucherEveryDayPlus, PlanDescription("Everyday+"), voucherMondayRules, Monthly),
-    (VoucherSixDayPlus, PlanDescription("Sixday+"), voucherMondayRules, Monthly),
+    (VoucherWeekend, PlanDescription("Weekend"), saturdayDateRules, Monthly),
+    (VoucherSaturday, PlanDescription("Saturday"), saturdayDateRules, Monthly),
+    (VoucherSunday, PlanDescription("Sunday"), sundayDateRules, Monthly),
+    (VoucherEveryDay, PlanDescription("Everyday"), mondayRules, Monthly),
+    (VoucherSixDay, PlanDescription("Sixday"), mondayRules, Monthly),
+    (VoucherWeekendPlus, PlanDescription("Weekend+"), saturdayDateRules, Monthly),
+    (VoucherSaturdayPlus, PlanDescription("Saturday+"), saturdayDateRules, Monthly),
+    (VoucherSundayPlus, PlanDescription("Sunday+"), sundayDateRules, Monthly),
+    (VoucherEveryDayPlus, PlanDescription("Everyday+"), mondayRules, Monthly),
+    (VoucherSixDayPlus, PlanDescription("Sixday+"), mondayRules, Monthly),
   )
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -42,7 +42,7 @@ class ContributionStepsTest extends AnyFlatSpec with Matchers {
 
     val expectedIn = ZuoraCreateSubRequest(
       ZuoraAccountId("acccc"),
-      LocalDate.of(2018, 7, 28),
+      LocalDate.of(2018, 7, 18),
       CaseId("case"),
       AcquisitionSource("CSR"),
       CreatedByCSR("bob"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
@@ -42,7 +42,7 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
 
     val expectedIn = ZuoraCreateSubRequest(
       ZuoraAccountId("acccc"),
-      LocalDate.of(2018, 7, 28),
+      LocalDate.of(2018, 7, 18),
       CaseId("case"),
       AcquisitionSource("CSR"),
       CreatedByCSR("bob"),


### PR DESCRIPTION
Some comments from Emily on the previous PR https://github.com/guardian/support-service-lambdas/pull/2044#discussion_r1336022703
Basically to remove the "homeDelivery" prefix from classes that are wholly about home delivery, etc.  This was a hangover from the refactor where they were previously all in one long function.

I decided to push as a separate PR just to keep things simpler.

No functionality changes, and the tests all still pass.