### PR TITLE
Don't try to adjust an invoice which already has a balance of zero

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala
@@ -534,7 +534,7 @@ object RecurringContributionToSupporterPlus {
       balanceToAdjust: BigDecimal,
   ): ZIO[InvoiceItemAdjustment with GetInvoiceItems, ErrorResponse, Unit] =
     for {
-      _ <- ZIO.log(s" Attempting to adjust invoice $invoiceId")
+      _ <- ZIO.log(s"Attempting to adjust invoice $invoiceId")
       invoiceResponse <- GetInvoiceItems.get(invoiceId)
       invoiceItems = invoiceResponse.invoiceItems
       invoiceItem <- ZIO

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala
@@ -266,8 +266,10 @@ object RecurringContributionToSupporterPlus {
         charge of 50 cents. Instead we write-off the invoices in the `adjustNonCollectedInvoices` function.
        */
       paidAmount <-
-        // not clear why we would want to create a negative payment, but this logic was already in place
-        if (invoiceBalance < 0 || invoiceBalance >= 0.5) {
+        if (invoiceBalance == 0) {
+          ZIO.succeed(BigDecimal(0))
+        } else if (invoiceBalance < 0 || invoiceBalance >= 0.5) {
+          // not clear why we would want to create a negative payment, but this logic was already in place
           import account._
           CreatePayment
             .create(
@@ -532,7 +534,7 @@ object RecurringContributionToSupporterPlus {
       balanceToAdjust: BigDecimal,
   ): ZIO[InvoiceItemAdjustment with GetInvoiceItems, ErrorResponse, Unit] =
     for {
-      _ <- ZIO.log(s"Attempting to adjust invoice $invoiceId")
+      _ <- ZIO.log(s" Attempting to adjust invoice $invoiceId")
       invoiceResponse <- GetInvoiceItems.get(invoiceId)
       invoiceItems = invoiceResponse.invoiceItems
       invoiceItem <- ZIO


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
There is a bug in the product-move api with the logic which avoids taking payment for amounts less than $0.50 - when it tries to write off the amount by adjusting the balance of the relevant invoice down to zero, it fails to consider the case where the balance is already zero. This PR fixes that.

Log of this error happening in PROD:
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmove-product-PROD/log-events/2023$252F12$252F08$252F$255B$2524LATEST$255Df27851dbff9643ffb83e9c4b2200f09f$3Fstart$3D1702030802738$26refEventId$3D37956555254140750205574089267826444890909770908943450123