### PR TITLE
Fix bug caused by trying to apply a discount outside the term

### DIFF
--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -81,6 +81,7 @@ export const discountEndpoint = async (
 		return applyDiscount(
 			zuoraClient,
 			requestBody.subscriptionNumber,
+			subscription.termStartDate,
 			nextBillingDate,
 			discount.productRatePlanId,
 		);
@@ -125,6 +126,7 @@ const getDiscountPreview = async (
 const applyDiscount = async (
 	zuoraClient: ZuoraClient,
 	subscriptionNumber: string,
+	termStartDate: Date,
 	nextBillingDate: Date,
 	discountProductRatePlanId: string,
 ) => {
@@ -132,6 +134,7 @@ const applyDiscount = async (
 	const discounted = await addDiscount(
 		zuoraClient,
 		subscriptionNumber,
+		dayjs(termStartDate),
 		dayjs(nextBillingDate),
 		discountProductRatePlanId,
 	);

--- a/handlers/discount-api/test/applyDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/applyDiscountIntegration.test.ts
@@ -60,6 +60,7 @@ test('createPriceRiseSubscription', async () => {
 	const discounted = await addDiscount(
 		zuoraClient,
 		subscriptionNumber,
+		dayjs(subscription.termStartDate),
 		nextBillingDate,
 		'8ad09be48b23d33f018b23e53afd522d',
 	);

--- a/handlers/discount-api/test/newTermLength.test.ts
+++ b/handlers/discount-api/test/newTermLength.test.ts
@@ -1,0 +1,8 @@
+import { getNewTermLength } from '@modules/zuora/addDiscount';
+import dayjs from 'dayjs';
+
+test('newTermLength', () => {
+	const termStartDate = dayjs('2023-12-22');
+	const nextBillingDate = dayjs('2025-01-07');
+	expect(getNewTermLength(termStartDate, nextBillingDate)).toEqual(382);
+});

--- a/modules/zuora/src/addDiscount.ts
+++ b/modules/zuora/src/addDiscount.ts
@@ -10,9 +10,16 @@ import {
 export const addDiscount = async (
 	zuoraClient: ZuoraClient,
 	subscriptionNumber: string,
+	termStartDate: Dayjs,
 	contractEffectiveDate: Dayjs,
 	discountProductRatePlanId: string,
 ): Promise<ZuoraSuccessResponse> => {
+	// We need to extend the current term up to the next billing date as you can't add a rate plan after the end of
+	// the current term.
+	// As digital subscriptions have their customer acceptance date (when first payment is taken therefore billing date)
+	// 14 days after the contract effective date (acquisition date/when the term begins) to provide a free
+	// trial period, for annual subs in particular the next billing date is going to be outside the current term.
+	const newTermLength = getNewTermLength(termStartDate, contractEffectiveDate);
 	const path = `/v1/subscriptions/${subscriptionNumber}`;
 	const body = JSON.stringify({
 		add: [
@@ -21,9 +28,16 @@ export const addDiscount = async (
 				productRatePlanId: discountProductRatePlanId,
 			},
 		],
+		currentTerm: newTermLength,
+		currentTermPeriodType: 'Day',
 	});
 	return zuoraClient.put(path, body, zuoraSuccessResponseSchema);
 };
+
+export const getNewTermLength = (
+	termStartDate: Dayjs,
+	nextBillingDate: Dayjs,
+) => nextBillingDate.diff(termStartDate, 'day');
 
 export const previewDiscount = async (
 	zuoraClient: ZuoraClient,
@@ -39,6 +53,11 @@ export const previewDiscount = async (
 				productRatePlanId: discountProductRatePlanId,
 			},
 		],
+		// Set to 24 months because you can't preview adding product rate plan after the end of the current term
+		// and as digital subscriptions have their customer acceptance date (when payment is taken therefore billing date)
+		// 14 days after the contract effective date (acquisition date/when the term begins) to provide a free
+		// trial period, for annual subs in particular the next billing date is going to be outside the current term.
+		currentTerm: 24,
 		preview: 'true',
 		invoiceTargetDate: zuoraDateFormat(contractEffectiveDate),
 	});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Fixes a bug with the discount-api which occurs mainly with annual digital subscriptions.

## What is the bug?
When we try to preview adding a discount to an annual digital subscription from the next billing date, Zuora returns an error - `The Contract effective date should not be later than the term end date of the basic subscription.`. 

This is because for digital subscriptions, the billing date (customer acceptance date in zuora terminology) is 14 days after the acquisition date (contract effective date) to give the user a 14 day free trial. This means that for annual subscriptions the next billing date is actually after the end of the current 12 month term and Zuora does not allow us to add a rate plan after the end of the current term.

## What is the fix?
This PR change the preview call to zuora to set the current term to 24 months - as this is just a preview it doesn't actually change the sub in any way but it allows us run the preview as if the term was that length.

For the update call which does actually change the sub we extend the length of the current term so that it runs exactly up to the next billing date. This allows us to add the new discount plan and has the added benefit that from this point on the term and the billing date are in sync.

The reason that we use 24 months for the preview but an exact number for the update is that for the preview we actually need a term which extends beyond the next billing date or there will be no preview invoices produced - Zuora will assume that the sub ends on that date. For the update we want to extend only to the billing date and then let autorenewal take care of creating a new term after that.

[Spreadsheets of bugs found in discount-api is here](https://docs.google.com/spreadsheets/d/1q9D4DBqgNBbOXhLMj7OXKMq_1oobP0jGBSc6NSnyuwE/edit#gid=0)
