### PR TITLE
prevent disabling similar_guardian_products when responding to a cancellation notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Each lambda is a separate [pnpm workspace](https://pnpm.io/workspaces) which all
 dependencies for all projects, add dependencies between projects build all projects at once and generally facilitates 
 the management of a monorepo
 
-
 Linting rules (`.eslintrc.json`), formatting rules (`.prettierrc`) and Typescript configuration (`tsconfig.json`) are all defined at the root
 of the repository and use standard Guardian configuration where available. 
 

--- a/handlers/soft-opt-in-consent-setter/README.md
+++ b/handlers/soft-opt-in-consent-setter/README.md
@@ -2,17 +2,13 @@
 
 This is a lambda that alters a user's Soft Opt-In setting based on the subscriptions they acquire and cancel.
 
-The lambda will fetch 200 subscriptions at a time from Salesforce, process them, set the consents in IDAPI, and update
-their records in Salesforce with the outcome. It will first process acquisitions and then process cancellations.
+The lambda will fetch 200 subscriptions at a time from Salesforce, process them, set the consents in IDAPI, and update their records in Salesforce with the outcome. It will first process acquisitions and then process cancellations.
 
-For an acquisition, it will enable the Soft Opt-In consents associated with that subscription according to the consents
-mapping.
+For an acquisition, it will enable the Soft Opt-In consents associated with that subscription according to the consents mapping.
 
-For a cancellation, it will disable the Soft Opt-In consents that are associated only with the subscription being
-cancelled, out of all the products the user has active.
+For a cancellation, it will disable the Soft Opt-In consents that are associated only with the subscription being cancelled, except similar_guardian_products
 
-If it is unable to update a record, it will increment the number of retries and try again later in a subsequent run. It
-will only attempt to update records 5 times.
+If it is unable to update a record, it will increment the number of retries and try again later in a subsequent run. It will only attempt to update records 5 times.
 
 ## Metrics
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculator.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculator.scala
@@ -63,4 +63,14 @@ class ConsentsCalculator(consentsMappings: Map[String, Set[String]]) {
     consents.map(ConsentsObject(_, state)).asJson.toString()
   }
 
+  def removeSimilarGuardianProductFromSet(consents: Set[String]): Set[String] = {
+    // This method was added during https://github.com/guardian/support-service-lambdas/pull/2130
+    // for the sole purpose of removing similar_guardian_products to the set of consents that are
+    // passed sendCancellationConsents. If one day more than one consent needs to be excluded from
+    // being turned off, then the author of the change can adopt the same method, but should
+    // probably rename this function
+
+    consents - "similar_guardian_products"
+  }
+
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -187,13 +187,14 @@ object Handler extends LazyLogging {
       consentsCalculator: ConsentsCalculator,
   ): Either[SoftOptInError, Unit] = {
     def sendCancellationConsents(identityId: String, consents: Set[String]): Either[SoftOptInError, Unit] = {
-      if (consents.nonEmpty)
+      if (consents.nonEmpty) {
         sendConsentsReq(
           identityId,
           consentsCalculator.buildConsentsBody(consents, state = false),
         )
-      else
+      } else {
         Right(())
+      }
     }
 
     Metrics.put(event = "cancellations_to_process", cancelledSubs.size)
@@ -209,7 +210,8 @@ object Handler extends LazyLogging {
               sub.Product__c,
               associatedActiveNonGiftSubs.map(_.Product__c).toSet,
             )
-            _ <- sendCancellationConsents(sub.Buyer__r.IdentityID__c, consents)
+            consentWithoutSimilarProducts = consentsCalculator.removeSimilarGuardianProductFromSet(consents)
+            _ <- sendCancellationConsents(sub.Buyer__r.IdentityID__c, consentWithoutSimilarProducts)
           } yield ()
 
         logErrors(updateResult)

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -220,7 +220,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       sfConnector: SalesforceConnector,
   ): Either[SoftOptInError, Unit] = {
     def sendCancellationConsents(identityId: String, consents: Set[String]): Either[SoftOptInError, Unit] = {
-      if (consents.nonEmpty)
+      if (consents.nonEmpty) {
         for {
           _ <- {
             val consentsBody = consentsCalculator.buildConsentsBody(consents, state = false)
@@ -230,8 +230,9 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
             sendConsentsReq(identityId, consentsBody)
           }
         } yield ()
-      else
+      } else {
         Right(())
+      }
     }
 
     for {
@@ -248,7 +249,8 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
         messageBody.productName,
         productNames.toSet,
       )
-      _ <- sendCancellationConsents(messageBody.identityId, consents)
+      consentWithoutSimilarProducts = consentsCalculator.removeSimilarGuardianProductFromSet(consents)
+      _ <- sendCancellationConsents(messageBody.identityId, consentWithoutSimilarProducts)
     } yield ()
   }
 

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -147,7 +147,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     mockSendConsentsReq
       .expects(
         "someIdentityId",
-        "[\n  {\n    \"id\" : \"your_support_onboarding\",\n    \"consented\" : false\n  },\n  {\n    \"id\" : \"similar_guardian_products\",\n    \"consented\" : false\n  },\n  {\n    \"id\" : \"supporter_newsletter\",\n    \"consented\" : false\n  },\n  {\n    \"id\" : \"digital_subscriber_preview\",\n    \"consented\" : false\n  }\n]",
+        "[\n  {\n    \"id\" : \"your_support_onboarding\",\n    \"consented\" : false\n  },\n  {\n    \"id\" : \"supporter_newsletter\",\n    \"consented\" : false\n  },\n  {\n    \"id\" : \"digital_subscriber_preview\",\n    \"consented\" : false\n  }\n]",
       )
       .returning(Right(()))
     mockGetMobileSubscriptions.expects("someIdentityId").returning(Right(mobileSubscriptions))


### PR DESCRIPTION
This implements a change in the way we process cancellations. We no longer remove all associated consents, but leave `similar_guardian_products` active.

For this, and to avoid affecting the delicate balance of the `ConsentsCalculator`, we simply give it a method which only remove `similar_guardian_products` from the set of consents that are going to be turned off. That method is then called just before `sendCancellationConsents`
