### PR TITLE
Remove stripe-webhook-endpoints from ci-scala.yaml build step

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -83,7 +83,6 @@ jobs:
           - sf-gocardless-sync
           - sf-move-subscriptions-api
           - soft-opt-in-consent-setter
-          - stripe-webhook-endpoints
           - zuora-callout-apis
           - zuora-datalake-export
           - zuora-rer


### PR DESCRIPTION
## What does this change?

This PR removes stripe-webhook-endpoints from ci-scala.yaml build step , as it is already added in gu-cdk-build step.This will prevent it form deploying twice