### PR TITLE
Don't try to cancel a non-active subscription

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscriptionToCancel.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/zuora/GetSubscriptionToCancel.scala
@@ -33,6 +33,7 @@ object GetSubscriptionToCancel {
 
   case class GetSubscriptionToCancelResponse(
       id: String,
+      status: String,
       version: Int,
       contractEffectiveDate: LocalDate,
       accountId: String,

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -81,6 +81,7 @@ val getSubscriptionResponse = GetSubscriptionResponse(
 val getSubscriptionForCancelResponse = GetSubscriptionToCancelResponse(
   id = "A-S00339056",
   version = 1,
+  status = "Active",
   contractEffectiveDate = LocalDate.of(2020, 11, 29),
   accountId = "zuoraAccountId",
   accountNumber = AccountNumber("anAccountNumber"),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We are getting alarms for attempted cancellation of already cancelled subscriptions. I'm not sure how this is possible on the front end but this change validates these attempts and fails with a bad request (400) rather than an internal server error (500) so we will no longer receive alarms for them.