### PR TITLE
Adjust Holiday Stop Allowance to 5 weeks for all Newspaper Products

### DIFF
--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -193,7 +193,7 @@ object SupportedProduct {
     SupportedProduct(
       name = "Newspaper Delivery",
       productType = NewspaperHomeDelivery,
-      annualIssueLimitPerEdition = 6,
+      annualIssueLimitPerEdition = 5,
       ratePlans = List(
         SupportedRatePlan("Echo-Legacy", everyDayCharges),
         SupportedRatePlan("Everyday", everyDayCharges),
@@ -214,7 +214,7 @@ object SupportedProduct {
     SupportedProduct(
       name = "Newspaper Voucher",
       productType = NewspaperVoucherBook,
-      annualIssueLimitPerEdition = 6,
+      annualIssueLimitPerEdition = 5,
       ratePlans = List(
         SupportedRatePlan("Everyday", everyDayCharges),
         SupportedRatePlan("Everyday+", everyDayCharges),
@@ -231,7 +231,7 @@ object SupportedProduct {
     SupportedProduct(
       name = "Newspaper Digital Voucher",
       productType = NewspaperDigitalVoucher,
-      annualIssueLimitPerEdition = 6,
+      annualIssueLimitPerEdition = 5,
       ratePlans = List(
         SupportedRatePlan("Everyday", everyDayCharges),
         SupportedRatePlan("Everyday+", everyDayCharges),
@@ -248,7 +248,7 @@ object SupportedProduct {
     SupportedProduct(
       name = "Newspaper - National Delivery",
       productType = NewspaperNationalDelivery,
-      annualIssueLimitPerEdition = 6,
+      annualIssueLimitPerEdition = 5,
       ratePlans = List(
         SupportedRatePlan("Weekend", weekendCharges),
         SupportedRatePlan("Everyday", everyDayCharges),

--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -214,7 +214,7 @@ object SupportedProduct {
     SupportedProduct(
       name = "Newspaper Voucher",
       productType = NewspaperVoucherBook,
-      annualIssueLimitPerEdition = 10,
+      annualIssueLimitPerEdition = 6,
       ratePlans = List(
         SupportedRatePlan("Everyday", everyDayCharges),
         SupportedRatePlan("Everyday+", everyDayCharges),
@@ -231,7 +231,7 @@ object SupportedProduct {
     SupportedProduct(
       name = "Newspaper Digital Voucher",
       productType = NewspaperDigitalVoucher,
-      annualIssueLimitPerEdition = 10,
+      annualIssueLimitPerEdition = 6,
       ratePlans = List(
         SupportedRatePlan("Everyday", everyDayCharges),
         SupportedRatePlan("Everyday+", everyDayCharges),

--- a/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionDataVoucherWeekendPlusIntegrationTest.scala
+++ b/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionDataVoucherWeekendPlusIntegrationTest.scala
@@ -44,7 +44,7 @@ class SubscriptionDataVoucherWeekendPlusIntegrationTest extends AnyFlatSpec {
       subscriptionFile = "VoucherWeekendPlusSubscription.json",
       startDate = startDate,
       expectedIssueData = expectedIssueData,
-      expectedTotalAnnualIssueLimitPerSubscription = 12,
+      expectedTotalAnnualIssueLimitPerSubscription = 10,
       expectedProductType = ZuoraProductTypes.NewspaperVoucherBook,
       expectedEditionDaysOfWeek = List(SATURDAY, SUNDAY),
     )

--- a/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionDataVoucherWeekendPlusIntegrationTest.scala
+++ b/lib/zuora-core/src/test/scala/com/gu/zuora/subscription/SubscriptionDataVoucherWeekendPlusIntegrationTest.scala
@@ -44,7 +44,7 @@ class SubscriptionDataVoucherWeekendPlusIntegrationTest extends AnyFlatSpec {
       subscriptionFile = "VoucherWeekendPlusSubscription.json",
       startDate = startDate,
       expectedIssueData = expectedIssueData,
-      expectedTotalAnnualIssueLimitPerSubscription = 20,
+      expectedTotalAnnualIssueLimitPerSubscription = 12,
       expectedProductType = ZuoraProductTypes.NewspaperVoucherBook,
       expectedEditionDaysOfWeek = List(SATURDAY, SUNDAY),
     )


### PR DESCRIPTION
## What does this change?

Updates the annual holiday stop allowance to 5 weeks across all Newspaper Products to align with the latests Terms and Conditions: https://www.theguardian.com/info/2021/aug/04/guardian-and-observer-voucher-subscription-card-and-home-delivery-subscription-services-terms-and-conditions

The Home Delivery allowance was previously increased to 6 weeks in Feb 2020: #553 
The Voucher Book allowance was temporarily increased to 10 weeks in March 2020: #615 

## How to test
Acquire a print subscription and verify that the holiday stop allowance in MMA is shown as `5 x Number of Publications per week` (e.g. an Everyday subscription would be `5 x 7 = 35`, and a Weekend subscription would be `5 x 2 = 10`).

## How can we measure success?
Holiday Stop allowances align with the stated Terms & Conditions.

## Have we considered potential risks?
We have a number of test print subs in production that we can verify the change with.

## Images
