### PR TITLE
Add delivery agent to the new-product-api add-subscription call

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
@@ -12,6 +12,7 @@ case class AddSubscriptionRequest(
     zuoraAccountId: ZuoraAccountId,
     startDate: LocalDate,
     acquisitionSource: AcquisitionSource,
+    deliveryAgent: Option[DeliveryAgent],
     createdByCSR: CreatedByCSR,
     amountMinorUnits: Option[AmountMinorUnits],
     acquisitionCase: CaseId,
@@ -20,6 +21,7 @@ case class AddSubscriptionRequest(
 
 case class CaseId(value: String) extends AnyVal
 case class AcquisitionSource(value: String) extends AnyVal
+case class DeliveryAgent(value: String) extends AnyVal
 case class CreatedByCSR(value: String) extends AnyVal
 object AddSubscriptionRequest {
 
@@ -27,6 +29,7 @@ object AddSubscriptionRequest {
       zuoraAccountId: String,
       startDate: String,
       acquisitionSource: String,
+      deliveryAgent: Option[String],
       createdByCSR: String,
       amountMinorUnits: Option[Int],
       acquisitionCase: String,
@@ -40,6 +43,7 @@ object AddSubscriptionRequest {
         zuoraAccountId = ZuoraAccountId(zuoraAccountId),
         startDate = parsedDate,
         acquisitionSource = AcquisitionSource(this.acquisitionSource),
+        deliveryAgent = deliveryAgent.map(DeliveryAgent.apply),
         createdByCSR = CreatedByCSR(this.createdByCSR),
         amountMinorUnits = amountMinorUnits.map(AmountMinorUnits.apply),
         CaseId(acquisitionCase),

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -48,6 +48,7 @@ object CreateSubscription {
         AcquisitionCase__c: String,
         AcquisitionSource__c: String,
         CreatedByCSR__c: String,
+        DeliveryAgent__c: Option[String],
     )
 
     implicit val writesRequest = Json.writes[WireCreateRequest]
@@ -64,6 +65,7 @@ object CreateSubscription {
       AcquisitionCase__c = acquisitionCase.value,
       AcquisitionSource__c = acquisitionSource.value,
       CreatedByCSR__c = createdByCSR.value,
+      DeliveryAgent__c = deliveryAgent.map(_.value),
       subscribeToRatePlans = ratePlans.map { ratePlan =>
         SubscribeToRatePlans(
           productRatePlanId = ratePlan.productRatePlanId.value,
@@ -90,6 +92,7 @@ object CreateSubscription {
       acquisitionCase: CaseId,
       acquisitionSource: AcquisitionSource,
       createdByCSR: CreatedByCSR,
+      deliveryAgent: Option[DeliveryAgent],
       ratePlans: List[ZuoraCreateSubRequestRatePlan],
   )
 
@@ -109,6 +112,7 @@ object CreateSubscription {
       acquisitionCase = request.acquisitionCase,
       acquisitionSource = request.acquisitionSource,
       createdByCSR = request.createdByCSR,
+      deliveryAgent = request.deliveryAgent,
       ratePlans = ratePlans,
     )
   }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
@@ -28,6 +28,7 @@ class AddSubscriptionRequestTest extends AnyFlatSpec with Matchers {
       zuoraAccountId = ZuoraAccountId("accountkeyValue"),
       startDate = LocalDate.of(2018, 7, 11),
       acquisitionSource = AcquisitionSource("CSR"),
+      deliveryAgent = None,
       createdByCSR = CreatedByCSR("CSRName"),
       amountMinorUnits = Some(AmountMinorUnits(123)),
       acquisitionCase = CaseId("5006E000005b5cf"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -6,7 +6,12 @@ import com.gu.newproduct.api.addsubscription.email.ContributionsEmailData
 import com.gu.newproduct.api.addsubscription.validation.contribution.ContributionValidations.ValidatableFields
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest, ZuoraCreateSubRequestRatePlan}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
+  ChargeOverride,
+  SubscriptionName,
+  ZuoraCreateSubRequest,
+  ZuoraCreateSubRequestRatePlan,
+}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
@@ -41,11 +46,12 @@ class ContributionStepsTest extends AnyFlatSpec with Matchers {
     def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
 
     val expectedIn = ZuoraCreateSubRequest(
-      ZuoraAccountId("acccc"),
-      LocalDate.of(2018, 7, 18),
-      CaseId("case"),
-      AcquisitionSource("CSR"),
-      CreatedByCSR("bob"),
+      accountId = ZuoraAccountId("acccc"),
+      acceptanceDate = LocalDate.of(2018, 7, 18),
+      acquisitionCase = CaseId("case"),
+      acquisitionSource = AcquisitionSource("CSR"),
+      createdByCSR = CreatedByCSR("bob"),
+      deliveryAgent = None,
       ratePlans = List(
         ZuoraCreateSubRequestRatePlan(
           productRatePlanId = planAndCharge.productRatePlanId,
@@ -77,7 +83,8 @@ class ContributionStepsTest extends AnyFlatSpec with Matchers {
 
     def fakeGetCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.contributionCustomerData)
 
-    def getPlan: Map[PlanId, Plan] = Map().withDefaultValue(Plan(MonthlyContribution, PlanDescription("some description"), testStartDateRules))
+    def getPlan: Map[PlanId, Plan] =
+      Map().withDefaultValue(Plan(MonthlyContribution, PlanDescription("some description"), testStartDateRules))
 
     def currentDate() = LocalDate.of(2018, 12, 12)
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
@@ -109,12 +109,13 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
         request: CreateSubscription.ZuoraCreateSubRequest,
     ): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
       request shouldBe ZuoraCreateSubRequest(
-        testZuoraAccountId,
-        testFirstPaymentDate,
-        testCaseId,
-        testAcquistionSource,
-        testCSR,
-        List(
+        accountId = testZuoraAccountId,
+        acceptanceDate = testFirstPaymentDate,
+        acquisitionCase = testCaseId,
+        acquisitionSource = testAcquistionSource,
+        createdByCSR = testCSR,
+        deliveryAgent = None,
+        ratePlans = List(
           ZuoraCreateSubRequestRatePlan(
             productRatePlanId = quarterlyTestRatePlanZuoraId,
             maybeChargeOverride = None,
@@ -181,12 +182,13 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
         request: CreateSubscription.ZuoraCreateSubRequest,
     ): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
       request shouldBe ZuoraCreateSubRequest(
-        testZuoraAccountId,
-        monthlySubscriptionStartDate,
-        testCaseId,
-        testAcquistionSource,
-        testCSR,
-        List(
+        accountId = testZuoraAccountId,
+        acceptanceDate = monthlySubscriptionStartDate,
+        acquisitionCase = testCaseId,
+        acquisitionSource = testAcquistionSource,
+        createdByCSR = testCSR,
+        deliveryAgent = None,
+        ratePlans = List(
           ZuoraCreateSubRequestRatePlan(
             productRatePlanId = sixForSixTestRatePlanZuoraId,
             maybeChargeOverride = Some(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
@@ -60,12 +60,13 @@ class PaperStepsTest extends AnyFlatSpec with Matchers {
     }
 
     val expectedIn = ZuoraCreateSubRequest(
-      ZuoraAccountId("acccc"),
-      LocalDate.of(2018, 7, 18),
-      CaseId("case"),
-      AcquisitionSource("CSR"),
-      CreatedByCSR("bob"),
-      List(
+      accountId = ZuoraAccountId("acccc"),
+      acceptanceDate = LocalDate.of(2018, 7, 18),
+      acquisitionCase = CaseId("case"),
+      acquisitionSource = AcquisitionSource("CSR"),
+      createdByCSR = CreatedByCSR("bob"),
+      deliveryAgent = None,
+      ratePlans = List(
         ZuoraCreateSubRequestRatePlan(
           productRatePlanId = ratePlanId,
           maybeChargeOverride = None,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
@@ -7,7 +7,12 @@ import com.gu.newproduct.api.addsubscription.email.SupporterPlusEmailData
 import com.gu.newproduct.api.addsubscription.validation.supporterplus.SupporterPlusValidations.ValidatableFields
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest, ZuoraCreateSubRequestRatePlan}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
+  ChargeOverride,
+  SubscriptionName,
+  ZuoraCreateSubRequest,
+  ZuoraCreateSubRequestRatePlan,
+}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlySupporterPlus
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
@@ -41,11 +46,12 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
     def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
 
     val expectedIn = ZuoraCreateSubRequest(
-      ZuoraAccountId("acccc"),
-      LocalDate.of(2018, 7, 18),
-      CaseId("case"),
-      AcquisitionSource("CSR"),
-      CreatedByCSR("bob"),
+      accountId = ZuoraAccountId("acccc"),
+      acceptanceDate = LocalDate.of(2018, 7, 18),
+      acquisitionCase = CaseId("case"),
+      acquisitionSource = AcquisitionSource("CSR"),
+      createdByCSR = CreatedByCSR("bob"),
+      deliveryAgent = None,
       ratePlans = List(
         ZuoraCreateSubRequestRatePlan(
           productRatePlanId = planAndCharge.productRatePlanId,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -30,6 +30,7 @@ class CreateSubscriptionEffectsTest extends AnyFlatSpec with Matchers {
       validCaseIdToAvoidCausingSFErrors,
       AcquisitionSource("sourcesource"),
       CreatedByCSR("csrcsr"),
+      None,
       List(
         ZuoraCreateSubRequestRatePlan(
           productRatePlanId = monthlyContribution.productRatePlanId,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -42,6 +42,7 @@ class CreateSubscriptionTest extends AnyFlatSpec with Matchers {
       AcquisitionCase__c = "casecase",
       AcquisitionSource__c = "sourcesource",
       CreatedByCSR__c = "csrcsr",
+      DeliveryAgent__c = None,
       subscribeToRatePlans = List(
         SubscribeToRatePlans(
           productRatePlanId = "hiProductRatePlanId",
@@ -67,6 +68,7 @@ class CreateSubscriptionTest extends AnyFlatSpec with Matchers {
       acquisitionCase = CaseId("casecase"),
       acquisitionSource = AcquisitionSource("sourcesource"),
       createdByCSR = CreatedByCSR("csrcsr"),
+      deliveryAgent = None,
       ratePlans = List(
         ZuoraCreateSubRequestRatePlan(
           productRatePlanId = ids.productRatePlanId,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of the National Delivery work we want to record the delivery agent associated with a particular subscription in Zuora when that subscription is created via the new-product-api. To achieve this we have created a new Zuora custom field `DeliveryAgent__c` on the Subscription object. 

This PR adds a new field to the `/add-subscription` endpoint to take the ID of the delivery agent from Salesforce and write it to Zuora.