### PR TITLE
Add billing period to new-product-api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -25,6 +25,12 @@ object WireModel {
 
   case object Sunday extends WireDayOfWeek
 
+  sealed trait WireBillingPeriod
+  case object Monthly extends WireBillingPeriod
+  case object Quarterly extends WireBillingPeriod
+  case object Annual extends WireBillingPeriod
+  case object SixWeeks extends WireBillingPeriod
+
   case class WirePlanInfo(
       id: String,
       label: String,
@@ -33,7 +39,7 @@ object WireModel {
       paymentPlan: Option[String], // todo legacy field, remove once salesforce is reading from paymentPlans
   )
 
-  case class WirePaymentPlan(currencyCode: String, description: String)
+  case class WirePaymentPlan(currencyCode: String, billingPeriod: WireBillingPeriod, description: String)
   object WirePaymentPlan {
     implicit val writes: OWrites[WirePaymentPlan] = Json.writes[WirePaymentPlan]
 
@@ -71,6 +77,16 @@ object WireModel {
     }
   }
 
+  object WireBillingPeriod {
+    implicit val writes: Writes[WireBillingPeriod] = { (period: WireBillingPeriod) => JsString(period.toString) }
+    def fromBillingPeriod(billingPeriod: BillingPeriod) = billingPeriod match {
+      case com.gu.newproduct.api.productcatalog.Monthly => Monthly
+      case com.gu.newproduct.api.productcatalog.Quarterly => Quarterly
+      case com.gu.newproduct.api.productcatalog.Annual => Annual
+      case com.gu.newproduct.api.productcatalog.SixWeeks => SixWeeks
+    }
+  }
+
   object WireSelectableWindow {
     implicit val writes: OWrites[WireSelectableWindow] = Json.writes[WireSelectableWindow]
 
@@ -98,7 +114,11 @@ object WireModel {
     def fromPlan(plan: Plan) = {
 
       val paymentPlans = plan.paymentPlans.map { case (currency: Currency, paymentPlan: PaymentPlan) =>
-        WirePaymentPlan(currency.iso, paymentPlan.description)
+        WirePaymentPlan(
+          currency.iso,
+          WireBillingPeriod.fromBillingPeriod(paymentPlan.billingPeriod),
+          paymentPlan.description,
+        )
       }
 
       val legacyPaymentPlan = plan.paymentPlans.get(GBP).map(_.description)
@@ -178,7 +198,7 @@ object WireModel {
       val nationalDelivery = WireProduct(
         label = "National Delivery",
         plans = PlanId.enabledNationalDeliveryPlans.map(wirePlanForPlanId),
-        enabledForDeliveryCountries = Some(List(Country.UK.name))
+        enabledForDeliveryCountries = Some(List(Country.UK.name)),
       )
 
       val availableProductsAndPlans = {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -39,7 +39,12 @@ object WireModel {
       paymentPlan: Option[String], // todo legacy field, remove once salesforce is reading from paymentPlans
   )
 
-  case class WirePaymentPlan(currencyCode: String, billingPeriod: WireBillingPeriod, description: String)
+  case class WirePaymentPlan(
+      currencyCode: String,
+      amount: BigDecimal,
+      billingPeriod: WireBillingPeriod,
+      description: String,
+  )
   object WirePaymentPlan {
     implicit val writes: OWrites[WirePaymentPlan] = Json.writes[WirePaymentPlan]
 
@@ -116,6 +121,7 @@ object WireModel {
       val paymentPlans = plan.paymentPlans.map { case (currency: Currency, paymentPlan: PaymentPlan) =>
         WirePaymentPlan(
           currency.iso,
+          paymentPlan.amountMinorUnits.value / 100d,
           WireBillingPeriod.fromBillingPeriod(paymentPlan.billingPeriod),
           paymentPlan.description,
         )

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
@@ -63,6 +63,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 47.62,
         "billingPeriod" : "Monthly",
         "description" : "GBP 47.62 every month"
       } ],
@@ -79,6 +80,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 51.96,
         "billingPeriod" : "Monthly",
         "description" : "GBP 51.96 every month"
       } ],
@@ -95,6 +97,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 10.36,
         "billingPeriod" : "Monthly",
         "description" : "GBP 10.36 every month"
       } ],
@@ -111,6 +114,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 21.62,
         "billingPeriod" : "Monthly",
         "description" : "GBP 21.62 every month"
       } ],
@@ -127,6 +131,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 41.12,
         "billingPeriod" : "Monthly",
         "description" : "GBP 41.12 every month"
       } ],
@@ -143,6 +148,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 47.62,
         "billingPeriod" : "Monthly",
         "description" : "GBP 47.62 every month"
       } ],
@@ -159,6 +165,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 10.79,
         "billingPeriod" : "Monthly",
         "description" : "GBP 10.79 every month"
       } ],
@@ -175,6 +182,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 22.06,
         "billingPeriod" : "Monthly",
         "description" : "GBP 22.06 every month"
       } ],
@@ -191,6 +199,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 20.76,
         "billingPeriod" : "Monthly",
         "description" : "GBP 20.76 every month"
       } ],
@@ -207,6 +216,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 29.42,
         "billingPeriod" : "Monthly",
         "description" : "GBP 29.42 every month"
       } ],
@@ -226,6 +236,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 1.23,
         "billingPeriod" : "Monthly",
         "description" : "GBP 1.23 every month"
       } ],
@@ -242,6 +253,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 9.99,
         "billingPeriod" : "Monthly",
         "description" : "GBP 9.99 every month"
       } ],
@@ -258,6 +270,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 4.56,
         "billingPeriod" : "Monthly",
         "description" : "GBP 4.56 every month"
       } ],
