### PR TITLE
make salesforce-core scala 3 ready

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ lazy val zuora = library(project in file("lib/zuora"))
 lazy val `salesforce-core` = library(project in file("lib/salesforce/core"))
   .dependsOn(`config-core`)
   .settings(
-    libraryDependencies ++= Seq(playJson) ++ logging,
+    libraryDependencies ++= Seq(playJson),
     dependencyOverrides ++= jacksonDependencies,
   )
 

--- a/lib/salesforce/core/src/main/scala/com/gu/salesforce/SFAuthConfig.scala
+++ b/lib/salesforce/core/src/main/scala/com/gu/salesforce/SFAuthConfig.scala
@@ -14,7 +14,7 @@ case class SFAuthConfig(
 
 object SFAuthConfig {
   implicit val reads: Reads[SFAuthConfig] = Json.reads[SFAuthConfig]
-  implicit val location = ConfigLocation[SFAuthConfig](path = "sfAuth", version = 1)
+  implicit val location: ConfigLocation[SFAuthConfig] = ConfigLocation[SFAuthConfig](path = "sfAuth", version = 1)
 }
 
 object SFExportAuthConfig {

--- a/lib/test/src/test/scala/com/gu/test/JsonMatchersTest.scala
+++ b/lib/test/src/test/scala/com/gu/test/JsonMatchersTest.scala
@@ -1,6 +1,6 @@
 package com.gu.test
 
-import play.api.libs.json.{JsSuccess, Json, JsonValidationError}
+import play.api.libs.json.{JsSuccess, Json, JsonValidationError, OFormat}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -9,7 +9,7 @@ class JSComparisonTest extends AnyFlatSpec with Matchers {
   import JsonMatchers._
 
   case class Simple(key: String)
-  implicit val sR = Json.format[Simple]
+  implicit val sR: OFormat[Simple] = Json.format[Simple]
 
   it should "handle missed fields as normal" in {
     val testData = """{}"""
@@ -40,9 +40,9 @@ class JSComparisonEmdeddedTest extends AnyFlatSpec with Matchers {
   import JsonMatchers._
 
   case class Simple(key: String)
-  implicit val sR = Json.format[Simple]
+  implicit val sR: OFormat[Simple] = Json.format[Simple]
   case class WithEmbed(embed: JsStringContainingJson[Simple])
-  implicit val wR = Json.format[WithEmbed]
+  implicit val wR: OFormat[WithEmbed] = Json.format[WithEmbed]
 
   it should "handle missed fields as normal" in {
     val testData = """{}"""


### PR DESCRIPTION
This is just a small PR to make salesforce-core module possible to compile against scala 3 (but it still compiles against 2.13 in reality)