### PR TITLE
Test users

### DIFF
--- a/modules/test-users/README.md
+++ b/modules/test-users/README.md
@@ -1,5 +1,5 @@
 ## Test Users
-This module provides an easy way to create, cancel and delete test subscriptions and accounts in CODE Zuora from the command line.
+This module provides an easy way to create, cancel and delete test subscriptions and accounts in CODE Zuora from the command line. You will need to have fresh Janus credentials.
 
 Usage examples are below:
 ### Create a subscription

--- a/modules/test-users/README.md
+++ b/modules/test-users/README.md
@@ -1,0 +1,36 @@
+## Test Users
+This module provides an easy way to create, cancel and delete test subscriptions and accounts in CODE Zuora from the command line.
+
+Usage examples are below:
+### Create a subscription
+```shell
+pnpm -filter test-users createSubscription
+```
+Result will be: 
+```json
+[
+  {
+    Success: true,
+    SubscriptionNumber: 'A-S00815422',
+    AccountNumber: 'A00826604'
+  }
+]
+```
+Check create.ts to see what type of sub has been created.
+### Cancel a subscription
+```shell
+pnpm -filter test-users cancelSubscription A-S00815422
+```
+Result will be:
+```json
+{ success: true }
+```
+
+### Delete an account
+```shell
+pnpm -filter test-users deleteAccount A00826604
+```
+Result will be:
+```json
+{ success: true }
+```

--- a/modules/test-users/README.md
+++ b/modules/test-users/README.md
@@ -16,7 +16,7 @@ Result will be:
   }
 ]
 ```
-Check create.ts to see what type of sub has been created.
+This will create a monthly digital subscription
 ### Cancel a subscription
 ```shell
 pnpm -filter test-users cancelSubscription A-S00815422

--- a/modules/test-users/package.json
+++ b/modules/test-users/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-users",
+  "version": "1.0.0",
+  "scripts": {
+    "createSubscription": "ts-node ./src/create.ts",
+    "cancelSubscription": "ts-node ./src/cancel.ts",
+    "deleteAccount": "ts-node ./src/deleteAccount.ts",
+    "test": "jest --group=-integration",
+    "it-test": "jest --group=integration"
+  },
+  "devDependencies": {
+    "dayjs": "^1.11.10",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0"
+  }
+}

