### PR TITLE
refactor and add logic to include delivery partner in thank you email

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -375,7 +375,7 @@ lazy val `identity-retention` = lambdaProject(
 lazy val `new-product-api` = lambdaProject(
   "new-product-api",
   "Add subscription to account",
-  Seq(),
+  Seq(diffx),
 )
   .settings(
     Test / unmanagedResourceDirectories += (Test / scalaSource).value,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddPaperSub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddPaperSub.scala
@@ -3,11 +3,11 @@ package com.gu.newproduct.api.addsubscription
 import com.gu.effects.sqs.AwsSQSSend
 import com.gu.effects.sqs.AwsSQSSend.QueueName
 import com.gu.newproduct.api.addsubscription.TypeConvert._
-import com.gu.newproduct.api.addsubscription.email.paper.PaperEmailDataSerialiser._
+import com.gu.newproduct.api.addsubscription.email.serialisers.PaperEmailDataSerialiser._
 import com.gu.newproduct.api.addsubscription.email.{EtSqsSend, PaperEmailData, SendConfirmationEmail}
 import com.gu.newproduct.api.addsubscription.validation.Validation._
 import com.gu.newproduct.api.addsubscription.validation.paper.{GetPaperCustomerData, PaperAccountValidation, PaperCustomerData}
-import com.gu.newproduct.api.addsubscription.validation.{ValidateAccount, ValidatePaymentMethod, ValidatedAccount, ValidationResult}
+import com.gu.newproduct.api.addsubscription.validation._
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{SubscriptionName, ZuoraCreateSubRequest, ZuoraCreateSubRequestRatePlan}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAccount
@@ -16,9 +16,9 @@ import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetCont
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.PaymentMethodWire
 import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetContacts, GetPaymentMethod}
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{ProductRatePlanId, ZuoraIds}
-import com.gu.newproduct.api.productcatalog.{Plan, PlanId}
+import com.gu.newproduct.api.productcatalog.{NationalDeliveryPlanId, Plan, PlanId}
 import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
-import com.gu.util.reader.AsyncTypes.{AsyncApiGatewayOp, _}
+import com.gu.util.reader.AsyncTypes._
 import com.gu.util.reader.Types.{ApiGatewayOp, OptionOps}
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.ClientFailableOp
@@ -26,17 +26,23 @@ import com.gu.util.resthttp.Types.ClientFailableOp
 import java.time.LocalDate
 import scala.concurrent.Future
 
-object AddPaperSub {
-  def steps(
-      getPlan: PlanId => Plan,
-      getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
-      getCustomerData: ZuoraAccountId => ApiGatewayOp[PaperCustomerData],
-      validateStartDate: (PlanId, LocalDate) => ValidationResult[Unit],
-      validateAddress: (PlanId, SoldToAddress) => ValidationResult[Unit],
-      createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
-      sendConfirmationEmail: (Option[SfContactId], PaperEmailData) => AsyncApiGatewayOp[Unit],
-  )(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] = for {
+class AddPaperSub(
+  getPlan: PlanId => Plan,
+  getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
+  getCustomerData: ZuoraAccountId => ApiGatewayOp[PaperCustomerData],
+  validateStartDate: (PlanId, LocalDate) => ValidationResult[Unit],
+  validateAddress: (PlanId, SoldToAddress) => ValidationResult[Unit],
+  createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
+  sendConfirmationEmail: (Option[SfContactId], PaperEmailData) => AsyncApiGatewayOp[Unit],
+) extends AddSpecificProduct {
+  override def addProduct(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] = for {
     _ <- validateStartDate(request.planId, request.startDate).toApiGatewayOp.toAsync
+    _ <- ((request.planId, request.deliveryAgent) match {
+      case (_: NationalDeliveryPlanId, Some(_)) => Passed(())
+      case (_: NationalDeliveryPlanId, None) => Failed("delivery agent must ALWAYS be specified for national delivery")
+      case (_, Some(_)) => Failed("delivery agent must ONLY be specified for national delivery")
+      case (_, None) => Passed(())
+    }).toApiGatewayOp.toAsync
 
     customerData <- getCustomerData(request.zuoraAccountId).toAsync
     _ <- validateAddress(request.planId, customerData.contacts.soldTo.address).toApiGatewayOp.toAsync
@@ -63,10 +69,14 @@ object AddPaperSub {
       contacts = customerData.contacts,
       paymentMethod = customerData.paymentMethod,
       currency = customerData.account.currency,
+      deliveryAgentDetails = None // TODO go out to PPR to get the agent info then pass in below
     )
     _ <- sendConfirmationEmail(customerData.account.sfContactId, paperEmailData)
       .recoverAndLog("send paper confirmation email")
   } yield subscriptionName
+}
+
+object AddPaperSub {
 
   def wireSteps(
     catalog: Map[PlanId, Plan],
@@ -77,12 +87,12 @@ object AddPaperSub {
       createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
       awsSQSSend: QueueName => AwsSQSSend.Payload => Future[Unit],
       emailQueueName: QueueName,
-  ): AddSubscriptionRequest => AsyncApiGatewayOp[SubscriptionName] = {
+  ): AddSpecificProduct = {
     val paperSqsQueueSend = awsSQSSend(emailQueueName)
     val paperBrazeConfirmationSqsSend = EtSqsSend[PaperEmailData](paperSqsQueueSend) _
     val sendConfirmationEmail = SendConfirmationEmail(paperBrazeConfirmationSqsSend) _
     val validatedCustomerData = getValidatedCustomerData(zuoraClient)
-    steps(
+    new AddPaperSub(
       catalog,
       zuoraIds.apiIdToRateplanId.get,
       validatedCustomerData,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionResponse.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionResponse.scala
@@ -1,25 +1,22 @@
 package com.gu.newproduct.api.addsubscription
 
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, OWrites, Writes}
 
 sealed trait AddSubscriptionResponse
 case class Error(message: String) extends AddSubscriptionResponse
 case class AddedSubscription(subscriptionNumber: String) extends AddSubscriptionResponse
 
 object Error {
-  implicit val writes = Json.writes[Error]
+  implicit val writes: OWrites[Error] = Json.writes[Error]
 }
 
 object AddedSubscription {
-  implicit val writes = Json.writes[AddedSubscription]
+  implicit val writes: OWrites[AddedSubscription] = Json.writes[AddedSubscription]
 }
 
 object AddSubscriptionResponse {
-  implicit val writes: Writes[AddSubscriptionResponse] = { response =>
-    response match {
-      case e: Error => Error.writes.writes(e)
-      case s: AddedSubscription => AddedSubscription.writes.writes(s)
-    }
-
+  implicit val writes: Writes[AddSubscriptionResponse] = {
+    case e: Error => Error.writes.writes(e)
+    case s: AddedSubscription => AddedSubscription.writes.writes(s)
   }
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
@@ -89,62 +89,6 @@ class AddSupporterPlus(
 }
 
 object AddSupporterPlus {
-//  def steps(
-//      getPlan: PlanId => Plan,
-//      getCurrentDate: () => LocalDate,
-//      getPlanAndCharge: PlanId => Option[PlanAndCharges],
-//      getCustomerData: ZuoraAccountId => ApiGatewayOp[SupporterPlusCustomerData],
-//      supporterPlusValidations: (
-//          SupporterPlusValidations.ValidatableFields,
-//          PlanId,
-//          Currency,
-//      ) => ValidationResult[AmountMinorUnits],
-//      createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
-//      sendConfirmationEmail: (Option[SfContactId], SupporterPlusEmailData) => AsyncApiGatewayOp[Unit],
-//  ): SubscriptionAdd = new SubscriptionAdd {
-//    override def apply(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] =
-//    for {
-//      customerData <- getCustomerData(request.zuoraAccountId).toAsync
-//      SupporterPlusCustomerData(account, paymentMethod, subscriptions, contacts) = customerData
-//      validatableFields = ValidatableFields(request.amountMinorUnits, request.startDate)
-//      amountMinorUnits <- supporterPlusValidations(
-//        validatableFields,
-//        request.planId,
-//        account.currency,
-//      ).toApiGatewayOp.toAsync
-//      acceptanceDate = request.startDate
-//      plan = getPlan(request.planId)
-//      planAndCharge <- getPlanAndCharge(request.planId)
-//        .toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!"))
-//        .toAsync
-//      contributionAmount = getContributionAmount(amountMinorUnits, account.currency, plan)
-//      chargeOverride = ChargeOverride(Some(contributionAmount), planAndCharge.contributionProductRatePlanChargeId, None)
-//      zuoraCreateSubRequest = ZuoraCreateSubRequest(
-//        request = request,
-//        acceptanceDate = acceptanceDate,
-//        ratePlans = List(
-//          ZuoraCreateSubRequestRatePlan(
-//            productRatePlanId = planAndCharge.productRatePlanId,
-//            maybeChargeOverride = Some(chargeOverride),
-//          ),
-//        ),
-//      )
-//      subscriptionName <- createSubscription(zuoraCreateSubRequest).toAsyncApiGatewayOp("create monthly supporter plus")
-//      supporterPlusEmailData = toSupporterPlusEmailData(
-//        request = request,
-//        currency = account.currency,
-//        paymentMethod = paymentMethod,
-//        firstPaymentDate = acceptanceDate,
-//        contacts = contacts,
-//        amountMinorUnits = amountMinorUnits,
-//        plan = plan,
-//        currentDate = getCurrentDate(),
-//      )
-//      _ <- sendConfirmationEmail(account.sfContactId, supporterPlusEmailData).recoverAndLog(
-//        "send supporter plus confirmation email",
-//      )
-//    } yield subscriptionName
-//  }
 
   def wireSteps(
     catalog: Map[PlanId, Plan],

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/ETPayload.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/ETPayload.scala
@@ -1,6 +1,6 @@
 package com.gu.newproduct.api.addsubscription.email
 
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, OWrites, Writes}
 
 case class CContactAttributes[A](SubscriberAttributes: A)
 
@@ -9,16 +9,16 @@ case class CTo[A](Address: String, SubscriberKey: String, ContactAttributes: CCo
 case class ETPayload[A](To: CTo[A], DataExtensionName: String, SfContactId: Option[String])
 
 object CContactAttributes {
-  implicit def writes[A: Writes] = Json.writes[CContactAttributes[A]]
+  implicit def writes[A: Writes]: OWrites[CContactAttributes[A]] = Json.writes[CContactAttributes[A]]
 }
 
 object CTo {
-  implicit def writes[A: Writes] = Json.writes[CTo[A]]
+  implicit def writes[A: Writes]: OWrites[CTo[A]] = Json.writes[CTo[A]]
 }
 
 object ETPayload {
 
-  implicit def writes[A: Writes] = Json.writes[ETPayload[A]]
+  implicit def writes[A: Writes]: OWrites[ETPayload[A]] = Json.writes[ETPayload[A]]
 
   def apply[A](email: String, fields: A, name: DataExtensionName, sfContactId: Option[String]): ETPayload[A] =
     ETPayload(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/EmailData.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/EmailData.scala
@@ -25,7 +25,19 @@ case class PaperEmailData(
     contacts: Contacts,
     paymentMethod: PaymentMethod,
     currency: Currency,
+    deliveryAgentDetails: Option[DeliveryAgentDetails], // only for national delivery
 ) extends EmailData
+
+case class DeliveryAgentDetails(
+  agentName: String,
+  telephone: String,
+  email: String,
+  address1: String,
+  address2: String,
+  town: String,
+  county: String,
+  postcode: String,
+)
 
 case class TrialPeriod(days: Int)
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/SendConfirmationEmail.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/SendConfirmationEmail.scala
@@ -49,7 +49,7 @@ object SendConfirmationEmail extends Logging {
       case _: HomeDeliveryPlanId => "paper-delivery"
       case _: GuardianWeeklyDomestic => "guardian-weekly"
       case _: GuardianWeeklyRow => "guardian-weekly"
-      case _: NationalDeliveryPlanId => "paper-national-delivery" // TODO membership-workflow and braze
+      case _: NationalDeliveryPlanId => "paper-national-delivery"
     },
   )
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/serialisers/ContributionFields.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/serialisers/ContributionFields.scala
@@ -1,29 +1,29 @@
-package com.gu.newproduct.api.addsubscription.email.supporterplus
+package com.gu.newproduct.api.addsubscription.email.serialisers
+
+import com.gu.newproduct.api.addsubscription.Formatters._
+import com.gu.newproduct.api.addsubscription.email.ContributionsEmailData
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod}
+import com.gu.newproduct.api.productcatalog.Plan
+import com.gu.newproduct.api.productcatalog.PlanId.{AnnualContribution, MonthlyContribution}
+import play.api.libs.json.{Json, Writes}
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-import com.gu.newproduct.api.addsubscription.Formatters._
-import com.gu.newproduct.api.addsubscription.email.SupporterPlusEmailData
-import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod}
-import com.gu.newproduct.api.productcatalog.Plan
-import com.gu.newproduct.api.productcatalog.PlanId.{AnnualSupporterPlus, MonthlySupporterPlus}
-import play.api.libs.json.{Json, Writes}
-
-object SupporterPlusEmailDataSerialiser {
-  implicit val writes: Writes[SupporterPlusEmailData] = (data: SupporterPlusEmailData) => {
-    val fields: Map[String, String] = SupporterPlusFields(data)
+object ContributionEmailDataSerialiser {
+  implicit val writes: Writes[ContributionsEmailData] = (data: ContributionsEmailData) => {
+    val fields: Map[String, String] = ContributionFields.serialise(data)
     Json.toJson(fields)
   }
 }
 
-object SupporterPlusFields {
+object ContributionFields {
 
   val firstPaymentDateFormat = DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy")
 
   def productId(plan: Plan) = plan.id match {
-    case AnnualSupporterPlus => "annual-supporter-plus"
-    case MonthlySupporterPlus => "monthly-supporter-plus"
+    case AnnualContribution => "annual-contribution"
+    case MonthlyContribution => "monthly-contribution"
     case other => other.name
   }
 
@@ -41,7 +41,7 @@ object SupporterPlusFields {
 
   }
 
-  def apply(data: SupporterPlusEmailData): Map[String, String] = Map(
+  def serialise(data: ContributionsEmailData): Map[String, String] = Map(
     "EmailAddress" -> data.contacts.billTo.email.map(_.value).getOrElse(""),
     "created" -> data.created.toString,
     "amount" -> data.amountMinorUnits.formatted,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/serialisers/DigipackEmailFields.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/serialisers/DigipackEmailFields.scala
@@ -1,6 +1,4 @@
-package com.gu.newproduct.api.addsubscription.email.digipack
-
-import java.time.format.DateTimeFormatter
+package com.gu.newproduct.api.addsubscription.email.serialisers
 
 import com.gu.newproduct.api.addsubscription.Formatters._
 import com.gu.newproduct.api.addsubscription.email.DigipackEmailData
@@ -9,12 +7,14 @@ import com.gu.newproduct.api.addsubscription.zuora.GetContacts.BillToContact
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, NonDirectDebitMethod, PaymentMethod}
 import com.gu.newproduct.api.addsubscription.zuora.PaymentMethodType._
 import com.gu.newproduct.api.productcatalog.PlanId._
-import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly, Quarterly, SixWeeks}
+import com.gu.newproduct.api.productcatalog._
 import play.api.libs.json.{Json, Writes}
+
+import java.time.format.DateTimeFormatter
 
 object DigipackEmailDataSerialiser {
   implicit val writes: Writes[DigipackEmailData] = (data: DigipackEmailData) => {
-    val fields: Map[String, String] = DigipackEmailFields(data)
+    val fields: Map[String, String] = DigipackEmailFields.serialise(data)
     Json.toJson(fields)
   }
 }
@@ -31,7 +31,7 @@ object DigipackEmailFields {
     case Quarterly => "quarter"
     case SixWeeks => "six weeks"
   }
-  def apply(
+  def serialise(
       data: DigipackEmailData,
   ): Map[String, String] = {
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/serialisers/GuardianWeeklyFields.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/serialisers/GuardianWeeklyFields.scala
@@ -1,6 +1,4 @@
-package com.gu.newproduct.api.addsubscription.email.guardianweekly
-
-import java.time.format.DateTimeFormatter
+package com.gu.newproduct.api.addsubscription.email.serialisers
 
 import com.gu.newproduct.api.addsubscription.email.EmailData.paymentMethodFields
 import com.gu.newproduct.api.addsubscription.email.GuardianWeeklyEmailData
@@ -8,9 +6,11 @@ import com.gu.newproduct.api.productcatalog.Plan
 import com.gu.newproduct.api.productcatalog.PlanId.{AnnualContribution, MonthlyContribution}
 import play.api.libs.json.{Json, Writes}
 
+import java.time.format.DateTimeFormatter
+
 object GuardianWeeklyEmailDataSerialiser {
   implicit val writes: Writes[GuardianWeeklyEmailData] = (data: GuardianWeeklyEmailData) => {
-    val fields: Map[String, String] = GuardianWeeklyFields(data)
+    val fields: Map[String, String] = GuardianWeeklyFields.serialise(data)
     Json.toJson(fields)
   }
 }
@@ -24,7 +24,7 @@ object GuardianWeeklyFields {
     case other => other.name
   }
 
-  def apply(data: GuardianWeeklyEmailData): Map[String, String] = Map(
+  def serialise(data: GuardianWeeklyEmailData): Map[String, String] = Map(
     "EmailAddress" -> data.contacts.billTo.email.map(_.value).getOrElse(""),
     "first_name" -> data.contacts.soldTo.firstName.value,
     "last_name" -> data.contacts.soldTo.lastName.value,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/serialisers/SupporterPlusFields.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/serialisers/SupporterPlusFields.scala
@@ -1,29 +1,29 @@
-package com.gu.newproduct.api.addsubscription.email.contributions
+package com.gu.newproduct.api.addsubscription.email.serialisers
+
+import com.gu.newproduct.api.addsubscription.Formatters._
+import com.gu.newproduct.api.addsubscription.email.SupporterPlusEmailData
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod}
+import com.gu.newproduct.api.productcatalog.Plan
+import com.gu.newproduct.api.productcatalog.PlanId.{AnnualSupporterPlus, MonthlySupporterPlus}
+import play.api.libs.json.{Json, Writes}
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-import com.gu.newproduct.api.addsubscription.Formatters._
-import com.gu.newproduct.api.addsubscription.email.ContributionsEmailData
-import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod}
-import com.gu.newproduct.api.productcatalog.Plan
-import com.gu.newproduct.api.productcatalog.PlanId.{AnnualContribution, MonthlyContribution}
-import play.api.libs.json.{Json, Writes}
-
-object ContributionEmailDataSerialiser {
-  implicit val writes: Writes[ContributionsEmailData] = (data: ContributionsEmailData) => {
-    val fields: Map[String, String] = ContributionFields(data)
+object SupporterPlusEmailDataSerialiser {
+  implicit val writes: Writes[SupporterPlusEmailData] = (data: SupporterPlusEmailData) => {
+    val fields: Map[String, String] = SupporterPlusFields.serialise(data)
     Json.toJson(fields)
   }
 }
 
-object ContributionFields {
+object SupporterPlusFields {
 
   val firstPaymentDateFormat = DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy")
 
   def productId(plan: Plan) = plan.id match {
-    case AnnualContribution => "annual-contribution"
-    case MonthlyContribution => "monthly-contribution"
+    case AnnualSupporterPlus => "annual-supporter-plus"
+    case MonthlySupporterPlus => "monthly-supporter-plus"
     case other => other.name
   }
 
@@ -41,7 +41,7 @@ object ContributionFields {
 
   }
 
-  def apply(data: ContributionsEmailData): Map[String, String] = Map(
+  def serialise(data: SupporterPlusEmailData): Map[String, String] = Map(
     "EmailAddress" -> data.contacts.billTo.email.map(_.value).getOrElse(""),
     "created" -> data.created.toString,
     "amount" -> data.amountMinorUnits.formatted,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -2,14 +2,13 @@ package com.gu.newproduct.api.addsubscription.zuora
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-
 import com.gu.newproduct.api.addsubscription._
 import com.gu.newproduct.api.productcatalog.AmountMinorUnits
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.util.resthttp.ClientFailableOpLogging.LogImplicit2
 import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
 import com.gu.util.resthttp.Types.ClientFailableOp
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OWrites, Reads}
 
 object CreateSubscription {
   val SpecificDateTriggerEventId = "USD"
@@ -27,14 +26,14 @@ object CreateSubscription {
         triggerEvent: Option[String],
     )
 
-    implicit val writesCharge = Json.writes[ChargeOverrides]
+    implicit val writesCharge: OWrites[ChargeOverrides] = Json.writes[ChargeOverrides]
 
     case class SubscribeToRatePlans(
         productRatePlanId: String,
         chargeOverrides: List[ChargeOverrides],
     )
 
-    implicit val writesSubscribe = Json.writes[SubscribeToRatePlans]
+    implicit val writesSubscribe: OWrites[SubscribeToRatePlans] = Json.writes[SubscribeToRatePlans]
 
     case class WireCreateRequest(
         accountKey: String,
@@ -51,7 +50,7 @@ object CreateSubscription {
         DeliveryAgent__c: Option[String],
     )
 
-    implicit val writesRequest = Json.writes[WireCreateRequest]
+    implicit val writesRequest: OWrites[WireCreateRequest] = Json.writes[WireCreateRequest]
   }
 
   import WireModel._

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccount.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccount.scala
@@ -4,7 +4,7 @@ import com.gu.i18n.Currency
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.util.resthttp.RestRequestMaker.{RequestsGet, WithoutCheck}
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 
 object GetAccount {
 
@@ -19,7 +19,7 @@ object GetAccount {
         Currency: String,
     )
 
-    implicit val zaReadsZuoraAccount = Json.reads[ZuoraAccount]
+    implicit val zaReadsZuoraAccount: Reads[ZuoraAccount] = Json.reads[ZuoraAccount]
 
     def fromWire(zuoraAccount: ZuoraAccount): ClientFailableOp[Account] =
       Currency.fromString(zuoraAccount.Currency) match {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountSubscriptions.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountSubscriptions.scala
@@ -4,7 +4,7 @@ import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
 import com.gu.util.resthttp.RestRequestMaker.{RequestsGet, WithCheck}
 import com.gu.util.resthttp.Types.ClientFailableOp
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 
 object GetAccountSubscriptions {
 
@@ -25,9 +25,9 @@ object GetAccountSubscriptions {
       productRateplanIds = zuoraSubscription.ratePlans.map(rp => ProductRatePlanId(rp.productRatePlanId)).toSet,
     )
 
-    implicit val zuoraRateplanReads = Json.reads[ZuoraRatePlan]
-    implicit val zuoraSubscriptionReads = Json.reads[ZuoraSubscription]
-    implicit val zuoraSubscriptionsResponseReads = Json.reads[ZuoraSubscriptionsResponse]
+    implicit val zuoraRateplanReads: Reads[ZuoraRatePlan] = Json.reads[ZuoraRatePlan]
+    implicit val zuoraSubscriptionReads: Reads[ZuoraSubscription] = Json.reads[ZuoraSubscription]
+    implicit val zuoraSubscriptionsResponseReads: Reads[ZuoraSubscriptionsResponse] = Json.reads[ZuoraSubscriptionsResponse]
   }
 
   import WireModel._

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetContacts.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetContacts.scala
@@ -6,7 +6,7 @@ import com.gu.newproduct.api.addsubscription.TypeConvert._
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.util.resthttp.RestRequestMaker.{RequestsGet, WithCheck}
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 
 object GetContacts {
 
@@ -94,9 +94,9 @@ object GetContacts {
 
     case class GetContactsResponse(billToContact: ZuoraBillTo, soldToContact: ZuoraSoldTo)
 
-    implicit val ZuoraBillToReads = Json.reads[ZuoraBillTo]
-    implicit val ZuoraSoldToReads = Json.reads[ZuoraSoldTo]
-    implicit val ZuoraContactsReads = Json.reads[GetContactsResponse]
+    implicit val ZuoraBillToReads: Reads[ZuoraBillTo] = Json.reads[ZuoraBillTo]
+    implicit val ZuoraSoldToReads: Reads[ZuoraSoldTo] = Json.reads[ZuoraSoldTo]
+    implicit val ZuoraContactsReads: Reads[GetContactsResponse] = Json.reads[GetContactsResponse]
 
     def fromWireContacts(zuoraAccount: GetContactsResponse): ClientFailableOp[Contacts] = for {
       billTo <- zuoraAccount.billToContact.toBillToContact

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethod.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethod.scala
@@ -54,7 +54,7 @@ object GetPaymentMethod {
   private def toStatus(statusString: String) =
     if (statusString == "Active") ActivePaymentMethod else NotActivePaymentMethod
 
-  implicit val wireReads = Json.reads[PaymentMethodWire]
+  implicit val wireReads: Reads[PaymentMethodWire] = Json.reads[PaymentMethodWire]
 
   sealed trait PaymentMethod {
     def status: PaymentMethodStatus

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/PricesFromZuoraCatalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/PricesFromZuoraCatalog.scala
@@ -6,7 +6,7 @@ import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.ZuoraEnvironment
 import com.gu.effects.S3Location
 import com.gu.util.resthttp.Types.ClientFailableOp
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 import ZuoraCatalogWireModel._
 import com.gu.i18n.Currency
 
@@ -19,7 +19,7 @@ object ZuoraCatalogWireModel {
   case class Price(price: Option[Double], currency: String)
 
   object Price {
-    implicit val reads = Json.reads[Price]
+    implicit val reads: Reads[Price] = Json.reads[Price]
   }
 
   case class RateplanCharge(
@@ -27,7 +27,7 @@ object ZuoraCatalogWireModel {
   )
 
   object RateplanCharge {
-    implicit val reads = Json.reads[RateplanCharge]
+    implicit val reads: Reads[RateplanCharge] = Json.reads[RateplanCharge]
   }
 
   def toMinorUnits(amount: Double) = AmountMinorUnits((amount * 100).toInt)
@@ -75,7 +75,7 @@ object ZuoraCatalogWireModel {
   }
 
   object Rateplan {
-    implicit val reads = Json.reads[Rateplan]
+    implicit val reads: Reads[Rateplan] = Json.reads[Rateplan]
 
   }
 
@@ -85,7 +85,7 @@ object ZuoraCatalogWireModel {
   )
 
   object Product {
-    implicit val reads = Json.reads[Product]
+    implicit val reads: Reads[Product] = Json.reads[Product]
   }
 
   case class ZuoraCatalog(
@@ -103,7 +103,7 @@ object ZuoraCatalogWireModel {
   }
 
   object ZuoraCatalog {
-    implicit val reads = Json.reads[ZuoraCatalog]
+    implicit val reads: Reads[ZuoraCatalog] = Json.reads[ZuoraCatalog]
   }
 }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -3,7 +3,7 @@ package com.gu.newproduct.api.productcatalog
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.newproduct.api.addsubscription.validation.guardianweekly.GuardianWeeklyAddressValidator
-import play.api.libs.json.{JsString, Json, Writes}
+import play.api.libs.json.{JsString, Json, OWrites, Writes}
 
 import java.time.{DayOfWeek, LocalDate}
 
@@ -35,7 +35,7 @@ object WireModel {
 
   case class WirePaymentPlan(currencyCode: String, description: String)
   object WirePaymentPlan {
-    implicit val writes = Json.writes[WirePaymentPlan]
+    implicit val writes: OWrites[WirePaymentPlan] = Json.writes[WirePaymentPlan]
 
   }
 
@@ -72,7 +72,7 @@ object WireModel {
   }
 
   object WireSelectableWindow {
-    implicit val writes = Json.writes[WireSelectableWindow]
+    implicit val writes: OWrites[WireSelectableWindow] = Json.writes[WireSelectableWindow]
 
     def fromWindowRule(rule: WindowRule) = {
       WireSelectableWindow(rule.startDate, rule.maybeSize.map(_.value))
@@ -80,7 +80,7 @@ object WireModel {
   }
 
   object WireStartDateRules {
-    implicit val writes = Json.writes[WireStartDateRules]
+    implicit val writes: OWrites[WireStartDateRules] = Json.writes[WireStartDateRules]
 
     def fromStartDateRules(rule: StartDateRules): WireStartDateRules = {
       val allowedDays = rule.daysOfWeekRule.map(_.allowedDays) getOrElse DayOfWeek.values.toList
@@ -90,7 +90,7 @@ object WireModel {
   }
 
   object WirePlanInfo {
-    implicit val writes = Json.writes[WirePlanInfo]
+    implicit val writes: OWrites[WirePlanInfo] = Json.writes[WirePlanInfo]
 
     def toWireRules(startDateRules: StartDateRules): WireStartDateRules =
       WireStartDateRules.fromStartDateRules(startDateRules)
@@ -114,11 +114,11 @@ object WireModel {
   }
 
   object WireProduct {
-    implicit val writes = Json.writes[WireProduct]
+    implicit val writes: OWrites[WireProduct] = Json.writes[WireProduct]
   }
 
   object WireCatalog {
-    implicit val writes = Json.writes[WireCatalog]
+    implicit val writes: OWrites[WireCatalog] = Json.writes[WireCatalog]
 
     def fromCatalog(
       catalog: Map[PlanId, Plan],

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -103,7 +103,7 @@ class ContributionStepsTest extends AnyFlatSpec with Matchers {
     implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
     val expectedOutput = ExpectedOut("well done")
 
-    val fakeAddContributionSteps = AddContribution.steps(
+    val fakeAddContributionSteps = new AddContribution(
       getPlan,
       currentDate _,
       getPlanAndCharge,
@@ -111,13 +111,14 @@ class ContributionStepsTest extends AnyFlatSpec with Matchers {
       fakeValidateRequest,
       fakeCreate,
       fakeSendEmails,
-    ) _
-    // todo separate the tests properly so that we don't need this anymore (and the same in the PaperStepsTest)
+    )
 
-    val dummySteps = (req: AddSubscriptionRequest) => {
-      fail("unexpected execution of voucher steps while processing contribution request!")
+    val dummySteps = new AddSpecificProduct {
+      override def addProduct(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] =
+        fail("unexpected execution of voucher steps while processing contribution request!")
     }
-    val futureActual = Steps.handleRequest(
+
+    val futureActual = new handleRequest(
       addSupporterPlus = dummySteps,
       addContribution = fakeAddContributionSteps,
       addPaperSub = dummySteps,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
@@ -100,8 +100,9 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  val dummySteps = (req: AddSubscriptionRequest) => {
-    fail("unexpected execution of contribution steps while processing voucher request!")
+  val dummySteps = new AddSpecificProduct {
+    override def addProduct(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] =
+      fail("unexpected execution of voucher steps while processing contribution request!")
   }
 
   it should "create subscription for non 6-for-6 rate plan" in {
@@ -125,7 +126,7 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
       ClientSuccess(SubscriptionName(newSubscriptionName))
     }
 
-    val stubAddVoucherSteps = AddGuardianWeeklySub.steps(
+    val stubAddVoucherSteps = new AddGuardianWeeklySub(
       stubGetPlan,
       stubGetZuoraId,
       stubGetPlanAndCharge,
@@ -136,9 +137,9 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
       stubSendEmail(quarterlyRatePlan),
       GuardianWeeklyDomestic6for6,
       GuardianWeeklyDomesticQuarterly,
-    ) _
+    )
 
-    val futureActual = Steps.handleRequest(
+    val futureActual = new handleRequest(
       addSupporterPlus = dummySteps,
       addContribution = dummySteps,
       addPaperSub = dummySteps,
@@ -208,7 +209,7 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
       ClientSuccess(SubscriptionName(newSubscriptionName))
     }
 
-    val stubAddVoucherSteps = AddGuardianWeeklySub.steps(
+    val stubAddVoucherSteps = new AddGuardianWeeklySub(
       stubGetPlan,
       stubGetZuoraId,
       stubGetPlanAndCharge,
@@ -219,9 +220,9 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
       stubSendEmail(sixForSixRatePlan),
       GuardianWeeklyDomestic6for6,
       GuardianWeeklyDomesticQuarterly,
-    ) _
+    )
 
-    val futureActual = Steps.handleRequest(
+    val futureActual = new handleRequest(
       addSupporterPlus = dummySteps,
       addContribution = dummySteps,
       addPaperSub = dummySteps,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
@@ -54,9 +54,9 @@ class PaperStepsTest extends AnyFlatSpec with Matchers {
     implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
     val expectedOutput = ExpectedOut("well done")
 
-    // todo separate the tests properly so that we don't need this anymore (and the same in the contributionStepsTest)
-    val dummySteps = (req: AddSubscriptionRequest) => {
-      fail("unexpected execution of contribution steps while processing voucher request!")
+    val dummySteps = new AddSpecificProduct {
+      override def addProduct(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] =
+        fail("unexpected execution of voucher steps while processing contribution request!")
     }
 
     val expectedIn = ZuoraCreateSubRequest(
@@ -93,7 +93,7 @@ class PaperStepsTest extends AnyFlatSpec with Matchers {
     def fakeSendEmail(sfContactId: Option[SfContactId], paperData: PaperEmailData) = ContinueProcessing(()).toAsync
 
     def fakeGetPlan(planId: PlanId) = Plan(VoucherEveryDay, PlanDescription("Everyday"), testStartDateRules)
-    val fakeAddVoucherSteps = AddPaperSub.steps(
+    val fakeAddVoucherSteps = new AddPaperSub(
       fakeGetPlan,
       fakeGetZuoraId,
       fakeGetVoucherCustomerData,
@@ -101,9 +101,9 @@ class PaperStepsTest extends AnyFlatSpec with Matchers {
       fakeValidateAddress,
       fakeCreate,
       fakeSendEmail,
-    ) _
+    )
 
-    val futureActual = Steps.handleRequest(
+    val futureActual = new handleRequest(
       addSupporterPlus = dummySteps,
       addContribution = dummySteps,
       addPaperSub = fakeAddVoucherSteps,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
@@ -3,15 +3,10 @@ package com.gu.newproduct.api.addsubscription
 import com.gu.newproduct.TestData
 import com.gu.newproduct.api.addsubscription.email.PaperEmailData
 import com.gu.newproduct.api.addsubscription.validation._
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
-  SubscriptionName,
-  ZuoraCreateSubRequest,
-  ZuoraCreateSubRequestRatePlan,
-}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{SubscriptionName, ZuoraCreateSubRequest, ZuoraCreateSubRequestRatePlan}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.SoldToAddress
-import com.gu.newproduct.api.productcatalog.PlanId.VoucherEveryDay
+import com.gu.newproduct.api.productcatalog.PlanId.{NationalDeliveryWeekend, VoucherEveryDay}
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
 import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
 import com.gu.newproduct.api.productcatalog.{Plan, PlanDescription, PlanId}
@@ -21,6 +16,9 @@ import com.gu.util.reader.AsyncTypes._
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import com.gu.util.resthttp.Types
 import com.gu.util.resthttp.Types.ClientSuccess
+import com.softwaremill.diffx.generic.auto._
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher
+import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
@@ -30,14 +28,11 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class PaperStepsTest extends AnyFlatSpec with Matchers {
+class PaperStepsTest extends AnyFlatSpec with Matchers with Inside with DiffShouldMatcher {
 
   case class ExpectedOut(subscriptionNumber: String)
 
   it should "run end to end with fakes" in {
-    val ratePlanId = ProductRatePlanId("ratePlanId")
-
-    def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
 
     val requestInput = JsObject(
       Map(
@@ -59,49 +54,7 @@ class PaperStepsTest extends AnyFlatSpec with Matchers {
         fail("unexpected execution of voucher steps while processing contribution request!")
     }
 
-    val expectedIn = ZuoraCreateSubRequest(
-      accountId = ZuoraAccountId("acccc"),
-      acceptanceDate = LocalDate.of(2018, 7, 18),
-      acquisitionCase = CaseId("case"),
-      acquisitionSource = AcquisitionSource("CSR"),
-      createdByCSR = CreatedByCSR("bob"),
-      deliveryAgent = None,
-      ratePlans = List(
-        ZuoraCreateSubRequestRatePlan(
-          productRatePlanId = ratePlanId,
-          maybeChargeOverride = None,
-        ),
-      ),
-    )
-
-    def fakeCreate(
-        in: CreateSubscription.ZuoraCreateSubRequest,
-    ): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
-      in shouldBe expectedIn
-      ClientSuccess(SubscriptionName("well done"))
-    }
-
-    val fakeGetZuoraId = (planId: PlanId) => {
-      planId shouldBe VoucherEveryDay
-      Some(ratePlanId)
-    }
-
-    def fakeValidateStartDate(id: PlanId, d: LocalDate) = Passed(())
-
-    def fakeValidateAddress(id: PlanId, a: SoldToAddress) = Passed(())
-
-    def fakeSendEmail(sfContactId: Option[SfContactId], paperData: PaperEmailData) = ContinueProcessing(()).toAsync
-
-    def fakeGetPlan(planId: PlanId) = Plan(VoucherEveryDay, PlanDescription("Everyday"), testStartDateRules)
-    val fakeAddVoucherSteps = new AddPaperSub(
-      fakeGetPlan,
-      fakeGetZuoraId,
-      fakeGetVoucherCustomerData,
-      fakeValidateStartDate,
-      fakeValidateAddress,
-      fakeCreate,
-      fakeSendEmail,
-    )
+    val fakeAddVoucherSteps = buildAddPaperSteps(VoucherEveryDay, None)
 
     val futureActual = new handleRequest(
       addSupporterPlus = dummySteps,
@@ -117,4 +70,78 @@ class PaperStepsTest extends AnyFlatSpec with Matchers {
     actual.body jsonMatchesFormat expectedOutput
   }
 
+  it should "run paper steps with a delivery agent" in {
+
+    val addVoucherSteps: AddPaperSub = buildAddPaperSteps(NationalDeliveryWeekend, Some(DeliveryAgent("helloAgent")))
+
+    val requestInput = AddSubscriptionRequest(
+      zuoraAccountId = ZuoraAccountId("acccc"),
+      startDate = LocalDate.of(2018, 7, 18),
+      acquisitionSource = AcquisitionSource("CSR"),
+      deliveryAgent = Some(DeliveryAgent("helloAgent")),
+      createdByCSR = CreatedByCSR("bob"),
+      amountMinorUnits = None,
+      acquisitionCase = CaseId("case"),
+      planId = NationalDeliveryWeekend
+    )
+
+    val futureActual = addVoucherSteps.addProduct(requestInput)
+
+    val actual = Await.result(futureActual.underlying, 30 seconds)
+    inside(actual) {
+      case ContinueProcessing(SubscriptionName("well done")) =>
+    }
+
+  }
+
+  private def buildAddPaperSteps(expectedPlanId: PlanId, expectedDeliveryAgent: Option[DeliveryAgent]): AddPaperSub = {
+    val ratePlanId = ProductRatePlanId("ratePlanId")
+
+    def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
+
+    val expectedIn = ZuoraCreateSubRequest(
+      accountId = ZuoraAccountId("acccc"),
+      acceptanceDate = LocalDate.of(2018, 7, 18),
+      acquisitionCase = CaseId("case"),
+      acquisitionSource = AcquisitionSource("CSR"),
+      createdByCSR = CreatedByCSR("bob"),
+      deliveryAgent = expectedDeliveryAgent,
+      ratePlans = List(
+        ZuoraCreateSubRequestRatePlan(
+          productRatePlanId = ratePlanId,
+          maybeChargeOverride = None,
+        ),
+      ),
+    )
+
+    def fakeCreate(
+      in: ZuoraCreateSubRequest,
+    ): Types.ClientFailableOp[SubscriptionName] = {
+      in shouldMatchTo expectedIn
+      ClientSuccess(SubscriptionName("well done"))
+    }
+
+    val fakeGetZuoraId = (planId: PlanId) => {
+      planId shouldMatchTo expectedPlanId
+      Some(ratePlanId)
+    }
+
+    def fakeValidateStartDate(id: PlanId, d: LocalDate) = Passed(())
+
+    def fakeValidateAddress(id: PlanId, a: SoldToAddress) = Passed(())
+
+    def fakeSendEmail(sfContactId: Option[SfContactId], paperData: PaperEmailData) = ContinueProcessing(()).toAsync
+
+    def fakeGetPlan(planId: PlanId) = Plan(VoucherEveryDay, PlanDescription("Everyday"), testStartDateRules)
+
+    new AddPaperSub(
+      fakeGetPlan,
+      fakeGetZuoraId,
+      fakeGetVoucherCustomerData,
+      fakeValidateStartDate,
+      fakeValidateAddress,
+      fakeCreate,
+      fakeSendEmail,
+    )
+  }
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
@@ -107,7 +107,7 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
     implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
     val expectedOutput = ExpectedOut("well done")
 
-    val fakeAddSupporterPlusSteps = AddSupporterPlus.steps(
+    val fakeAddSupporterPlusSteps = new AddSupporterPlus(
       getPlan,
       currentDate _,
       getPlanAndCharge,
@@ -115,12 +115,13 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
       fakeValidateRequest,
       fakeCreate,
       fakeSendEmails,
-    ) _
+    )
 
-    val dummySteps = (req: AddSubscriptionRequest) => {
-      fail("unexpected execution of voucher steps while processing contribution request!")
+    val dummySteps = new AddSpecificProduct {
+      override def addProduct(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] =
+        fail("unexpected execution of voucher steps while processing contribution request!")
     }
-    val futureActual = Steps.handleRequest(
+    val futureActual = new handleRequest(
       addSupporterPlus = fakeAddSupporterPlusSteps,
       addContribution = dummySteps,
       addPaperSub = dummySteps,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/ETPayloadTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/ETPayloadTest.scala
@@ -1,6 +1,6 @@
 package com.gu.newproduct.api.addsubscription.email
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OWrites}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -9,7 +9,7 @@ class ETPayloadTest extends AnyFlatSpec with Matchers {
   case class TestPayload(data: String)
 
   object TestPayload {
-    implicit val writes = Json.writes[TestPayload]
+    implicit val writes: OWrites[TestPayload] = Json.writes[TestPayload]
   }
 
   it should "serialise payload to json" in {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/SendConfirmationEmailTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/SendConfirmationEmailTest.scala
@@ -66,6 +66,7 @@ class SendConfirmationEmailTest extends AsyncFlatSpec with Matchers {
     contacts = TestData.contacts,
     paymentMethod = TestData.directDebitPaymentMethod,
     currency = GBP,
+    None,
   )
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/contributions/ContributionsFieldsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/contributions/ContributionsFieldsTest.scala
@@ -4,7 +4,7 @@ import com.gu.i18n.Country
 import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.newproduct.api.addsubscription.email.ContributionsEmailData
-import com.gu.newproduct.api.addsubscription.email.contributions.ContributionEmailDataSerialiser._
+import com.gu.newproduct.api.addsubscription.email.serialisers.ContributionEmailDataSerialiser._
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts._
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{BankAccountName, BankAccountNumberMask, DirectDebit, MandateId, NonDirectDebitMethod, SortCode}
 import com.gu.newproduct.api.addsubscription.zuora.PaymentMethodStatus.ActivePaymentMethod

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/digipack/DigipackEmailDataTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/digipack/DigipackEmailDataTest.scala
@@ -1,26 +1,19 @@
 package com.gu.newproduct.api.addsubscription.email.digipack
 
 import java.time.LocalDate
-
 import com.gu.i18n.Country
 import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.email.{DigipackEmailData, TrialPeriod}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.SubscriptionName
-import com.gu.newproduct.api.addsubscription.zuora.GetContacts.{BillToContact, _}
-import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{
-  BankAccountName,
-  BankAccountNumberMask,
-  DirectDebit,
-  MandateId,
-  NonDirectDebitMethod,
-  SortCode,
-}
+import com.gu.newproduct.api.addsubscription.zuora.GetContacts._
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{BankAccountName, BankAccountNumberMask, DirectDebit, MandateId, NonDirectDebitMethod, SortCode}
 import com.gu.newproduct.api.addsubscription.zuora.PaymentMethodStatus.ActivePaymentMethod
 import com.gu.newproduct.api.addsubscription.zuora.PaymentMethodType.CreditCard
 import com.gu.newproduct.api.productcatalog.PlanId._
 import com.gu.newproduct.api.productcatalog._
 import play.api.libs.json.Json
-import DigipackEmailDataSerialiser._
+import com.gu.newproduct.api.addsubscription.email.serialisers.DigipackEmailDataSerialiser._
+import com.gu.newproduct.api.addsubscription.email.serialisers.DigipackEmailFields
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -117,13 +110,13 @@ class DigipackEmailDataTest extends AnyFlatSpec with Matchers {
 
     val directDebitFieldNames = List("bank_account_no", "bank_sort_code", "account_holder", "mandate_id")
 
-    DigipackEmailFields(cardVoucherData).keySet.filter(directDebitFieldNames.contains(_)) shouldBe Set.empty
+    DigipackEmailFields.serialise(cardVoucherData).keySet.filter(directDebitFieldNames.contains(_)) shouldBe Set.empty
   }
 
   def fieldsForPlanIds(ids: List[PlanId]): List[Map[String, String]] = {
     val allPlansVoucherData =
       ids.map(planId => directDebitData.copy(plan = Plan(planId, PlanDescription("test plan"), testStartDateRules)))
-    allPlansVoucherData.map(DigipackEmailFields(_))
+    allPlansVoucherData.map(DigipackEmailFields.serialise)
   }
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/guardianweekly/GuardianWeeklyEmailDataTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/guardianweekly/GuardianWeeklyEmailDataTest.scala
@@ -3,6 +3,7 @@ package com.gu.newproduct.api.addsubscription.email.guardianweekly
 import com.gu.i18n.Country
 import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.email.GuardianWeeklyEmailData
+import com.gu.newproduct.api.addsubscription.email.serialisers.GuardianWeeklyFields
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.SubscriptionName
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts._
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{BankAccountName, BankAccountNumberMask, DirectDebit, MandateId, NonDirectDebitMethod, SortCode}
@@ -69,7 +70,7 @@ class GuardianWeeklyEmailDataTest extends AnyFlatSpec with Matchers {
     currency = GBP,
   )
   it should "generate email fields with direct debit fields" in {
-    GuardianWeeklyFields(directDebitEmailData) should equal(
+    GuardianWeeklyFields.serialise(directDebitEmailData) should equal(
       Map(
         "EmailAddress" -> "bill@contact.com",
         "ZuoraSubscriberId" -> "A-S000SubId",
@@ -97,6 +98,6 @@ class GuardianWeeklyEmailDataTest extends AnyFlatSpec with Matchers {
     val cardVoucherData =
       directDebitEmailData.copy(paymentMethod = NonDirectDebitMethod(ActivePaymentMethod, CreditCard))
     val directDebitFieldNames = List("bank_account_no", "bank_sort_code", "account_holder", "mandate_id")
-    GuardianWeeklyFields(cardVoucherData).keySet.filter(directDebitFieldNames.contains(_)) shouldBe Set.empty
+    GuardianWeeklyFields.serialise(cardVoucherData).keySet.filter(directDebitFieldNames.contains(_)) shouldBe Set.empty
   }
 }

--- a/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
@@ -9,13 +9,13 @@ object AddSubscriptionManualTest extends App {
   val requestBody =
     """{
       |	"zuoraAccountId":"8ad09b7d83634b880183698ea4ff27cc",
-      |	"startDate":"2022-09-23",
-      |	"productRatePlanChargeId":"monthly_supporter_plus",
-      |	"planId":"monthly_supporter_plus",
-      |	"createdByCSR":"David Pepper",
+      |	"startDate":"2023-10-26",
+      |	"planId":"national_delivery_sixday",
+      |	"createdByCSR":"John Duffell",
       |	"amountMinorUnits":2000,
       |	"acquisitionSource":"CSR",
-      |	"acquisitionCase":"5009E00000Lyy3T"
+      |	"acquisitionCase":"5009E00000Lyy3T",
+      | "deliveryAgent":"1821"
       |}
     """.stripMargin
 

--- a/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
@@ -1,9 +1,8 @@
 package manualTest
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-
 import com.gu.newproduct.api.addsubscription.Handler
-import play.api.libs.json.{JsString, Json}
+import play.api.libs.json.{JsString, Json, OWrites}
 
 //This is just a way to locally run the addSubscription lambda in code
 object AddSubscriptionManualTest extends App {
@@ -22,7 +21,7 @@ object AddSubscriptionManualTest extends App {
 
   val bodyAsJsString = JsString(requestBody)
   case class ApiRequest(body: String)
-  implicit val writes = Json.writes[ApiRequest]
+  implicit val writes: OWrites[ApiRequest] = Json.writes[ApiRequest]
   val requestText = Json.prettyPrint(Json.toJson(ApiRequest(requestBody)))
 
   println(s"sending request..")

--- a/handlers/new-product-api/src/test/scala/manualTest/SendConfirmationEmailsManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/SendConfirmationEmailsManualTest.scala
@@ -4,7 +4,7 @@ import com.gu.effects.sqs.AwsSQSSend.EmailQueueName
 import com.gu.effects.sqs.SqsAsync
 import com.gu.i18n.{Country, Currency}
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
-import com.gu.newproduct.api.addsubscription.email.contributions.ContributionEmailDataSerialiser._
+import com.gu.newproduct.api.addsubscription.email.serialisers.ContributionEmailDataSerialiser._
 import com.gu.newproduct.api.addsubscription.email.{ContributionsEmailData, EtSqsSend, SendConfirmationEmail}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts._


### PR DESCRIPTION
This PR adds logic to allow delivery partner information to be sent to braze via membership workflow.

It is based on the field names in support-frontend
https://github.com/guardian/support-frontend/blob/386a9fde94de7d1c266f7fbae245385ef9bf9990/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala#L24-L31


It's been tested on CODE and the email comes through with the name in it (although weirdly formatted)
![image](https://github.com/guardian/support-service-lambdas/assets/7304387/f4803f24-c558-4c2d-8499-23588d656ad3)

This PR also includes some refactoring to bring the new product api code up to more modern standards.