### PR TITLE
Enable discount at point of acquisition in new-product-api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddDigipackSub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddDigipackSub.scala
@@ -49,27 +49,21 @@ class AddDigipackSub(
     zuoraRatePlanId <- getZuoraRateplanId(request.planId)
       .toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!"))
       .toAsync
-    ratePlans = request.discountRatePlanId
+    ratePlans = List(
+      ZuoraCreateSubRequestRatePlan(
+        maybeChargeOverride = None,
+        productRatePlanId = zuoraRatePlanId,
+      ),
+    ) ++ request.discountRatePlanId
       .map(id =>
         List(
           ZuoraCreateSubRequestRatePlan(
             productRatePlanId = id,
             maybeChargeOverride = None,
           ),
-          ZuoraCreateSubRequestRatePlan(
-            maybeChargeOverride = None,
-            productRatePlanId = zuoraRatePlanId,
-          ),
         ),
       )
-      .getOrElse(
-        List(
-          ZuoraCreateSubRequestRatePlan(
-            maybeChargeOverride = None,
-            productRatePlanId = zuoraRatePlanId,
-          ),
-        ),
-      )
+      .getOrElse(Nil)
 
     createSubRequest = ZuoraCreateSubRequest(
       request = request,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
@@ -143,53 +143,25 @@ object AddGuardianWeeklySub {
           * subscription is used. This is triggered by the contractAcceptanceDate which in this case is pushed forward
           * by 6 weeks to avoid running concurrently with the 6 for 6 period
           */
-
-        ratePlans = request.discountRatePlanId
-          .map(id =>
-            List(
-              ZuoraCreateSubRequestRatePlan(
-                productRatePlanId = id,
-                maybeChargeOverride = None,
-              ),
-              ZuoraCreateSubRequestRatePlan(
-                productRatePlanId = zuora6for6RatePlanAndCharge.productRatePlanId,
-                maybeChargeOverride = Some(
-                  ChargeOverride(
-                    amountMinorUnits = None,
-                    productRatePlanChargeId = zuora6for6RatePlanAndCharge.productRatePlanChargeId,
-                    triggerDate = Some(request.startDate),
-                  ),
-                ),
-              ),
-              ZuoraCreateSubRequestRatePlan(
-                productRatePlanId = zuoraQuarterlyRatePlanId,
-                maybeChargeOverride = None,
-              ),
-            ),
-          )
-          .getOrElse(
-            List(
-              ZuoraCreateSubRequestRatePlan(
-                productRatePlanId = zuora6for6RatePlanAndCharge.productRatePlanId,
-                maybeChargeOverride = Some(
-                  ChargeOverride(
-                    amountMinorUnits = None,
-                    productRatePlanChargeId = zuora6for6RatePlanAndCharge.productRatePlanChargeId,
-                    triggerDate = Some(request.startDate),
-                  ),
-                ),
-              ),
-              ZuoraCreateSubRequestRatePlan(
-                productRatePlanId = zuoraQuarterlyRatePlanId,
-                maybeChargeOverride = None,
-              ),
-            ),
-          )
-
         createSubRequest = ZuoraCreateSubRequest(
           request = request,
           acceptanceDate = request.startDate.plusWeeks(6),
-          ratePlans = ratePlans,
+          ratePlans = List(
+            ZuoraCreateSubRequestRatePlan(
+              productRatePlanId = zuora6for6RatePlanAndCharge.productRatePlanId,
+              maybeChargeOverride = Some(
+                ChargeOverride(
+                  amountMinorUnits = None,
+                  productRatePlanChargeId = zuora6for6RatePlanAndCharge.productRatePlanChargeId,
+                  triggerDate = Some(request.startDate),
+                ),
+              ),
+            ),
+            ZuoraCreateSubRequestRatePlan(
+              productRatePlanId = zuoraQuarterlyRatePlanId,
+              maybeChargeOverride = None,
+            ),
+          ),
         )
       } yield createSubRequest
     } else {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
@@ -197,15 +197,31 @@ object AddGuardianWeeklySub {
         zuoraRatePlanId <- getZuoraRateplanId(request.planId).toApiGatewayContinueProcessing(
           internalServerError(s"no Zuora id for ${request.planId}!"),
         )
+        ratePlans = request.discountRatePlanId
+          .map(id =>
+            List(
+              ZuoraCreateSubRequestRatePlan(
+                productRatePlanId = id,
+                maybeChargeOverride = None,
+              ),
+              ZuoraCreateSubRequestRatePlan(
+                productRatePlanId = zuoraRatePlanId,
+                maybeChargeOverride = None,
+              ),
+            ),
+          )
+          .getOrElse(
+            List(
+              ZuoraCreateSubRequestRatePlan(
+                productRatePlanId = zuoraRatePlanId,
+                maybeChargeOverride = None,
+              ),
+            ),
+          )
         createSubRequest = ZuoraCreateSubRequest(
           request = request,
           acceptanceDate = request.startDate,
-          ratePlans = List(
-            ZuoraCreateSubRequestRatePlan(
-              productRatePlanId = zuoraRatePlanId,
-              maybeChargeOverride = None,
-            ),
-          ),
+          ratePlans = ratePlans,
         )
       } yield createSubRequest
     }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddPaperSub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddPaperSub.scala
@@ -48,15 +48,33 @@ class AddPaperSub(
     zuoraRatePlanId <- getZuoraRateplanId(request.planId)
       .toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!"))
       .toAsync
+
+    ratePlans = request.discountRatePlanId
+      .map(id =>
+        List(
+          ZuoraCreateSubRequestRatePlan(
+            productRatePlanId = id,
+            maybeChargeOverride = None,
+          ),
+          ZuoraCreateSubRequestRatePlan(
+            maybeChargeOverride = None,
+            productRatePlanId = zuoraRatePlanId,
+          ),
+        ),
+      )
+      .getOrElse(
+        List(
+          ZuoraCreateSubRequestRatePlan(
+            maybeChargeOverride = None,
+            productRatePlanId = zuoraRatePlanId,
+          ),
+        ),
+      )
+
     createSubRequest = ZuoraCreateSubRequest(
       request = request,
       acceptanceDate = request.startDate,
-      ratePlans = List(
-        ZuoraCreateSubRequestRatePlan(
-          maybeChargeOverride = None,
-          productRatePlanId = zuoraRatePlanId,
-        ),
-      ),
+      ratePlans = ratePlans,
     )
     subscriptionName <- createSubscription(createSubRequest).toAsyncApiGatewayOp("create paper subscription")
     plan = getPlan(request.planId)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
@@ -1,7 +1,8 @@
 package com.gu.newproduct.api.addsubscription
 
-import java.time.LocalDate
+import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
 
+import java.time.LocalDate
 import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PlanId}
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
 
@@ -17,6 +18,7 @@ case class AddSubscriptionRequest(
     amountMinorUnits: Option[AmountMinorUnits],
     acquisitionCase: CaseId,
     planId: PlanId,
+    discountRatePlanId: Option[ProductRatePlanId],
 )
 
 case class CaseId(value: String) extends AnyVal
@@ -34,6 +36,7 @@ object AddSubscriptionRequest {
       amountMinorUnits: Option[Int],
       acquisitionCase: String,
       planId: String,
+      discountRatePlanId: Option[String],
   ) {
     def toAddSubscriptionRequest = {
       val parsedRequestOrError = for {
@@ -48,6 +51,7 @@ object AddSubscriptionRequest {
         amountMinorUnits = amountMinorUnits.map(AmountMinorUnits.apply),
         CaseId(acquisitionCase),
         parsedPlanId,
+        discountRatePlanId = discountRatePlanId.map(ProductRatePlanId.apply),
       )
 
       parsedRequestOrError match {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
@@ -33,6 +33,7 @@ class AddSubscriptionRequestTest extends AnyFlatSpec with Matchers {
       amountMinorUnits = Some(AmountMinorUnits(123)),
       acquisitionCase = CaseId("5006E000005b5cf"),
       planId = MonthlyContribution,
+      discountRatePlanId = None,
     )
   }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
@@ -93,7 +93,8 @@ class PaperStepsTest extends AnyFlatSpec with Matchers with Inside with DiffShou
       createdByCSR = CreatedByCSR("bob"),
       amountMinorUnits = None,
       acquisitionCase = CaseId("case"),
-      planId = NationalDeliveryWeekend
+      planId = NationalDeliveryWeekend,
+      discountRatePlanId= None,
     )
 
     val futureActual = addVoucherSteps.addProduct(requestInput)

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/PlanId.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/PlanId.scala
@@ -175,7 +175,7 @@ object PlanId {
     DigitalVoucherSixday,
     DigitalVoucherSixdayPlus,
   )
-  
+
   val enabledNationalDeliveryPlans = List(
     NationalDeliverySixday,
     NationalDeliveryEveryday,


### PR DESCRIPTION

## What does this change?

As part of the new 3 tier product proposition, we need to be able to add discounts to Supporter Plus subscriptions at the point of acquisition in Salesforce.

This PR updates the AddSubscriptionRequest object with a discountRatePlanId  ( an Optional ProductRatePlanId) and is passed to Zuora along with the other ratePlans  when ever  a new subscription is added to an existing Zuora account.This change is done for products  like - SupporterPlus, Guardian Weekly, Digital Subs, Newspaper  