### PR TITLE
Widen scope of test emails that get cancelled in Zuora CODE (and removed from Salesforce sandbox)

### DIFF
--- a/handlers/dev-env-cleaner/cfn.yaml
+++ b/handlers/dev-env-cleaner/cfn.yaml
@@ -15,7 +15,7 @@ Mappings:
   Stages:
     Schedule:
       CODE: 'rate(365 days)'
-      PROD: 'rate(12 hours)'
+      PROD: 'rate(6 hours)'
   Constants:
     Alarm:
       Process: See the wiki at https://github.com/guardian/support-frontend/wiki/Automated-IT-Tests

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -135,7 +135,7 @@ class Steps(log: String => Unit) {
       subs_to_cancel,
       """select Id, TermEndDate
         |from Subscription
-        |where (billtocontact.WorkEmail = 'integration-test@thegulocal.com' OR billtocontact.WorkEmail = 'test@thegulocal.com') and Status = 'Active' and account.Status = 'Active'
+        |where (billtocontact.WorkEmail LIKE '%@thegulocal.com' OR (billtocontact.WorkEmail LIKE 'test%' AND billtocontact.WorkEmail LIKE '@theguardian.com')) and Status = 'Active' and account.Status = 'Active'
         |""".stripMargin,
     )
     val accounts_to_cancel = "accounts_to_cancel"
