### PR TITLE
Update Salesforce Single Contribution Writes alarm description

### DIFF
--- a/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
+++ b/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
@@ -112,10 +112,11 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
           "Fn::Join": [
             "",
             [
-              "Impact: customer service representative cannot see single contribution in Salesforce. Fix: check logs for lambda ",
+              "Impact: A Single Contribution record has not been added to Salesforce. Fix: check logs for lambda ",
               {
                 "Ref": "singlecontributionsalesforcewriteslambda1B9830FE",
               },
+              " and redrive from dead letter queue or, if Salesforce is preventing record creation due to a data quality issue, fix and add record manually to Salesforce",
             ],
           ],
         },
@@ -668,10 +669,11 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
           "Fn::Join": [
             "",
             [
-              "Impact: customer service representative cannot see single contribution in Salesforce. Fix: check logs for lambda ",
+              "Impact: A Single Contribution record has not been added to Salesforce. Fix: check logs for lambda ",
               {
                 "Ref": "singlecontributionsalesforcewriteslambda1B9830FE",
               },
+              " and redrive from dead letter queue or, if Salesforce is preventing record creation due to a data quality issue, fix and add record manually to Salesforce",
             ],
           ],
         },

--- a/cdk/lib/single-contribution-salesforce-writes.ts
+++ b/cdk/lib/single-contribution-salesforce-writes.ts
@@ -104,7 +104,7 @@ export class SingleContributionSalesforceWrites extends GuStack {
 			app: APP_NAME,
 			snsTopicName: snsTopic.topicName,
 			alarmName: `${this.stage}: Failed to sync single contribution to Salesforce`,
-			alarmDescription: `Impact: customer service representative cannot see single contribution in Salesforce. Fix: check logs for lambda ${lambda.functionName}`,
+			alarmDescription: `Impact: A Single Contribution record has not been added to Salesforce. Fix: check logs for lambda ${lambda.functionName} and redrive from dead letter queue or, if Salesforce is preventing record creation due to a data quality issue, fix and add record manually to Salesforce`,
 			metric: deadLetterQueue
 				.metric('ApproximateNumberOfMessagesVisible')
 				.with({ statistic: 'Sum', period: Duration.hours(1) }),


### PR DESCRIPTION
## What does this change?
Clarifies the fix in the description for the `Failed to sync single contribution to Salesforce` CloudWatch alarm. 

Most failures seem to be related to invalid email addresses which are not being validated in support-frontend. Therefore simply redriving the message via the dead-letter queue won't work. If the invalid email address is clearly a minor typo, this could be manually fixed and added to Salesforce.