### PR TITLE
Change noisy alarm in discount-api

### DIFF
--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -47,7 +47,7 @@ exports[`The Discount API stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "ApiGateway4XXAlarmCDKC83EACCA": {
+    "ApiGateway5XXAlarmCDK11905206": {
       "Properties": {
         "ActionsEnabled": false,
         "AlarmActions": [
@@ -69,7 +69,7 @@ exports[`The Discount API stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Impact - Discount api received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "DISCOUNT-API-CODE API gateway 4XX response",
+        "AlarmName": "DISCOUNT-API-CODE API gateway 5XX response",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -78,7 +78,7 @@ exports[`The Discount API stack matches the snapshot 1`] = `
           },
         ],
         "EvaluationPeriods": 1,
-        "MetricName": "4XXError",
+        "MetricName": "5XXError",
         "Namespace": "AWS/ApiGateway",
         "Period": 300,
         "Statistic": "Sum",
@@ -1053,7 +1053,7 @@ exports[`The Discount API stack matches the snapshot 2`] = `
     },
   },
   "Resources": {
-    "ApiGateway4XXAlarmCDKC83EACCA": {
+    "ApiGateway5XXAlarmCDK11905206": {
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -1075,7 +1075,7 @@ exports[`The Discount API stack matches the snapshot 2`] = `
           },
         ],
         "AlarmDescription": "Impact - Discount api received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "DISCOUNT-API-PROD API gateway 4XX response",
+        "AlarmName": "DISCOUNT-API-PROD API gateway 5XX response",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1084,7 +1084,7 @@ exports[`The Discount API stack matches the snapshot 2`] = `
           },
         ],
         "EvaluationPeriods": 1,
-        "MetricName": "4XXError",
+        "MetricName": "5XXError",
         "Namespace": "AWS/ApiGateway",
         "Period": 300,
         "Statistic": "Sum",

--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -68,8 +68,8 @@ exports[`The Discount API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "Impact - Discount api received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "DISCOUNT-API-CODE API gateway 5XX response",
+        "AlarmDescription": "Impact - Discount api returned a 5XX response check the logs for more information: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdiscount-api-PROD. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "AlarmName": "DISCOUNT-API-CODE Discount-api 5XX response",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1074,8 +1074,8 @@ exports[`The Discount API stack matches the snapshot 2`] = `
             ],
           },
         ],
-        "AlarmDescription": "Impact - Discount api received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "DISCOUNT-API-PROD API gateway 5XX response",
+        "AlarmDescription": "Impact - Discount api returned a 5XX response check the logs for more information: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdiscount-api-PROD. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "AlarmName": "DISCOUNT-API-PROD Discount-api 5XX response",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -125,9 +125,9 @@ export class DiscountApi extends GuStack {
 		const alarmDescription = (description: string) =>
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
-		new GuAlarm(this, 'ApiGateway4XXAlarmCDK', {
+		new GuAlarm(this, 'ApiGateway5XXAlarmCDK', {
 			app,
-			alarmName: alarmName('API gateway 4XX response'),
+			alarmName: alarmName('API gateway 5XX response'),
 			alarmDescription: alarmDescription(
 				'Discount api received an invalid request',
 			),
@@ -137,7 +137,7 @@ export class DiscountApi extends GuStack {
 			actionsEnabled: this.stage === 'PROD',
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
-				metricName: '4XXError',
+				metricName: '5XXError',
 				namespace: 'AWS/ApiGateway',
 				statistic: 'Sum',
 				period: Duration.seconds(300),

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -127,9 +127,9 @@ export class DiscountApi extends GuStack {
 
 		new GuAlarm(this, 'ApiGateway5XXAlarmCDK', {
 			app,
-			alarmName: alarmName('API gateway 5XX response'),
+			alarmName: alarmName('Discount-api 5XX response'),
 			alarmDescription: alarmDescription(
-				'Discount api received an invalid request',
+				'Discount api returned a 5XX response check the logs for more information: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdiscount-api-PROD',
 			),
 			evaluationPeriods: 1,
 			threshold: 1,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Changes the alarm in the discount api to trigger on 500 errors not 400s as it did previously. 

400s are expected from the discount api as it responds with them when a user is not eligible for a discount due to one of a number of reasons so we do not want to alarm on it.