### PR TITLE
fix: make identityId optional

### DIFF
--- a/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/handlers/CreateSalesforceSingleContributionRecordHandler.scala
+++ b/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/handlers/CreateSalesforceSingleContributionRecordHandler.scala
@@ -13,7 +13,7 @@ case class PaymentApiMessageDetail(
     country: String,
     currency: String,
     eventTimeStamp: String,
-    identityId: String,
+    identityId: Option[String],
     paymentId: String,
     paymentProvider: String,
     postalCode: Option[String],

--- a/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/services/Salesforce.scala
+++ b/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/services/Salesforce.scala
@@ -17,7 +17,7 @@ case class CreateSingleContributionRecordRequestData(
     Country_Subdivision_Code__c: Option[String],
     Currency__c: String,
     Email__c: String,
-    Identity_ID__c: String,
+    Identity_ID__c: Option[String],
     Payment_Date__c: String,
     Payment_ID__c: String,
     Payment_Provider__c: String,


### PR DESCRIPTION
## What does this change?

This makes the `identityId` field optional, to avoid breaking the lambda when the identityId is not present in the event.

```scala
case class PaymentApiMessageDetail(
    amount: Double,
    contributionId: String,
    country: String,
    currency: String,
    eventTimeStamp: String,
    identityId: Option[String],
    paymentId: String,
    paymentProvider: String,
    postalCode: Option[String],
    state: Option[String],
    email: String,
)
```

This is a fix relative to this [PR](https://github.com/guardian/support-service-lambdas/pull/2080).