### PR TITLE
ops: add rule to acquisition bus to send payment-api messages to the single-contribution-salesforce-writes-queue

### DIFF
--- a/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
+++ b/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
@@ -7,6 +7,40 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
     "gu:cdk:version": "TEST",
   },
   "Resources": {
+    "AcquisitionBusToSingleContributionSalesforceWritesQueueRule2CC5A818": {
+      "Properties": {
+        "Description": "Send payment api events to the single-contribution-salesforce-writes-queue",
+        "EventBusName": "acquisitions-bus-CODE",
+        "EventPattern": {
+          "account": [
+            {
+              "Ref": "AWS::AccountId",
+            },
+          ],
+          "region": [
+            {
+              "Ref": "AWS::Region",
+            },
+          ],
+          "source": [
+            "payment-api",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "singlecontributionsalesforcewritesqueue227D3F6D",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "deadletterssinglecontributionsalesforcewritesqueueA3CB7F4A": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -68,6 +102,72 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
+    "singlecontributionsalesforcewritesqueuePolicyDC24ED87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "AcquisitionBusToSingleContributionSalesforceWritesQueueRule2CC5A818",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "singlecontributionsalesforcewritesqueue227D3F6D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "sqs:SendMessage",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "AcquisitionBusToSingleContributionSalesforceWritesQueueRule2CC5A818",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "singlecontributionsalesforcewritesqueue227D3F6D",
+                  "Arn",
+                ],
+              },
+              "Sid": "Allow acquisition bus to send messages to the single-contribution-salesforce-writes-queue",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Queues": [
+          {
+            "Ref": "singlecontributionsalesforcewritesqueue227D3F6D",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
+    },
   },
 }
 `;
@@ -79,6 +179,40 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
     "gu:cdk:version": "TEST",
   },
   "Resources": {
+    "AcquisitionBusToSingleContributionSalesforceWritesQueueRule2CC5A818": {
+      "Properties": {
+        "Description": "Send payment api events to the single-contribution-salesforce-writes-queue",
+        "EventBusName": "acquisitions-bus-PROD",
+        "EventPattern": {
+          "account": [
+            {
+              "Ref": "AWS::AccountId",
+            },
+          ],
+          "region": [
+            {
+              "Ref": "AWS::Region",
+            },
+          ],
+          "source": [
+            "payment-api",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "singlecontributionsalesforcewritesqueue227D3F6D",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "deadletterssinglecontributionsalesforcewritesqueueA3CB7F4A": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -139,6 +273,72 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
+    },
+    "singlecontributionsalesforcewritesqueuePolicyDC24ED87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "AcquisitionBusToSingleContributionSalesforceWritesQueueRule2CC5A818",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "singlecontributionsalesforcewritesqueue227D3F6D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "sqs:SendMessage",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "AcquisitionBusToSingleContributionSalesforceWritesQueueRule2CC5A818",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "singlecontributionsalesforcewritesqueue227D3F6D",
+                  "Arn",
+                ],
+              },
+              "Sid": "Allow acquisition bus to send messages to the single-contribution-salesforce-writes-queue",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Queues": [
+          {
+            "Ref": "singlecontributionsalesforcewritesqueue227D3F6D",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
     },
   },
 }

--- a/cdk/lib/single-contribution-salesforce-writes.ts
+++ b/cdk/lib/single-contribution-salesforce-writes.ts
@@ -1,6 +1,9 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
+import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
+import { SqsQueue } from 'aws-cdk-lib/aws-events-targets';
+import { Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 export const APP_NAME = 'single-contribution-salesforce-writes';
@@ -13,12 +16,55 @@ export class SingleContributionSalesforceWrites extends GuStack {
 			queueName: `dead-letters-${APP_NAME}-queue-${props.stage}`,
 		});
 
-		new Queue(this, `${APP_NAME}-queue`, {
+		const queue = new Queue(this, `${APP_NAME}-queue`, {
 			queueName: `${APP_NAME}-queue-${props.stage}`,
 			deadLetterQueue: {
 				queue: deadLetterQueue,
 				maxReceiveCount: 3,
 			},
 		});
+
+		enum AcquisitionBusSource {
+			PaymentApi = 'payment-api',
+		}
+
+		const acquisitionBusName = `acquisitions-bus-${props.stage}`;
+
+		const acquisitionBus = EventBus.fromEventBusArn(
+			this,
+			'AcquisitionBus',
+			`arn:aws:events:${this.region}:${this.account}:event-bus/${acquisitionBusName}`,
+		);
+
+		const rule = new Rule(
+			this,
+			'AcquisitionBusToSingleContributionSalesforceWritesQueueRule',
+			{
+				description:
+					'Send payment api events to the single-contribution-salesforce-writes-queue',
+				eventPattern: {
+					region: [this.region],
+					account: [this.account],
+					source: [AcquisitionBusSource.PaymentApi],
+				},
+				eventBus: acquisitionBus,
+				targets: [new SqsQueue(queue)],
+			},
+		);
+
+		const policyStatement = new PolicyStatement({
+			sid: 'Allow acquisition bus to send messages to the single-contribution-salesforce-writes-queue',
+			principals: [new ServicePrincipal('events.amazonaws.com')],
+			effect: Effect.ALLOW,
+			resources: [queue.queueArn],
+			actions: ['sqs:SendMessage'],
+			conditions: {
+				ArnEquals: {
+					'aws:SourceArn': rule.ruleArn,
+				},
+			},
+		});
+
+		queue.addToResourcePolicy(policyStatement);
 	}
 }


### PR DESCRIPTION
## What does this change?

- Add rule to acquisition bus (defined in the [support-frontend](https://github.com/guardian/support-frontend/blob/9f40a08d073fc16570427e1edaebe5f44d4bf130/cdk/lib/bigquery-acquisitions-publisher.ts#L22) repo) to send messages (with source `payment-api`) to the `single-contribution-salesforce-writes-queue`

  Event pattern:

  ```js
  {
    "source": ["payment-api"],
    "region": [...],
    "account": [...]
  }
  ```
- Add policy to SQS queue to receive messages from the event bus rule

[**Trello Card**](https://trello.com/c/RnoUF5ec/336-single-contribution-record-add-rule-to-event-bridge-to-push-message-to-sqs-queue)

## Why are you doing this?

This is part 2 of the epic [Create a single contribution record in Salesforce via support-payment-api](https://trello.com/c/qibQVaR2/295-create-a-single-contribution-record-in-salesforce-via-support-frontend-payment-api).

The pull request for part 1 is [here](https://github.com/guardian/support-service-lambdas/pull/2059).

## Architecture

<img width="1406" alt="Screenshot 2023-10-04 at 16 24 17" src="https://github.com/guardian/support-service-lambdas/assets/39066365/319f62b3-080e-4597-92f1-0ce73545d096">

## Design notes

- The event bus rule is defined in the same [stack](https://eu-west-1.console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/resources?filteringText=single&filteringStatus=active&viewNested=true&stackId=arn%3Aaws%3Acloudformation%3Aeu-west-1%3A865473395570%3Astack%2Fmembership-CODE-single-contribution-salesforce-writes%2Fff7fd3e0-5de7-11ee-a333-02bb7cc63f09) where the consumer is defined, to define clear ownership and separation of concerns
- The queue policy that contains the `sendMessage` permission needs to refer to the rule, not the event bus (something I was stuck on for a bit)
- It would be nice to have a shared npm package with the event bus types (source, name, etc.) to minimise bugs due to misspelling strings
- CloudWatch alarm strategy needs to be added to the diagram

## How to test

1. Make a single contribution from the [CODE site](https://support.code.dev-theguardian.com/uk/contribute)
2. From the AWS console, poll the message in the [single-contribution-salesforce-writes-queue-CODE](https://eu-west-1.console.aws.amazon.com/sqs/v2/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F865473395570%2Fsingle-contribution-salesforce-writes-queue-CODE/send-receive) queue
3. Additionally check CloudWatch metrics for [rule invocations](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2?graph=~(view~'timeSeries~stacked~false~metrics~(~(~'AWS*2fEvents~'TriggeredRules~'EventBusName~'acquisitions-bus-CODE~'RuleName~'membership-CODE-single-co-AcquisitionBusToSingleCo-1BVITLIUON4LF)~(~'.~'Invocations~'.~'.~'.~'.))~region~'eu-west-1)&query=~'*7bAWS*2fEvents*2cEventBusName*2cRuleName*7d*20RuleName*3d*22membership-CODE-single-co-AcquisitionBusToSingleCo-1BVITLIUON4LF*22*20EventBusName*3d*22acquisitions-bus-CODE*22)

<img width="1593" alt="Screenshot 2023-10-04 at 16 31 55" src="https://github.com/guardian/support-service-lambdas/assets/39066365/241edfc9-2e45-4965-b0a4-1d21fb357d3f">

## How can we measure success?

All events coming from the `payment-api` should be available in the SQS queue.

## Have we considered potential risks?

From the AWS [docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-dlq.html):
> Sometimes an event isn't successfully delivered to the target specified in a rule. This can happen when, for example, the target resource is unavailable, when EventBridge lacks permission to the target resource, or due to network conditions. When an event isn't successfully delivered to a target because of retriable errors, EventBridge retries sending the event. You set the length of time it tries, and number of retry attempts in the Retry policy settings for the target. By default, EventBridge retries sending the event for 24 hours and up to 185 times with an exponential back off and jitter, or randomized delay. If an event isn't delivered after all retry attempts are exhausted, the event is dropped and EventBridge doesn't continue to process it. To avoid losing events after they fail to be delivered to a target, you can configure a dead-letter queue (DLQ) and send all failed events to it for processing later.

## Next steps

1. Implement lambda function logic to create a single contribution record in Salesforce
2. Add alarm strategy to DLQ
5. Experiment adding a DLQ to the event bus rule to avoid losing events after they fail to be delivered to a target