### PR TITLE
make salesforce-core compile as scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val zuora = library(project in file("lib/zuora"))
     dependencyOverrides ++= jacksonDependencies,
   )
 
-lazy val `salesforce-core` = library(project in file("lib/salesforce/core"))
+lazy val `salesforce-core` = library(project in file("lib/salesforce/core"), scala3Settings)
   .dependsOn(`config-core`)
   .settings(
     libraryDependencies ++= Seq(playJson),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
   val circe = "io.circe" %% "circe-generic" % circeVersion
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val circeConfig = "io.circe" %% "circe-config" % "0.8.0"
-  val playJson = "org.playframework" %% "play-json" % "3.0.1"
+  val playJson = ("org.playframework" %% "play-json" % "3.0.1").cross(CrossVersion.for2_13Use3)
 
   // upickle here is a temporary redundancy of circe while we are migrating to it
   val upickle = "com.lihaoyi" %% "upickle" % "3.1.0"


### PR DESCRIPTION
This PR flips over salesforce-core module to scala 3.  This is part of our gradual migration from scala 2.13 to scala 3 of this repo.

After flipping the module over to scala 3 it compiles fine on its own `salesforce-core/compile`.

However if you try to compile a scala 2 project that depends on both it and play json e.g. `salesforce-client/compile` you get incompatible version suffixes
```
[IJ]compile
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef(uri("file:/Users/john_duffell/code/support-service-lambdas/"), "salesforce-client"):
[error]    org.playframework:play-json _2.13, _3
[error]    org.playframework:play-functional _2.13, _3
[error] stack trace is suppressed; run last update for the full output
[error] (update) Conflicting cross-version suffixes in: org.playframework:play-json, org.playframework:play-functional
```

As per the scala 3 migration docs you can add `.cross(CrossVersion.for2_13Use3)` to make it use the same version everywhere.  This makes it get past the `update` stage, but then it fails to `compile` any scala 2.13 module that depends on play-json, e.g.
```
[error] /Users/john_duffell/code/support-service-lambdas/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala:24:33: illegal cyclic reference involving object Json
[error]   implicit val wireReads = Json.reads[UrlParamsWire]
```

This is not really a clear error but I believe it's caused by the scala 3 artifacts not including the scala 2.13 macros, so the compiler just gives up.

I think the solution for this problem is macro mixing, so play-json would need to include both scala 2.13 and scala 3 macros in the scala 3 artifact.  As per benefit 2 of the docs https://docs.scala-lang.org/scala3/guides/migration/tutorial-macro-mixing.html