### PR TITLE
Dual stack cloudformation (Step 2)

### DIFF
--- a/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
+++ b/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
@@ -15,10 +15,49 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
   },
   "Description": "API to receive email batches from Salesforce and add the items to the queue.",
   "Metadata": {
-    "gu:cdk:constructs": [],
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuLambdaFunction",
+      "GuApiGatewayWithLambdaByPath",
+      "GuAlarm",
+      "GuAlarm",
+    ],
     "gu:cdk:version": "TEST",
   },
+  "Outputs": {
+    "RestApiEndpoint0551178A": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "RestApiDeploymentStageprod3855DE66",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
   "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stage": {
       "AllowedValues": [
         "PROD",
@@ -109,27 +148,11 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "BatchEmailSenderApiKey": {
-      "DependsOn": [
-        "BatchEmailSenderApi",
-        "BatchEmailSenderApiStage",
-      ],
+    "BatchEmailSenderApiKey7802AC02": {
       "Properties": {
         "Description": "Key required to call batch email sender API",
         "Enabled": true,
-        "Name": {
-          "Fn::Sub": "batch-email-sender-api-key-\${Stage}",
-        },
-        "StageKeys": [
-          {
-            "RestApiId": {
-              "Ref": "BatchEmailSenderApi",
-            },
-            "StageName": {
-              "Fn::Sub": "\${Stage}",
-            },
-          },
-        ],
+        "Name": "batch-email-sender-api-key-CODE",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -258,20 +281,226 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "BatchEmailSenderUsagePlan": {
+    "BatchEmailSenderLambda455EDB9F": {
       "DependsOn": [
-        "BatchEmailSenderApi",
-        "BatchEmailSenderApiStage",
+        "BatchEmailSenderLambdaServiceRoleDefaultPolicy612E7D22",
+        "BatchEmailSenderLambdaServiceRoleADC9CE54",
       ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/CODE/batch-email-sender/batch-email-sender.jar",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "batch-email-sender",
+            "STACK": "membership",
+            "STAGE": "CODE",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "batch-email-sender-CODE",
+        "Handler": "com.gu.batchemailsender.api.batchemail.Handler::apply",
+        "MemorySize": 1536,
+        "Role": {
+          "Fn::GetAtt": [
+            "BatchEmailSenderLambdaServiceRoleADC9CE54",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "batch-email-sender",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "BatchEmailSenderLambdaServiceRoleADC9CE54": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "batch-email-sender",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "BatchEmailSenderLambdaServiceRoleDefaultPolicy612E7D22": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/CODE/batch-email-sender/batch-email-sender.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/membership/batch-email-sender",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/membership/batch-email-sender/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "BatchEmailSenderLambdaServiceRoleDefaultPolicy612E7D22",
+        "Roles": [
+          {
+            "Ref": "BatchEmailSenderLambdaServiceRoleADC9CE54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "BatchEmailSenderUsagePlan01358D74": {
       "Properties": {
         "ApiStages": [
           {
             "ApiId": {
-              "Ref": "BatchEmailSenderApi",
+              "Ref": "RestApi0C43BF4B",
             },
             "Stage": {
-              "Ref": "BatchEmailSenderApiStage",
+              "Ref": "RestApiDeploymentStageprod3855DE66",
             },
+            "Throttle": {},
           },
         ],
         "Tags": [
@@ -292,24 +521,18 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
             "Value": "CODE",
           },
         ],
-        "UsagePlanName": {
-          "Fn::Sub": "batch-email-sender-api-usage-plan-\${Stage}",
-        },
+        "UsagePlanName": "batch-email-sender-api-usage-plan-CODE",
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
     "BatchEmailSenderUsagePlanKey": {
-      "DependsOn": [
-        "BatchEmailSenderApiKey",
-        "BatchEmailSenderUsagePlan",
-      ],
       "Properties": {
         "KeyId": {
-          "Ref": "BatchEmailSenderApiKey",
+          "Ref": "BatchEmailSenderApiKey7802AC02",
         },
         "KeyType": "API_KEY",
         "UsagePlanId": {
-          "Ref": "BatchEmailSenderUsagePlan",
+          "Ref": "BatchEmailSenderUsagePlan01358D74",
         },
       },
       "Type": "AWS::ApiGateway::UsagePlanKey",
@@ -352,6 +575,45 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "FailedEmailApiAlarm5492D7DD": {
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":retention-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": "BatchEmailSender-CODE",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "FailedEmailLambdaAlarm": {
       "Condition": "IsProd",
       "DependsOn": [
@@ -381,6 +643,47 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
         "Statistic": "Sum",
         "Threshold": 1,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "FailedEmailLambdaAlarmFC8FF2C4": {
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":retention-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "BatchEmailSenderLambda455EDB9F",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -462,6 +765,360 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "RestApi0C43BF4B": {
+      "Properties": {
+        "Name": "membership-CODE-batch-email-sender",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiAccount7C83CF5A": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50320c7740981cb8798219e620f08263bf5": {
+      "DependsOn": [
+        "RestApiemailbatchOPTIONS53263E0B",
+        "RestApiemailbatchPOSTE3D979FC",
+        "RestApiemailbatchCF22C960",
+        "RestApiOPTIONS6AA64D2D",
+      ],
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageprod3855DE66": {
+      "DependsOn": [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "RestApiDeployment180EC50320c7740981cb8798219e620f08263bf5",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiOPTIONS6AA64D2D": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiemailbatchCF22C960": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "email-batch",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApiemailbatchOPTIONS53263E0B": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApiemailbatchCF22C960",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiemailbatchPOSTApiPermissionTestbatchemailsenderCODERestApiBF9F1327POSTemailbatch3AE71655": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "BatchEmailSenderLambda455EDB9F",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/POST/email-batch",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApiemailbatchPOSTApiPermissionbatchemailsenderCODERestApiBF9F1327POSTemailbatchD99292A1": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "BatchEmailSenderLambda455EDB9F",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/POST/email-batch",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApiemailbatchPOSTE3D979FC": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "BatchEmailSenderLambda455EDB9F",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApiemailbatchCF22C960",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
     },
   },
 }
@@ -482,10 +1139,49 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
   },
   "Description": "API to receive email batches from Salesforce and add the items to the queue.",
   "Metadata": {
-    "gu:cdk:constructs": [],
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuLambdaFunction",
+      "GuApiGatewayWithLambdaByPath",
+      "GuAlarm",
+      "GuAlarm",
+    ],
     "gu:cdk:version": "TEST",
   },
+  "Outputs": {
+    "RestApiEndpoint0551178A": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "RestApiDeploymentStageprod3855DE66",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
   "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stage": {
       "AllowedValues": [
         "PROD",
@@ -576,27 +1272,11 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "BatchEmailSenderApiKey": {
-      "DependsOn": [
-        "BatchEmailSenderApi",
-        "BatchEmailSenderApiStage",
-      ],
+    "BatchEmailSenderApiKey7802AC02": {
       "Properties": {
         "Description": "Key required to call batch email sender API",
         "Enabled": true,
-        "Name": {
-          "Fn::Sub": "batch-email-sender-api-key-\${Stage}",
-        },
-        "StageKeys": [
-          {
-            "RestApiId": {
-              "Ref": "BatchEmailSenderApi",
-            },
-            "StageName": {
-              "Fn::Sub": "\${Stage}",
-            },
-          },
-        ],
+        "Name": "batch-email-sender-api-key-PROD",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -725,20 +1405,226 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "BatchEmailSenderUsagePlan": {
+    "BatchEmailSenderLambda455EDB9F": {
       "DependsOn": [
-        "BatchEmailSenderApi",
-        "BatchEmailSenderApiStage",
+        "BatchEmailSenderLambdaServiceRoleDefaultPolicy612E7D22",
+        "BatchEmailSenderLambdaServiceRoleADC9CE54",
       ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/PROD/batch-email-sender/batch-email-sender.jar",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "batch-email-sender",
+            "STACK": "membership",
+            "STAGE": "PROD",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "batch-email-sender-PROD",
+        "Handler": "com.gu.batchemailsender.api.batchemail.Handler::apply",
+        "MemorySize": 1536,
+        "Role": {
+          "Fn::GetAtt": [
+            "BatchEmailSenderLambdaServiceRoleADC9CE54",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "batch-email-sender",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "BatchEmailSenderLambdaServiceRoleADC9CE54": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "batch-email-sender",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "BatchEmailSenderLambdaServiceRoleDefaultPolicy612E7D22": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/PROD/batch-email-sender/batch-email-sender.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/membership/batch-email-sender",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/membership/batch-email-sender/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "BatchEmailSenderLambdaServiceRoleDefaultPolicy612E7D22",
+        "Roles": [
+          {
+            "Ref": "BatchEmailSenderLambdaServiceRoleADC9CE54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "BatchEmailSenderUsagePlan01358D74": {
       "Properties": {
         "ApiStages": [
           {
             "ApiId": {
-              "Ref": "BatchEmailSenderApi",
+              "Ref": "RestApi0C43BF4B",
             },
             "Stage": {
-              "Ref": "BatchEmailSenderApiStage",
+              "Ref": "RestApiDeploymentStageprod3855DE66",
             },
+            "Throttle": {},
           },
         ],
         "Tags": [
@@ -759,24 +1645,18 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
             "Value": "PROD",
           },
         ],
-        "UsagePlanName": {
-          "Fn::Sub": "batch-email-sender-api-usage-plan-\${Stage}",
-        },
+        "UsagePlanName": "batch-email-sender-api-usage-plan-PROD",
       },
       "Type": "AWS::ApiGateway::UsagePlan",
     },
     "BatchEmailSenderUsagePlanKey": {
-      "DependsOn": [
-        "BatchEmailSenderApiKey",
-        "BatchEmailSenderUsagePlan",
-      ],
       "Properties": {
         "KeyId": {
-          "Ref": "BatchEmailSenderApiKey",
+          "Ref": "BatchEmailSenderApiKey7802AC02",
         },
         "KeyType": "API_KEY",
         "UsagePlanId": {
-          "Ref": "BatchEmailSenderUsagePlan",
+          "Ref": "BatchEmailSenderUsagePlan01358D74",
         },
       },
       "Type": "AWS::ApiGateway::UsagePlanKey",
@@ -819,6 +1699,45 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "FailedEmailApiAlarm5492D7DD": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":retention-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": "BatchEmailSender-PROD",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "FailedEmailLambdaAlarm": {
       "Condition": "IsProd",
       "DependsOn": [
@@ -848,6 +1767,47 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Threshold": 1,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "FailedEmailLambdaAlarmFC8FF2C4": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":retention-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "BatchEmailSenderLambda455EDB9F",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -929,6 +1889,360 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "RestApi0C43BF4B": {
+      "Properties": {
+        "Name": "membership-PROD-batch-email-sender",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiAccount7C83CF5A": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50385e7143a774f2dcac01e1b70c06b0ece": {
+      "DependsOn": [
+        "RestApiemailbatchOPTIONS53263E0B",
+        "RestApiemailbatchPOSTE3D979FC",
+        "RestApiemailbatchCF22C960",
+        "RestApiOPTIONS6AA64D2D",
+      ],
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageprod3855DE66": {
+      "DependsOn": [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "RestApiDeployment180EC50385e7143a774f2dcac01e1b70c06b0ece",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiOPTIONS6AA64D2D": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiemailbatchCF22C960": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "email-batch",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApiemailbatchOPTIONS53263E0B": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApiemailbatchCF22C960",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiemailbatchPOSTApiPermissionTestbatchemailsenderPRODRestApi560191DDPOSTemailbatch4FA956A5": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "BatchEmailSenderLambda455EDB9F",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/POST/email-batch",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApiemailbatchPOSTApiPermissionbatchemailsenderPRODRestApi560191DDPOSTemailbatchB4358CF7": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "BatchEmailSenderLambda455EDB9F",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/POST/email-batch",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApiemailbatchPOSTE3D979FC": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "BatchEmailSenderLambda455EDB9F",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApiemailbatchCF22C960",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
     },
   },
 }

--- a/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
+++ b/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
@@ -1202,6 +1202,86 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
+    "cloudwatchlogsinlinepolicyB03D217C": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "lambda:InvokeFunction",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:logs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/aws/lambda/batch-email-sender-CODE:log-stream:*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "cloudwatchlogsinlinepolicyB03D217C",
+        "Roles": [
+          {
+            "Ref": "BatchEmailSenderLambdaServiceRoleADC9CE54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "sqsinlinepolicyA7B14341": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:SendMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sqs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":braze-emails-CODE",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "sqsinlinepolicyA7B14341",
+        "Roles": [
+          {
+            "Ref": "BatchEmailSenderLambdaServiceRoleADC9CE54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
   },
 }
 `;
@@ -2407,6 +2487,86 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
         },
       },
       "Type": "AWS::ApiGateway::Method",
+    },
+    "cloudwatchlogsinlinepolicyB03D217C": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "lambda:InvokeFunction",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:logs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/aws/lambda/batch-email-sender-PROD:log-stream:*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "cloudwatchlogsinlinepolicyB03D217C",
+        "Roles": [
+          {
+            "Ref": "BatchEmailSenderLambdaServiceRoleADC9CE54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "sqsinlinepolicyA7B14341": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:SendMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sqs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":braze-emails-PROD",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "sqsinlinepolicyA7B14341",
+        "Roles": [
+          {
+            "Ref": "BatchEmailSenderLambdaServiceRoleADC9CE54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
   },
 }

--- a/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
+++ b/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
@@ -338,6 +338,9 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "batch-email-sender",
+            "EmailQueueName": {
+              "Fn::ImportValue": "comms-CODE-EmailQueueName",
+            },
             "STACK": "membership",
             "STAGE": "CODE",
             "Stage": "CODE",
@@ -1640,6 +1643,9 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "batch-email-sender",
+            "EmailQueueName": {
+              "Fn::ImportValue": "comms-PROD-EmailQueueName",
+            },
             "STACK": "membership",
             "STAGE": "PROD",
             "Stage": "PROD",

--- a/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
+++ b/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
@@ -148,6 +148,48 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
+    "BatchEmailSenderApiKey": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiStage",
+      ],
+      "Properties": {
+        "Description": "Key required to call batch email sender API",
+        "Enabled": true,
+        "Name": {
+          "Fn::Sub": "batch-email-sender-api-key-\${Stage}",
+        },
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "BatchEmailSenderApi",
+            },
+            "StageName": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::ApiKey",
+    },
     "BatchEmailSenderApiKey7802AC02": {
       "Properties": {
         "Description": "Key required to call batch email sender API",
@@ -489,6 +531,46 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "BatchEmailSenderUsagePlan": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiStage",
+      ],
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "BatchEmailSenderApi",
+            },
+            "Stage": {
+              "Ref": "BatchEmailSenderApiStage",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "UsagePlanName": {
+          "Fn::Sub": "batch-email-sender-api-usage-plan-\${Stage}",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlan",
     },
     "BatchEmailSenderUsagePlan01358D74": {
       "Properties": {
@@ -1272,6 +1354,48 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
+    "BatchEmailSenderApiKey": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiStage",
+      ],
+      "Properties": {
+        "Description": "Key required to call batch email sender API",
+        "Enabled": true,
+        "Name": {
+          "Fn::Sub": "batch-email-sender-api-key-\${Stage}",
+        },
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "BatchEmailSenderApi",
+            },
+            "StageName": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::ApiKey",
+    },
     "BatchEmailSenderApiKey7802AC02": {
       "Properties": {
         "Description": "Key required to call batch email sender API",
@@ -1613,6 +1737,46 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "BatchEmailSenderUsagePlan": {
+      "DependsOn": [
+        "BatchEmailSenderApi",
+        "BatchEmailSenderApiStage",
+      ],
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "BatchEmailSenderApi",
+            },
+            "Stage": {
+              "Ref": "BatchEmailSenderApiStage",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "UsagePlanName": {
+          "Fn::Sub": "batch-email-sender-api-usage-plan-\${Stage}",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlan",
     },
     "BatchEmailSenderUsagePlan01358D74": {
       "Properties": {

--- a/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
+++ b/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
@@ -194,7 +194,7 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       "Properties": {
         "Description": "Key required to call batch email sender API",
         "Enabled": true,
-        "Name": "batch-email-sender-api-key-CODE",
+        "Name": "batch-email-sender-api-key-CODE-CDK",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -343,7 +343,7 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
             "Stage": "CODE",
           },
         },
-        "FunctionName": "batch-email-sender-CODE",
+        "FunctionName": "batch-email-sender-CODE-CDK",
         "Handler": "com.gu.batchemailsender.api.batchemail.Handler::apply",
         "MemorySize": 1536,
         "Role": {
@@ -608,6 +608,22 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       "Type": "AWS::ApiGateway::UsagePlan",
     },
     "BatchEmailSenderUsagePlanKey": {
+      "DependsOn": [
+        "BatchEmailSenderApiKey",
+        "BatchEmailSenderUsagePlan",
+      ],
+      "Properties": {
+        "KeyId": {
+          "Ref": "BatchEmailSenderApiKey",
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "BatchEmailSenderUsagePlan",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+    },
+    "BatchEmailSenderUsagePlanKeyCDK": {
       "Properties": {
         "KeyId": {
           "Ref": "BatchEmailSenderApiKey7802AC02",
@@ -679,7 +695,7 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
-        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError (CDK)",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -750,7 +766,7 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
-        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash (CDK)",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -939,7 +955,7 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50320c7740981cb8798219e620f08263bf5": {
+    "RestApiDeployment180EC503338ce94a0fc5fd6309ea5dd02cab4176": {
       "DependsOn": [
         "RestApiemailbatchOPTIONS53263E0B",
         "RestApiemailbatchPOSTE3D979FC",
@@ -960,7 +976,7 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50320c7740981cb8798219e620f08263bf5",
+          "Ref": "RestApiDeployment180EC503338ce94a0fc5fd6309ea5dd02cab4176",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -1480,7 +1496,7 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
       "Properties": {
         "Description": "Key required to call batch email sender API",
         "Enabled": true,
-        "Name": "batch-email-sender-api-key-PROD",
+        "Name": "batch-email-sender-api-key-PROD-CDK",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1629,7 +1645,7 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
             "Stage": "PROD",
           },
         },
-        "FunctionName": "batch-email-sender-PROD",
+        "FunctionName": "batch-email-sender-PROD-CDK",
         "Handler": "com.gu.batchemailsender.api.batchemail.Handler::apply",
         "MemorySize": 1536,
         "Role": {
@@ -1894,6 +1910,22 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
       "Type": "AWS::ApiGateway::UsagePlan",
     },
     "BatchEmailSenderUsagePlanKey": {
+      "DependsOn": [
+        "BatchEmailSenderApiKey",
+        "BatchEmailSenderUsagePlan",
+      ],
+      "Properties": {
+        "KeyId": {
+          "Ref": "BatchEmailSenderApiKey",
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "BatchEmailSenderUsagePlan",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+    },
+    "BatchEmailSenderUsagePlanKeyCDK": {
       "Properties": {
         "KeyId": {
           "Ref": "BatchEmailSenderApiKey7802AC02",
@@ -1965,7 +1997,7 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
           },
         ],
         "AlarmDescription": "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
-        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError (CDK)",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -2036,7 +2068,7 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
           },
         ],
         "AlarmDescription": "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
-        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash",
+        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash (CDK)",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -2225,7 +2257,7 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50385e7143a774f2dcac01e1b70c06b0ece": {
+    "RestApiDeployment180EC50320c00c3abae4ea075e8b0fa9a0edb377": {
       "DependsOn": [
         "RestApiemailbatchOPTIONS53263E0B",
         "RestApiemailbatchPOSTE3D979FC",
@@ -2246,7 +2278,7 @@ exports[`The BatchEmailSender stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50385e7143a774f2dcac01e1b70c06b0ece",
+          "Ref": "RestApiDeployment180EC50320c00c3abae4ea075e8b0fa9a0edb377",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -29,7 +29,7 @@ export class BatchEmailSender extends GuStack {
         const batchEmailSenderLambda = new GuLambdaFunction(this, "BatchEmailSenderLambda", {
             app,
             handler: "com.gu.batchemailsender.api.batchemail.Handler::apply",
-            functionName: `batch-email-sender-${this.stage}`,
+            functionName: `batch-email-sender-${this.stage}-CDK`,
             runtime: Runtime.JAVA_11,
             fileName: "batch-email-sender.jar",
             memorySize: 1536,
@@ -72,12 +72,12 @@ export class BatchEmailSender extends GuStack {
         })
 
         const apiKey = new ApiKey(this, "BatchEmailSenderApiKey", {
-            apiKeyName: `batch-email-sender-api-key-${this.stage}`,
+            apiKeyName: `batch-email-sender-api-key-${this.stage}-CDK`,
             description: "Key required to call batch email sender API",
             enabled: true,
         })
 
-        new CfnUsagePlanKey(this, "BatchEmailSenderUsagePlanKey", {
+        new CfnUsagePlanKey(this, "BatchEmailSenderUsagePlanKey-CDK", {
             keyId: apiKey.keyId,
             keyType: "API_KEY",
             usagePlanId: usagePlan.usagePlanId,
@@ -87,7 +87,7 @@ export class BatchEmailSender extends GuStack {
         // ---- Alarms ---- //
         new GuAlarm(this, 'FailedEmailApiAlarm', {
             app,
-            alarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError",
+            alarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError (CDK)",
             alarmDescription: "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
             evaluationPeriods: 1,
             threshold: 1,
@@ -107,7 +107,7 @@ export class BatchEmailSender extends GuStack {
 
         new GuAlarm(this, 'FailedEmailLambdaAlarm', {
             app,
-            alarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash",
+            alarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash (CDK)",
             alarmDescription: "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
             evaluationPeriods: 1,
             threshold: 1,

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -4,7 +4,7 @@ import type { GuStackProps} from "@guardian/cdk/lib/constructs/core";
 import {GuStack} from "@guardian/cdk/lib/constructs/core";
 import {GuLambdaFunction} from "@guardian/cdk/lib/constructs/lambda";
 import type {App} from "aws-cdk-lib";
-import {Duration} from "aws-cdk-lib";
+import {Duration, Fn} from "aws-cdk-lib";
 import {ApiKey, CfnUsagePlanKey, Cors, UsagePlan} from "aws-cdk-lib/aws-apigateway";
 import {ComparisonOperator, Metric} from "aws-cdk-lib/aws-cloudwatch";
 import {Effect, Policy, PolicyStatement} from "aws-cdk-lib/aws-iam";
@@ -36,6 +36,7 @@ export class BatchEmailSender extends GuStack {
             timeout: Duration.seconds(300),
             environment: {
                 "Stage": this.stage,
+                "EmailQueueName": Fn.importValue(`comms-${this.stage}-EmailQueueName`)
             },
         });
 

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -1,6 +1,13 @@
+import {GuApiGatewayWithLambdaByPath} from "@guardian/cdk";
+import {GuAlarm} from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps} from "@guardian/cdk/lib/constructs/core";
 import {GuStack} from "@guardian/cdk/lib/constructs/core";
+import {GuLambdaFunction} from "@guardian/cdk/lib/constructs/lambda";
 import type {App} from "aws-cdk-lib";
+import {Duration} from "aws-cdk-lib";
+import {ApiKey, CfnUsagePlanKey, Cors, UsagePlan} from "aws-cdk-lib/aws-apigateway";
+import {ComparisonOperator, Metric} from "aws-cdk-lib/aws-cloudwatch";
+import {Runtime} from "aws-cdk-lib/aws-lambda";
 import {CfnInclude} from "aws-cdk-lib/cloudformation-include";
 
 export class BatchEmailSender extends GuStack {
@@ -10,5 +17,115 @@ export class BatchEmailSender extends GuStack {
         new CfnInclude(this, "YamlTemplate", {
             templateFile: yamlTemplateFilePath,
         });
+
+
+        // ---- Miscellaneous constants ---- //
+        const isProd = this.stage === 'PROD';
+        const app = "batch-email-sender";
+
+
+        // ---- API-triggered lambda functions ---- //
+        const batchEmailSenderLambda = new GuLambdaFunction(this, "BatchEmailSenderLambda", {
+            app,
+            handler: "com.gu.batchemailsender.api.batchemail.Handler::apply",
+            functionName: `batch-email-sender-${this.stage}`,
+            runtime: Runtime.JAVA_11,
+            fileName: "batch-email-sender.jar",
+            memorySize: 1536,
+            timeout: Duration.seconds(300),
+            environment: {
+                "Stage": this.stage,
+            },
+        });
+
+
+        // ---- API gateway ---- //
+        const batchEmailSenderApi = new GuApiGatewayWithLambdaByPath(this, {
+            app,
+            defaultCorsPreflightOptions: {
+                allowOrigins: Cors.ALL_ORIGINS,
+                allowMethods: Cors.ALL_METHODS,
+                allowHeaders: ["Content-Type"],
+            },
+            monitoringConfiguration: { noMonitoring: true },
+            targets: [
+                {
+                    path: "/email-batch",
+                    httpMethod: "POST",
+                    lambda: batchEmailSenderLambda,
+                    apiKeyRequired: true,
+                },
+            ],
+        })
+
+
+        // ---- Usage plan and API key ---- //
+        const usagePlan = new UsagePlan(this, "BatchEmailSenderUsagePlan", {
+            name: `batch-email-sender-api-usage-plan-${this.stage}`,
+            apiStages: [
+                {
+                    api: batchEmailSenderApi.api,
+                    stage: batchEmailSenderApi.api.deploymentStage
+                }
+            ]
+        })
+
+        const apiKey = new ApiKey(this, "BatchEmailSenderApiKey", {
+            apiKeyName: `batch-email-sender-api-key-${this.stage}`,
+            description: "Key required to call batch email sender API",
+            enabled: true,
+        })
+
+        new CfnUsagePlanKey(this, "BatchEmailSenderUsagePlanKey", {
+            keyId: apiKey.keyId,
+            keyType: "API_KEY",
+            usagePlanId: usagePlan.usagePlanId,
+        })
+
+
+        // ---- Alarms ---- //
+        new GuAlarm(this, 'FailedEmailApiAlarm', {
+            app,
+            alarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError",
+            alarmDescription: "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+            evaluationPeriods: 1,
+            threshold: 1,
+            actionsEnabled: isProd,
+            snsTopicName: "retention-dev",
+            comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            metric: new Metric({
+                metricName: "5XXError",
+                namespace: "AWS/ApiGateway",
+                statistic: "Sum",
+                period: Duration.seconds(60),
+                dimensionsMap: {
+                    ApiName: `BatchEmailSender-${this.stage}`,
+                }
+            }),
+        });
+
+        new GuAlarm(this, 'FailedEmailLambdaAlarm', {
+            app,
+            alarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash",
+            alarmDescription: "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+            evaluationPeriods: 1,
+            threshold: 1,
+            actionsEnabled: isProd,
+            snsTopicName: "retention-dev",
+            comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            metric: new Metric({
+                metricName: "Errors",
+                namespace: "AWS/Lambda",
+                statistic: "Sum",
+                period: Duration.seconds(300),
+                dimensionsMap: {
+                    FunctionName: batchEmailSenderLambda.functionName,
+                }
+            }),
+        });
+
+
+        // ---- Apply policies ---- //
+        // TODO
     }
 }

--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -175,36 +175,36 @@ Resources:
     DependsOn:
       - BatchEmailMethod
 
-  BatchEmailSenderApiKey:
-    Type: AWS::ApiGateway::ApiKey
-    Properties:
-      Description: Key required to call batch email sender API
-      Enabled: true
-      Name: !Sub batch-email-sender-api-key-${Stage}
-      StageKeys:
-        - RestApiId: !Ref BatchEmailSenderApi
-          StageName: !Sub ${Stage}
-    DependsOn:
-    - BatchEmailSenderApi
-    - BatchEmailSenderApiStage
-
-  BatchEmailSenderUsagePlan:
-    Type: "AWS::ApiGateway::UsagePlan"
-    Properties:
-      UsagePlanName: !Sub batch-email-sender-api-usage-plan-${Stage}
-      ApiStages:
-      - ApiId: !Ref BatchEmailSenderApi
-        Stage: !Ref BatchEmailSenderApiStage
-    DependsOn:
-    - BatchEmailSenderApi
-    - BatchEmailSenderApiStage
-
-  BatchEmailSenderUsagePlanKey:
-    Type: "AWS::ApiGateway::UsagePlanKey"
-    Properties:
-      KeyId: !Ref BatchEmailSenderApiKey
-      KeyType: API_KEY
-      UsagePlanId: !Ref BatchEmailSenderUsagePlan
-    DependsOn:
-    - BatchEmailSenderApiKey
-    - BatchEmailSenderUsagePlan
+#  BatchEmailSenderApiKey:
+#    Type: AWS::ApiGateway::ApiKey
+#    Properties:
+#      Description: Key required to call batch email sender API
+#      Enabled: true
+#      Name: !Sub batch-email-sender-api-key-${Stage}
+#      StageKeys:
+#        - RestApiId: !Ref BatchEmailSenderApi
+#          StageName: !Sub ${Stage}
+#    DependsOn:
+#    - BatchEmailSenderApi
+#    - BatchEmailSenderApiStage
+#
+#  BatchEmailSenderUsagePlan:
+#    Type: "AWS::ApiGateway::UsagePlan"
+#    Properties:
+#      UsagePlanName: !Sub batch-email-sender-api-usage-plan-${Stage}
+#      ApiStages:
+#      - ApiId: !Ref BatchEmailSenderApi
+#        Stage: !Ref BatchEmailSenderApiStage
+#    DependsOn:
+#    - BatchEmailSenderApi
+#    - BatchEmailSenderApiStage
+#
+#  BatchEmailSenderUsagePlanKey:
+#    Type: "AWS::ApiGateway::UsagePlanKey"
+#    Properties:
+#      KeyId: !Ref BatchEmailSenderApiKey
+#      KeyType: API_KEY
+#      UsagePlanId: !Ref BatchEmailSenderUsagePlan
+#    DependsOn:
+#    - BatchEmailSenderApiKey
+#    - BatchEmailSenderUsagePlan

--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -199,12 +199,12 @@ Resources:
     - BatchEmailSenderApi
     - BatchEmailSenderApiStage
 
-#  BatchEmailSenderUsagePlanKey:
-#    Type: "AWS::ApiGateway::UsagePlanKey"
-#    Properties:
-#      KeyId: !Ref BatchEmailSenderApiKey
-#      KeyType: API_KEY
-#      UsagePlanId: !Ref BatchEmailSenderUsagePlan
-#    DependsOn:
-#    - BatchEmailSenderApiKey
-#    - BatchEmailSenderUsagePlan
+  BatchEmailSenderUsagePlanKey:
+    Type: "AWS::ApiGateway::UsagePlanKey"
+    Properties:
+      KeyId: !Ref BatchEmailSenderApiKey
+      KeyType: API_KEY
+      UsagePlanId: !Ref BatchEmailSenderUsagePlan
+    DependsOn:
+    - BatchEmailSenderApiKey
+    - BatchEmailSenderUsagePlan

--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -175,30 +175,30 @@ Resources:
     DependsOn:
       - BatchEmailMethod
 
-#  BatchEmailSenderApiKey:
-#    Type: AWS::ApiGateway::ApiKey
-#    Properties:
-#      Description: Key required to call batch email sender API
-#      Enabled: true
-#      Name: !Sub batch-email-sender-api-key-${Stage}
-#      StageKeys:
-#        - RestApiId: !Ref BatchEmailSenderApi
-#          StageName: !Sub ${Stage}
-#    DependsOn:
-#    - BatchEmailSenderApi
-#    - BatchEmailSenderApiStage
-#
-#  BatchEmailSenderUsagePlan:
-#    Type: "AWS::ApiGateway::UsagePlan"
-#    Properties:
-#      UsagePlanName: !Sub batch-email-sender-api-usage-plan-${Stage}
-#      ApiStages:
-#      - ApiId: !Ref BatchEmailSenderApi
-#        Stage: !Ref BatchEmailSenderApiStage
-#    DependsOn:
-#    - BatchEmailSenderApi
-#    - BatchEmailSenderApiStage
-#
+  BatchEmailSenderApiKey:
+    Type: AWS::ApiGateway::ApiKey
+    Properties:
+      Description: Key required to call batch email sender API
+      Enabled: true
+      Name: !Sub batch-email-sender-api-key-${Stage}
+      StageKeys:
+        - RestApiId: !Ref BatchEmailSenderApi
+          StageName: !Sub ${Stage}
+    DependsOn:
+    - BatchEmailSenderApi
+    - BatchEmailSenderApiStage
+
+  BatchEmailSenderUsagePlan:
+    Type: "AWS::ApiGateway::UsagePlan"
+    Properties:
+      UsagePlanName: !Sub batch-email-sender-api-usage-plan-${Stage}
+      ApiStages:
+      - ApiId: !Ref BatchEmailSenderApi
+        Stage: !Ref BatchEmailSenderApiStage
+    DependsOn:
+    - BatchEmailSenderApi
+    - BatchEmailSenderApiStage
+
 #  BatchEmailSenderUsagePlanKey:
 #    Type: "AWS::ApiGateway::UsagePlanKey"
 #    Properties:


### PR DESCRIPTION
This PR uses the GuCDK to define a duplicate stack of resources, alongside the current YAML template defined ones. This is a non-destructive process and has been tested manually in `CODE` ahead of merging.

Related PRs:
- [Step 1](https://github.com/guardian/support-service-lambdas/pull/2077)