### PR TITLE
Add Effects tests for delivery records api national delivery and version bumps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies.*
 
 val scala2Settings = Seq(
-  ThisBuild / scalaVersion := "2.13.10",
+  ThisBuild / scalaVersion := "2.13.12",
   version := "0.0.1",
   organization := "com.gu",
   scalacOptions ++= Seq(
@@ -19,13 +19,14 @@ val scala2Settings = Seq(
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",
+    "-Ytasty-reader",
   ),
   Test / fork := true,
   autoCompilerPlugins := true,
 )
 
 val scala3Settings = Seq(
-  scalaVersion := "3.2.2",
+  scalaVersion := "3.3.1",
   version := "0.0.1",
   organization := "com.gu",
   scalacOptions ++= Seq(
@@ -216,7 +217,7 @@ lazy val `effects-lambda` = library(project in file("lib/effects-lambda"))
     dependencyOverrides ++= jacksonDependencies,
   )
 
-lazy val `config-core` = library(project in file("lib/config-core"))
+lazy val `config-core` = library(project in file("lib/config-core"), scala3Settings)
 
 lazy val `config-cats` = library(project in file("lib/config-cats"))
   .settings(
@@ -377,7 +378,6 @@ lazy val `new-product-api` = lambdaProject(
   Seq(),
 )
   .settings(
-    scalacOptions += "-Ytasty-reader",
     Test / unmanagedResourceDirectories += (Test / scalaSource).value,
     Test / unmanagedResources / excludeFilter := "*.scala"
   )
@@ -636,13 +636,22 @@ lazy val `fulfilment-date-calculator` = lambdaProject(
 lazy val `delivery-records-api` = lambdaProject(
   "delivery-records-api",
   "API for accessing delivery records in Salesforce",
-  Seq(http4sDsl, http4sCirce, http4sServer, circe, sttpAsyncHttpClientBackendCats, scalatest),
+  Seq(
+    http4sDsl,
+    http4sCirce,
+    http4sServer,
+    circe,
+    sttpAsyncHttpClientBackendCats,
+    scalatest,
+    diffx
+  ),
 ).dependsOn(
   `effects-s3`,
   `config-core`,
   `salesforce-sttp-client`,
   `salesforce-sttp-test-stub` % Test,
   `http4s-lambda-handler`,
+  testDep,
 )
 
 lazy val `digital-voucher-api` = lambdaProject(

--- a/handlers/delivery-problem-credit-processor/src/test/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequestTest.scala
+++ b/handlers/delivery-problem-credit-processor/src/test/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditRequestTest.scala
@@ -2,7 +2,7 @@ package com.gu.deliveryproblemcreditprocessor
 
 import com.gu.salesforce.RecordsWrapperCaseClass
 import com.softwaremill.diffx.generic.auto._
-import com.softwaremill.diffx.scalatest.DiffMatcher
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import io.circe.generic.auto._
 import io.circe.parser._
 import org.scalatest.EitherValues
@@ -12,11 +12,11 @@ import org.scalatest.matchers.should.Matchers
 import java.time.LocalDate
 import scala.io.Source
 
-class DeliveryCreditRequestTest extends AnyFlatSpec with Matchers with DiffMatcher with EitherValues {
+class DeliveryCreditRequestTest extends AnyFlatSpec with Matchers with DiffShouldMatcher with EitherValues {
 
   "Json decode" should "decode SF response correctly" in {
     val json = Source.fromResource("sf-credit-request.json").mkString
-    decode[RecordsWrapperCaseClass[DeliveryCreditRequest]](json).value should matchTo(
+    decode[RecordsWrapperCaseClass[DeliveryCreditRequest]](json).value shouldMatchTo(
       RecordsWrapperCaseClass(
         List(
           DeliveryCreditRequest(

--- a/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiEffectsTest.scala
+++ b/handlers/delivery-records-api/src/test/scala/com/gu/delivery_records_api/DeliveryRecordsApiEffectsTest.scala
@@ -1,0 +1,135 @@
+package com.gu.delivery_records_api
+
+import cats.effect.{ContextShift, IO}
+import com.gu.delivery_records_api.service.createproblem._
+import com.gu.delivery_records_api.service.getrecords.{DeliveryProblemCase, DeliveryProblemCredit, DeliveryRecord, DeliveryRecordsApiResponse}
+import com.gu.test.EffectsTest
+import com.softwaremill.diffx.generic.auto._
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher
+import io.circe.Json
+import io.circe.generic.auto._
+import io.circe.parser._
+import io.circe.syntax.EncoderOps
+import org.http4s._
+import org.http4s.circe._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
+
+import java.time.LocalDate
+import scala.concurrent._
+
+class DeliveryRecordsApiEffectsTest extends AnyFlatSpec with DiffShouldMatcher with EitherValues {
+
+  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  def expectedFor(result: DeliveryRecordsApiResponse): DeliveryRecordsApiResponse = {
+    val deliveryProblemCase = result.deliveryProblemMap.values.head
+    val caseId = deliveryProblemCase.id
+    val caseNo = deliveryProblemCase.ref
+    DeliveryRecordsApiResponse(
+      results = List(
+        DeliveryRecord(
+          id = "a339E000000wF7MQAU",
+          deliveryDate = Some(LocalDate.of(2023, 10, 4)),
+          deliveryInstruction = Some("inst"),
+          deliveryAddress = Some("a1, a2, a3, atown, United Kingdom, pcode"),
+          addressLine1 = Some("a1"),
+          addressLine2 = Some("a2"),
+          addressLine3 = Some("a3"),
+          addressTown = Some("atown"),
+          addressCountry = Some("United Kingdom"),
+          addressPostcode = Some("pcode"),
+          hasHolidayStop = Some(false),
+          bulkSuspensionReason = None,
+          problemCaseId = Some(caseId),
+          isChangedAddress = Some(false),
+          isChangedDeliveryInstruction = Some(false),
+          credit = Some(DeliveryProblemCredit(
+            1.23,
+            Some(LocalDate.of(2000, 1, 1)),
+            isActioned = false
+          ))
+        )
+      ),
+      deliveryProblemMap = Map(
+        caseId ->
+          DeliveryProblemCase(
+            id = caseId,
+            ref = caseNo,
+            subject = Some("[Self Service] Delivery Problem : No Delivery (Newspaper - National Delivery - A-S00689849)"),
+            description = Some("descdesc"),
+            problemType = Some("No Delivery")
+          )
+      ),
+      contactPhoneNumbers = SFApiContactPhoneNumbers(
+        Id = Some("0039E00001q22KdQAI"),
+        Phone = None,
+        HomePhone = None,
+        MobilePhone = None,
+        OtherPhone = None
+      )
+    )
+  }
+
+  "DeliveryRecordsApp" should "lookup sandbox national delivery subscription with identity id" taggedAs EffectsTest in {
+
+    val subscriptionNumber = "A-S00689849" // test national delivery
+    val identityId = "13552794" // has the above subscription
+
+    val request = Request[IO](
+      method = Method.GET,
+      Uri(path = s"/delivery-records/$subscriptionNumber"),
+      headers = Headers.of(Header("x-identity-id", identityId)),
+    )
+
+    val result = runRequestOnSandbox(request).unsafeRunSync()
+
+    result shouldMatchTo((200, expectedFor(result._2)))
+  }
+
+  it should "create a delivery problem record in salesforce" taggedAs EffectsTest in {
+
+    val subscriptionNumber = "A-S00689849" // test national delivery
+    val identityId = "13552794" // has the above subscription
+
+    val createDeliveryProblemBody: Json = CreateDeliveryProblem(
+      productName = "Newspaper - National Delivery",
+      description = Some("descdesc"),
+      problemType = "No Delivery",
+      deliveryRecords = List(
+        DeliveryRecordToLink(
+          id = "a339E000000wF7MQAU",
+          creditAmount = Some(1.23),
+          invoiceDate = Some(LocalDate.of(2000, 1, 1)),
+        ),
+      ),
+      repeatDeliveryProblem = Some(true),
+      newContactPhoneNumbers = None,
+    ).asJson
+
+    val request = Request[IO](
+      method = Method.POST,
+      Uri(path = s"/delivery-records/$subscriptionNumber"),
+      headers = Headers.of(Header("x-identity-id", identityId)),
+    ).withEntity(
+      createDeliveryProblemBody,
+    )
+
+    val result = runRequestOnSandbox(request).unsafeRunSync()
+
+    result shouldMatchTo ((200, expectedFor(result._2)))
+  }
+
+  private def runRequestOnSandbox(request: Request[IO]): IO[(Int, DeliveryRecordsApiResponse)] =
+    for {
+      sttp <- AsyncHttpClientCatsBackend[IO]()
+      maybeRoutes <- DeliveryRecordsApiApp.buildHttpRoutes(sttp).value
+      httpRoutesApp = maybeRoutes.left.map(e => throw new RuntimeException(s"failed to connect to SF: $e")).merge
+      maybeResponse <- httpRoutesApp.run(request).value
+      response = maybeResponse.get
+      bodyData <- response.bodyText.compile.toList
+      parsedBody = parse(bodyData.mkString).value.as[DeliveryRecordsApiResponse].value
+    } yield (response.status.code, parsedBody)
+
+}

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/CreateVoucherRequestBodyTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/CreateVoucherRequestBodyTest.scala
@@ -1,18 +1,18 @@
 package com.gu.digital_voucher_api
 
 import com.softwaremill.diffx.generic.auto._
-import com.softwaremill.diffx.scalatest.DiffMatcher
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
-class CreateVoucherRequestBodyTest extends AnyFlatSpec with should.Matchers with DiffMatcher with EitherValues {
+class CreateVoucherRequestBodyTest extends AnyFlatSpec with should.Matchers with DiffShouldMatcher with EitherValues {
 
   "Json decode" should "decode expected Json object successfully" in {
     val json = """{"ratePlanName": "Weekend"}"""
-    decode[CreateVoucherRequestBody](json).value should matchTo(
+    decode[CreateVoucherRequestBody](json).value shouldMatchTo(
       CreateVoucherRequestBody("Weekend"),
     )
   }

--- a/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
+++ b/handlers/digital-voucher-api/src/test/scala/com/gu/digital_voucher_api/DigitalVoucherApiTest.scala
@@ -5,7 +5,7 @@ import com.gu.DevIdentity
 import com.gu.imovo.ImovoStub._
 import com.gu.imovo._
 import com.softwaremill.diffx.generic.auto._
-import com.softwaremill.diffx.scalatest.DiffMatcher
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import io.circe.Decoder
 import io.circe.generic.auto._
 import io.circe.parser.decode
@@ -21,7 +21,7 @@ import sttp.client3.testing.SttpBackendStub
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext
 
-class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMatcher with EitherValues {
+class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffShouldMatcher with EitherValues {
 
   private implicit val contextShift = IO.contextShift(ExecutionContext.global)
 
@@ -60,8 +60,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    response.status.code should matchTo(201)
-    getBody[SubscriptionVouchers](response) should matchTo(SubscriptionVouchers("new-card-code", "new-letter-code"))
+    response.status.code shouldMatchTo(201)
+    getBody[SubscriptionVouchers](response) shouldMatchTo(SubscriptionVouchers("new-card-code", "new-letter-code"))
   }
 
   it should "get existing voucher details from imovo if create fails because the vouchers already exist" in {
@@ -105,8 +105,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    response.status.code should matchTo(201)
-    getBody[SubscriptionVouchers](response) should matchTo(
+    response.status.code shouldMatchTo(201)
+    getBody[SubscriptionVouchers](response) shouldMatchTo(
       SubscriptionVouchers("existing-card-code", "existing-letter-code"),
     )
   }
@@ -138,8 +138,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    response.status.code should matchTo(502)
-    getBody[DigitalVoucherApiRoutesError](response) should matchTo(
+    response.status.code shouldMatchTo(502)
+    getBody[DigitalVoucherApiRoutesError](response) shouldMatchTo(
       DigitalVoucherApiRoutesError(
         s"""Imovo failure to create voucher: Imovo create request failed:Request GET ${imovoConfig.imovoBaseUrl}/Subscription/RequestSubscriptionVouchers?SubscriptionId=123456&SchemeName=Guardian7Day&StartDate=$tomorrow failed with response ({
          |  "errorMessages" : [
@@ -172,8 +172,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    response.status.code should matchTo(422)
-    getBody[DigitalVoucherApiRoutesError](response) should matchTo(
+    response.status.code shouldMatchTo(422)
+    getBody[DigitalVoucherApiRoutesError](response) shouldMatchTo(
       DigitalVoucherApiRoutesError(
         "Bad request argument: Rate plan name has no matching scheme name: RatePlanName(HomeDelivery)",
       ),
@@ -212,13 +212,13 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    getBody[ReplacementSubscriptionVouchers](response) should matchTo(
+    getBody[ReplacementSubscriptionVouchers](response) shouldMatchTo(
       ReplacementSubscriptionVouchers(
         Some("replaced-card-test-voucher-code"),
         Some("replaced-letter-test-voucher-code"),
       ),
     )
-    response.status.code should matchTo(200)
+    response.status.code shouldMatchTo(200)
   }
 
   it should "return replaced letter details for replace only letter request with subscriptionId" in {
@@ -252,10 +252,10 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    getBody[ReplacementSubscriptionVouchers](response) should matchTo(
+    getBody[ReplacementSubscriptionVouchers](response) shouldMatchTo(
       ReplacementSubscriptionVouchers(None, Some("replaced-letter-test-voucher-code")),
     )
-    response.status.code should matchTo(200)
+    response.status.code shouldMatchTo(200)
   }
 
   it should "return replaced card details for replace only card request with subscriptionId" in {
@@ -289,10 +289,10 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    getBody[ReplacementSubscriptionVouchers](response) should matchTo(
+    getBody[ReplacementSubscriptionVouchers](response) shouldMatchTo(
       ReplacementSubscriptionVouchers(Some("replaced-card-test-voucher-code"), None),
     )
-    response.status.code should matchTo(200)
+    response.status.code shouldMatchTo(200)
   }
 
   it should "return error response when one imovo replace request fails" in {
@@ -319,7 +319,7 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    response.status.code should matchTo(500)
+    response.status.code shouldMatchTo(500)
   }
 
   it should "return voucher details for get subscription request" in {
@@ -351,8 +351,8 @@ class DigitalVoucherApiTest extends AnyFlatSpec with should.Matchers with DiffMa
       .unsafeRunSync()
       .get
 
-    getBody[SubscriptionVouchers](response) should matchTo(SubscriptionVouchers("card-code", "letter-code"))
-    response.status.code should matchTo(200)
+    getBody[SubscriptionVouchers](response) shouldMatchTo(SubscriptionVouchers("card-code", "letter-code"))
+    response.status.code shouldMatchTo(200)
   }
 
   it should "return 200 response for cancel request" in {

--- a/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
+++ b/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/SubscriptionUpdateTest.scala
@@ -11,7 +11,7 @@ import com.gu.zuora.subscription.{
   Fixtures => SubscriptionFixtures,
 }
 import com.softwaremill.diffx.generic.auto._
-import com.softwaremill.diffx.scalatest.DiffMatcher
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -19,7 +19,7 @@ import org.scalatest.matchers.should.Matchers
 import java.time.temporal.TemporalAdjusters
 import java.time.{DayOfWeek, LocalDate}
 
-class SubscriptionUpdateTest extends AnyFlatSpec with Matchers with DiffMatcher with EitherValues {
+class SubscriptionUpdateTest extends AnyFlatSpec with Matchers with DiffShouldMatcher with EitherValues {
   MutableCalendar.setFakeToday(Some(LocalDate.parse("2019-08-12")))
   val effectiveStartDate = LocalDate.of(2019, 6, 12)
   val dateCreditIsApplied = effectiveStartDate.plusMonths(3)
@@ -164,7 +164,7 @@ class SubscriptionUpdateTest extends AnyFlatSpec with Matchers with DiffMatcher 
       stoppedPublicationDate,
       Some(givenInvoiceDate),
     )
-    update.value should matchTo(
+    update.value shouldMatchTo(
       SubscriptionUpdate(
         currentTerm = Some(536),
         currentTermPeriodType = Some("Day"),

--- a/handlers/sf-move-subscriptions-api/src/test/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiTest.scala
+++ b/handlers/sf-move-subscriptions-api/src/test/scala/com/gu/sf/move/subscriptions/api/SFMoveSubscriptionsApiTest.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import com.gu.DevIdentity
 import com.gu.zuora.MoveSubscriptionAtZuoraAccountResponse
 import com.softwaremill.diffx.generic.auto._
-import com.softwaremill.diffx.scalatest.DiffMatcher
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import sttp.client3.Identity
 import sttp.client3.testing.SttpBackendStub
 import io.circe.Decoder
@@ -15,7 +15,7 @@ import org.http4s._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
-class SFMoveSubscriptionsApiTest extends AnyFlatSpec with should.Matchers with DiffMatcher with ZuoraTestBackendMixin {
+class SFMoveSubscriptionsApiTest extends AnyFlatSpec with should.Matchers with DiffShouldMatcher with ZuoraTestBackendMixin {
 
   it should "return SUCCESS for move subscription request if all downstream calls were successful" in {
 
@@ -41,7 +41,7 @@ class SFMoveSubscriptionsApiTest extends AnyFlatSpec with should.Matchers with D
       .get
 
     responseActual.status shouldEqual Status.Ok
-    getBody[MoveSubscriptionApiSuccess](responseActual) should matchTo(
+    getBody[MoveSubscriptionApiSuccess](responseActual) shouldMatchTo(
       MoveSubscriptionApiSuccess(
         MoveSubscriptionAtZuoraAccountResponse("SUCCESS").toString,
       ),
@@ -72,7 +72,7 @@ class SFMoveSubscriptionsApiTest extends AnyFlatSpec with should.Matchers with D
       .get
 
     responseActual.status shouldEqual Status.InternalServerError
-    getBody[MoveSubscriptionApiError](responseActual) should matchTo(
+    getBody[MoveSubscriptionApiError](responseActual) shouldMatchTo(
       MoveSubscriptionApiError(
         FetchZuoraAccessTokenError(
           accessTokenUnAuthError.body.swap.map(_.reason).getOrElse(throw new RuntimeException),
@@ -104,7 +104,7 @@ class SFMoveSubscriptionsApiTest extends AnyFlatSpec with should.Matchers with D
       .get
 
     responseActual.status shouldEqual Status.InternalServerError
-    getBody[MoveSubscriptionApiError](responseActual) should matchTo(
+    getBody[MoveSubscriptionApiError](responseActual) shouldMatchTo(
       MoveSubscriptionApiError(
         FetchZuoraSubscriptionError(
           fetchSubscriptionFailedRes.body.swap.map(_.reason).getOrElse(throw new RuntimeException),
@@ -136,7 +136,7 @@ class SFMoveSubscriptionsApiTest extends AnyFlatSpec with should.Matchers with D
       .get
 
     responseActual.status shouldEqual Status.InternalServerError
-    getBody[MoveSubscriptionApiError](responseActual) should matchTo(
+    getBody[MoveSubscriptionApiError](responseActual) shouldMatchTo(
       MoveSubscriptionApiError(
         UpdateZuoraAccountError(
           updateAccountFailedRes.body.swap.map(_.reason).getOrElse(throw new RuntimeException),
@@ -169,7 +169,7 @@ class SFMoveSubscriptionsApiTest extends AnyFlatSpec with should.Matchers with D
       .get
 
     responseActual.status shouldEqual Status.Ok
-    getBody[MoveSubscriptionApiSuccess](responseActual) should matchTo(
+    getBody[MoveSubscriptionApiSuccess](responseActual) shouldMatchTo(
       MoveSubscriptionApiSuccess(
         MoveSubscriptionAtZuoraAccountResponse("SUCCESS_DRY_RUN").toString,
       ),

--- a/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionUpdateTest.scala
+++ b/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionUpdateTest.scala
@@ -1,14 +1,14 @@
 package com.gu.zuora.subscription
 
 import com.softwaremill.diffx.generic.auto._
-import com.softwaremill.diffx.scalatest.DiffMatcher
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.time.LocalDate
 
-class SubscriptionUpdateTest extends AnyFlatSpec with Matchers with DiffMatcher with EitherValues {
+class SubscriptionUpdateTest extends AnyFlatSpec with Matchers with DiffShouldMatcher with EitherValues {
 
   it should "extend term of sub if invoice date is later than term end" in {
     val invoiceDate = InvoiceDate(LocalDate.parse("2020-06-14"))
@@ -25,7 +25,7 @@ class SubscriptionUpdateTest extends AnyFlatSpec with Matchers with DiffMatcher 
       maybeInvoiceDate = Some(invoiceDate),
     )
 
-    update.value should matchTo(
+    update.value shouldMatchTo(
       SubscriptionUpdate(
         currentTerm = Some(418),
         currentTermPeriodType = Some("Day"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val catsVersion = "2.9.0"
   val catsEffectVersion = "2.5.5"
 
-  val logging = Seq(
+  val logging: Seq[ModuleID] = Seq(
     "ch.qos.logback" % "logback-classic" % "1.4.7",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   )
@@ -79,7 +79,7 @@ object Dependencies {
   val parallelCollections = "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
 
   // Testing
-  val diffx = "com.softwaremill.diffx" %% "diffx-scalatest" % "0.8.3" % Test
+  val diffx = "com.softwaremill.diffx" %% "diffx-scalatest-should" % "0.9.0" % Test
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.16" % Test
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.17.0" % Test
   val scalaMock = "org.scalamock" %% "scalamock" % "5.2.0" % Test
@@ -88,7 +88,7 @@ object Dependencies {
   val jacksonVersion = "2.13.2"
   val jacksonDatabindVersion = "2.13.2.2"
 
-  val jacksonDependencies = Seq(
+  val jacksonDependencies: Seq[ModuleID] = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
     "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.6


### PR DESCRIPTION
As part of the national delivery work, we need to make sure the delivery records api can support "National delivery"  devliery records in salesforce.

This PR adds some effects tests to make sure it's working.  Ideally they would create the national delivery sub and the delivery record as part of the test, so that it won't break later.  I will add a ticket to do that in trello.

It also involves some small version bumps and tidy up along the way.

The diffx API has changed a bit in the version bump so I have fixed up the compile in other modules that use it.