### PR TITLE
Change the event pattern for EventBridge rule to use a prefix

### DIFF
--- a/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
+++ b/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
@@ -23,7 +23,7 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
             },
           ],
           "source": [
-            "payment-api",
+            "{"prefix": "payment-api"}",
           ],
         },
         "State": "ENABLED",
@@ -195,7 +195,7 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
             },
           ],
           "source": [
-            "payment-api",
+            "{"prefix": "payment-api"}",
           ],
         },
         "State": "ENABLED",

--- a/cdk/lib/single-contribution-salesforce-writes.ts
+++ b/cdk/lib/single-contribution-salesforce-writes.ts
@@ -25,7 +25,7 @@ export class SingleContributionSalesforceWrites extends GuStack {
 		});
 
 		enum AcquisitionBusSource {
-			PaymentApi = 'payment-api',
+			PaymentApi = '{"prefix": "payment-api"}',
 		}
 
 		const acquisitionBusName = `acquisitions-bus-${props.stage}`;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Because of [this change](https://github.com/guardian/support-frontend/pull/5319) in the payment-api, we need to channge the event pattern we are using for the single contributions soft opt-in event rule to match the new format.