### PR TITLE
slightly more helpful logging on internal server errors

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/TypeConvert.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/TypeConvert.scala
@@ -16,16 +16,16 @@ object TypeConvert {
 
   implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
 
-    def failureHandler(clientFailure: ClientFailure) = clientFailure match {
+    private def failureHandler(action: String, clientFailure: ClientFailure) = clientFailure match {
       case PaymentError(_) => ApiGatewayResponse.paymentRequired
-      case _ => ApiGatewayResponse.internalServerError(s"unknown error: ${clientFailure.message}")
+      case _ => ApiGatewayResponse.internalServerError(s"unknown error during: $action: ${clientFailure.message}")
     }
 
-    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(failureHandler(_))
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(failureHandler(action, _))
   }
 
   implicit class TypeConvertClientOpAsync[A](clientOp: ClientFailableOp[A]) {
-    def toAsyncApiGatewayOp(action: String) = {
+    def toAsyncApiGatewayOp(action: String): AsyncApiGatewayOp[A] = {
       val apiGatewayOp = Future.successful(clientOp.toApiGatewayOp(action))
       AsyncApiGatewayOp(apiGatewayOp)
     }


### PR DESCRIPTION
noticed an unused variable, so I decided to use it.

The resulting string is logged by this code:
https://github.com/guardian/support-service-lambdas/blob/b0194326780271679c71a63096cf4c863ae1aa52/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala#L93

Interestingly, the string is logged when the internal server error is created, rather than when it's actually returned, but this was probably so it wasn't accidentally leaked to the client.