### PR TITLE
Check subscription belongs to the signed-in user

### DIFF
--- a/handlers/discount-api/src/index.ts
+++ b/handlers/discount-api/src/index.ts
@@ -22,11 +22,11 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 		switch (true) {
 			case event.path === '/apply-discount' && event.httpMethod === 'POST': {
 				console.log('Applying a discount');
-				return await discountEndpoint(stage, false, event.body);
+				return await discountEndpoint(stage, false, event.headers, event.body);
 			}
 			case event.path === '/preview-discount' && event.httpMethod === 'POST': {
 				console.log('Previewing discount');
-				return await discountEndpoint(stage, true, event.body);
+				return await discountEndpoint(stage, true, event.headers, event.body);
 			}
 			default:
 				return {

--- a/handlers/discount-api/src/zuora/getAccount.ts
+++ b/handlers/discount-api/src/zuora/getAccount.ts
@@ -1,0 +1,11 @@
+import type { ZuoraClient } from './zuoraClient';
+import type { ZuoraAccount } from './zuoraSchemas';
+import { zuoraAccountSchema } from './zuoraSchemas';
+
+export const getAccount = async (
+	zuoraClient: ZuoraClient,
+	accountNumber: string,
+): Promise<ZuoraAccount> => {
+	const path = `v1/accounts/${accountNumber}`;
+	return zuoraClient.get<ZuoraAccount>(path, zuoraAccountSchema);
+};

--- a/handlers/discount-api/src/zuora/zuoraSchemas.ts
+++ b/handlers/discount-api/src/zuora/zuoraSchemas.ts
@@ -66,6 +66,15 @@ export type ZuoraSubscription = z.infer<typeof zuoraSubscriptionSchema>;
 export type RatePlan = ZuoraSubscription['ratePlans'][number];
 
 export type RatePlanCharge = RatePlan['ratePlanCharges'][number];
+
+export const zuoraAccountSchema = z.object({
+	success: z.boolean(),
+	basicInfo: z.object({
+		id: z.string(),
+		IdentityId__c: z.string(),
+	}),
+});
+export type ZuoraAccount = z.infer<typeof zuoraAccountSchema>;
 export const zuoraSubscribeResponseSchema = z.array(
 	z.object({
 		Success: z.boolean(),

--- a/handlers/discount-api/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
+++ b/handlers/discount-api/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
@@ -39,7 +39,7 @@ export const digiSubSubscribeBody = (
 				BillToContact: {
 					FirstName: 'Test',
 					LastName: 'User',
-					WorkEmail: 'test.user@test.com',
+					WorkEmail: 'test.user@thegulocal.com',
 					Country: 'GB',
 				},
 				PaymentMethod: {

--- a/handlers/discount-api/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
+++ b/handlers/discount-api/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
@@ -39,7 +39,7 @@ export const digiSubSubscribeBody = (
 				BillToContact: {
 					FirstName: 'Test',
 					LastName: 'User',
-					WorkEmail: 'test.user@thegulocal.com',
+					WorkEmail: 'test.user@test.com',
 					Country: 'GB',
 				},
 				PaymentMethod: {

--- a/handlers/discount-api/test/previewDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/previewDiscountIntegration.test.ts
@@ -11,7 +11,42 @@ import { ZuoraClient } from '../src/zuora/zuoraClient';
 import { createDigitalSubscription } from './helpers';
 
 const stage: Stage = 'CODE';
+const validIdentityId = '200175946';
+const invalidIdentityId = 'qwertyuiop';
+``;
+test("Subscriptions which don't belong to the provided identity Id are not eligible", async () => {
+	const zuoraClient = await ZuoraClient.create(stage);
 
+	console.log('Creating a new digital subscription');
+	const subscribeResponse = await createDigitalSubscription(zuoraClient, true);
+
+	const subscriptionNumber = checkDefined(
+		subscribeResponse[0]?.SubscriptionNumber,
+		'SubscriptionNumber was undefined in response from Zuora',
+	);
+
+	const requestBody = {
+		subscriptionNumber: subscriptionNumber,
+		preview: true,
+	};
+
+	await expect(async () => {
+		await discountEndpoint(
+			stage,
+			true,
+			{ 'x-identity-id': invalidIdentityId },
+			JSON.stringify(requestBody),
+		);
+	}).rejects.toThrow('does not belong to identity ID');
+
+	console.log('Cancelling the subscription');
+	const cancellationResult = await cancelSubscription(
+		zuoraClient,
+		subscriptionNumber,
+		dayjs().add(1, 'month'),
+	);
+	expect(cancellationResult.success).toEqual(true);
+}, 30000);
 test('Subscriptions on the old price are not eligible', async () => {
 	const zuoraClient = await ZuoraClient.create(stage);
 
@@ -29,7 +64,12 @@ test('Subscriptions on the old price are not eligible', async () => {
 	};
 
 	await expect(async () => {
-		await discountEndpoint(stage, true, JSON.stringify(requestBody));
+		await discountEndpoint(
+			stage,
+			true,
+			{ 'x-identity-id': validIdentityId },
+			JSON.stringify(requestBody),
+		);
 	}).rejects.toThrow('it is not eligible for a discount');
 
 	console.log('Cancelling the subscription');
@@ -60,6 +100,7 @@ test('Subscriptions on the new price are eligible', async () => {
 	const result = await discountEndpoint(
 		stage,
 		true,
+		{ 'x-identity-id': validIdentityId },
 		JSON.stringify(requestBody),
 	);
 	const eligibilityCheckResult = previewDiscountSchema.parse(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
When checking the eligibility of a digital subscription user for a discount we want to ensure that the subscription we would be discounting actually belongs to the currently signed in user. This PR adds that check