### PR TITLE
Order Billing Accounts by most recently ready to avoid bottleneck in removals

### DIFF
--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -156,7 +156,7 @@ object BillingAccountRemover extends App with LazyLogging {
     val limit = 200;
 
     val query =
-      s"SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit"
+      s"SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit"
 
     decode[SfGetBillingAccsResponse](doSfGetWithQuery(sfAuthentication, query))
   }

--- a/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
+++ b/handlers/sf-billing-account-remover/src/main/scala/com/gu/sf_billing_account_remover/BillingAccountRemover.scala
@@ -156,7 +156,7 @@ object BillingAccountRemover extends App with LazyLogging {
     val limit = 200;
 
     val query =
-      s"Select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts limit $limit"
+      s"SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit"
 
     decode[SfGetBillingAccsResponse](doSfGetWithQuery(sfAuthentication, query))
   }


### PR DESCRIPTION
## Background
sf-billing-account-remover is a Lambda that forms part of the Salesforce GDPR Data Erasure flow. Essentially it queries for a batch of Billing Accounts in Salesforce that are ready to be removed from Salesforce, and then updates the corresponding Customer Accounts in Zuora - it removes the CRM Account Id value in Zuora, which prompts Z360 to delete all of the related Zuora data in Salesforce (and stops it syncing any further data to Salesforce for the Customer Account).

The Lambda runs on batches of 200 records at a time. 

## What does this change?
I've noticed that Z360 is not consistently deleting data in Salesforce after removing the CRM Account ID. Sometimes it works, and sometimes it doesn't - there's no sign of an error or anything from Zuora or Salesforce. This is often observed for one-off GDPR Data Subject Erasure Requests, but it also happens for general Retention Policy erasures. "Retrying" the Z360 delete by restoring the CRM Account ID to the Customer Account in Zuora oftens prompts the deletion, but not always.

The unreliability of this Z360 deletion means that we'll need to look at some sort of Salesforce side solution to ensure that Customer Accounts (and all their associated customer data) are not being left in SF beyond their expected retention window. For the moment we can manually delete the records but we may want to implement an automated job to do this.

The problem addressed in this PR is that once there are 200 Billing Accounts that have had CRM Account Ids removed in Zuora but have NOT been deleted from Salesforce by Z360, this Lambda will tend to pick them up again on each run as the query to get the batch of records was not ordered. This leads to a bottleneck where the Lambda is repeatedly running on the same set of records, trying to remove the CRM Account IDs, but never actually prompting any deletion by Z360 (because the CRM Account IDs on those accounts are already blank). This is particularly annoying for GDPR Erasure Requests where we have to spot that a request is "stuck" and manually complete the CRM Account ID removal.

I have added `ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc` to the query. `GDPR_Date_Successfully_Removed_Related__c` is a timestamp recording when the previous step in the Salesforce GDPR Data Erasure flow was completed, so this should ensure that the 200 records that most recently became "Ready for Removal" and in scope of the Lambda are picked up first.

## How to test
There should not be any functional difference to the Lambda if there are less than 200 records for it to process, which is typical in CODE, except in the order that it processes customer accounts. If there are more than 200 records, verify that it is processing the newer records first.

## How can we measure success?
We avoid bottlenecks in data retention erasures, particularly for time sensitive GDPR Data Subject Erasure Requests.