### PR TITLE
Enable Zod schema transforms and add one for IdentityId__c to identityId

### DIFF
--- a/handlers/discount-api/src/endpoints/discountEndpoint.ts
+++ b/handlers/discount-api/src/endpoints/discountEndpoint.ts
@@ -150,7 +150,7 @@ const checkSubscriptionBelongsToIdentityId = async (
 	identityId: string,
 ) => {
 	const account = await getAccount(zuoraClient, subscription.accountNumber);
-	if (account.basicInfo.IdentityId__c !== identityId) {
+	if (account.basicInfo.identityId !== identityId) {
 		throw new ValidationError(
 			`Subscription ${subscription.subscriptionNumber} does not belong to identity ID ${identityId}`,
 		);

--- a/handlers/discount-api/src/zuora/addDiscount.ts
+++ b/handlers/discount-api/src/zuora/addDiscount.ts
@@ -1,6 +1,7 @@
 import type { Dayjs } from 'dayjs';
 import { zuoraDateFormat } from './common';
 import type { ZuoraClient } from './zuoraClient';
+import type { AddDiscountPreview, ZuoraSuccessResponse } from './zuoraSchemas';
 import {
 	addDiscountPreviewSchema,
 	zuoraSuccessResponseSchema,
@@ -11,7 +12,7 @@ export const addDiscount = async (
 	subscriptionNumber: string,
 	contractEffectiveDate: Dayjs,
 	discountProductRatePlanId: string,
-) => {
+): Promise<ZuoraSuccessResponse> => {
 	const path = `/v1/subscriptions/${subscriptionNumber}`;
 	const body = JSON.stringify({
 		add: [
@@ -29,7 +30,7 @@ export const previewDiscount = async (
 	subscriptionNumber: string,
 	contractEffectiveDate: Dayjs,
 	discountProductRatePlanId: string,
-) => {
+): Promise<AddDiscountPreview> => {
 	const path = `/v1/subscriptions/${subscriptionNumber}`;
 	const body = JSON.stringify({
 		add: [

--- a/handlers/discount-api/src/zuora/billingPreview.ts
+++ b/handlers/discount-api/src/zuora/billingPreview.ts
@@ -18,7 +18,7 @@ export const getBillingPreview = async (
 		targetDate: zuoraDateFormat(targetDate),
 		assumeRenewal: 'Autorenew',
 	});
-	return zuoraClient.post<BillingPreview>(path, body, billingPreviewSchema);
+	return zuoraClient.post(path, body, billingPreviewSchema);
 };
 
 export const getNextInvoiceItems = (

--- a/handlers/discount-api/src/zuora/cancelSubscription.ts
+++ b/handlers/discount-api/src/zuora/cancelSubscription.ts
@@ -1,13 +1,14 @@
 import type { Dayjs } from 'dayjs';
 import { zuoraDateFormat } from './common';
 import type { ZuoraClient } from './zuoraClient';
+import type { ZuoraSuccessResponse } from './zuoraSchemas';
 import { zuoraSuccessResponseSchema } from './zuoraSchemas';
 
 export const cancelSubscription = async (
 	zuoraClient: ZuoraClient,
 	subscriptionNumber: string,
 	contractEffectiveDate: Dayjs,
-) => {
+): Promise<ZuoraSuccessResponse> => {
 	const path = `/v1/subscriptions/${subscriptionNumber}/cancel`;
 	const body = JSON.stringify({
 		cancellationEffectiveDate: zuoraDateFormat(contractEffectiveDate),

--- a/handlers/discount-api/src/zuora/getAccount.ts
+++ b/handlers/discount-api/src/zuora/getAccount.ts
@@ -7,5 +7,5 @@ export const getAccount = async (
 	accountNumber: string,
 ): Promise<ZuoraAccount> => {
 	const path = `v1/accounts/${accountNumber}`;
-	return zuoraClient.get<ZuoraAccount>(path, zuoraAccountSchema);
+	return zuoraClient.get(path, zuoraAccountSchema);
 };

--- a/handlers/discount-api/src/zuora/getSubscription.ts
+++ b/handlers/discount-api/src/zuora/getSubscription.ts
@@ -7,5 +7,5 @@ export const getSubscription = async (
 	subscriptionNumber: string,
 ): Promise<ZuoraSubscription> => {
 	const path = `v1/subscriptions/${subscriptionNumber}`;
-	return zuoraClient.get<ZuoraSubscription>(path, zuoraSubscriptionSchema);
+	return zuoraClient.get(path, zuoraSubscriptionSchema);
 };

--- a/handlers/discount-api/src/zuora/zuoraClient.ts
+++ b/handlers/discount-api/src/zuora/zuoraClient.ts
@@ -18,24 +18,35 @@ export class ZuoraClient {
 		this.zuoraServerUrl = zuoraServerUrl(stage).replace(/\/$/, ''); // remove trailing slash
 	}
 
-	public async get<T>(path: string, schema: z.ZodType<T>) {
+	public async get<I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
+		path: string,
+		schema: T,
+	): Promise<O> {
 		return await this.fetch(path, 'GET', schema);
 	}
 
-	public async post<T>(path: string, body: string, schema: z.ZodType<T>) {
+	public async post<I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
+		path: string,
+		body: string,
+		schema: T,
+	): Promise<O> {
 		return await this.fetch(path, 'POST', schema, body);
 	}
 
-	public async put<T>(path: string, body: string, schema: z.ZodType<T>) {
+	public async put<I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
+		path: string,
+		body: string,
+		schema: T,
+	): Promise<O> {
 		return await this.fetch(path, 'PUT', schema, body);
 	}
 
-	private async fetch<T>(
+	private async fetch<I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
 		path: string,
 		method: string,
-		schema: z.ZodType<T>,
+		schema: T,
 		body?: string,
-	): Promise<T> {
+	): Promise<O> {
 		const bearerToken = await this.tokenProvider.getBearerToken();
 		const url = `${this.zuoraServerUrl}/${path.replace(/^\//, '')}`;
 		console.log(`${method} ${url} ${body ? `with body ${body}` : ''}`);

--- a/handlers/discount-api/src/zuora/zuoraSchemas.ts
+++ b/handlers/discount-api/src/zuora/zuoraSchemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { BillingPeriodValues } from '../../../../modules/billingPeriod';
 
+// --------------- Auth ---------------
 export type OAuthClientCredentials = z.infer<
 	typeof oAuthClientCredentialsSchema
 >;
@@ -16,6 +17,7 @@ export const zuoraBearerTokenSchema = z.object({
 	expires_in: z.number(),
 });
 
+// --------------- Subscription ---------------
 export const zuoraSubscriptionSchema = z.object({
 	success: z.boolean(),
 	id: z.string(),
@@ -65,16 +67,24 @@ export type ZuoraSubscription = z.infer<typeof zuoraSubscriptionSchema>;
 
 export type RatePlan = ZuoraSubscription['ratePlans'][number];
 
-export type RatePlanCharge = RatePlan['ratePlanCharges'][number];
+// --------------- Account ---------------
+export const zuoraAccountBasicInfoSchema = z
+	.object({
+		id: z.string(),
+		IdentityId__c: z.string(),
+	})
+	.transform((obj) => ({
+		id: obj.id,
+		identityId: obj.IdentityId__c,
+	}));
 
 export const zuoraAccountSchema = z.object({
 	success: z.boolean(),
-	basicInfo: z.object({
-		id: z.string(),
-		IdentityId__c: z.string(),
-	}),
+	basicInfo: zuoraAccountBasicInfoSchema,
 });
 export type ZuoraAccount = z.infer<typeof zuoraAccountSchema>;
+
+// --------------- Subscribe ---------------
 export const zuoraSubscribeResponseSchema = z.array(
 	z.object({
 		Success: z.boolean(),
@@ -87,12 +97,14 @@ export type ZuoraSubscribeResponse = z.infer<
 	typeof zuoraSubscribeResponseSchema
 >;
 
+// --------------- Basic success response ---------------
 export const zuoraSuccessResponseSchema = z.object({
 	success: z.boolean(),
 });
 
 export type ZuoraSuccessResponse = z.infer<typeof zuoraSuccessResponseSchema>;
 
+// --------------- Billing preview ---------------
 export const billingPreviewSchema = z.object({
 	accountId: z.string(),
 	invoiceItems: z.array(
@@ -110,6 +122,7 @@ export const billingPreviewSchema = z.object({
 export type BillingPreview = z.infer<typeof billingPreviewSchema>;
 export type InvoiceItem = BillingPreview['invoiceItems'][number];
 
+// --------------- Add discount preview ---------------
 export const addDiscountPreviewSchema = z.object({
 	success: z.boolean(),
 	invoiceItems: z.array(

--- a/handlers/discount-api/test/helpers.ts
+++ b/handlers/discount-api/test/helpers.ts
@@ -16,17 +16,13 @@ import { updateSubscriptionBody } from './fixtures/request-bodies/update-subscri
 export const createDigitalSubscription = async (
 	zuoraClient: ZuoraClient,
 	createWithOldPrice: boolean,
-) => {
+): Promise<ZuoraSubscribeResponse> => {
 	const path = `/v1/action/subscribe`;
 	const body = JSON.stringify(
 		digiSubSubscribeBody(dayjs(), createWithOldPrice),
 	);
 
-	return zuoraClient.post<ZuoraSubscribeResponse>(
-		path,
-		body,
-		zuoraSubscribeResponseSchema,
-	);
+	return zuoraClient.post(path, body, zuoraSubscribeResponseSchema);
 };
 
 export const doPriceRise = async (

--- a/handlers/discount-api/test/zuora/zuoraClientIntegration.test.ts
+++ b/handlers/discount-api/test/zuora/zuoraClientIntegration.test.ts
@@ -17,7 +17,7 @@ test('ZuoraClient', async () => {
 	const bearerTokenProvider = new BearerTokenProvider(stage, credentials);
 	const zuoraClient = new ZuoraClient(stage, bearerTokenProvider);
 	const path = `v1/subscriptions/${subscriptionNumber}`;
-	const subscription = await zuoraClient.get<ZuoraSubscription>(
+	const subscription: ZuoraSubscription = await zuoraClient.get(
 		path,
 		zuoraSubscriptionSchema,
 	);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
It is useful to be able to change the structure and naming of fields in objects that are returned from api requests after they have been validated. For instance, the identity id field on a Zuora account is stored in a field called `IdentityId__c` which looks odd as a field on a Typescript object.

We can use the [Zod `transform` function](https://zod.dev/?id=transform) to make these changes, however the generic `fetch` method in the `ZuoraClient` class we were using to retrieve and validate data from Zuora did not understand the resulting schemas. 

This PR refines the `fetch` method to work correctly with transformed schemas and adds a transformation of the identity id field so that it is now `identityId`