### PR TITLE
Enable nightly backups of soft-opt-in-consent-setter table

### DIFF
--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -227,6 +227,8 @@ Resources:
       Tags:
         - Key: Stage
           Value: !Ref Stage
+        - Key: devx-backup-enabled
+          Value: true
 
   failedRunAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up the `soft-opt-in-consent-setter-<stage>-logging` DynamoDB table using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering.

## How to test

I have [deployed this change to `CODE`](https://riffraff.gutools.co.uk/deployment/view/4083587a-1bda-4dcc-aa2e-a0da2f15f682?verbose=1) and confirmed that the backup is taken overnight:

![image](https://github.com/guardian/support-service-lambdas/assets/19384074/f8357fc6-1935-4670-b45b-d26d980e0d74)

## How can we measure success?

We will be able to recover (most) data stored in this table in the unlikely event that it is deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.