@@ -274,6 +287,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 6.78,
         "billingPeriod" : "Monthly",
         "description" : "GBP 6.78 every month"
       } ],
@@ -290,6 +304,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 7.77,
         "billingPeriod" : "Monthly",
         "description" : "GBP 7.77 every month"
       } ],
@@ -306,6 +321,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 11.11,
         "billingPeriod" : "Monthly",
         "description" : "GBP 11.11 every month"
       } ],
@@ -322,6 +338,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 3.21,
         "billingPeriod" : "Monthly",
         "description" : "GBP 3.21 every month"
       } ],
@@ -338,6 +355,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 10.1,
         "billingPeriod" : "Monthly",
         "description" : "GBP 10.10 every month"
       } ],
@@ -354,6 +372,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 8.88,
         "billingPeriod" : "Monthly",
         "description" : "GBP 8.88 every month"
       } ],
@@ -370,6 +389,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 22.22,
         "billingPeriod" : "Monthly",
         "description" : "GBP 22.22 every month"
       } ],
@@ -389,10 +409,12 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 666.66,
         "billingPeriod" : "Annual",
         "description" : "GBP 666.66 every 12 months"
       }, {
         "currencyCode" : "USD",
+        "amount" : 666.65,
         "billingPeriod" : "Annual",
         "description" : "USD 666.65 every 12 months"
       } ],
@@ -409,10 +431,12 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 55.55,
         "billingPeriod" : "Monthly",
         "description" : "GBP 55.55 every month"
       }, {
         "currencyCode" : "USD",
+        "amount" : 55.54,
         "billingPeriod" : "Monthly",
         "description" : "USD 55.54 every month"
       } ],
@@ -432,10 +456,12 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 11111.11,
         "billingPeriod" : "SixWeeks",
         "description" : "GBP 11111.11 for the first six weeks"
       }, {
         "currencyCode" : "USD",
+        "amount" : 111111.11,
         "billingPeriod" : "SixWeeks",
         "description" : "USD 111111.11 for the first six weeks"
       } ],
@@ -452,10 +478,12 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 22222.22,
         "billingPeriod" : "Quarterly",
         "description" : "GBP 22222.22 every 3 months"
       }, {
         "currencyCode" : "USD",
+        "amount" : 222222.22,
         "billingPeriod" : "Quarterly",
         "description" : "USD 222222.22 every 3 months"
       } ],
@@ -472,10 +500,12 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 33333.33,
         "billingPeriod" : "Annual",
         "description" : "GBP 33333.33 every 12 months"
       }, {
         "currencyCode" : "USD",
+        "amount" : 333333.33,
         "billingPeriod" : "Annual",
         "description" : "USD 333333.33 every 12 months"
       } ],
@@ -496,10 +526,12 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 44444.44,
         "billingPeriod" : "SixWeeks",
         "description" : "GBP 44444.44 for the first six weeks"
       }, {
         "currencyCode" : "USD",
+        "amount" : 444444.44,
         "billingPeriod" : "SixWeeks",
         "description" : "USD 444444.44 for the first six weeks"
       } ],
@@ -516,10 +548,12 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 55555.55,
         "billingPeriod" : "Quarterly",
         "description" : "GBP 55555.55 every 3 months"
       }, {
         "currencyCode" : "USD",
+        "amount" : 555555.55,
         "billingPeriod" : "Quarterly",
         "description" : "USD 555555.55 every 3 months"
       } ],
@@ -536,10 +570,12 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 66666.66,
         "billingPeriod" : "Annual",
         "description" : "GBP 66666.66 every 12 months"
       }, {
         "currencyCode" : "USD",
+        "amount" : 666666.66,
         "billingPeriod" : "Annual",
         "description" : "USD 666666.66 every 12 months"
       } ],
@@ -560,6 +596,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.05,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.05 every month"
       } ],
@@ -576,6 +613,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.06,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.06 every month"
       } ],
@@ -592,6 +630,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.01,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.01 every month"
       } ],
@@ -608,6 +647,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.02,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.02 every month"
       } ],
@@ -624,6 +664,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.07,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.07 every month"
       } ],
@@ -640,6 +681,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.08,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.08 every month"
       } ],
@@ -656,6 +698,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.09,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.09 every month"
       } ],
@@ -672,6 +715,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.1,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.10 every month"
       } ],
@@ -688,6 +732,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.03,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.03 every month"
       } ],
@@ -704,6 +749,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 70.04,
         "billingPeriod" : "Monthly",
         "description" : "GBP 70.04 every month"
       } ],
@@ -724,6 +770,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 71.01,
         "billingPeriod" : "Monthly",
         "description" : "GBP 71.01 every month"
       } ],
@@ -740,6 +787,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 71,
         "billingPeriod" : "Monthly",
         "description" : "GBP 71.00 every month"
       } ],
