### PR TITLE
fix: make state and postal code optional fields

### DIFF
--- a/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/handlers/CreateSalesforceSingleContributionRecordHandler.scala
+++ b/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/handlers/CreateSalesforceSingleContributionRecordHandler.scala
@@ -17,8 +17,8 @@ case class PaymentApiMessageDetail(
     identityId: String,
     paymentId: String,
     paymentProvider: String,
-    postalCode: String,
-    state: String,
+    postalCode: Option[String],
+    state: Option[String],
     email: String,
 )
 

--- a/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/services/salesforce/CreateSingleContributionRecord.scala
+++ b/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/services/salesforce/CreateSingleContributionRecord.scala
@@ -14,7 +14,7 @@ import scala.util.{Try, Success, Failure}
 case class CreateSingleContributionRecordRequestData(
     Amount__c: Double,
     Country_Code__c: String,
-    Country_Subdivision_Code__c: String,
+    Country_Subdivision_Code__c: Option[String],
     Currency__c: String,
     Email__c: String,
     Identity_ID__c: String,
@@ -22,7 +22,7 @@ case class CreateSingleContributionRecordRequestData(
     Payment_ID__c: String,
     Payment_Provider__c: String,
     Payment_Status__c: String,
-    Postal_Code__c: String,
+    Postal_Code__c: Option[String],
 )
 
 case class CreateSingleContributionRecordResponseData(


### PR DESCRIPTION
## What does this change?

This makes `state` and `postalCode` optional fields since sometimes there are not present (`null`) in the event.

```scala
case class PaymentApiMessageDetail(
    amount: Double,
    contributionId: String,
    country: String,
    currency: String,
    eventTimeStamp: String,
    identityId: String,
    paymentId: String,
    paymentProvider: String,
    postalCode: Option[String],
    state: Option[String],
    email: String,
)
```

This is a fix relative to this [PR](https://github.com/guardian/support-service-lambdas/pull/2080).