### PR TITLE
ensures unique names and descriptions for alarms, even if they're dis…

### DIFF
--- a/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
+++ b/cdk/lib/__snapshots__/batch-email-sender.test.ts.snap
@@ -697,8 +697,8 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
-        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError (CDK)",
+        "AlarmDescription": "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-CODE repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - CODE: Failed to send email triggered by Salesforce - 5XXError (CDK)",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -768,8 +768,8 @@ exports[`The BatchEmailSender stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
-        "AlarmName": "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash (CDK)",
+        "AlarmDescription": "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-CODE repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+        "AlarmName": "URGENT 9-5 - CODE: Failed to send email triggered by Salesforce - Lambda crash (CDK)",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -88,8 +88,8 @@ export class BatchEmailSender extends GuStack {
         // ---- Alarms ---- //
         new GuAlarm(this, 'FailedEmailApiAlarm', {
             app,
-            alarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - 5XXError (CDK)",
-            alarmDescription: "API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+            alarmName: `URGENT 9-5 - ${this.stage}: Failed to send email triggered by Salesforce - 5XXError (CDK)`,
+            alarmDescription: `API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-${this.stage} repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/`,
             evaluationPeriods: 1,
             threshold: 1,
             actionsEnabled: isProd,
@@ -108,8 +108,8 @@ export class BatchEmailSender extends GuStack {
 
         new GuAlarm(this, 'FailedEmailLambdaAlarm', {
             app,
-            alarmName: "URGENT 9-5 - PROD: Failed to send email triggered by Salesforce - Lambda crash (CDK)",
-            alarmDescription: "Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-PROD repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/",
+            alarmName: `URGENT 9-5 - ${this.stage}: Failed to send email triggered by Salesforce - Lambda crash (CDK)`,
+            alarmDescription: `Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-${this.stage} repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/`,
             evaluationPeriods: 1,
             threshold: 1,
             actionsEnabled: isProd,


### PR DESCRIPTION
Follow-up to #2079. Alarms defined using the GuCDK are created in both `CODE` and `PROD` environments, but only enabled in `PROD`. Therefore the names need to be unique per environment. This is a new requirement as we only created these alarms in `PROD` when the stack was defined using a YAML template.