### PR TITLE
don't delay DD subs by 10 days

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
@@ -49,7 +49,7 @@ object AddContribution {
         request.planId,
         account.currency,
       ).toApiGatewayOp.toAsync
-      acceptanceDate = request.startDate.plusDays(paymentDelayFor(paymentMethod))
+      acceptanceDate = request.startDate
       planAndCharge <- getPlanAndCharge(request.planId)
         .toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!"))
         .toAsync
@@ -115,11 +115,6 @@ object AddContribution {
       sendConfirmationEmail = sendConfirmationEmail,
     ) _
 
-  }
-
-  def paymentDelayFor(paymentMethod: PaymentMethod): Long = paymentMethod match {
-    case d: DirectDebit => 10L
-    case _ => 0L
   }
 
   def toContributionEmailData(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
@@ -16,7 +16,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAcc
 import com.gu.newproduct.api.addsubscription.zuora.GetAccountSubscriptions.WireModel.ZuoraSubscriptionsResponse
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.Contacts
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetContactsResponse
-import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod, PaymentMethodWire}
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{PaymentMethod, PaymentMethodWire}
 import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetAccountSubscriptions, GetContacts, GetPaymentMethod}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{HasPlanAndChargeIds, ProductRatePlanId, ZuoraIds}

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
@@ -16,7 +16,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAcc
 import com.gu.newproduct.api.addsubscription.zuora.GetAccountSubscriptions.WireModel.ZuoraSubscriptionsResponse
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.Contacts
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetContactsResponse
-import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod, PaymentMethodWire}
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{PaymentMethod, PaymentMethodWire}
 import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetAccountSubscriptions, GetContacts, GetPaymentMethod}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlySupporterPlus
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharges, ProductRatePlanId, ZuoraIds}

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
@@ -53,7 +53,7 @@ object AddSupporterPlus {
         request.planId,
         account.currency,
       ).toApiGatewayOp.toAsync
-      acceptanceDate = request.startDate.plusDays(paymentDelayFor(paymentMethod))
+      acceptanceDate = request.startDate
       plan = getPlan(request.planId)
       planAndCharge <- getPlanAndCharge(request.planId)
         .toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!"))
@@ -121,11 +121,6 @@ object AddSupporterPlus {
       sendConfirmationEmail = sendConfirmationEmail,
     ) _
 
-  }
-
-  def paymentDelayFor(paymentMethod: PaymentMethod): Long = paymentMethod match {
-    case d: DirectDebit => 10L
-    case _ => 0L
   }
 
   def toSupporterPlusEmailData(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -42,7 +42,7 @@ class ContributionStepsTest extends AnyFlatSpec with Matchers {
 
     val expectedIn = ZuoraCreateSubRequest(
       ZuoraAccountId("acccc"),
-      LocalDate.of(2018, 7, 28),
+      LocalDate.of(2018, 7, 18),
       CaseId("case"),
       AcquisitionSource("CSR"),
       CreatedByCSR("bob"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
@@ -42,7 +42,7 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
 
     val expectedIn = ZuoraCreateSubRequest(
       ZuoraAccountId("acccc"),
-      LocalDate.of(2018, 7, 28),
+      LocalDate.of(2018, 7, 18),
       CaseId("case"),
       AcquisitionSource("CSR"),
       CreatedByCSR("bob"),


### PR DESCRIPTION
(don't merge until after new product api refactor PR is approved and merged https://github.com/guardian/support-service-lambdas/pull/2058 )

We have always had a 10 day delay on DD contributions via new product-api [1] .  However this is not technically needed under the DD guarantee as it's a specifically agreed payment rather than an updated recurring amount.

This code was copied into the Supporter plus code and it was spotted during testing as an incorrect "fulfilment start date" in salesforce.

I checked with Matt and he didn't see a reason for the delay.  The PR [2] implicied you might have suggested it originally @paulbrown1982 so just adding in case you have an opinion.

[1] https://github.com/guardian/support-service-lambdas/blob/6417309fd415126e9f349b081edd27e63a9ef006/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala#L53
[2] https://github.com/guardian/support-service-lambdas/pull/164/files#diff-bae1d5b1d39da9219c297afd04d53a576bae5713674d9ce3e4fdb6f21bf64583R53