### PR TITLE
call paperround during acquisition to get email data

### DIFF
--- a/handlers/cancellation-sf-cases-api/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases-api/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -60,7 +60,7 @@ object Handler extends Logging {
   ): ApiGatewayOp[Operation] = {
 
     for {
-      sfConfig <- LoadConfigModule(stage, fetchString)(SFAuthConfig.location, sfAuthConfigReads).toApiGatewayOp(
+      sfConfig <- LoadConfigModule(stage, fetchString).load(SFAuthConfig.location, sfAuthConfigReads).toApiGatewayOp(
         "load SF config",
       )
       sfClient <- SalesforceClient(response, sfConfig).value.toApiGatewayOp("Failed to authenticate with Salesforce")

--- a/handlers/cancellation-sf-cases-api/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases-api/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -44,7 +44,7 @@ class EndToEndHandlerEffectsTest extends AnyFlatSpec with Matchers {
 
     // fetch the case to ensure the 'Description' field has been updated
     val caseDescription = for {
-      sfConfig <- LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)(SFAuthConfig.location, sfAuthConfigReads)
+      sfConfig <- LoadConfigModule(RawEffects.stage, GetFromS3.fetchString).load(SFAuthConfig.location, sfAuthConfigReads)
       sfClient <- SalesforceClient(RawEffects.response, sfConfig).value.toDisjunction
       getCaseOp = SalesforceCase.GetById[JsValue](sfClient.wrapWith(JsonHttp.get))
       caseResponse <- getCaseOp(CaseId(firstRaiseCaseResponse.id.value)).toDisjunction

--- a/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
+++ b/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
@@ -33,7 +33,7 @@ object Handler extends Logging {
       s3Write: (PutObjectRequest, RequestBody) => Try[PutObjectResponse],
   ): Unit = {
     val attempt = for {
-      zuoraRestConfig <- LoadConfigModule(zuoraEnvironment.stageToLoad, fetchString)[ZuoraRestConfig].left.map(_.error)
+      zuoraRestConfig <- LoadConfigModule(zuoraEnvironment.stageToLoad, fetchString).load[ZuoraRestConfig].left.map(_.error)
       zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)
       fetchCatalogAttempt <- ZuoraReadCatalog(zuoraRequests).toDisjunction.left.map(_.message)
       _ <- S3UploadCatalog(stage, zuoraEnvironment, fetchCatalogAttempt, s3Write)

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -38,13 +38,13 @@ object DeliveryCreditProcessor extends Logging {
   private lazy val sfConfig: Task[SFAuthConfig] =
     config(
       LoadConfigModule(stage, GetFromS3.fetchString)
-        .apply[SFAuthConfig](ConfigLocation("sfAuth", 1), SFAuthConfig.reads),
+        .load[SFAuthConfig](ConfigLocation("sfAuth", 1), SFAuthConfig.reads),
     )
 
   private lazy val zuoraConfig: Task[HolidayStopProcessorZuoraConfig] =
     config(
       LoadConfigModule(stage, GetFromS3.fetchString)
-        .apply[HolidayStopProcessorZuoraConfig](ConfigLocation("zuoraRest", 1), HolidayStopProcessorZuoraConfig.reads),
+        .load[HolidayStopProcessorZuoraConfig](ConfigLocation("zuoraRest", 1), HolidayStopProcessorZuoraConfig.reads),
     )
 
   private def config[A](a: Either[ConfigFailure, A]): Task[A] = {

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -76,7 +76,7 @@ object Handler extends RequestStreamHandler {
     val downloadResponse = RawEffects.downloadResponse
     val stage = RawEffects.stage
     val maybeSuccess = for {
-      zuoraRestConfig <- loadConfig[ZuoraRestConfig]
+      zuoraRestConfig <- loadConfig.load[ZuoraRestConfig]
       requests = ZuoraRestRequestMaker(response, zuoraRestConfig)
       cancelSub = CancelSub(log, requests)
       cancelAccount = CancelAccount(log, requests)

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -47,8 +47,8 @@ object Handler extends Logging {
   ): ApiGatewayOp[ApiGatewayHandler.Operation] = {
     val loadConfig = LoadConfigModule(stage, fetchString)
     for {
-      zuoraRestConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-      emergencyTokensConfig <- loadConfig[EmergencyTokensConfig].toApiGatewayOp("load emergency tokens config")
+      zuoraRestConfig <- loadConfig.load[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+      emergencyTokensConfig <- loadConfig.load[EmergencyTokensConfig].toApiGatewayOp("load emergency tokens config")
     } yield {
       val emergencyTokens = EmergencyTokens(emergencyTokensConfig)
       val zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetAccountSummaryEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetAccountSummaryEffectsTest.scala
@@ -16,7 +16,7 @@ class GetAccountSummaryEffectsTest extends AnyFlatSpec with Matchers {
     val testAccountId = AccountId("2c92c0f86078c4d4016079e1402d6536")
 
     val actual: ApiGatewayOp[AccountSummaryResult] = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
         .toApiGatewayOp("parse config")
 
       zuoraRequests = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionEffectsTest.scala
@@ -22,7 +22,7 @@ import org.scalatest.matchers.should.Matchers
 class GetSubscriptionEffectsTest extends AnyFlatSpec with Matchers {
 
   private def actual(testSubscriptionId: SubscriptionId): ApiGatewayOp[SubscriptionResult] = for {
-    zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+    zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       .toApiGatewayOp("couldn't load config")
     zuoraRequests = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
     subscription <- GetSubscription(zuoraRequests)(testSubscriptionId)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -120,9 +120,9 @@ object Handler {
 
     val loadConfig = LoadConfigModule(stage, fetchString)
     val fOperation = for {
-      zuoraRestConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-      sfAuthConfig <- loadConfig[SFAuthConfig].toApiGatewayOp("load sfAuth config")
-      identityConfig <- loadConfig[IdentityConfig].toApiGatewayOp("load identity config")
+      zuoraRestConfig <- loadConfig.load[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+      sfAuthConfig <- loadConfig.load[SFAuthConfig].toApiGatewayOp("load sfAuth config")
+      identityConfig <- loadConfig.load[IdentityConfig].toApiGatewayOp("load identity config")
       configuredOp = operation(zuoraRestConfig, sfAuthConfig, identityConfig)
 
     } yield configuredOp

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/CreateGuestAccountEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/CreateGuestAccountEffectsTest.scala
@@ -22,7 +22,7 @@ class CreateGuestAccountEffectsTest extends AnyFlatSpec with Matchers {
     val testContact = EmailAddress(s"sx.CreateGuestAccountEffectsTest+$unique@gu.com")
 
     val actual = for {
-      identityConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[IdentityConfig]
+      identityConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[IdentityConfig]
       response = RawEffects.response
       identityClient = IdentityClient(response, identityConfig)
       createGuestAccount = identityClient.wrapWith(JsonHttp.post).wrapWith(CreateGuestAccount.wrapper)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
@@ -16,7 +16,7 @@ class GetByEmailEffectsTest extends AnyFlatSpec with Matchers {
   it should "successfully run the health check using the local code against real backend" taggedAs EffectsTest in {
 
     val actual = for {
-      identityConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[IdentityConfig]
+      identityConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[IdentityConfig]
 
       response = RawEffects.response
       identityClient = IdentityClient(response, identityConfig)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByIdentityIdEffectsTest.scala
@@ -15,7 +15,7 @@ class GetByIdentityIdEffectsTest extends AnyFlatSpec with Matchers {
   it should "successfully run the health check using the local code against real backend" taggedAs EffectsTest in {
 
     val actual = for {
-      identityConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[IdentityConfig]
+      identityConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[IdentityConfig]
 
       response = RawEffects.response
       identityClient = IdentityClient(response, identityConfig)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsEffectsTest.scala
@@ -18,7 +18,7 @@ class GetSFContactSyncCheckFieldsEffectsTest extends AnyFlatSpec with Matchers {
   it should "get auth SF correctly" taggedAs EffectsTest in {
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       sfAuth <- SalesforceClient(RawEffects.response, sfConfig).value.toDisjunction
       getOp = sfAuth.wrapWith(JsonHttp.get)
       result <- GetSFContactSyncCheckFields(getOp)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -23,7 +23,7 @@ class UpdateSalesforceIdentityIdEffectsTest extends AnyFlatSpec with Matchers {
     val testContact = SFEffectsData.updateIdentityIdEmailAndFirstNameContact
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       auth <- SalesforceClient(response, sfConfig).value.toDisjunction
       updateSalesforceIdentityId = UpdateSalesforceIdentityId(auth.wrapWith(JsonHttp.patch))

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/AddIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/AddIdentityIdEffectsTest.scala
@@ -23,7 +23,7 @@ class AddIdentityIdEffectsTest extends AnyFlatSpec with Matchers {
     val testAccount = Types.AccountId("2c92c0f9624bbc5f016253e573970b16")
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
         .toApiGatewayOp("load config")
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       _ <- AddIdentityIdToAccount(zuoraDeps)(testAccount, IdentityId(unique)).toApiGatewayOp("AddIdentityIdToAccount")

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/Handler.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/Handler.scala
@@ -34,7 +34,7 @@ object Handler {
       fetchString: StringFromS3,
   ): ApiGatewayOp[Operation] = {
     val loadConfig = LoadConfigModule(stage, fetchString)
-    loadConfig[BigQueryConfig].toApiGatewayOp("load bigquery config").map { bigQueryConfig =>
+    loadConfig.load[BigQueryConfig].toApiGatewayOp("load bigquery config").map { bigQueryConfig =>
       val bigQueryHelper = BigQueryHelper(bigQueryConfig)
       IdentityRetentionSteps(bigQueryHelper)
     }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.sqs.AwsSQSSend.{EmailQueueName, QueueName}
 import com.gu.effects.sqs.{AwsSQSSend, SqsAsync}
 import com.gu.effects.{GetFromS3, RawEffects}
+import com.gu.paperround.client.PaperRoundConfig.ApiKey
 import com.gu.newproduct.api.addsubscription.TypeConvert._
 import com.gu.newproduct.api.addsubscription.email.digipack.DigipackAddressValidator
 import com.gu.newproduct.api.addsubscription.validation._
@@ -15,16 +16,18 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAcc
 import com.gu.newproduct.api.addsubscription.zuora._
 import com.gu.newproduct.api.productcatalog.PlanId.{GuardianWeeklyDomestic6for6, GuardianWeeklyDomesticQuarterly, GuardianWeeklyROW6for6, GuardianWeeklyROWQuarterly}
 import com.gu.newproduct.api.productcatalog._
+import com.gu.paperround.client.{GetAgents, PaperRoundConfig, PaperRoundRestRequestMaker}
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.config.LoadConfigModule.StringFromS3
-import com.gu.util.config.{LoadConfigModule, Stage, ZuoraEnvironment}
+import com.gu.util.config.{ConfigLocation, LoadConfigModule, Stage, ZuoraEnvironment}
 import com.gu.util.reader.AsyncTypes._
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
 import okhttp3.{Request, Response}
+import play.api.libs.json.{Json, Reads}
 
 import java.io.{InputStream, OutputStream}
 import java.time.LocalDateTime
@@ -85,12 +88,14 @@ object Steps {
   ): ApiGatewayOp[Operation] =
     for {
       zuoraIds <- ZuoraIds.zuoraIdsForStage(stage).toApiGatewayOp(ApiGatewayResponse.internalServerError _)
-      zuoraConfig <- {
-        val loadConfig = LoadConfigModule(stage, fetchString)
-        loadConfig[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-      }
+      loadConfig = LoadConfigModule(stage, fetchString)
+      zuoraConfig <- loadConfig.load[ZuoraRestConfig].toApiGatewayOp("load zuora config")
       zuoraClient = ZuoraRestRequestMaker(response, zuoraConfig)
       currentDate = () => currentDatetime().toLocalDate
+
+      paperRoundConfig <- loadConfig.load[PaperRoundConfig].toApiGatewayOp("load zuora config")
+      paperRoundClient = PaperRoundRestRequestMaker(response, paperRoundConfig)
+      getAgents = GetAgents(paperRoundClient)
 
       validatorFor = DateValidator.validatorFor(currentDate, _: DateRule)
       zuoraEnv = ZuoraEnvironment.EnvForStage(stage)
@@ -139,6 +144,7 @@ object Steps {
         createSubscription,
         awsSQSSend,
         EmailQueueName,
+        getAgents,
       )
 
       digipackSteps = AddDigipackSub.wireSteps(

--- a/handlers/new-product-api/src/main/scala/com/gu/paperround/client/FormRequestMaker.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/paperround/client/FormRequestMaker.scala
@@ -1,0 +1,40 @@
+package com.gu.paperround.client
+
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
+import com.typesafe.scalalogging.LazyLogging
+import okhttp3.{FormBody, Request, Response}
+import play.api.libs.json.{Json, Reads}
+
+class FormRequestMaker(getResponse: Request => Response, headers: Map[String, String], baseUrl: String)
+    extends LazyLogging {
+
+  private val formType = "application/x-www-form-urlencoded"
+
+  def post[RESP: Reads](formdata: Map[String, String], path: String): ClientFailableOp[RESP] = {
+    val requestBody = formdata
+      .foldLeft(new FormBody.Builder())({ case (builder, (key, value)) =>
+        builder.add(key, value)
+      })
+      .build()
+    val request = headers
+      .foldLeft(new Request.Builder())({ case (builder, (header, value)) =>
+        builder.addHeader(header, value)
+      })
+      .url(baseUrl + path)
+      .addHeader("Content-type", formType)
+      .addHeader("Accept", "application/json")
+      .post(requestBody)
+      .build()
+    val response = getResponse(request)
+    val code = response.code()
+    val responseBody = response.body().string()
+    logger.info("response body: " + responseBody)
+    (code / 100) match {
+      case 2 => ClientSuccess(Json.parse(responseBody).as[RESP])
+      case _ =>
+        logger.warn(s"request failed with status $code: $responseBody")
+        GenericError("failed to successfully call out to API")
+    }
+  }
+
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/paperround/client/GetAgents.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/paperround/client/GetAgents.scala
@@ -1,0 +1,85 @@
+package com.gu.paperround.client
+
+import com.gu.newproduct.api.addsubscription.DeliveryAgent
+import com.gu.paperround.client.GetAgents.DeliveryAgentRecord
+import com.gu.util.resthttp.Types.ClientFailableOp
+import play.api.libs.json.{Json, Reads}
+
+trait GetAgents {
+
+  def getAgents(): ClientFailableOp[List[DeliveryAgentRecord]]
+  
+}
+class GetAgentsImpl(formRequestMaker: FormRequestMaker) extends GetAgents {
+
+  import GetAgents._
+
+  def getAgents(): ClientFailableOp[List[DeliveryAgentRecord]] =
+    for {
+      wireResponse <- formRequestMaker.post[WireResponse](Map(), "/agents")
+    } yield
+      wireResponse.data.agents.map { agent =>
+        import agent._
+        DeliveryAgentRecord(
+          DeliveryAgent(refid.toString),
+          agentname,
+          telephone,
+          town,
+          postcode,
+          address2,
+          email,
+          address1,
+          county
+        )
+      }
+
+}
+
+object GetAgents {
+
+  def apply(formRequestMaker: FormRequestMaker): GetAgents = new GetAgentsImpl(formRequestMaker)
+
+  private[client] implicit val agentReads: Reads[WireResponseAgent] = Json.reads
+
+  private[client] case class WireResponseAgent(
+    telephone: String,
+    town: String,
+    postcode: String,
+    address2: String,
+    email: String,
+//    enddate: LocalDate,//": "2100-01-01",
+//    startdate: LocalDate,//": "2022-01-01",
+    address1: String,
+    agentname: String,
+    refid: Int,
+    county: String,
+//    refgroupid: Int,
+  )
+
+  private[client] implicit val responseDataReads: Reads[WireResponseData] = Json.reads
+
+  private[client] case class WireResponseData(
+      agents: List[WireResponseAgent],
+  )
+
+  private[client] implicit val responseReads: Reads[WireResponse] = Json.reads
+
+  private[client] case class WireResponse(
+      //    status_code: Int,
+      data: WireResponseData,
+      //    message: String,
+  )
+
+  case class DeliveryAgentRecord(
+    deliveryAgent: DeliveryAgent,
+    agentName: String,
+    telephone: String,
+    town: String,
+    postcode: String,
+    address2: String,
+    email: String,
+    address1: String,
+    county: String,
+  )
+
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/paperround/client/GetCoverage.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/paperround/client/GetCoverage.scala
@@ -1,0 +1,52 @@
+package com.gu.paperround.client
+
+import com.gu.newproduct.api.addsubscription.DeliveryAgent
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
+import play.api.libs.json.{Json, Reads}
+
+class GetCoverage(formRequestMaker: FormRequestMaker) {
+
+  import GetCoverage._
+
+  def getCoverage(postcode: String): ClientFailableOp[List[DeliveryAgent]] =
+    for {
+      wireResponse <- formRequestMaker.post[WireResponse](Map("postcode" -> postcode), "/coverage")
+      _ <- if (List("CO", "NC").contains(wireResponse.data.status)) ClientSuccess(()) else GenericError("invalid status")
+    } yield
+      wireResponse.data.agents.map { agent =>
+        DeliveryAgent(agent.agentid.toString)
+      }
+
+}
+
+object GetCoverage {
+
+  private implicit val agentReads: Reads[WireResponseAgent] = Json.reads
+
+  private case class WireResponseAgent(
+//    deliverymethod: String,
+//    postcode: String,
+      agentid: Int,
+//    nbrdeliverydays: Int,
+//    summary: String,
+//    agentname: String,
+//    refgroupid: Int,
+  )
+
+  private implicit val responseDataReads: Reads[WireResponseData] = Json.reads
+
+  private case class WireResponseData(
+      //    message: String,
+      status: String,
+      agents: List[WireResponseAgent],
+  )
+
+  private implicit val responseReads: Reads[WireResponse] = Json.reads
+
+  private case class WireResponse(
+      //    status_code: Int,
+      data: WireResponseData,
+      //    message: String,
+  )
+
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/paperround/client/PaperRoundConfig.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/paperround/client/PaperRoundConfig.scala
@@ -1,0 +1,22 @@
+package com.gu.paperround.client
+
+import com.gu.paperround.client.PaperRoundConfig.ApiKey
+import com.gu.util.config.ConfigLocation
+import play.api.libs.json.{Json, Reads}
+
+case class PaperRoundConfig(
+  apiKey: ApiKey,
+  url: String,
+)
+
+object PaperRoundConfig {
+
+  implicit val apiKeyReads: Reads[ApiKey] = implicitly[Reads[String]].map(ApiKey.apply)
+
+  case class ApiKey(value: String) extends AnyVal
+
+  implicit val configReads: Reads[PaperRoundConfig] = Json.reads
+  implicit val location: ConfigLocation[PaperRoundConfig] =
+    ConfigLocation[PaperRoundConfig](path = "paperround", version = 1)
+
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/paperround/client/PaperRoundRestRequestMaker.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/paperround/client/PaperRoundRestRequestMaker.scala
@@ -1,0 +1,15 @@
+package com.gu.paperround.client
+
+import com.typesafe.scalalogging.LazyLogging
+import okhttp3.{Request, Response}
+
+object PaperRoundRestRequestMaker extends LazyLogging {
+
+  def apply(response: Request => Response, config: PaperRoundConfig): FormRequestMaker =
+    new FormRequestMaker(
+      headers = Map("x-api-key" -> config.apiKey.value),
+      baseUrl = config.url,
+      getResponse = response,
+    )
+
+}

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/HealthCheckEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/HealthCheckEffectsTest.scala
@@ -16,7 +16,7 @@ class HealthCheckEffectsTest extends AnyFlatSpec with Matchers {
 
     val stage = Stage("CODE")
     val actual = (for {
-      zuoraConfig <- LoadConfigModule(stage, GetFromS3.fetchString)[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+      zuoraConfig <- LoadConfigModule(stage, GetFromS3.fetchString).load[ZuoraRestConfig].toApiGatewayOp("load zuora config")
       zuoraClient = ZuoraRestRequestMaker(Http.response, zuoraConfig)
       getAccount = GetAccount(zuoraClient.get[ZuoraAccount]) _
     } yield HealthCheck(getAccount, AccountIdentitys.accountIdentitys(stage))).apiResponse

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
@@ -4,23 +4,20 @@ import com.gu.newproduct.TestData
 import com.gu.newproduct.api.addsubscription.email.PaperEmailData
 import com.gu.newproduct.api.addsubscription.validation._
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
-  SubscriptionName,
-  ZuoraCreateSubRequest,
-  ZuoraCreateSubRequestRatePlan,
-}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{SubscriptionName, ZuoraCreateSubRequest, ZuoraCreateSubRequestRatePlan}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.SoldToAddress
 import com.gu.newproduct.api.productcatalog.PlanId.VoucherEveryDay
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
 import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
 import com.gu.newproduct.api.productcatalog.{Plan, PlanDescription, PlanId}
+import com.gu.paperround.client.GetAgents
 import com.gu.test.JsonMatchers.JsonMatcher
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.reader.AsyncTypes._
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import com.gu.util.resthttp.Types
-import com.gu.util.resthttp.Types.ClientSuccess
+import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
@@ -81,6 +78,10 @@ class PaperStepsTest extends AnyFlatSpec with Matchers {
       ClientSuccess(SubscriptionName("well done"))
     }
 
+    def fakeGetAgents = new GetAgents {
+      override def getAgents(): Types.ClientFailableOp[List[GetAgents.DeliveryAgentRecord]] = GenericError("oops")
+    }
+
     val fakeGetZuoraId = (planId: PlanId) => {
       planId shouldBe VoucherEveryDay
       Some(ratePlanId)
@@ -101,6 +102,7 @@ class PaperStepsTest extends AnyFlatSpec with Matchers {
       fakeValidateAddress,
       fakeCreate,
       fakeSendEmail,
+      fakeGetAgents,
     )
 
     val futureActual = new handleRequest(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -45,7 +45,7 @@ class CreateSubscriptionEffectsTest extends AnyFlatSpec with Matchers {
       ),
     )
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       post: RequestsPost[WireCreateRequest, WireSubscription] = zuoraDeps.post[WireCreateRequest, WireSubscription]
       res <- CreateSubscription(post, currentDate)(request).toDisjunction

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountEffectsTest.scala
@@ -15,7 +15,7 @@ class GetAccountEffectsTest extends AnyFlatSpec with Matchers {
 
   it should "get account from Zuora" taggedAs EffectsTest in {
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       res <- GetAccount(zuoraDeps.get[ZuoraAccount])(ZuoraAccountId("8ad095dd82f7aaa50182f96de24d3ddb")).toDisjunction
     } yield res

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountSubscriptionsEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountSubscriptionsEffectsTest.scala
@@ -15,7 +15,7 @@ class GetAccountSubscriptionsEffectsTest extends AnyFlatSpec with Matchers {
 
   it should "get payment details" taggedAs EffectsTest in {
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       res <- GetAccountSubscriptions(zuoraDeps.get[ZuoraSubscriptionsResponse])(
         ZuoraAccountId("8ad095b882f7aaa60182f9c2a69a043a"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetContactsEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetContactsEffectsTest.scala
@@ -15,7 +15,7 @@ class GetContactsEffectsTest extends AnyFlatSpec with Matchers {
 
   it should "get contacts for account from Zuora" taggedAs EffectsTest in {
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       res <- GetContacts(zuoraDeps.get[GetContactsResponse])(
         ZuoraAccountId("8ad095dd830721b201830e51862b425b"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethodEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethodEffectsTest.scala
@@ -15,7 +15,7 @@ class GetPaymentMethodEffectsTest extends AnyFlatSpec with Matchers {
 
   it should "get payment details" taggedAs EffectsTest in {
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       res <- GetPaymentMethod(zuoraDeps.get[PaymentMethodWire])(
         PaymentMethodId("8ad095dd82f7aaa50182f96de2883de1"),

--- a/handlers/new-product-api/src/test/scala/com/gu/paperround/client/PaperRoundClientTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/paperround/client/PaperRoundClientTest.scala
@@ -1,0 +1,31 @@
+package com.gu.paperround.client
+
+import com.gu.effects.{GetFromS3, Http, RawEffects}
+import com.gu.test.EffectsTest
+import com.gu.util.config.LoadConfigModule
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PaperRoundClientTest extends AnyFlatSpec with Matchers {
+
+  val client = for {
+    config <- LoadConfigModule(RawEffects.stage, GetFromS3.fetchString).load[PaperRoundConfig]
+  } yield PaperRoundRestRequestMaker(Http.response, config)
+
+  "paperround client" should "get coverage successfully in sandbox" taggedAs EffectsTest in {
+    val actual = for {
+      client <- client
+      coverage <- GetAgents(client).getAgents().toDisjunction
+    } yield coverage
+    println("actual: " + actual)
+  }
+
+  it should "get all agents successfully in sandbox" taggedAs EffectsTest in {
+    val actual = for {
+      client <- client
+      coverage <- GetAgents(client).getAgents().toDisjunction
+    } yield coverage
+    println("actual: " + actual)
+  }
+
+}

--- a/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/Handler.scala
+++ b/handlers/revenue-recogniser-job/src/main/scala/com/gu/recogniser/Handler.scala
@@ -29,7 +29,7 @@ object Handler extends RequestStreamHandler {
 
     val loadConfig = LoadConfigModule(stage, GetFromS3.fetchString)
     val maybeSuccess = for {
-      zuoraRestConfig <- loadConfig[ZuoraRestConfig]
+      zuoraRestConfig <- loadConfig.load[ZuoraRestConfig]
       steps = Steps(
         log,
         error(stage, _),

--- a/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/GetSubscriptionEffectsTest.scala
+++ b/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/GetSubscriptionEffectsTest.scala
@@ -15,7 +15,7 @@ class GetSubscriptionEffectsTest extends AnyFlatSpec with Matchers {
   it should "get a subscription that hasn't been redeemed" taggedAs EffectsTest in {
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       subscription <- GetSubscription(zuoraDeps)
         .execute("A-S00102333")
@@ -31,7 +31,7 @@ class GetSubscriptionEffectsTest extends AnyFlatSpec with Matchers {
   it should "get a subscription that's been redeemed" taggedAs EffectsTest in {
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       subscription <- GetSubscription(zuoraDeps)
         .execute("A-S00102334")

--- a/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/HandlerManualTest.scala
+++ b/handlers/revenue-recogniser-job/src/test/scala/com/gu/recogniser/HandlerManualTest.scala
@@ -23,7 +23,7 @@ object CreateExpiredGiftTestSubscriptionManualTest {
     val startDate = LocalDate.of(2020, 2, 9)
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       subNumber <- ZuoraGiftSubscribe
         .subscribe(zuoraDeps, startDate)
@@ -44,7 +44,7 @@ object CreateRefundedBeforeRedemptionTestSubscriptionManualTest {
     val startDate = LocalDate.now().minusWeeks(2) // arbitrary recent but not expired
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       subNumber <- ZuoraGiftSubscribe
         .subscribe(zuoraDeps, startDate)
@@ -63,7 +63,7 @@ object RunQueryManualTest {
   def main(args: Array[String]): Unit = {
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       downloadRequests = ZuoraAquaRequestMaker(RawEffects.downloadResponse, zuoraRestConfig)
       aquaQuerier = Querier.lowLevel(downloadRequests) _
       schedules <- new RevenueSchedulesQuerier(
@@ -83,7 +83,7 @@ object RunQueryAndPartitionManualTest {
   def main(args: Array[String]): Unit = {
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("PROD"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("PROD"), GetFromS3.fetchString).load[ZuoraRestConfig]
       downloadRequests = ZuoraAquaRequestMaker(RawEffects.downloadResponse, zuoraRestConfig)
       aquaQuerier = Querier.lowLevel(downloadRequests) _
       schedules <- new RevenueSchedulesQuerier(
@@ -104,7 +104,7 @@ object RunLambdaManualTest {
   def main(args: Array[String]): Unit = {
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("PROD"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("PROD"), GetFromS3.fetchString).load[ZuoraRestConfig]
       _ <- fakeSteps(
         println,
         RawEffects.downloadResponse,

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -46,11 +46,11 @@ object Handler {
     val loadConfig = LoadConfigModule(stage, fetchString)
     for {
 
-      zuoraRestConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load trusted Api config")
+      zuoraRestConfig <- loadConfig.load[ZuoraRestConfig].toApiGatewayOp("load trusted Api config")
       requests = ZuoraRestRequestMaker(getResponse, zuoraRestConfig)
       zuoraQuerier = ZuoraQuery(requests)
 
-      sfConfig <- loadConfig[SFAuthConfig].toApiGatewayOp("load trusted Api config")
+      sfConfig <- loadConfig.load[SFAuthConfig].toApiGatewayOp("load trusted Api config")
       sfAuth <- SalesforceClient(getResponse, sfConfig).value.toApiGatewayOp("Failed to authenticate with Salesforce")
 
     } yield Operation.noHealthcheck {

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetZuoraEmailsForAccountsEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetZuoraEmailsForAccountsEffectsTest.scala
@@ -23,7 +23,7 @@ class GetZuoraEmailsForAccountsEffectsTest extends AnyFlatSpec with Matchers {
     val testData = NonEmptyList(CodeZuora.account1, List(CodeZuora.account2))
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
         .toApiGatewayOp("parse config")
       zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig))
       getZuoraEmailsForAccounts = GetIdentityAndZuoraEmailsForAccountsSteps(zuoraQuerier)

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getsfcontacts/GetSfAddressEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getsfcontacts/GetSfAddressEffectsTest.scala
@@ -23,7 +23,7 @@ class GetSfAddressEffectsTest extends AnyFlatSpec with Matchers {
     val testContact = SFEffectsData.testContactHasNamePhoneOtherAddress
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
       getSfContact = sfAuth

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/identityid/UpdateAccountSFLinksEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/identityid/UpdateAccountSFLinksEffectsTest.scala
@@ -27,7 +27,7 @@ class UpdateAccountSFLinksEffectsTest extends AnyFlatSpec with Matchers {
     val unique = s"${Random.nextInt(10000)}"
 
     val actual = for {
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
         .toApiGatewayOp("load config")
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       update = UpdateAccountSFLinks(zuoraDeps.put)

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -46,7 +46,7 @@ class UpdateSalesforceIdentityIdEffectsTest extends AnyFlatSpec with Matchers {
     val testEmail = EmailAddress(s"fulfilment.dev+$unique@guardian.co.uk")
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfClient <- SalesforceClient(response, sfConfig).value.toDisjunction
       patch = sfClient.wrapWith(JsonHttp.patch)

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
@@ -102,7 +102,7 @@ object DownloadBatchHandler extends LazyLogging {
   )(request: WireState): Try[WireState] = {
     val loadConfig = LoadConfigModule(stage, getFromS3)
     for {
-      sfConfig <- loadConfig[SFAuthConfig](SFExportAuthConfig.location, sfAuthConfigReads).toTry
+      sfConfig <- loadConfig.load[SFAuthConfig](SFExportAuthConfig.location, sfAuthConfigReads).toTry
       sfClient <- SalesforceClient(getResponse, sfConfig).value.toTry
       wiredGetBatchResultId = sfClient.wrapWith(GetBatchResultId.wrapper).runRequest _
       wiredGetBatchResult = sfClient.wrapWith(GetBatchResult.wrapper).runRequest _

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/EndJobHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/EndJobHandler.scala
@@ -84,7 +84,7 @@ object EndJobHandler {
 
     for {
       _ <- uploadDummySuccessFileToTriggerOphanJob(request)
-      sfConfig <- loadConfig[SFAuthConfig](SFExportAuthConfig.location, sfAuthConfigReads).toTry
+      sfConfig <- loadConfig.load[SFAuthConfig](SFExportAuthConfig.location, sfAuthConfigReads).toTry
       sfClient <- SalesforceClient(getResponse, sfConfig).value.toTry
       wiredCloseJob = sfClient.wrapWith(JsonHttp.post).wrapWith(CloseJob.wrapper)
       _ <- wiredCloseJob.runRequest(jobId).toTry

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/GetBatchesHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/GetBatchesHandler.scala
@@ -101,7 +101,7 @@ object GetBatchesHandler {
     val jobId = JobId(request.jobId)
 
     for {
-      sfConfig <- loadConfig[SFAuthConfig](SFExportAuthConfig.location, sfAuthConfigReads).toTry
+      sfConfig <- loadConfig.load[SFAuthConfig](SFExportAuthConfig.location, sfAuthConfigReads).toTry
       sfClient <- SalesforceClient(getResponse, sfConfig).value.toTry
       getJobBatchesOp = sfClient.wrapWith(GetJobBatches.wrapper)
       batches <- getJobBatchesOp.runRequest(jobId).toTry

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/StartJobHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/StartJobHandler.scala
@@ -86,7 +86,7 @@ object StartJobHandler {
   )(request: WireRequest): Try[WireResponse] = {
     val loadConfig = LoadConfigModule(stage, fetchString)
     for {
-      sfConfig <- loadConfig[SFAuthConfig](SFExportAuthConfig.location, sfAuthConfigReads).toTry
+      sfConfig <- loadConfig.load[SFAuthConfig](SFExportAuthConfig.location, sfAuthConfigReads).toTry
       sfClient <- SalesforceClient(getResponse, sfConfig).value.toTry
       createJobOp = sfClient.wrapWith(JsonHttp.postWithHeaders).wrapWith(CreateJob.wrapper).runRequest _
       addQueryToJobOp = sfClient.wrapWith(AddQueryToJob.wrapper).runRequest _

--- a/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/Handler.scala
+++ b/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/Handler.scala
@@ -34,7 +34,7 @@ object Handler extends Logging {
   case class GcGet(get: HttpOp[RestRequestMaker.GetRequest, JsValue]) extends AnyVal
 
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = for {
-    goCardlessConfig <- LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)[GoCardlessConfig]
+    goCardlessConfig <- LoadConfigModule(RawEffects.stage, GetFromS3.fetchString).load[GoCardlessConfig]
     goCardlessClient = GoCardlessClient(RawEffects.response, goCardlessConfig)
     sfClient <- prepareSfClient
     sfGet = sfClient.wrapWith(JsonHttp.get)
@@ -51,7 +51,7 @@ object Handler extends Logging {
       logger.info("No mandate events to process")
 
   def prepareSfClient = for {
-    sfConfig <- LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)[SFAuthConfig]
+    sfConfig <- LoadConfigModule(RawEffects.stage, GetFromS3.fetchString).load[SFAuthConfig]
     sfClient <- SalesforceClient(RawEffects.response, sfConfig).value.toDisjunction
   } yield sfClient
 

--- a/handlers/sf-gocardless-sync/src/test/scala/com/gu/sf_gocardless_sync/gocardless/GoCardlessDDMandateEventEffectsTest.scala
+++ b/handlers/sf-gocardless-sync/src/test/scala/com/gu/sf_gocardless_sync/gocardless/GoCardlessDDMandateEventEffectsTest.scala
@@ -38,7 +38,7 @@ class GoCardlessDDMandateEventEffectsTest extends AnyFlatSpec with Matchers {
   it should "fetch a set of mandate events from GoCardless, with accompanying mandate detail" taggedAs EffectsTest in {
 
     val actual = for {
-      goCardlessConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[GoCardlessConfig]
+      goCardlessConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[GoCardlessConfig]
       goCardlessClient = GoCardlessClient(RawEffects.response, goCardlessConfig)
       wiredOp = GetEventsSince(goCardlessClient.wrapWith(JsonHttp.get), 2)
     } yield wiredOp(GoCardlessMandateEventID("EV002140EW1YFZ"))
@@ -98,7 +98,7 @@ class GoCardlessDDMandateEventEffectsTest extends AnyFlatSpec with Matchers {
   it should "fetch bank details given a customer_account_id" taggedAs EffectsTest in {
 
     val actual = for {
-      goCardlessConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[GoCardlessConfig]
+      goCardlessConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[GoCardlessConfig]
       response = RawEffects.response
       goCardlessClient = GoCardlessClient(response, goCardlessConfig)
       wiredOp = GetBankDetail(goCardlessClient.wrapWith(JsonHttp.get))

--- a/handlers/sf-gocardless-sync/src/test/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandateEffectsTest.scala
+++ b/handlers/sf-gocardless-sync/src/test/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandateEffectsTest.scala
@@ -26,7 +26,7 @@ class SalesforceDDMandateEffectsTest extends AnyFlatSpec with Matchers {
   it should "create a 'DD Mandate' in salesforce" taggedAs EffectsTest in {
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
       wiredOp = SalesforceDDMandate.Create(sfAuth.wrapWith(JsonHttp.post))
@@ -52,7 +52,7 @@ class SalesforceDDMandateEffectsTest extends AnyFlatSpec with Matchers {
   it should "event an existing 'DD Mandate' in salesforce" taggedAs EffectsTest in {
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
       wiredOp = SalesforceDDMandate.Update(sfAuth.wrapWith(JsonHttp.patch))(MandateSfId("a2q6E0000007XgS"))
@@ -74,7 +74,7 @@ class SalesforceDDMandateEffectsTest extends AnyFlatSpec with Matchers {
   it should "fetch the PaymentMethod and BillingAccount IDs from salesforce given a list of GoCardless References" taggedAs EffectsTest in {
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
       wiredOp = SalesforceDDMandate.GetPaymentMethodsEtc(sfAuth.wrapWith(JsonHttp.get))
@@ -91,7 +91,7 @@ class SalesforceDDMandateEffectsTest extends AnyFlatSpec with Matchers {
   it should "fetch the DD Mandate from salesforce given a GoCardless mandate ID" taggedAs EffectsTest in {
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
       wiredOp = SalesforceDDMandate.LookupAll(sfAuth.wrapWith(JsonHttp.get))

--- a/handlers/sf-gocardless-sync/src/test/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandateEventEffectsTest.scala
+++ b/handlers/sf-gocardless-sync/src/test/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandateEventEffectsTest.scala
@@ -18,7 +18,7 @@ class SalesforceDDMandateEventEffectsTest extends AnyFlatSpec with Matchers {
   it should "create a 'DD Mandate Event' in salesforce" taggedAs EffectsTest in {
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
       wiredOp = SalesforceDDMandateEvent.Create(sfAuth.wrapWith(JsonHttp.post))
@@ -46,7 +46,7 @@ class SalesforceDDMandateEventEffectsTest extends AnyFlatSpec with Matchers {
   it should "fetch the GoCardlessID of the last successfully processed 'DD Mandate Event' from salesforce" taggedAs EffectsTest in {
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
       wiredOp = SalesforceDDMandateEvent.GetGoCardlessIdOfLastProcessed(sfAuth.wrapWith(JsonHttp.get))

--- a/handlers/stripe-webhook-endpoints/src/main/scala/com/gu/stripeCardUpdated/Lambda.scala
+++ b/handlers/stripe-webhook-endpoints/src/main/scala/com/gu/stripeCardUpdated/Lambda.scala
@@ -25,15 +25,15 @@ object Lambda {
 
     ApiGatewayHandler(lambdaIO) {
       for {
-        zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-        stripeConfig <- loadConfigModule[StripeConfig].toApiGatewayOp("load stripe config")
+        zuoraRestConfig <- loadConfigModule.load[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+        stripeConfig <- loadConfigModule.load[StripeConfig].toApiGatewayOp("load stripe config")
         zuoraClient = ZuoraRestRequestMaker(response, zuoraRestConfig)
         stripeChecker = StripeDeps(stripeConfig, new StripeSignatureChecker)
         configuredOp = CardUpdatedSteps(
           zuoraClient,
           stripeChecker,
         )
-      } yield configuredOp.prependRequestValidationToSteps(Auth(loadConfigModule[TrustedApiConfig]))
+      } yield configuredOp.prependRequestValidationToSteps(Auth(loadConfigModule.load[TrustedApiConfig]))
     }
 
   }

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -30,7 +30,7 @@ object AutoCancelHandler extends App with Logging {
   ): ApiGatewayOp[ApiGatewayHandler.Operation] = {
     val loadConfigModule = LoadConfigModule(stage, fetchString)
     for {
-      zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+      zuoraRestConfig <- loadConfigModule.load[ZuoraRestConfig].toApiGatewayOp("load zuora config")
     } yield {
       val zuoraRequest = ZuoraRestRequestMaker(response, zuoraRestConfig)
 
@@ -48,7 +48,7 @@ object AutoCancelHandler extends App with Logging {
           EmailSendSteps(awsSQSSend(EmailQueueName)),
           ZuoraGetInvoiceTransactions(ZuoraRestRequestMaker(response, zuoraRestConfig)),
         ),
-      ).prependRequestValidationToSteps(Auth(loadConfigModule[TrustedApiConfig]))
+      ).prependRequestValidationToSteps(Auth(loadConfigModule.load[TrustedApiConfig]))
     }
   }
 

--- a/handlers/zuora-rer/src/local/com/gu/zuora/rer/ZuoraRerLocalRun.scala
+++ b/handlers/zuora-rer/src/local/com/gu/zuora/rer/ZuoraRerLocalRun.scala
@@ -39,12 +39,11 @@ object ZuoraRerLocalRun extends App {
   }
 
   private def runTestPerformZuoraRer(request: RerRequest): Unit = {
-    val loadZuoraRerConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
-    val loadZuoraRestConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
+    val loadConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
     val streams = requestStreams(request)
     for {
-      zuoraRerConfig <- loadZuoraRerConfig[ZuoraRerConfig]
-      zuoraRestConfig <- loadZuoraRestConfig[BatonZuoraRestConfig]
+      zuoraRerConfig <- loadConfig.load[ZuoraRerConfig]
+      zuoraRestConfig <- loadConfig.load[BatonZuoraRestConfig]
       requests = ZuoraRestRequestMaker(RawEffects.response, toZuoraRestConfig(zuoraRestConfig))
       zuoraQuerier = ZuoraQuery(requests)
       zuoraHelper = ZuoraRerService(requests, zuoraQuerier)

--- a/handlers/zuora-rer/src/main/scala/com/gu/zuora/rer/Handler.scala
+++ b/handlers/zuora-rer/src/main/scala/com/gu/zuora/rer/Handler.scala
@@ -42,8 +42,8 @@ trait ZuoraHandler[Req, Res] {
 object Handler {
 
   def handleRer(input: InputStream, output: OutputStream): Either[ConfigFailure, Unit] = {
-    val loadZuoraRerConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
-    loadZuoraRerConfig[ZuoraRerConfig].map(config => {
+    val loadConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
+    loadConfig.load[ZuoraRerConfig].map(config => {
       val rerLambda = ZuoraRerHandler(S3Helper, config)
       rerLambda.handleRequest(input, output)
     })
@@ -53,12 +53,11 @@ object Handler {
       input: InputStream,
       output: OutputStream,
   ): Either[ConfigFailure, Unit] = {
-    val loadZuoraRerConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
-    val loadZuoraRestConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
+    val loadConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
     val response = RawEffects.response
     for {
-      zuoraRerConfig <- loadZuoraRerConfig[ZuoraRerConfig]
-      batonZuoraRestConfig <- loadZuoraRestConfig[BatonZuoraRestConfig]
+      zuoraRerConfig <- loadConfig.load[ZuoraRerConfig]
+      batonZuoraRestConfig <- loadConfig.load[BatonZuoraRestConfig]
       requests = ZuoraRestRequestMaker(response, toZuoraRestConfig(batonZuoraRestConfig))
       zuoraQuerier = ZuoraQuery(requests)
       zuoraHelper = ZuoraRerService(requests, zuoraQuerier)

--- a/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/updateAccounts/Handler.scala
+++ b/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/updateAccounts/Handler.scala
@@ -32,7 +32,7 @@ object Handler {
       stage: Stage,
       fetchString: StringFromS3,
   ): Try[Requests] = for {
-    zuoraRestConfig <- toTry(LoadConfigModule(stage, fetchString)[ZuoraRestConfig])
+    zuoraRestConfig <- toTry(LoadConfigModule(stage, fetchString).load[ZuoraRestConfig])
   } yield ZuoraRestRequestMaker(response, zuoraRestConfig)
 
   def operation(

--- a/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/Handler.scala
+++ b/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/Handler.scala
@@ -43,8 +43,8 @@ trait ZuoraHandler[Req, Res] {
 object Handler {
 
   def handleSar(input: InputStream, output: OutputStream): Either[ConfigFailure, Unit] = {
-    val loadZuoraSarConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
-    loadZuoraSarConfig[ZuoraSarConfig].map(config => {
+    val loadConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
+    loadConfig.load[ZuoraSarConfig].map(config => {
       val sarLambda = ZuoraSarHandler(S3Helper, config)
       sarLambda.handleRequest(input, output)
     })
@@ -54,13 +54,12 @@ object Handler {
       input: InputStream,
       output: OutputStream,
   ): Either[ConfigFailure, Unit] = {
-    val loadZuoraSarConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
-    val loadZuoraRestConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
+    val loadConfig = LoadConfigModule(RawEffects.stage, GetFromS3.fetchString)
     val response = RawEffects.response
     val downloadResponse = RawEffects.downloadResponse
     for {
-      zuoraSarConfig <- loadZuoraSarConfig[ZuoraSarConfig]
-      batonZuoraRestConfig <- loadZuoraRestConfig[BatonZuoraRestConfig]
+      zuoraSarConfig <- loadConfig.load[ZuoraSarConfig]
+      batonZuoraRestConfig <- loadConfig.load[BatonZuoraRestConfig]
       zuoraRestConfig = toZuoraRestConfig(batonZuoraRestConfig)
       requests = ZuoraRestRequestMaker(response, zuoraRestConfig)
       downloadRequests = ZuoraAquaRequestMaker(downloadResponse, zuoraRestConfig)

--- a/lib/effects/src/main/scala/com/gu/effects/Http.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/Http.scala
@@ -6,6 +6,7 @@ import okio.Buffer
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters.IterableHasAsScala
 
 object Http extends Logging {
 
@@ -27,7 +28,7 @@ object Http extends Logging {
     { request: Request =>
       val maybeBodySummary = Option(request.body).map(bodySummary)
       logger.info(
-        s"HTTP request: ${request.method} ${request.url} " + maybeBodySummary
+        s"HTTP request: ${request.method} ${request.url} ${request.headers().asScala.mkString("\n")}" + maybeBodySummary
           .map(summary => s", body:  $summary")
           .getOrElse(""),
       )

--- a/lib/google-bigquery/src/test/scala/com/gu/google/BigQueryConfigTest.scala
+++ b/lib/google-bigquery/src/test/scala/com/gu/google/BigQueryConfigTest.scala
@@ -27,7 +27,7 @@ class BigQueryConfigTest extends AnyFlatSpec with Matchers {
         |""".stripMargin)
 
     val loadConfig = LoadConfigModule(Stage("DEV"), config)
-    val maybeConfig = loadConfig[BigQueryConfig]
+    val maybeConfig = loadConfig.load[BigQueryConfig]
     maybeConfig match {
       case Left(error) => fail(error.toString)
       case Right(config) =>
@@ -45,7 +45,7 @@ class BigQueryConfigTest extends AnyFlatSpec with Matchers {
         |""".stripMargin)
 
     val loadConfig = LoadConfigModule(Stage("DEV"), config)
-    val maybeConfig = loadConfig[BigQueryConfig]
+    val maybeConfig = loadConfig.load[BigQueryConfig]
     maybeConfig match {
       case Left(error) =>
         error shouldBe a[ConfigFailure]

--- a/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
+++ b/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
@@ -52,6 +52,8 @@ object ZuoraEnvironment extends Logging {
 
 object ConfigReads {
 
-  case class ConfigFailure(error: String) extends Throwable
+  case class ConfigFailure(error: String) extends Throwable {
+    override def toString: String = s"${getClass.getName}($error)"
+  }
 
 }

--- a/lib/handler/src/main/scala/com/gu/util/config/LoadConfigModule.scala
+++ b/lib/handler/src/main/scala/com/gu/util/config/LoadConfigModule.scala
@@ -20,8 +20,8 @@ object LoadConfigModule extends Logging {
   val bucketName = "gu-reader-revenue-private"
 
   // we need this extra class here because otherwise we cannot partially apply the LoadConfig apply method without specifying the generic param
-  class PartialApply(stage: Stage, fetchString: StringFromS3) {
-    def apply[CONF](implicit configLocation: ConfigLocation[CONF], reads: Reads[CONF]): Either[ConfigFailure, CONF] = {
+  class LoadConfigModule(stage: Stage, fetchString: StringFromS3) {
+    def load[CONF](implicit configLocation: ConfigLocation[CONF], reads: Reads[CONF]): Either[ConfigFailure, CONF] = {
       logger.info(s"Attempting to load config in $stage")
       val s3Location = S3Location(bucket = bucketName, key = configLocation.toPath(stage))
       for {
@@ -33,7 +33,7 @@ object LoadConfigModule extends Logging {
     }
   }
 
-  def apply(stage: Stage, fetchString: StringFromS3) = new PartialApply(stage = stage, fetchString = fetchString)
+  def apply(stage: Stage, fetchString: StringFromS3) = new LoadConfigModule(stage = stage, fetchString = fetchString)
 
   def validateStage(jsValue: JsValue, expectedStage: Stage): Either[ConfigFailure, Unit] = {
     jsValue.validate[ConfigWithStage] match {

--- a/lib/handler/src/test/scala/com/gu/util/config/LoadConfigModuleTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/config/LoadConfigModuleTest.scala
@@ -33,7 +33,7 @@ class LoadConfigModuleTest extends AnyFlatSpec with Matchers {
 
     val prodConfig = LoadConfigModule(prodStage, prodS3Load)
 
-    prodConfig[TestConfig] shouldBe Right(TestConfig("prodValue", 92))
+    prodConfig.load[TestConfig] shouldBe Right(TestConfig("prodValue", 92))
 
   }
 
@@ -49,7 +49,7 @@ class LoadConfigModuleTest extends AnyFlatSpec with Matchers {
     def invalidJsonLoad = fakeS3Load(jsonMissingSomeValue) _
 
     val prodConfig = LoadConfigModule(prodStage, invalidJsonLoad)
-    prodConfig[TestConfig].isLeft shouldBe (true)
+    prodConfig.load[TestConfig].isLeft shouldBe (true)
 
   }
 
@@ -66,7 +66,7 @@ class LoadConfigModuleTest extends AnyFlatSpec with Matchers {
     def invalidJsonLoad = fakeS3Load(jsonMissingSomeValue) _
 
     val prodConfig = LoadConfigModule(prodStage, invalidJsonLoad)
-    prodConfig[TestConfig].isLeft shouldBe (true)
+    prodConfig.load[TestConfig].isLeft shouldBe (true)
 
   }
 
@@ -76,7 +76,7 @@ class LoadConfigModuleTest extends AnyFlatSpec with Matchers {
 
     val prodConfig = LoadConfigModule(prodStage, invalidJsonLoad)
 
-    prodConfig[TestConfig].isLeft shouldBe (true)
+    prodConfig.load[TestConfig].isLeft shouldBe (true)
   }
 
   it should "fail if the stage in the config file differs from the expected stage provided" in {
@@ -86,7 +86,7 @@ class LoadConfigModuleTest extends AnyFlatSpec with Matchers {
 
     val prodConfig = LoadConfigModule(prodStage, wrongFileS3Load)
 
-    prodConfig[TestConfig] shouldBe Left(ConfigFailure("Expected to load PROD config, but loaded CODE config"))
+    prodConfig.load[TestConfig] shouldBe Left(ConfigFailure("Expected to load PROD config, but loaded CODE config"))
   }
 
   it should "fail if no stage variable in configuration file" in {
@@ -101,7 +101,7 @@ class LoadConfigModuleTest extends AnyFlatSpec with Matchers {
 
     val prodConfig = LoadConfigModule(prodStage, noStageS3Load)
 
-    prodConfig[TestConfig].isLeft shouldBe (true)
+    prodConfig.load[TestConfig].isLeft shouldBe (true)
   }
 
   it should "fail if the stage variable in configuration file is not a string" in {
@@ -117,7 +117,7 @@ class LoadConfigModuleTest extends AnyFlatSpec with Matchers {
 
     val prodConfig = LoadConfigModule(prodStage, invalidStageS3Load)
 
-    prodConfig[TestConfig].isLeft shouldBe (true)
+    prodConfig.load[TestConfig].isLeft shouldBe (true)
   }
 
   val prodJson: String =

--- a/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/Config.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/holiday_stops/Config.scala
@@ -30,7 +30,7 @@ object Config {
   ): Either[OverallFailure, T] = {
     val loadConfigModule = LoadConfigModule(Stage(stage), fetchString)
     loadConfigModule
-      .apply[T](ConfigLocation(filePrefix, 1), reads)
+      .load[T](ConfigLocation(filePrefix, 1), reads)
       .left
       .map(failure => OverallFailure(failure.error))
   }

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -28,7 +28,7 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends AnyFlatSpec with M
     val contact = IdentityId("100004814") // must exist in CODE SalesForce
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
 

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/RestRequestMaker.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/RestRequestMaker.scala
@@ -158,8 +158,9 @@ object RestRequestMaker extends LazyLogging {
         skipCheck: IsCheckNeeded = WithCheck,
     ): ClientFailableOp[RESP] = {
       val body = createBody[REQ](req)
+      val headersWithContentType = headers + ("Content-Type" -> "application/json") + ("accept" -> "application/json")
       for {
-        bodyAsJson <- sendRequest(buildRequest(headers, baseUrl + path, _.post(body)), getResponse).map(Json.parse)
+        bodyAsJson <- sendRequest(buildRequest(headersWithContentType, baseUrl + path, _.post(body)), getResponse).map(Json.parse)
         _ <- if (skipCheck == WithoutCheck) ClientSuccess(()) else jsonIsSuccessful(bodyAsJson)
         respModel <- toResult[RESP](bodyAsJson)
       } yield respModel

--- a/lib/s3ConfigValidator/src/test/scala/com/gu/test/S3ConfigFilesEffectsTest.scala
+++ b/lib/s3ConfigValidator/src/test/scala/com/gu/test/S3ConfigFilesEffectsTest.scala
@@ -72,7 +72,7 @@ class S3ConfigFilesEffectsTest extends AnyFlatSpec with Matchers {
   )
   def validate[CONF](stage: String)(implicit loc: ConfigLocation[CONF], r: Reads[CONF]) = {
     val configLoader = configLoaders(stage)
-    val config = configLoader[CONF]
+    val config = configLoader.load[CONF]
     config.isRight shouldBe (true)
   }
 }

--- a/lib/salesforce/client/src/test/scala/com/gu/salesforce/auth/SalesforceAuthenticateEffectsTest.scala
+++ b/lib/salesforce/client/src/test/scala/com/gu/salesforce/auth/SalesforceAuthenticateEffectsTest.scala
@@ -14,7 +14,7 @@ class SalesforceAuthenticateEffectsTest extends AnyFlatSpec with Matchers {
   it should "get auth SF correctly" taggedAs EffectsTest in {
 
     val actual = for {
-      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[SFAuthConfig]
+      sfConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[SFAuthConfig]
       identityId <- SalesforceAuthenticate.apply(RawEffects.response)(sfConfig).value.toDisjunction
     } yield {
       identityId

--- a/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/ReportsLambda.scala
+++ b/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/ReportsLambda.scala
@@ -22,7 +22,7 @@ object ReportsLambda extends Logging {
 
     val lambdaResponse = for {
       request <- ParseRequest[REQUEST](lambdaIO.inputStream).toEither
-      config <- LoadConfigModule(stage, fetchString)[ZuoraRestConfig].left.map(configError =>
+      config <- LoadConfigModule(stage, fetchString).load[ZuoraRestConfig].left.map(configError =>
         LambdaException(configError.error),
       )
       aquaCall = wireCall(config)

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/ReportsManualEffectsTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/ReportsManualEffectsTest.scala
@@ -11,7 +11,7 @@ import play.api.libs.json.Json
 object ReportsManualEffectsTest extends App {
 
   def getZuoraRequest(response: Request => Response) = for {
-    zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+    zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
     zuoraRequests = ZuoraAquaRequestMaker(RawEffects.response, zuoraRestConfig)
   } yield zuoraRequests
 

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
@@ -18,7 +18,7 @@ class ZuoraQueryEffectsTest extends AnyFlatSpec with Matchers {
 
     val actual = for {
 
-      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig))
       subs <- SubscriptionsForPromoCode(zuoraQuerier)("""qwerty"asdf'zxcv\1234""").toDisjunction
 


### PR DESCRIPTION
This PR follows on from https://github.com/guardian/support-service-lambdas/pull/2076 and is off the same branch

This makes us call paper round API to get the details that we need to send to braze for the thank you email.

It's a bit rough as I haven't really had time to tidy it.

It's not tested (beyond the little bits of test code that are there)

It also includes a new rest/form post client and some tweaks to how the config is loaded to match more modern scala standards.