### PR TITLE
GuCDK Migration Step 3 (Clean up)

### DIFF
--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -10,7 +10,6 @@ import {ComparisonOperator, Metric} from "aws-cdk-lib/aws-cloudwatch";
 import {Effect, Policy, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Runtime} from "aws-cdk-lib/aws-lambda";
 import {CfnRecordSet} from "aws-cdk-lib/aws-route53";
-import {CfnInclude} from "aws-cdk-lib/cloudformation-include";
 
 export interface BatchEmailSenderProps extends GuStackProps {
     certificateId: string;
@@ -21,10 +20,6 @@ export interface BatchEmailSenderProps extends GuStackProps {
 export class BatchEmailSender extends GuStack {
     constructor(scope: App, id: string, props: BatchEmailSenderProps) {
         super(scope, id, props);
-        const yamlTemplateFilePath = `${__dirname}/../../handlers/batch-email-sender/cfn.yaml`;
-        new CfnInclude(this, "YamlTemplate", {
-            templateFile: yamlTemplateFilePath,
-        });
 
 
         // ---- Miscellaneous constants ---- //


### PR DESCRIPTION
This PR removes the `CfnInclude` portion of the CDK template definition, resulting in a single (new) stack of resources.

Related PRs:
- [Step 1](https://github.com/guardian/support-service-lambdas/pull/2077)
- [Step 2](https://github.com/guardian/support-service-lambdas/pull/2079)
- [Step 2a (small follow-up fix)](https://github.com/guardian/support-service-lambdas/pull/2082)
- [Step 2b (adds custom URL and DNS records)](https://github.com/guardian/support-service-lambdas/pull/2085)