### PR TITLE
Add S3 access to config for new product api lambda

### DIFF
--- a/cdk/lib/__snapshots__/new-product-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/new-product-api.test.ts.snap
@@ -1069,7 +1069,10 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
             {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/zuoraRest-CODE*.json",
+              "Resource": [
+                "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/zuoraRest-CODE*.json",
+                "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/paperround-CODE*.json",
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -2478,7 +2481,10 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
             {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/zuoraRest-PROD*.json",
+              "Resource": [
+                "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/zuoraRest-PROD*.json",
+                "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/paperround-PROD*.json",
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/new-product-api.ts
+++ b/cdk/lib/new-product-api.ts
@@ -208,6 +208,7 @@ export class NewProductApi extends GuStack {
           ],
           resources: [
             `arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${this.stage}/zuoraRest-${this.stage}*.json`,
+            `arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${this.stage}/paperround-${this.stage}*.json`,
           ]
         }),
       ],


### PR DESCRIPTION
The PR went out https://github.com/guardian/support-service-lambdas/pull/2081
however it needs access to the new config file, but the access wasn't provided.

This PR adds permission to read the config from S3.