--- a/modules/test-users/src/cancel.ts
+++ b/modules/test-users/src/cancel.ts
@@ -4,7 +4,10 @@ import dayjs from 'dayjs';
 
 void (async () => {
 	const subscriptionNumber = process.argv[2];
-	if (!subscriptionNumber?.startsWith('A-S')) {
+	if (
+		!subscriptionNumber?.startsWith('A-S') ||
+		subscriptionNumber.length != 11
+	) {
 		console.log('Please provide a valid Zuora subscription number');
 		return;
 	}

--- a/modules/test-users/src/cancel.ts
+++ b/modules/test-users/src/cancel.ts
@@ -1,0 +1,18 @@
+import { cancelSubscription } from '@modules/zuora/cancelSubscription';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import dayjs from 'dayjs';
+
+void (async () => {
+	const subscriptionNumber = process.argv[2];
+	if (!subscriptionNumber?.startsWith('A-S')) {
+		console.log('Please provide a valid Zuora subscription number');
+		return;
+	}
+	const zuoraClient = await ZuoraClient.create('CODE');
+	const response = await cancelSubscription(
+		zuoraClient,
+		subscriptionNumber,
+		dayjs(),
+	);
+	console.log(response);
+})();

--- a/modules/test-users/src/create.ts
+++ b/modules/test-users/src/create.ts
@@ -46,9 +46,9 @@ export const createSubscribeBody = (
 		subscribes: [
 			{
 				Account: {
-					Name: '0019E00002QSysUQAT',
+					Name: 'Test User',
 					Currency: 'GBP',
-					CrmId: '0019E00002QSysUQAT',
+					CrmId: '0019E00002QSysUQAT', // The Saleforce Account ID
 					IdentityId__c: '200175946',
 					PaymentGateway: 'GoCardless',
 					CreatedRequestId__c: '17d9e675-4198-c0b0-0000-00000001280e',
@@ -69,7 +69,7 @@ export const createSubscribeBody = (
 				PaymentMethod: {
 					FirstName: 'Test',
 					LastName: 'User',
-					BankTransferAccountName: 'blah',
+					BankTransferAccountName: 'Test User',
 					BankCode: '200000',
 					BankTransferAccountNumber: '55779911',
 					Country: 'GB',
@@ -91,7 +91,6 @@ export const createSubscribeBody = (
 						RenewalTerm: 12,
 						TermType: 'TERMED',
 						ReaderType__c: 'Direct',
-						CreatedRequestId__c: '17d9e675-4198-c0b0-0000-00000001280e',
 					},
 				},
 				SubscribeOptions: { GenerateInvoice: true, ProcessPayments: true },
@@ -100,6 +99,7 @@ export const createSubscribeBody = (
 	};
 };
 
+const stage = 'CODE';
 export const createAccountAndSubscription = async (
 	zuoraClient: ZuoraClient,
 ): Promise<ZuoraSubscribeResponse> => {
@@ -107,7 +107,7 @@ export const createAccountAndSubscription = async (
 	const subscribeItems = [
 		{
 			productRatePlanId: getProductRatePlan(
-				'CODE',
+				stage,
 				'Digital',
 				'DigitalSubscription',
 				'Monthly',
@@ -115,7 +115,7 @@ export const createAccountAndSubscription = async (
 		},
 		{
 			productRatePlanId: getProductRatePlan(
-				'CODE',
+				stage,
 				'GuardianWeekly',
 				'Domestic',
 				'Monthly',
@@ -129,7 +129,7 @@ export const createAccountAndSubscription = async (
 };
 
 void (async () => {
-	const zuoraClient = await ZuoraClient.create('CODE');
+	const zuoraClient = await ZuoraClient.create(stage);
 	const response = await createAccountAndSubscription(zuoraClient);
 	console.log(response);
 })();

--- a/modules/test-users/src/create.ts
+++ b/modules/test-users/src/create.ts
@@ -113,14 +113,6 @@ export const createAccountAndSubscription = async (
 				'Monthly',
 			).id as string,
 		},
-		{
-			productRatePlanId: getProductRatePlan(
-				stage,
-				'GuardianWeekly',
-				'Domestic',
-				'Monthly',
-			).id as string,
-		},
 	];
 	const today = dayjs();
 	const body = JSON.stringify(createSubscribeBody(subscribeItems, today));

--- a/modules/test-users/src/create.ts
+++ b/modules/test-users/src/create.ts
@@ -1,0 +1,135 @@
+import { getProductRatePlan } from '@modules/product/productCatalogMapping';
+import { zuoraDateFormat } from '@modules/zuora/common';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import type { ZuoraSubscribeResponse } from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscribeResponseSchema } from '@modules/zuora/zuoraSchemas';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+
+type SubscribeItem = {
+	productRatePlanId: string;
+	chargeOverride?: {
+		productRatePlanChargeId: string;
+		price: number;
+	};
+};
+export const createSubscribeBody = (
+	subscribeItems: SubscribeItem[],
+	subscriptionDate: Dayjs,
+) => {
+	const ratePlanData = subscribeItems.map((subscribeItem) => {
+		const chargeOverride = subscribeItem.chargeOverride
+			? {
+					RatePlanChargeData: [
+						{
+							RatePlanCharge: {
+								ProductRatePlanChargeId:
+									subscribeItem.chargeOverride.productRatePlanChargeId,
+								Price: subscribeItem.chargeOverride.price,
+								EndDateCondition: 'SubscriptionEnd',
+							},
+						},
+					],
+			  }
+			: {};
+
+		return {
+			RatePlan: {
+				ProductRatePlanId: subscribeItem.productRatePlanId,
+			},
+			...chargeOverride,
+			SubscriptionProductFeatureList: [],
+		};
+	});
+
+	return {
+		subscribes: [
+			{
+				Account: {
+					Name: '0019E00002QSysUQAT',
+					Currency: 'GBP',
+					CrmId: '0019E00002QSysUQAT',
+					IdentityId__c: '200175946',
+					PaymentGateway: 'GoCardless',
+					CreatedRequestId__c: '17d9e675-4198-c0b0-0000-00000001280e',
+					BillCycleDay: 0,
+					AutoPay: true,
+					PaymentTerm: 'Due Upon Receipt',
+					BcdSettingOption: 'AutoSet',
+					Batch: 'Batch1',
+					InvoiceTemplateId: '2c92c0f849369b8801493bf7db7e450e',
+					sfContactId__c: '0039E00001rm02wQAA',
+				},
+				BillToContact: {
+					FirstName: 'Test',
+					LastName: 'User',
+					WorkEmail: 'test.user@thegulocal.com',
+					Country: 'GB',
+				},
+				PaymentMethod: {
+					FirstName: 'Test',
+					LastName: 'User',
+					BankTransferAccountName: 'blah',
+					BankCode: '200000',
+					BankTransferAccountNumber: '55779911',
+					Country: 'GB',
+					BankTransferType: 'DirectDebitUK',
+					Type: 'BankTransfer',
+					PaymentGateway: 'GoCardless',
+				},
+				SubscriptionData: {
+					RatePlanData: ratePlanData,
+					Subscription: {
+						ContractEffectiveDate: zuoraDateFormat(subscriptionDate),
+						ContractAcceptanceDate: zuoraDateFormat(
+							subscriptionDate.add(16, 'day'),
+						),
+						TermStartDate: zuoraDateFormat(subscriptionDate),
+						AutoRenew: true,
+						InitialTermPeriodType: 'Month',
+						InitialTerm: 12,
+						RenewalTerm: 12,
+						TermType: 'TERMED',
+						ReaderType__c: 'Direct',
+						CreatedRequestId__c: '17d9e675-4198-c0b0-0000-00000001280e',
+					},
+				},
+				SubscribeOptions: { GenerateInvoice: true, ProcessPayments: true },
+			},
+		],
+	};
+};
+
+export const createAccountAndSubscription = async (
+	zuoraClient: ZuoraClient,
+): Promise<ZuoraSubscribeResponse> => {
+	const path = `/v1/action/subscribe`;
+	const subscribeItems = [
+		{
+			productRatePlanId: getProductRatePlan(
+				'CODE',
+				'Digital',
+				'DigitalSubscription',
+				'Monthly',
+			).id as string,
+		},
+		{
+			productRatePlanId: getProductRatePlan(
+				'CODE',
+				'GuardianWeekly',
+				'Domestic',
+				'Monthly',
+			).id as string,
+		},
+	];
+	const today = dayjs();
+	const body = JSON.stringify(createSubscribeBody(subscribeItems, today));
+
+	return zuoraClient.post(path, body, zuoraSubscribeResponseSchema);
+};
+
+void (async () => {
+	const zuoraClient = await ZuoraClient.create('CODE');
+	const response = await createAccountAndSubscription(zuoraClient);
+	console.log(response);
+})();

--- a/modules/test-users/src/deleteAccount.ts
+++ b/modules/test-users/src/deleteAccount.ts
@@ -1,9 +1,9 @@
-import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { deleteAccount } from '@modules/zuora/deleteAccount';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
 
 void (async () => {
 	const accountNumber = process.argv[2];
-	if (!accountNumber?.startsWith('A')) {
+	if (!accountNumber?.startsWith('A') || accountNumber.length != 9) {
 		console.log('Please provide a valid Zuora account number');
 		return;
 	}

--- a/modules/test-users/src/deleteAccount.ts
+++ b/modules/test-users/src/deleteAccount.ts
@@ -1,0 +1,13 @@
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { deleteAccount } from '@modules/zuora/deleteAccount';
+
+void (async () => {
+	const accountNumber = process.argv[2];
+	if (!accountNumber?.startsWith('A')) {
+		console.log('Please provide a valid Zuora account number');
+		return;
+	}
+	const zuoraClient = await ZuoraClient.create('CODE');
+	const response = await deleteAccount(zuoraClient, accountNumber);
+	console.log(response);
+})();

--- a/modules/test-users/tsconfig.json
+++ b/modules/test-users/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "ts-node": {
+    "require": [
+      "tsconfig-paths/register"
+    ]
+  },
+  "compilerOptions": {
+    "paths": {
+      "@modules/aws/*": ["../aws/src/*"],
+      "@modules/zuora/*": ["../zuora/src/*"],
+      "@modules/catalog/*": ["../catalog/src/*"],
+      "@modules/product/*": ["../product/src/*"],
+      "@modules/*": ["../*"]
+    }
+  },
+}

--- a/modules/zuora/src/deleteAccount.ts
+++ b/modules/zuora/src/deleteAccount.ts
@@ -1,0 +1,11 @@
+import type { ZuoraClient } from './zuoraClient';
+import type { ZuoraSuccessResponse } from './zuoraSchemas';
+import { zuoraSuccessResponseSchema } from './zuoraSchemas';
+
+export const deleteAccount = async (
+	zuoraClient: ZuoraClient,
+	accountNumber: string,
+): Promise<ZuoraSuccessResponse> => {
+	const path = `/v1/accounts/${accountNumber}`;
+	return zuoraClient.delete(path, zuoraSuccessResponseSchema);
+};

--- a/modules/zuora/src/zuoraClient.ts
+++ b/modules/zuora/src/zuoraClient.ts
@@ -41,6 +41,13 @@ export class ZuoraClient {
 		return await this.fetch(path, 'PUT', schema, body);
 	}
 
+	public async delete<I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
+		path: string,
+		schema: T,
+	): Promise<O> {
+		return await this.fetch(path, 'DELETE', schema);
+	}
+
 	private async fetch<I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
 		path: string,
 		method: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,18 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
 
+  modules/test-users:
+    devDependencies:
+      dayjs:
+        specifier: ^1.11.10
+        version: 1.11.10
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
+
   modules/zuora:
     dependencies:
       '@aws-sdk/client-s3':
@@ -2917,7 +2929,6 @@ packages:
 
   /dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
-    dev: false
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a module which allows creation, cancellation and deletion of test subscriptions in CODE Zuora from the command line.

Usage examples from the README:
### Create a subscription
```shell
pnpm -filter test-users createSubscription
```
Result will be: 
```json
[
  {
    Success: true,
    SubscriptionNumber: 'A-S00815422',
    AccountNumber: 'A00826604'
  }
]
```
This will create a monthly digital subscription
### Cancel a subscription
```shell
pnpm -filter test-users cancelSubscription A-S00815422
```
Result will be:
```json
{ success: true }
```

### Delete an account
```shell
pnpm -filter test-users deleteAccount A00826604
```
Result will be:
```json
{ success: true }
```