### PR TITLE
Don't log HTTP client headers

### DIFF
--- a/lib/effects/src/main/scala/com/gu/effects/Http.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/Http.scala
@@ -28,7 +28,7 @@ object Http extends Logging {
     { request: Request =>
       val maybeBodySummary = Option(request.body).map(bodySummary)
       logger.info(
-        s"HTTP request: ${request.method} ${request.url} ${request.headers().asScala.mkString("\n")}" + maybeBodySummary
+        s"HTTP request: ${request.method} ${request.url}" + maybeBodySummary
           .map(summary => s", body:  $summary")
           .getOrElse(""),
       )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Don't log HTTP client headers as these may contain secrets. Although this is safe in priciple due to access being equivalent to all tools in the AWS account (CloudWatch & Systems / Secrets Manager), we have no protection from some other developer in the department configuring our AMI base recipes to ship these logs somewhere out of our AWS account, thus creating a security incident.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

1. Everything still compiles and unit tests pass.

## How can we measure success?
1. No headers sent to logs.