### PR TITLE
remove zuora-retention from support service lambdas build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
           - zuora-callout-apis
           - zuora-datalake-export
           - zuora-rer
-          - zuora-retention
           - zuora-sar
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What does this change?
Stop zuora-retention state machine from being deployed to production

We are working on a new typescript-based solution with a matching stack name which is causing confusion when deploying. These changes are aimed at stopping the old solution in support service lambdas from being built, deployed (and overwriting the new solution).

Once we are confident the new solution is working as expected, we will deprecate the old solution by deleting its folder in the repo. 