@@ -756,6 +804,7 @@
       },
       "paymentPlans" : [ {
         "currencyCode" : "GBP",
+        "amount" : 71.02,
         "billingPeriod" : "Monthly",
         "description" : "GBP 71.02 every month"
       } ],

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
@@ -1,1051 +1,766 @@
 {
-  "products": [
-    {
-      "label" : "Supporter Plus",
-      "plans" : [ {
-        "id" : "monthly_supporter_plus",
-        "label" : "Monthly",
-        "startDateRules" : {
-          "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
-          "selectableWindow" : {
-            "startDate" : "2019-12-01",
-            "sizeInDays" : 1
-          }
-        },
-        "paymentPlans": []
-      }, {
-        "id" : "annual_supporter_plus",
-        "label" : "Annual",
-        "startDateRules" : {
-          "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
-          "selectableWindow" : {
-            "startDate" : "2019-12-01",
-            "sizeInDays" : 1
-          }
-        },
-        "paymentPlans": []
-      } ]
-    },
-    {
-      "label": "Contribution",
-      "plans": [
-        {
-          "id": "monthly_contribution",
-          "label": "Monthly",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2019-12-01",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": []
-        },
-        {
-          "id": "annual_contribution",
-          "label": "Annual",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2019-12-01",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": []
+  "products" : [ {
+    "label" : "Supporter Plus",
+    "plans" : [ {
+      "id" : "monthly_supporter_plus",
+      "label" : "Monthly",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-01",
+          "sizeInDays" : 1
         }
-      ]
-    },
-    {
-      "label": "Voucher",
-      "plans": [
-        {
-          "id": "voucher_everyday",
-          "label": "Everyday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-01",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 47.62 every month"
-            }
-          ],
-          "paymentPlan": "GBP 47.62 every month"
-        },
-        {
-          "id": "voucher_everyday_plus",
-          "label": "Everyday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-01",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 51.96 every month"
-            }
-          ],
-          "paymentPlan": "GBP 51.96 every month"
-        },
-        {
-          "id": "voucher_saturday",
-          "label": "Saturday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-02",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 10.36 every month"
-            }
-          ],
-          "paymentPlan": "GBP 10.36 every month"
-        },
-        {
-          "id": "voucher_saturday_plus",
-          "label": "Saturday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-02",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 21.62 every month"
-            }
-          ],
-          "paymentPlan": "GBP 21.62 every month"
-        },
-        {
-          "id": "voucher_sixday",
-          "label": "Sixday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-01",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 41.12 every month"
-            }
-          ],
-          "paymentPlan": "GBP 41.12 every month"
-        },
-        {
-          "id": "voucher_sixday_plus",
-          "label": "Sixday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-01",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 47.62 every month"
-            }
-          ],
-          "paymentPlan": "GBP 47.62 every month"
-        },
-        {
-          "id": "voucher_sunday",
-          "label": "Sunday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-03",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 10.79 every month"
-            }
-          ],
-          "paymentPlan": "GBP 10.79 every month"
-        },
-        {
-          "id": "voucher_sunday_plus",
-          "label": "Sunday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-03",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 22.06 every month"
-            }
-          ],
-          "paymentPlan": "GBP 22.06 every month"
-        },
-        {
-          "id": "voucher_weekend",
-          "label": "Weekend",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-02",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 20.76 every month"
-            }
-          ],
-          "paymentPlan": "GBP 20.76 every month"
-        },
-        {
-          "id": "voucher_weekend_plus",
-          "label": "Weekend+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-03-02",
-              "sizeInDays": 35
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 29.42 every month"
-            }
-          ],
-          "paymentPlan": "GBP 29.42 every month"
-        }
-      ]
-    },
-    {
-      "label": "Home Delivery",
-      "plans": [
-        {
-          "id": "home_delivery_everyday",
-          "label": "Everyday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-01",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 1.23 every month"
-            }
-          ],
-          "paymentPlan": "GBP 1.23 every month"
-        },
-        {
-          "id": "home_delivery_everyday_plus",
-          "label": "Everyday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-01",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 9.99 every month"
-            }
-          ],
-          "paymentPlan": "GBP 9.99 every month"
-        },
-        {
-          "id": "home_delivery_saturday",
-          "label": "Saturday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-03",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 4.56 every month"
-            }
-          ],
-          "paymentPlan": "GBP 4.56 every month"
-        },
-        {
-          "id": "home_delivery_saturday_plus",
-          "label": "Saturday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-03",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 6.78 every month"
-            }
-          ],
-          "paymentPlan": "GBP 6.78 every month"
-        },
-        {
-          "id": "home_delivery_sixday",
-          "label": "Sixday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-02",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 7.77 every month"
-            }
-          ],
-          "paymentPlan": "GBP 7.77 every month"
-        },
-        {
-          "id": "home_delivery_sixday_plus",
-          "label": "Sixday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-02",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 11.11 every month"
-            }
-          ],
-          "paymentPlan": "GBP 11.11 every month"
-        },
-        {
-          "id": "home_delivery_sunday",
-          "label": "Sunday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-04",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 3.21 every month"
-            }
-          ],
-          "paymentPlan": "GBP 3.21 every month"
-        },
-        {
-          "id": "home_delivery_sunday_plus",
-          "label": "Sunday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-04",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 10.10 every month"
-            }
-          ],
-          "paymentPlan": "GBP 10.10 every month"
-        },
-        {
-          "id": "home_delivery_weekend",
-          "label": "Weekend",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-05",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 8.88 every month"
-            }
-          ],
-          "paymentPlan": "GBP 8.88 every month"
-        },
-        {
-          "id": "home_delivery_weekend_plus",
-          "label": "Weekend+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-02-05",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 22.22 every month"
-            }
-          ],
-          "paymentPlan": "GBP 22.22 every month"
-        }
-      ]
-    },
-    {
-      "label": "Digital Pack",
-      "plans": [
-        {
-          "id": "digipack_annual",
-          "label": "Annual",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2019-12-15",
-              "sizeInDays": 90
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 666.66 every 12 months"
-            },
-            {
-              "currencyCode": "USD",
-              "description": "USD 666.65 every 12 months"
-            }
-          ],
-          "paymentPlan": "GBP 666.66 every 12 months"
-        },
-        {
-          "id": "digipack_monthly",
-          "label": "Monthly",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2019-12-15",
-              "sizeInDays": 90
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 55.55 every month"
-            },
-            {
-              "currencyCode": "USD",
-              "description": "USD 55.54 every month"
-            }
-          ],
-          "paymentPlan": "GBP 55.55 every month"
-        }
-      ]
-    },
-    {
-      "label": "Guardian Weekly - Domestic",
-      "plans": [
-        {
-          "id": "guardian_weekly_domestic_6for6",
-          "label": "GW Oct 18 - Six for Six - Domestic",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Friday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-01-01",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 11111.11 for the first six weeks"
-            },
-            {
-              "currencyCode": "USD",
-              "description": "USD 111111.11 for the first six weeks"
-            }
-          ],
-          "paymentPlan": "GBP 11111.11 for the first six weeks"
-        },
-        {
-          "id": "guardian_weekly_domestic_quarterly",
-          "label": "GW Oct 18 - Quarterly - Domestic",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Friday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-01-01",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 22222.22 every 3 months"
-            },
-            {
-              "currencyCode": "USD",
-              "description": "USD 222222.22 every 3 months"
-            }
-          ],
-          "paymentPlan": "GBP 22222.22 every 3 months"
-        },
-        {
-          "id": "guardian_weekly_domestic_annual",
-          "label": "GW Oct 18 - Annual - Domestic",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Friday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-01-01",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 33333.33 every 12 months"
-            },
-            {
-              "currencyCode": "USD",
-              "description": "USD 333333.33 every 12 months"
-            }
-          ],
-          "paymentPlan": "GBP 33333.33 every 12 months"
-        }
-      ],
-      "enabledForDeliveryCountries": [
-        "Australia", "Kiribati", "Nauru", "Norfolk Island", "Tuvalu", "Canada", "Andorra", "Albania",
-        "Austria", "Bosnia-Herzegovina", "Belgium", "Bulgaria", "Saint Barthélemy", "Switzerland", "Cyprus",
-        "Czech Republic", "Germany", "Denmark", "Estonia", "Spain", "Finland", "Faroe Islands", "France",
-        "French Guiana", "Greenland", "Guadeloupe", "Greece", "Croatia", "Hungary", "Ireland", "Italy",
-        "Liechtenstein", "Lithuania", "Luxembourg", "Latvia", "Monaco", "Montenegro", "Saint Martin",
-        "Iceland", "Martinique", "Malta", "Netherlands", "Norway", "French Polynesia", "Poland",
-        "Saint Pierre & Miquelon", "Portugal", "Réunion", "Romania", "Serbia", "Sweden", "Slovenia",
-        "Svalbard and Jan Mayen", "Slovakia", "San Marino", "French Southern Territories",
-        "Wallis & Futuna", "Mayotte", "Holy See", "Åland Islands", "New Zealand", "Cook Islands",
-        "United Kingdom","Falkland Islands","Gibraltar","Guernsey","Isle of Man","Jersey","Saint Helena",
-        "United States"
-      ]
-    },
-    {
-      "label": "Guardian Weekly - ROW",
-      "plans": [
-        {
-          "id": "guardian_weekly_row_6for6",
-          "label": "GW Oct 18 - Six for Six - ROW",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Friday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-01-01",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 44444.44 for the first six weeks"
-            },
-            {
-              "currencyCode": "USD",
-              "description": "USD 444444.44 for the first six weeks"
-            }
-          ],
-          "paymentPlan": "GBP 44444.44 for the first six weeks"
-        },
-        {
-          "id": "guardian_weekly_row_quarterly",
-          "label": "GW Oct 18 - Quarterly - ROW",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Friday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-01-01",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 55555.55 every 3 months"
-            },
-            {
-              "currencyCode": "USD",
-              "description": "USD 555555.55 every 3 months"
-            }
-          ],
-          "paymentPlan": "GBP 55555.55 every 3 months"
-        },
-        {
-          "id": "guardian_weekly_row_annual",
-          "label": "GW Oct 18 - Annual - ROW",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Friday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-01-01",
-              "sizeInDays": 28
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 66666.66 every 12 months"
-            },
-            {
-              "currencyCode": "USD",
-              "description": "USD 666666.66 every 12 months"
-            }
-          ],
-          "paymentPlan": "GBP 66666.66 every 12 months"
-        }
-      ],
-      "enabledForDeliveryCountries": [
-        "United Arab Emirates", "Afghanistan", "Antigua & Barbuda", "Anguilla", "Armenia", "Angola",
-        "Antarctica", "Argentina", "American Samoa", "Aruba", "Azerbaijan", "Barbados", "Bangladesh",
-        "Burkina Faso", "Bahrain", "Burundi", "Benin", "Bermuda", "Brunei Darussalam", "Bolivia",
-        "Bonaire, Saint Eustatius and Saba", "Brazil", "Bahamas", "Bhutan", "Bouvet Island", "Botswana",
-        "Belarus", "Belize", "Cocos (Keeling) Islands", "Congo (Kinshasa)", "Central African Republic",
-        "Congo (Brazzaville)", "Ivory Coast", "Chile", "Cameroon", "China", "Colombia", "Costa Rica", "Cuba",
-        "Cape Verde Islands", "Curaçao", "Christmas Island", "Djibouti", "Dominica", "Dominican Republic",
-        "Algeria", "Ecuador", "Egypt", "Western Sahara", "Eritrea", "Ethiopia", "Fiji", "Micronesia", "Gabon",
-        "Grenada", "Georgia", "Ghana", "Gambia", "Guinea", "Equatorial Guinea",
-        "South Georgia & The South Sandwich Islands", "Guatemala", "Guam", "Guinea-Bissau", "Guyana",
-        "Hong Kong", "Heard Island and McDonald Islands", "Honduras", "Haiti", "Indonesia", "Israel",
-        "India", "British Indian Ocean Territory", "Iraq", "Iran", "Jamaica", "Jordan", "Japan", "Kenya",
-        "Kyrgyzstan", "Cambodia", "Comoros", "Saint Christopher & Nevis", "North Korea", "South Korea",
-        "Kuwait", "Cayman Islands", "Kazakhstan", "Laos", "Lebanon", "Saint Lucia", "Sri Lanka", "Liberia",
-        "Lesotho", "Libya", "Morocco", "Moldova", "Madagascar", "Marshall Islands", "Macedonia", "Mali",
-        "Myanmar", "Mongolia", "Macau", "Northern Mariana Islands", "Mauritania", "Montserrat", "Mauritius",
-        "Maldives", "Malawi", "Mexico", "Malaysia", "Mozambique", "Namibia", "New Caledonia", "Niger",
-        "Nigeria", "Nicaragua", "Nepal", "Niue", "Oman", "Panama", "Peru", "Papua New Guinea",
-        "Philippines", "Pakistan", "Pitcairn Islands", "Puerto Rico", "Palestinian Territories",
-        "Palau", "Paraguay", "Qatar", "Russia", "Rwanda", "Saudi Arabia", "Solomon Islands", "Seychelles",
-        "Sudan", "Singapore", "Sierra Leone", "Senegal", "Somalia", "Suriname", "South Sudan",
-        "Sao Tome & Principe", "El Salvador", "Sint Maarten", "Syria", "Swaziland", "Turks & Caicos Islands",
-        "Chad", "Togo", "Thailand", "Tajikistan", "Tokelau", "East Timor", "Turkmenistan", "Tunisia", "Tonga", "Turkey",
-        "Trinidad & Tobago", "Taiwan", "Tanzania", "Ukraine", "Uganda", "United States Minor Outlying Islands",
-        "Uruguay", "Uzbekistan", "Saint Vincent & The Grenadines", "Venezuela", "British Virgin Islands",
-        "United States Virgin Islands", "Vietnam", "Vanuatu", "Samoa", "Yemen", "South Africa", "Zambia",
-        "Zimbabwe"
-      ]
-    },
-    {
-      "label": "Subscription Card",
-      "plans": [
-        {
-          "id": "digital_voucher_weekend",
-          "label": "Weekend",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-03",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.05 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.05 every month"
-        },
-        {
-          "id": "digital_voucher_weekend_plus",
-          "label": "Weekend+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-03",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.06 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.06 every month"
-        },
-        {
-          "id": "digital_voucher_everyday",
-          "label": "Everyday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-01",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.01 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.01 every month"
-        },
-        {
-          "id": "digital_voucher_everyday_plus",
-          "label": "Everyday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday",
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-01",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.02 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.02 every month"
-        },
-        {
-          "id": "digital_voucher_saturday",
-          "label": "Saturday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-04",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.07 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.07 every month"
-        },
-        {
-          "id": "digital_voucher_saturday_plus",
-          "label": "Saturday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-04",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.08 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.08 every month"
-        },
-        {
-          "id": "digital_voucher_sunday",
-          "label": "Sunday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-05",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.09 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.09 every month"
-        },
-        {
-          "id": "digital_voucher_sunday_plus",
-          "label": "Sunday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Sunday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-05",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.10 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.10 every month"
-        },
-        {
-          "id": "digital_voucher_sixday",
-          "label": "Sixday",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-02",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.03 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.03 every month"
-        },
-        {
-          "id": "digital_voucher_sixday_plus",
-          "label": "Sixday+",
-          "startDateRules": {
-            "daysOfWeek": [
-              "Monday",
-              "Tuesday",
-              "Wednesday",
-              "Thursday",
-              "Friday",
-              "Saturday"
-            ],
-            "selectableWindow": {
-              "startDate": "2020-04-02",
-              "sizeInDays": 1
-            }
-          },
-          "paymentPlans": [
-            {
-              "currencyCode": "GBP",
-              "description": "GBP 70.04 every month"
-            }
-          ],
-          "paymentPlan": "GBP 70.04 every month"
-        }
-      ],
-      "enabledForDeliveryCountries": [
-        "United Kingdom"
-      ]
+      },
+      "paymentPlans" : [ ]
     }, {
-      "label" : "National Delivery",
-      "plans" : [ {
-        "id" : "national_delivery_sixday",
-        "label" : "Sixday",
-        "startDateRules" : {
-          "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
-          "selectableWindow" : {
-            "startDate" : "2020-04-02",
-            "sizeInDays" : 28
-          }
-        },
-        "paymentPlans" : [ {
-          "currencyCode" : "GBP",
-          "description" : "GBP 71.01 every month"
-        } ],
-        "paymentPlan" : "GBP 71.01 every month"
-      }, {
-        "id" : "national_delivery_everyday",
-        "label" : "Everyday",
-        "startDateRules" : {
-          "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
-          "selectableWindow" : {
-            "startDate" : "2020-04-01",
-            "sizeInDays" : 28
-          }
-        },
-        "paymentPlans" : [ {
-          "currencyCode" : "GBP",
-          "description" : "GBP 71.00 every month"
-        } ],
-        "paymentPlan" : "GBP 71.00 every month"
-      }, {
-        "id" : "national_delivery_weekend",
-        "label" : "Weekend",
-        "startDateRules" : {
-          "daysOfWeek" : [ "Saturday", "Sunday" ],
-          "selectableWindow" : {
-            "startDate" : "2020-04-03",
-            "sizeInDays" : 28
-          }
-        },
-        "paymentPlans" : [ {
-          "currencyCode" : "GBP",
-          "description" : "GBP 71.02 every month"
-        } ],
-        "paymentPlan" : "GBP 71.02 every month"
+      "id" : "annual_supporter_plus",
+      "label" : "Annual",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-01",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ ]
+    } ]
+  }, {
+    "label" : "Contribution",
+    "plans" : [ {
+      "id" : "monthly_contribution",
+      "label" : "Monthly",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-01",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ ]
+    }, {
+      "id" : "annual_contribution",
+      "label" : "Annual",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-01",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ ]
+    } ]
+  }, {
+    "label" : "Voucher",
+    "plans" : [ {
+      "id" : "voucher_everyday",
+      "label" : "Everyday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-01",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 47.62 every month"
       } ],
-      "enabledForDeliveryCountries" : [ "United Kingdom" ]
-    }
-  ]
+      "paymentPlan" : "GBP 47.62 every month"
+    }, {
+      "id" : "voucher_everyday_plus",
+      "label" : "Everyday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-01",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 51.96 every month"
+      } ],
+      "paymentPlan" : "GBP 51.96 every month"
+    }, {
+      "id" : "voucher_saturday",
+      "label" : "Saturday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-02",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 10.36 every month"
+      } ],
+      "paymentPlan" : "GBP 10.36 every month"
+    }, {
+      "id" : "voucher_saturday_plus",
+      "label" : "Saturday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-02",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 21.62 every month"
+      } ],
+      "paymentPlan" : "GBP 21.62 every month"
+    }, {
+      "id" : "voucher_sixday",
+      "label" : "Sixday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-01",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 41.12 every month"
+      } ],
+      "paymentPlan" : "GBP 41.12 every month"
+    }, {
+      "id" : "voucher_sixday_plus",
+      "label" : "Sixday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-01",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 47.62 every month"
+      } ],
+      "paymentPlan" : "GBP 47.62 every month"
+    }, {
+      "id" : "voucher_sunday",
+      "label" : "Sunday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-03",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 10.79 every month"
+      } ],
+      "paymentPlan" : "GBP 10.79 every month"
+    }, {
+      "id" : "voucher_sunday_plus",
+      "label" : "Sunday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-03",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 22.06 every month"
+      } ],
+      "paymentPlan" : "GBP 22.06 every month"
+    }, {
+      "id" : "voucher_weekend",
+      "label" : "Weekend",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-02",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 20.76 every month"
+      } ],
+      "paymentPlan" : "GBP 20.76 every month"
+    }, {
+      "id" : "voucher_weekend_plus",
+      "label" : "Weekend+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-03-02",
+          "sizeInDays" : 35
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 29.42 every month"
+      } ],
+      "paymentPlan" : "GBP 29.42 every month"
+    } ]
+  }, {
+    "label" : "Home Delivery",
+    "plans" : [ {
+      "id" : "home_delivery_everyday",
+      "label" : "Everyday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 1.23 every month"
+      } ],
+      "paymentPlan" : "GBP 1.23 every month"
+    }, {
+      "id" : "home_delivery_everyday_plus",
+      "label" : "Everyday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 9.99 every month"
+      } ],
+      "paymentPlan" : "GBP 9.99 every month"
+    }, {
+      "id" : "home_delivery_saturday",
+      "label" : "Saturday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-03",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 4.56 every month"
+      } ],
+      "paymentPlan" : "GBP 4.56 every month"
+    }, {
+      "id" : "home_delivery_saturday_plus",
+      "label" : "Saturday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-03",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 6.78 every month"
+      } ],
+      "paymentPlan" : "GBP 6.78 every month"
+    }, {
+      "id" : "home_delivery_sixday",
+      "label" : "Sixday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-02",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 7.77 every month"
+      } ],
+      "paymentPlan" : "GBP 7.77 every month"
+    }, {
+      "id" : "home_delivery_sixday_plus",
+      "label" : "Sixday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-02",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 11.11 every month"
+      } ],
+      "paymentPlan" : "GBP 11.11 every month"
+    }, {
+      "id" : "home_delivery_sunday",
+      "label" : "Sunday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-04",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 3.21 every month"
+      } ],
+      "paymentPlan" : "GBP 3.21 every month"
+    }, {
+      "id" : "home_delivery_sunday_plus",
+      "label" : "Sunday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-04",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 10.10 every month"
+      } ],
+      "paymentPlan" : "GBP 10.10 every month"
+    }, {
+      "id" : "home_delivery_weekend",
+      "label" : "Weekend",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-05",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 8.88 every month"
+      } ],
+      "paymentPlan" : "GBP 8.88 every month"
+    }, {
+      "id" : "home_delivery_weekend_plus",
+      "label" : "Weekend+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-02-05",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 22.22 every month"
+      } ],
+      "paymentPlan" : "GBP 22.22 every month"
+    } ]
+  }, {
+    "label" : "Digital Pack",
+    "plans" : [ {
+      "id" : "digipack_annual",
+      "label" : "Annual",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-15",
+          "sizeInDays" : 90
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Annual",
+        "description" : "GBP 666.66 every 12 months"
+      }, {
+        "currencyCode" : "USD",
+        "billingPeriod" : "Annual",
+        "description" : "USD 666.65 every 12 months"
+      } ],
+      "paymentPlan" : "GBP 666.66 every 12 months"
+    }, {
+      "id" : "digipack_monthly",
+      "label" : "Monthly",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-15",
+          "sizeInDays" : 90
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 55.55 every month"
+      }, {
+        "currencyCode" : "USD",
+        "billingPeriod" : "Monthly",
+        "description" : "USD 55.54 every month"
+      } ],
+      "paymentPlan" : "GBP 55.55 every month"
+    } ]
+  }, {
+    "label" : "Guardian Weekly - Domestic",
+    "plans" : [ {
+      "id" : "guardian_weekly_domestic_6for6",
+      "label" : "GW Oct 18 - Six for Six - Domestic",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Friday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-01-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "SixWeeks",
+        "description" : "GBP 11111.11 for the first six weeks"
+      }, {
+        "currencyCode" : "USD",
+        "billingPeriod" : "SixWeeks",
+        "description" : "USD 111111.11 for the first six weeks"
+      } ],
+      "paymentPlan" : "GBP 11111.11 for the first six weeks"
+    }, {
+      "id" : "guardian_weekly_domestic_quarterly",
+      "label" : "GW Oct 18 - Quarterly - Domestic",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Friday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-01-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Quarterly",
+        "description" : "GBP 22222.22 every 3 months"
+      }, {
+        "currencyCode" : "USD",
+        "billingPeriod" : "Quarterly",
+        "description" : "USD 222222.22 every 3 months"
+      } ],
+      "paymentPlan" : "GBP 22222.22 every 3 months"
+    }, {
+      "id" : "guardian_weekly_domestic_annual",
+      "label" : "GW Oct 18 - Annual - Domestic",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Friday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-01-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Annual",
+        "description" : "GBP 33333.33 every 12 months"
+      }, {
+        "currencyCode" : "USD",
+        "billingPeriod" : "Annual",
+        "description" : "USD 333333.33 every 12 months"
+      } ],
+      "paymentPlan" : "GBP 33333.33 every 12 months"
+    } ],
+    "enabledForDeliveryCountries" : [ "Australia", "Kiribati", "Nauru", "Norfolk Island", "Tuvalu", "Canada", "Andorra", "Albania", "Austria", "Bosnia-Herzegovina", "Belgium", "Bulgaria", "Saint Barthélemy", "Switzerland", "Cyprus", "Czech Republic", "Germany", "Denmark", "Estonia", "Spain", "Finland", "Faroe Islands", "France", "French Guiana", "Greenland", "Guadeloupe", "Greece", "Croatia", "Hungary", "Ireland", "Italy", "Liechtenstein", "Lithuania", "Luxembourg", "Latvia", "Monaco", "Montenegro", "Saint Martin", "Iceland", "Martinique", "Malta", "Netherlands", "Norway", "French Polynesia", "Poland", "Saint Pierre & Miquelon", "Portugal", "Réunion", "Romania", "Serbia", "Sweden", "Slovenia", "Svalbard and Jan Mayen", "Slovakia", "San Marino", "French Southern Territories", "Wallis & Futuna", "Mayotte", "Holy See", "Åland Islands", "New Zealand", "Cook Islands", "United Kingdom", "Falkland Islands", "Gibraltar", "Guernsey", "Isle of Man", "Jersey", "Saint Helena", "United States" ]
+  }, {
+    "label" : "Guardian Weekly - ROW",
+    "plans" : [ {
+      "id" : "guardian_weekly_row_6for6",
+      "label" : "GW Oct 18 - Six for Six - ROW",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Friday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-01-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "SixWeeks",
+        "description" : "GBP 44444.44 for the first six weeks"
+      }, {
+        "currencyCode" : "USD",
+        "billingPeriod" : "SixWeeks",
+        "description" : "USD 444444.44 for the first six weeks"
+      } ],
+      "paymentPlan" : "GBP 44444.44 for the first six weeks"
+    }, {
+      "id" : "guardian_weekly_row_quarterly",
+      "label" : "GW Oct 18 - Quarterly - ROW",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Friday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-01-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Quarterly",
+        "description" : "GBP 55555.55 every 3 months"
+      }, {
+        "currencyCode" : "USD",
+        "billingPeriod" : "Quarterly",
+        "description" : "USD 555555.55 every 3 months"
+      } ],
+      "paymentPlan" : "GBP 55555.55 every 3 months"
+    }, {
+      "id" : "guardian_weekly_row_annual",
+      "label" : "GW Oct 18 - Annual - ROW",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Friday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-01-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Annual",
+        "description" : "GBP 66666.66 every 12 months"
+      }, {
+        "currencyCode" : "USD",
+        "billingPeriod" : "Annual",
+        "description" : "USD 666666.66 every 12 months"
+      } ],
+      "paymentPlan" : "GBP 66666.66 every 12 months"
+    } ],
+    "enabledForDeliveryCountries" : [ "United Arab Emirates", "Afghanistan", "Antigua & Barbuda", "Anguilla", "Armenia", "Angola", "Antarctica", "Argentina", "American Samoa", "Aruba", "Azerbaijan", "Barbados", "Bangladesh", "Burkina Faso", "Bahrain", "Burundi", "Benin", "Bermuda", "Brunei Darussalam", "Bolivia", "Bonaire, Saint Eustatius and Saba", "Brazil", "Bahamas", "Bhutan", "Bouvet Island", "Botswana", "Belarus", "Belize", "Cocos (Keeling) Islands", "Congo (Kinshasa)", "Central African Republic", "Congo (Brazzaville)", "Ivory Coast", "Chile", "Cameroon", "China", "Colombia", "Costa Rica", "Cuba", "Cape Verde Islands", "Curaçao", "Christmas Island", "Djibouti", "Dominica", "Dominican Republic", "Algeria", "Ecuador", "Egypt", "Western Sahara", "Eritrea", "Ethiopia", "Fiji", "Micronesia", "Gabon", "Grenada", "Georgia", "Ghana", "Gambia", "Guinea", "Equatorial Guinea", "South Georgia & The South Sandwich Islands", "Guatemala", "Guam", "Guinea-Bissau", "Guyana", "Hong Kong", "Heard Island and McDonald Islands", "Honduras", "Haiti", "Indonesia", "Israel", "India", "British Indian Ocean Territory", "Iraq", "Iran", "Jamaica", "Jordan", "Japan", "Kenya", "Kyrgyzstan", "Cambodia", "Comoros", "Saint Christopher & Nevis", "North Korea", "South Korea", "Kuwait", "Cayman Islands", "Kazakhstan", "Laos", "Lebanon", "Saint Lucia", "Sri Lanka", "Liberia", "Lesotho", "Libya", "Morocco", "Moldova", "Madagascar", "Marshall Islands", "Macedonia", "Mali", "Myanmar", "Mongolia", "Macau", "Northern Mariana Islands", "Mauritania", "Montserrat", "Mauritius", "Maldives", "Malawi", "Mexico", "Malaysia", "Mozambique", "Namibia", "New Caledonia", "Niger", "Nigeria", "Nicaragua", "Nepal", "Niue", "Oman", "Panama", "Peru", "Papua New Guinea", "Philippines", "Pakistan", "Pitcairn Islands", "Puerto Rico", "Palestinian Territories", "Palau", "Paraguay", "Qatar", "Russia", "Rwanda", "Saudi Arabia", "Solomon Islands", "Seychelles", "Sudan", "Singapore", "Sierra Leone", "Senegal", "Somalia", "Suriname", "South Sudan", "Sao Tome & Principe", "El Salvador", "Sint Maarten", "Syria", "Swaziland", "Turks & Caicos Islands", "Chad", "Togo", "Thailand", "Tajikistan", "Tokelau", "East Timor", "Turkmenistan", "Tunisia", "Tonga", "Turkey", "Trinidad & Tobago", "Taiwan", "Tanzania", "Ukraine", "Uganda", "United States Minor Outlying Islands", "Uruguay", "Uzbekistan", "Saint Vincent & The Grenadines", "Venezuela", "British Virgin Islands", "United States Virgin Islands", "Vietnam", "Vanuatu", "Samoa", "Yemen", "South Africa", "Zambia", "Zimbabwe" ]
+  }, {
+    "label" : "Subscription Card",
+    "plans" : [ {
+      "id" : "digital_voucher_weekend",
+      "label" : "Weekend",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-03",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.05 every month"
+      } ],
+      "paymentPlan" : "GBP 70.05 every month"
+    }, {
+      "id" : "digital_voucher_weekend_plus",
+      "label" : "Weekend+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-03",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.06 every month"
+      } ],
+      "paymentPlan" : "GBP 70.06 every month"
+    }, {
+      "id" : "digital_voucher_everyday",
+      "label" : "Everyday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-01",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.01 every month"
+      } ],
+      "paymentPlan" : "GBP 70.01 every month"
+    }, {
+      "id" : "digital_voucher_everyday_plus",
+      "label" : "Everyday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-01",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.02 every month"
+      } ],
+      "paymentPlan" : "GBP 70.02 every month"
+    }, {
+      "id" : "digital_voucher_saturday",
+      "label" : "Saturday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-04",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.07 every month"
+      } ],
+      "paymentPlan" : "GBP 70.07 every month"
+    }, {
+      "id" : "digital_voucher_saturday_plus",
+      "label" : "Saturday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-04",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.08 every month"
+      } ],
+      "paymentPlan" : "GBP 70.08 every month"
+    }, {
+      "id" : "digital_voucher_sunday",
+      "label" : "Sunday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-05",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.09 every month"
+      } ],
+      "paymentPlan" : "GBP 70.09 every month"
+    }, {
+      "id" : "digital_voucher_sunday_plus",
+      "label" : "Sunday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-05",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.10 every month"
+      } ],
+      "paymentPlan" : "GBP 70.10 every month"
+    }, {
+      "id" : "digital_voucher_sixday",
+      "label" : "Sixday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-02",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.03 every month"
+      } ],
+      "paymentPlan" : "GBP 70.03 every month"
+    }, {
+      "id" : "digital_voucher_sixday_plus",
+      "label" : "Sixday+",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-02",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 70.04 every month"
+      } ],
+      "paymentPlan" : "GBP 70.04 every month"
+    } ],
+    "enabledForDeliveryCountries" : [ "United Kingdom" ]
+  }, {
+    "label" : "National Delivery",
+    "plans" : [ {
+      "id" : "national_delivery_sixday",
+      "label" : "Sixday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-02",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 71.01 every month"
+      } ],
+      "paymentPlan" : "GBP 71.01 every month"
+    }, {
+      "id" : "national_delivery_everyday",
+      "label" : "Everyday",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-01",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 71.00 every month"
+      } ],
+      "paymentPlan" : "GBP 71.00 every month"
+    }, {
+      "id" : "national_delivery_weekend",
+      "label" : "Weekend",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2020-04-03",
+          "sizeInDays" : 28
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "GBP",
+        "billingPeriod" : "Monthly",
+        "description" : "GBP 71.02 every month"
+      } ],
+      "paymentPlan" : "GBP 71.02 every month"
+    } ],
+    "enabledForDeliveryCountries" : [ "United Kingdom" ]
+  } ]
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
As part of the work to enable Salesforce to apply discounts to subscriptions at the point of acquisition we need to provide the billing period and price of payment plans in the product catalog endpoint of the new-product-api.