### PR TITLE
fix: fix STAGE env variable name to capital

### DIFF
--- a/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/handlers/CreateSalesforceSingleContributionRecordHandler.scala
+++ b/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/handlers/CreateSalesforceSingleContributionRecordHandler.scala
@@ -50,7 +50,7 @@ object CreateSalesforceSingleContributionRecordHandler extends RequestHandler[SQ
   }
 
   def processMessage(contribution: PaymentApiMessageDetail): Unit = {
-    val stage = sys.env.getOrElse("Stage", "CODE")
+    val stage = sys.env.getOrElse("STAGE", "CODE")
 
     val result = for {
       accessToken <- GetAccessToken(stage)


### PR DESCRIPTION
## What does this change?

This fixes this line of code where `STAGE` should be capital:
```scala
val stage = sys.env.getOrElse("STAGE", "CODE")
```
