### PR TITLE
Migrate batch-email-sender to CDK (Step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         subproject:
+          - batch-email-sender
           - new-product-api
           - single-contribution-salesforce-writes
     runs-on: ubuntu-latest
@@ -56,7 +57,6 @@ jobs:
     strategy:
       matrix:
         subproject:
-          - batch-email-sender
           - cancellation-sf-cases-api
           - catalog-service
           - contact-us-api

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,5 +1,6 @@
 import "source-map-support/register";
 import { App } from "aws-cdk-lib";
+import { BatchEmailSender } from "../lib/batch-email-sender";
 import { FailedNationalDeliveriesProcessor } from "../lib/failed-national-deliveries-processor";
 import type { NewProductApiProps } from "../lib/new-product-api";
 import { NewProductApi } from "../lib/new-product-api";
@@ -29,6 +30,8 @@ export const prodProps: NewProductApiProps = {
     fulfilmentDateCalculatorS3Resource: "arn:aws:s3:::fulfilment-date-calculator-prod/*"
 };
 
+new BatchEmailSender(app, "batch-email-sender-CODE", {stack: "membership", stage: "CODE"});
+new BatchEmailSender(app, "batch-email-sender-PROD", {stack: "membership", stage: "PROD"});
 new NewProductApi(app, "new-product-api-CODE", codeProps);
 new NewProductApi(app, "new-product-api-PROD", prodProps);
 new FailedNationalDeliveriesProcessor(app, "failed-national-deliveries-processor-CODE", {stack: "membership", stage: "CODE"});

--- a/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
+++ b/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
@@ -1,0 +1,935 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The BatchEmailSender stack matches the snapshot 1`] = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "IsProd": {
+      "Fn::Equals": [
+        {
+          "Ref": "Stage",
+        },
+        "PROD",
+      ],
+    },
+  },
+  "Description": "API to receive email batches from Salesforce and add the items to the queue.",
+  "Metadata": {
+    "gu:cdk:constructs": [],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "Stage": {
+      "AllowedValues": [
+        "PROD",
+        "CODE",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "BatchEmailMethod": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiGateway",
+        "BatchEmailSenderLambda",
+      ],
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Sub": "arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${BatchEmailSenderLambda.Arn}/invocations",
+          },
+        },
+        "ResourceId": {
+          "Ref": "BatchEmailSenderApiGateway",
+        },
+        "RestApiId": {
+          "Ref": "BatchEmailSenderApi",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "BatchEmailSenderApi": {
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "BatchEmailSender-\${Stage}",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "BatchEmailSenderApiDeployment": {
+      "DependsOn": [
+        "BatchEmailMethod",
+      ],
+      "Properties": {
+        "Description": "Deploys batch-email-sender into an environment/stage",
+        "RestApiId": {
+          "Ref": "BatchEmailSenderApi",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "BatchEmailSenderApiGateway": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "BatchEmailSenderApi",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "email-batch",
+        "RestApiId": {
+          "Ref": "BatchEmailSenderApi",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "BatchEmailSenderApiKey": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiStage",
+      ],
+      "Properties": {
+        "Description": "Key required to call batch email sender API",
+        "Enabled": true,
+        "Name": {
+          "Fn::Sub": "batch-email-sender-api-key-\${Stage}",
+        },
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "BatchEmailSenderApi",
+            },
+            "StageName": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::ApiKey",
+    },
+    "BatchEmailSenderApiPermission": {
+      "DependsOn": [
+        "BatchEmailSenderLambda",
+      ],
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "FunctionName": {
+          "Fn::Sub": "batch-email-sender-\${Stage}",
+        },
+        "Principal": "apigateway.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "BatchEmailSenderApiStage": {
+      "DependsOn": [
+        "BatchEmailMethod",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "BatchEmailSenderApiDeployment",
+        },
+        "Description": "Stage for batch email sender api",
+        "RestApiId": {
+          "Ref": "BatchEmailSenderApi",
+        },
+        "StageName": {
+          "Fn::Sub": "\${Stage}",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "BatchEmailSenderLambda": {
+      "DependsOn": [
+        "LogAndWriteToEmailQueueRole",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": "support-service-lambdas-dist",
+          "S3Key": {
+            "Fn::Sub": "membership/\${Stage}/batch-email-sender/batch-email-sender.jar",
+          },
+        },
+        "Description": "Receives calls from Salesforce containing batches of emails to be added to the email sending queue.",
+        "Environment": {
+          "Variables": {
+            "EmailQueueName": {
+              "Fn::ImportValue": {
+                "Fn::Sub": "comms-\${Stage}-EmailQueueName",
+              },
+            },
+            "Stage": {
+              "Ref": "Stage",
+            },
+          },
+        },
+        "FunctionName": {
+          "Fn::Sub": "batch-email-sender-\${Stage}",
+        },
+        "Handler": "com.gu.batchemailsender.api.batchemail.Handler::apply",
+        "MemorySize": 1536,
+        "Role": {
+          "Fn::GetAtt": [
+            "LogAndWriteToEmailQueueRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "BatchEmailSenderUsagePlan": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiStage",
+      ],
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "BatchEmailSenderApi",
+            },
+            "Stage": {
+              "Ref": "BatchEmailSenderApiStage",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "UsagePlanName": {
+          "Fn::Sub": "batch-email-sender-api-usage-plan-\${Stage}",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlan",
+    },
+    "BatchEmailSenderUsagePlanKey": {
+      "DependsOn": [
+        "BatchEmailSenderApiKey",
+        "BatchEmailSenderUsagePlan",
+      ],
+      "Properties": {
+        "KeyId": {
+          "Ref": "BatchEmailSenderApiKey",
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "BatchEmailSenderUsagePlan",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+    },
+    "FailedEmailApiAlarm": {
+      "Condition": "IsProd",
+      "DependsOn": [
+        "BatchEmailSenderApi",
+      ],
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:retention-dev",
+          },
+        ],
+        "AlarmDescription": "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": {
+              "Fn::Sub": "BatchEmailSender-\${Stage}",
+            },
+          },
+          {
+            "Name": "Stage",
+            "Value": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "FailedEmailLambdaAlarm": {
+      "Condition": "IsProd",
+      "DependsOn": [
+        "BatchEmailSenderLambda",
+      ],
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:retention-dev",
+          },
+        ],
+        "AlarmDescription": "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "BatchEmailSenderLambda",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "LogAndWriteToEmailQueueRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "lambda:InvokeFunction",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": "arn:aws:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:/aws/lambda/batch-email-sender-\${Stage}:log-stream:*",
+                  },
+                },
+              ],
+            },
+            "PolicyName": "LambdaPolicy",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:GetQueueUrl",
+                    "sqs:SendMessage",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::ImportValue": {
+                      "Fn::Sub": "comms-\${Stage}-EmailQueueArn",
+                    },
+                  },
+                },
+              ],
+            },
+            "PolicyName": "SQSAddEmailRequest",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
+exports[`The BatchEmailSender stack matches the snapshot 2`] = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "IsProd": {
+      "Fn::Equals": [
+        {
+          "Ref": "Stage",
+        },
+        "PROD",
+      ],
+    },
+  },
+  "Description": "API to receive email batches from Salesforce and add the items to the queue.",
+  "Metadata": {
+    "gu:cdk:constructs": [],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "Stage": {
+      "AllowedValues": [
+        "PROD",
+        "CODE",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "BatchEmailMethod": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiGateway",
+        "BatchEmailSenderLambda",
+      ],
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Sub": "arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${BatchEmailSenderLambda.Arn}/invocations",
+          },
+        },
+        "ResourceId": {
+          "Ref": "BatchEmailSenderApiGateway",
+        },
+        "RestApiId": {
+          "Ref": "BatchEmailSenderApi",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "BatchEmailSenderApi": {
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "BatchEmailSender-\${Stage}",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "BatchEmailSenderApiDeployment": {
+      "DependsOn": [
+        "BatchEmailMethod",
+      ],
+      "Properties": {
+        "Description": "Deploys batch-email-sender into an environment/stage",
+        "RestApiId": {
+          "Ref": "BatchEmailSenderApi",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "BatchEmailSenderApiGateway": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "BatchEmailSenderApi",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "email-batch",
+        "RestApiId": {
+          "Ref": "BatchEmailSenderApi",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "BatchEmailSenderApiKey": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiStage",
+      ],
+      "Properties": {
+        "Description": "Key required to call batch email sender API",
+        "Enabled": true,
+        "Name": {
+          "Fn::Sub": "batch-email-sender-api-key-\${Stage}",
+        },
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "BatchEmailSenderApi",
+            },
+            "StageName": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::ApiKey",
+    },
+    "BatchEmailSenderApiPermission": {
+      "DependsOn": [
+        "BatchEmailSenderLambda",
+      ],
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "FunctionName": {
+          "Fn::Sub": "batch-email-sender-\${Stage}",
+        },
+        "Principal": "apigateway.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "BatchEmailSenderApiStage": {
+      "DependsOn": [
+        "BatchEmailMethod",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "BatchEmailSenderApiDeployment",
+        },
+        "Description": "Stage for batch email sender api",
+        "RestApiId": {
+          "Ref": "BatchEmailSenderApi",
+        },
+        "StageName": {
+          "Fn::Sub": "\${Stage}",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "BatchEmailSenderLambda": {
+      "DependsOn": [
+        "LogAndWriteToEmailQueueRole",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": "support-service-lambdas-dist",
+          "S3Key": {
+            "Fn::Sub": "membership/\${Stage}/batch-email-sender/batch-email-sender.jar",
+          },
+        },
+        "Description": "Receives calls from Salesforce containing batches of emails to be added to the email sending queue.",
+        "Environment": {
+          "Variables": {
+            "EmailQueueName": {
+              "Fn::ImportValue": {
+                "Fn::Sub": "comms-\${Stage}-EmailQueueName",
+              },
+            },
+            "Stage": {
+              "Ref": "Stage",
+            },
+          },
+        },
+        "FunctionName": {
+          "Fn::Sub": "batch-email-sender-\${Stage}",
+        },
+        "Handler": "com.gu.batchemailsender.api.batchemail.Handler::apply",
+        "MemorySize": 1536,
+        "Role": {
+          "Fn::GetAtt": [
+            "LogAndWriteToEmailQueueRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "BatchEmailSenderUsagePlan": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiStage",
+      ],
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "BatchEmailSenderApi",
+            },
+            "Stage": {
+              "Ref": "BatchEmailSenderApiStage",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "UsagePlanName": {
+          "Fn::Sub": "batch-email-sender-api-usage-plan-\${Stage}",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlan",
+    },
+    "BatchEmailSenderUsagePlanKey": {
+      "DependsOn": [
+        "BatchEmailSenderApiKey",
+        "BatchEmailSenderUsagePlan",
+      ],
+      "Properties": {
+        "KeyId": {
+          "Ref": "BatchEmailSenderApiKey",
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "BatchEmailSenderUsagePlan",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+    },
+    "FailedEmailApiAlarm": {
+      "Condition": "IsProd",
+      "DependsOn": [
+        "BatchEmailSenderApi",
+      ],
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:retention-dev",
+          },
+        ],
+        "AlarmDescription": "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": {
+              "Fn::Sub": "BatchEmailSender-\${Stage}",
+            },
+          },
+          {
+            "Name": "Stage",
+            "Value": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "FailedEmailLambdaAlarm": {
+      "Condition": "IsProd",
+      "DependsOn": [
+        "BatchEmailSenderLambda",
+      ],
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:retention-dev",
+          },
+        ],
+        "AlarmDescription": "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "BatchEmailSenderLambda",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "LogAndWriteToEmailQueueRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "lambda:InvokeFunction",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": "arn:aws:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:/aws/lambda/batch-email-sender-\${Stage}:log-stream:*",
+                  },
+                },
+              ],
+            },
+            "PolicyName": "LambdaPolicy",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:GetQueueUrl",
+                    "sqs:SendMessage",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::ImportValue": {
+                      "Fn::Sub": "comms-\${Stage}-EmailQueueArn",
+                    },
+                  },
+                },
+              ],
+            },
+            "PolicyName": "SQSAddEmailRequest",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;

--- a/cdk/lib/batch-email-sender.test.ts
+++ b/cdk/lib/batch-email-sender.test.ts
@@ -1,13 +1,14 @@
 import { App } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import {BatchEmailSender, BatchEmailSenderProps} from "./batch-email-sender";
+import {BatchEmailSender} from "./batch-email-sender";
+import {GuStackProps} from "@guardian/cdk/lib/constructs/core";
 
-const codeProps: BatchEmailSenderProps = {
+const codeProps: GuStackProps = {
     stack: "membership",
     stage: "CODE"
 }
 
-const prodProps: BatchEmailSenderProps = {
+const prodProps: GuStackProps = {
     stack: "membership",
     stage: "PROD"
 }

--- a/cdk/lib/batch-email-sender.test.ts
+++ b/cdk/lib/batch-email-sender.test.ts
@@ -1,7 +1,7 @@
+import type {GuStackProps} from "@guardian/cdk/lib/constructs/core";
 import { App } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import {BatchEmailSender} from "./batch-email-sender";
-import {GuStackProps} from "@guardian/cdk/lib/constructs/core";
 
 const codeProps: GuStackProps = {
     stack: "membership",

--- a/cdk/lib/batch-email-sender.test.ts
+++ b/cdk/lib/batch-email-sender.test.ts
@@ -1,0 +1,31 @@
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import {BatchEmailSender, BatchEmailSenderProps} from "./batch-email-sender";
+
+const codeProps: BatchEmailSenderProps = {
+    stack: "membership",
+    stage: "CODE"
+}
+
+const prodProps: BatchEmailSenderProps = {
+    stack: "membership",
+    stage: "PROD"
+}
+
+describe("The BatchEmailSender stack", () => {
+    it("matches the snapshot", () => {
+        const app = new App();
+        const codeStack = new BatchEmailSender(
+            app,
+            "batch-email-sender-CODE",
+            codeProps
+        );
+        const prodStack = new BatchEmailSender(
+            app,
+            "batch-email-sender-PROD",
+            prodProps
+        );
+        expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
+        expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();
+    });
+});

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -1,10 +1,15 @@
 import {GuStack, GuStackProps} from "@guardian/cdk/lib/constructs/core";
 import {App} from "aws-cdk-lib";
+import {CfnInclude} from "aws-cdk-lib/cloudformation-include";
 
 export interface BatchEmailSenderProps extends GuStackProps {}
 
 export class BatchEmailSender extends GuStack {
     constructor(scope: App, id: string, props: BatchEmailSenderProps) {
         super(scope, id, props);
+        const yamlTemplateFilePath = `${__dirname}/../../handlers/batch-email-sender/cfn.yaml`;
+        new CfnInclude(this, "YamlTemplate", {
+            templateFile: yamlTemplateFilePath,
+        });
     }
 }

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -1,5 +1,6 @@
-import {GuStack, GuStackProps} from "@guardian/cdk/lib/constructs/core";
-import {App} from "aws-cdk-lib";
+import type { GuStackProps} from "@guardian/cdk/lib/constructs/core";
+import {GuStack} from "@guardian/cdk/lib/constructs/core";
+import type {App} from "aws-cdk-lib";
 import {CfnInclude} from "aws-cdk-lib/cloudformation-include";
 
 export class BatchEmailSender extends GuStack {

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -2,10 +2,8 @@ import {GuStack, GuStackProps} from "@guardian/cdk/lib/constructs/core";
 import {App} from "aws-cdk-lib";
 import {CfnInclude} from "aws-cdk-lib/cloudformation-include";
 
-export interface BatchEmailSenderProps extends GuStackProps {}
-
 export class BatchEmailSender extends GuStack {
-    constructor(scope: App, id: string, props: BatchEmailSenderProps) {
+    constructor(scope: App, id: string, props: GuStackProps) {
         super(scope, id, props);
         const yamlTemplateFilePath = `${__dirname}/../../handlers/batch-email-sender/cfn.yaml`;
         new CfnInclude(this, "YamlTemplate", {

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -1,0 +1,10 @@
+import {GuStack, GuStackProps} from "@guardian/cdk/lib/constructs/core";
+import {App} from "aws-cdk-lib";
+
+export interface BatchEmailSenderProps extends GuStackProps {}
+
+export class BatchEmailSender extends GuStack {
+    constructor(scope: App, id: string, props: BatchEmailSenderProps) {
+        super(scope, id, props);
+    }
+}

--- a/handlers/batch-email-sender/riff-raff.yaml
+++ b/handlers/batch-email-sender/riff-raff.yaml
@@ -1,23 +1,24 @@
 stacks:
-- membership
+  - membership
 regions:
-- eu-west-1
+  - eu-west-1
 allowedStages:
   - CODE
   - PROD
 deployments:
-  cfn:
+  cloudformation:
     type: cloud-formation
     app: batch-email-sender
     parameters:
-      templatePath: cfn.yaml
-
+      templateStagePaths:
+        CODE: batch-email-sender-CODE.template.json
+        PROD: batch-email-sender-PROD.template.json
   batch-email-sender:
     type: aws-lambda
     parameters:
       fileName: batch-email-sender.jar
-      bucket: support-service-lambdas-dist
+      bucketSsmLookup: true
       prefixStack: false
       functionNames:
       - batch-email-sender-
-    dependencies: [cfn]
+    dependencies: [cloudformation]

--- a/handlers/batch-email-sender/riff-raff.yaml
+++ b/handlers/batch-email-sender/riff-raff.yaml
@@ -6,7 +6,7 @@ allowedStages:
   - CODE
   - PROD
 deployments:
-  cloudformation:
+  batch-email-sender-cloudformation:
     type: cloud-formation
     app: batch-email-sender
     parameters:
@@ -21,4 +21,4 @@ deployments:
       prefixStack: false
       functionNames:
       - batch-email-sender-
-    dependencies: [cloudformation]
+    dependencies: [batch-email-sender-cloudformation]


### PR DESCRIPTION
This PR begins the process of migrating `batch-email-sender` to CDK, by importing the raw Cloudformation YAML template into the CDK, and then generating new templates for `PROD` and `CODE` environments.