@@ -143,7 +143,7 @@ class Steps(log: String => Unit) {
       accounts_to_cancel,
       """select Id
         |from Account
-        |where (billtocontact.WorkEmail = 'integration-test@thegulocal.com' OR billtocontact.WorkEmail = 'test@thegulocal.com') and Status = 'Active'
+        |where where (billtocontact.WorkEmail LIKE '%@thegulocal.com' OR (billtocontact.WorkEmail LIKE 'test%' AND billtocontact.WorkEmail LIKE '@theguardian.com')) and Status = 'Active'
         |""".stripMargin,
     )
     val request = AquaQueryRequest(

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -266,7 +266,7 @@ object RemoveAccountCrm {
   case class RemoveAccountCrmRequest(
       CrmId: String = "",
   )
-  implicit val writes = Json.writes[CancelAccountRequest]
+  implicit val writes = Json.writes[RemoveAccountCrmRequest]
 
 }
 case class RemoveAccountCrm(log: String => Unit, restRequestMaker: RestRequestMaker.Requests) {

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -143,7 +143,7 @@ class Steps(log: String => Unit) {
       accounts_to_cancel,
       """select Id
         |from Account
-        |where where (billtocontact.WorkEmail LIKE '%@thegulocal.com' OR (billtocontact.WorkEmail LIKE 'test%' AND billtocontact.WorkEmail LIKE '@theguardian.com')) and Status = 'Active'
+        |where (billtocontact.WorkEmail LIKE '%@thegulocal.com' OR (billtocontact.WorkEmail LIKE 'test%' AND billtocontact.WorkEmail LIKE '@theguardian.com')) and Status = 'Active'
         |""".stripMargin,
     )
     val request = AquaQueryRequest(

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -173,7 +173,7 @@ class Steps(log: String => Unit) {
         .sequence
       _ <- queryResults(accounts_to_cancel).map { 
         case id :: creditBalance :: Nil => 
-        creditBalance.toInt match {
+        creditBalance.toDouble match {
           case 0 => cancelAccount.run(id)
           case _ => removeAccountCrm.run(id) //can't cancel an account with a credit balance, so just remove the CRMId
         } 

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -139,7 +139,7 @@ class Steps(log: String => Unit) {
       subs_to_cancel,
       """select Id, TermEndDate
         |from Subscription
-        |where (billtocontact.WorkEmail LIKE '%@thegulocal.com' OR (billtocontact.WorkEmail LIKE 'test%' AND billtocontact.WorkEmail LIKE '@theguardian.com')) and Status = 'Active' and account.Status = 'Active'
+        |where (billtocontact.WorkEmail LIKE '%@thegulocal.com' OR (billtocontact.WorkEmail LIKE 'test%' AND billtocontact.WorkEmail LIKE '%@theguardian.com')) and Status = 'Active' and account.Status = 'Active'
         |""".stripMargin,
     )
     val accounts_to_cancel = "accounts_to_cancel"
@@ -147,7 +147,7 @@ class Steps(log: String => Unit) {
       accounts_to_cancel,
       """select Id, CreditBalance
         |from Account
-        |where (billtocontact.WorkEmail LIKE '%@thegulocal.com' OR (billtocontact.WorkEmail LIKE 'test%' AND billtocontact.WorkEmail LIKE '@theguardian.com')) and Status = 'Active'
+        |where (billtocontact.WorkEmail LIKE '%@thegulocal.com' OR (billtocontact.WorkEmail LIKE 'test%' AND billtocontact.WorkEmail LIKE '%@theguardian.com')) and Status = 'Active'
         |""".stripMargin,
     )
     val request = AquaQueryRequest(

--- a/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
+++ b/handlers/dev-env-cleaner/src/main/scala/com/gu/cleaner/Handler.scala
@@ -173,7 +173,7 @@ class Steps(log: String => Unit) {
         .sequence
       _ <- queryResults(accounts_to_cancel).map { 
         case id :: creditBalance :: Nil => 
-        creditBalance match {
+        creditBalance.toInt match {
           case 0 => cancelAccount.run(id)
           case _ => removeAccountCrm.run(id) //can't cancel an account with a credit balance, so just remove the CRMId
         } 


### PR DESCRIPTION
For a few months, we have noticed the rate that the Salesforce sandbox has been filling up has been increasing. More recently, the Conversions Team have introduced more end-to-end tests that would be adding more data to Zuora/Salesforce.

The dev-env-cleaner Lambda is intended to remove test data from the Salesforce Sandbox, by cancelling both subscriptions and accounts in Zuora. We found that it had a few issues that this PR addresses.

## What does this change?

#### Changes the filter for both queries to start including test data generated from new [support-frontend playwright tests](https://github.com/guardian/support-frontend/tree/main/support-e2e/tests)

These new tests will create up to 30 new brand new subscriptions for each deployment on support-frontend, which would substantially increase the rate of test data accumulation in our Salesforce Sandbox.

The query is updated to account for these new tests. Previously it would only cancel accounts for `integration-test@thegulocal.com` and `test@thegulocal.com`. Now it will find and cancel any accounts matching emails `%@thegulocal.com` or `test%...%@theguardian.com`. This should pick up all test data from the support-frontend deployment tests, plus users running tests locally or using other `@thegulocal.com` test users.

#### For Customer Accounts with a credit balance, only removes the CRM Id instead of cancelling the account

The Lambda was getting stuck with Accounts with a Credit Balance, as Zuora does not allow these to be cancelled. To rectify this would require manual invoice adjustments to remove the Balance. 

Instead I've updated the Lambda to remove their CRM ID instead of cancelling the Account, if the Credit Balance is not 0. This will ensure that the associated data is still removed from Salesforce.

#### Run Lambda four times a day, instead of twice

Within the 15 minute time limit, the Lambda can do about 1,000 records (subs + customer accounts) depending on the response time from the Zuora requests. So 1,000 new customer accounts and subs can be cleaned in 24 hours

Running twice is probably fine, but with the support-frontend tests now adding 30 accounts/subscriptions per merge it's easy to imagine more than 1,000 being generated on a particularly busy day (imagine many dependabot/snyk PRs all being merged together).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
The rate of test data accumulation in the Salesforce sandbox should be significantly reduced, leading to fewer instances of the Salesforce developers having to manually clear out data.

After testing these changes in CODE, the data storage in the Salesforce sandbox was reduced from 106% to 96% - the lowest it has been for a while (the hard upper limit is 110%):
<img width="532" alt="Screenshot 2023-12-12 at 15 50 27" src="https://github.com/guardian/support-service-lambdas/assets/23298731/8b67f35a-768e-4c52-a5d2-13907f1ff637">

We can reduce this further with other clean up efforts, but the changes are clearly effective. 

## Have we considered potential risks?
This is only dealing with test data, so there is no risk to live customer data. 

There is a risk that required test data is inadvertently deleted, but developers can easily avoid this by avoiding using `@gulocal.com`. The lambda also only runs every 6 hours, so test data will persist for a while.