### PR TITLE
Remove the top level `products` object from the product-catalog

### DIFF
--- a/modules/product-catalog/README.md
+++ b/modules/product-catalog/README.md
@@ -28,7 +28,7 @@ Finding the GBP price for home delivery of the Saturday Newspaper:
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 
 const catalog = await getProductCatalogFromApi('CODE');
-const price = catalog.products.HomeDelivery.ratePlans.Saturday.pricing.GBP;
+const price = catalog.HomeDelivery.ratePlans.Saturday.pricing.GBP;
 // price is 19.99
 
 ```
@@ -37,7 +37,7 @@ Fetching the Contribution charge id from the Supporter plus product to set the c
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 
 const catalog = await getProductCatalogFromApi('PROD');
-const contributionChargeId = catalog.products.SupporterPlus.ratePlans.Monthly.charges.Contribution.id;
+const contributionChargeId = catalog.SupporterPlus.ratePlans.Monthly.charges.Contribution.id;
 ```
 ## Implementation
 The mapping between our object model and Zuora's catalog is defined in the files `generateProductCatalog.ts`, `zuoraToProductNameMapping.ts` and `generateTypeObject.ts`.

--- a/modules/product-catalog/src/generateProductCatalog.ts
+++ b/modules/product-catalog/src/generateProductCatalog.ts
@@ -81,16 +81,13 @@ export const generateProductCatalog = (
 		isSupportedProduct(product.name),
 	);
 
-	const result = {
-		products: arrayToObject(
-			supportedProducts.map((product) => {
-				const productName = getZuoraProductKey(product.name);
-				return {
-					[productName]: getZuoraProduct(product.productRatePlans),
-				};
-			}),
-		),
-	};
-
+	const result = arrayToObject(
+		supportedProducts.map((product) => {
+			const productName = getZuoraProductKey(product.name);
+			return {
+				[productName]: getZuoraProduct(product.productRatePlans),
+			};
+		}),
+	);
 	return result as ProductCatalog;
 };

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -41,9 +41,7 @@ type Product<P extends ProductKey> = {
 };
 
 export type ProductCatalog = {
-	products: {
-		[P in ProductKey]: Product<P>;
-	};
+	[P in ProductKey]: Product<P>;
 };
 
 export class ProductCatalogHelper {
@@ -56,10 +54,10 @@ export class ProductCatalogHelper {
 		zuoraProduct: P,
 		productRatePlan: PRP,
 	) => {
-		return this.catalogData.products[zuoraProduct].ratePlans[productRatePlan];
+		return this.catalogData[zuoraProduct].ratePlans[productRatePlan];
 	};
 	getAllProductDetails = () => {
-		const stageMapping = this.catalogData.products;
+		const stageMapping = this.catalogData;
 		const zuoraProductKeys = Object.keys(stageMapping) as Array<
 			keyof typeof stageMapping
 		>;

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -1,360 +1,358 @@
 import { z } from 'zod';
 
 export const productCatalogSchema = z.object({
-	products: z.object({
-		DigitalSubscription: z.object({
-			ratePlans: z.object({
-				Annual: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+	DigitalSubscription: z.object({
+		ratePlans: z.object({
+			Annual: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
-				ThreeMonthGift: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			ThreeMonthGift: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
-				OneYearGift: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			OneYearGift: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
-				Monthly: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
+				}),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+		}),
+	}),
+	HomeDelivery: z.object({
+		ratePlans: z.object({
+			Everyday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Saturday: z.object({ id: z.string() }),
+					Monday: z.object({ id: z.string() }),
+					Sunday: z.object({ id: z.string() }),
+					Friday: z.object({ id: z.string() }),
+					Wednesday: z.object({ id: z.string() }),
+					Tuesday: z.object({ id: z.string() }),
+					Thursday: z.object({ id: z.string() }),
+				}),
+			}),
+			Sixday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Friday: z.object({ id: z.string() }),
+					Thursday: z.object({ id: z.string() }),
+					Wednesday: z.object({ id: z.string() }),
+					Tuesday: z.object({ id: z.string() }),
+					Monday: z.object({ id: z.string() }),
+					Saturday: z.object({ id: z.string() }),
+				}),
+			}),
+			Weekend: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Saturday: z.object({ id: z.string() }),
+					Sunday: z.object({ id: z.string() }),
+				}),
+			}),
+			Saturday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({ Saturday: z.object({ id: z.string() }) }),
+			}),
+			Sunday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({ Sunday: z.object({ id: z.string() }) }),
+			}),
+		}),
+	}),
+	NationalDelivery: z.object({
+		ratePlans: z.object({
+			Everyday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Monday: z.object({ id: z.string() }),
+					Tuesday: z.object({ id: z.string() }),
+					Wednesday: z.object({ id: z.string() }),
+					Thursday: z.object({ id: z.string() }),
+					Friday: z.object({ id: z.string() }),
+					Saturday: z.object({ id: z.string() }),
+					Sunday: z.object({ id: z.string() }),
+				}),
+			}),
+			Weekend: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Saturday: z.object({ id: z.string() }),
+					Sunday: z.object({ id: z.string() }),
+				}),
+			}),
+			Sixday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Thursday: z.object({ id: z.string() }),
+					Monday: z.object({ id: z.string() }),
+					Tuesday: z.object({ id: z.string() }),
+					Wednesday: z.object({ id: z.string() }),
+					Friday: z.object({ id: z.string() }),
+					Saturday: z.object({ id: z.string() }),
 				}),
 			}),
 		}),
-		HomeDelivery: z.object({
-			ratePlans: z.object({
-				Everyday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Saturday: z.object({ id: z.string() }),
-						Monday: z.object({ id: z.string() }),
-						Sunday: z.object({ id: z.string() }),
-						Friday: z.object({ id: z.string() }),
-						Wednesday: z.object({ id: z.string() }),
-						Tuesday: z.object({ id: z.string() }),
-						Thursday: z.object({ id: z.string() }),
-					}),
+	}),
+	SupporterPlus: z.object({
+		ratePlans: z.object({
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
-				Sixday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Friday: z.object({ id: z.string() }),
-						Thursday: z.object({ id: z.string() }),
-						Wednesday: z.object({ id: z.string() }),
-						Tuesday: z.object({ id: z.string() }),
-						Monday: z.object({ id: z.string() }),
-						Saturday: z.object({ id: z.string() }),
-					}),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+					Contribution: z.object({ id: z.string() }),
 				}),
-				Weekend: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Saturday: z.object({ id: z.string() }),
-						Sunday: z.object({ id: z.string() }),
-					}),
+			}),
+			Annual: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
-				Saturday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({ Saturday: z.object({ id: z.string() }) }),
-				}),
-				Sunday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({ Sunday: z.object({ id: z.string() }) }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+					Contribution: z.object({ id: z.string() }),
 				}),
 			}),
 		}),
-		NationalDelivery: z.object({
-			ratePlans: z.object({
-				Everyday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Monday: z.object({ id: z.string() }),
-						Tuesday: z.object({ id: z.string() }),
-						Wednesday: z.object({ id: z.string() }),
-						Thursday: z.object({ id: z.string() }),
-						Friday: z.object({ id: z.string() }),
-						Saturday: z.object({ id: z.string() }),
-						Sunday: z.object({ id: z.string() }),
-					}),
-				}),
-				Weekend: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Saturday: z.object({ id: z.string() }),
-						Sunday: z.object({ id: z.string() }),
-					}),
-				}),
-				Sixday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Thursday: z.object({ id: z.string() }),
-						Monday: z.object({ id: z.string() }),
-						Tuesday: z.object({ id: z.string() }),
-						Wednesday: z.object({ id: z.string() }),
-						Friday: z.object({ id: z.string() }),
-						Saturday: z.object({ id: z.string() }),
-					}),
-				}),
+	}),
+	GuardianWeeklyRestOfWorld: z.object({
+		ratePlans: z.object({
+			ThreeMonthGift: z.object({
+				id: z.string(),
+				pricing: z.object({ USD: z.number(), GBP: z.number() }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			OneYearGift: z.object({
+				id: z.string(),
+				pricing: z.object({ USD: z.number(), GBP: z.number() }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			SixWeekly: z.object({
+				id: z.string(),
+				pricing: z.object({ USD: z.number(), GBP: z.number() }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			Quarterly: z.object({
+				id: z.string(),
+				pricing: z.object({ USD: z.number(), GBP: z.number() }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			Annual: z.object({
+				id: z.string(),
+				pricing: z.object({ USD: z.number(), GBP: z.number() }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({ USD: z.number(), GBP: z.number() }),
+				charges: z.object({ Monthly: z.object({ id: z.string() }) }),
 			}),
 		}),
-		SupporterPlus: z.object({
-			ratePlans: z.object({
-				Monthly: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({
-						Subscription: z.object({ id: z.string() }),
-						Contribution: z.object({ id: z.string() }),
-					}),
+	}),
+	GuardianWeeklyDomestic: z.object({
+		ratePlans: z.object({
+			ThreeMonthGift: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
-				Annual: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({
-						Subscription: z.object({ id: z.string() }),
-						Contribution: z.object({ id: z.string() }),
-					}),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			SixWeekly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			Quarterly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
+				}),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			Annual: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
+				}),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
+				}),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			}),
+			OneYearGift: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
+				}),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 			}),
 		}),
-		GuardianWeeklyRestOfWorld: z.object({
-			ratePlans: z.object({
-				ThreeMonthGift: z.object({
-					id: z.string(),
-					pricing: z.object({ USD: z.number(), GBP: z.number() }),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				OneYearGift: z.object({
-					id: z.string(),
-					pricing: z.object({ USD: z.number(), GBP: z.number() }),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				SixWeekly: z.object({
-					id: z.string(),
-					pricing: z.object({ USD: z.number(), GBP: z.number() }),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				Quarterly: z.object({
-					id: z.string(),
-					pricing: z.object({ USD: z.number(), GBP: z.number() }),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				Annual: z.object({
-					id: z.string(),
-					pricing: z.object({ USD: z.number(), GBP: z.number() }),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				Monthly: z.object({
-					id: z.string(),
-					pricing: z.object({ USD: z.number(), GBP: z.number() }),
-					charges: z.object({ Monthly: z.object({ id: z.string() }) }),
+	}),
+	SubscriptionCard: z.object({
+		ratePlans: z.object({
+			Everyday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Monday: z.object({ id: z.string() }),
+					Friday: z.object({ id: z.string() }),
+					Thursday: z.object({ id: z.string() }),
+					Wednesday: z.object({ id: z.string() }),
+					Tuesday: z.object({ id: z.string() }),
+					Saturday: z.object({ id: z.string() }),
+					Sunday: z.object({ id: z.string() }),
 				}),
 			}),
-		}),
-		GuardianWeeklyDomestic: z.object({
-			ratePlans: z.object({
-				ThreeMonthGift: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				SixWeekly: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				Quarterly: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				Annual: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				Monthly: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				}),
-				OneYearGift: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+			Weekend: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Saturday: z.object({ id: z.string() }),
+					Sunday: z.object({ id: z.string() }),
 				}),
 			}),
-		}),
-		SubscriptionCard: z.object({
-			ratePlans: z.object({
-				Everyday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Monday: z.object({ id: z.string() }),
-						Friday: z.object({ id: z.string() }),
-						Thursday: z.object({ id: z.string() }),
-						Wednesday: z.object({ id: z.string() }),
-						Tuesday: z.object({ id: z.string() }),
-						Saturday: z.object({ id: z.string() }),
-						Sunday: z.object({ id: z.string() }),
-					}),
-				}),
-				Weekend: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Saturday: z.object({ id: z.string() }),
-						Sunday: z.object({ id: z.string() }),
-					}),
-				}),
-				Sixday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({
-						Thursday: z.object({ id: z.string() }),
-						Friday: z.object({ id: z.string() }),
-						Saturday: z.object({ id: z.string() }),
-						Wednesday: z.object({ id: z.string() }),
-						Tuesday: z.object({ id: z.string() }),
-						Monday: z.object({ id: z.string() }),
-					}),
-				}),
-				Sunday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({ Sunday: z.object({ id: z.string() }) }),
-				}),
-				Saturday: z.object({
-					id: z.string(),
-					pricing: z.object({ GBP: z.number() }),
-					charges: z.object({ Saturday: z.object({ id: z.string() }) }),
+			Sixday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Thursday: z.object({ id: z.string() }),
+					Friday: z.object({ id: z.string() }),
+					Saturday: z.object({ id: z.string() }),
+					Wednesday: z.object({ id: z.string() }),
+					Tuesday: z.object({ id: z.string() }),
+					Monday: z.object({ id: z.string() }),
 				}),
 			}),
+			Sunday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({ Sunday: z.object({ id: z.string() }) }),
+			}),
+			Saturday: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({ Saturday: z.object({ id: z.string() }) }),
+			}),
 		}),
-		Contribution: z.object({
-			ratePlans: z.object({
-				Annual: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Contribution: z.object({ id: z.string() }) }),
+	}),
+	Contribution: z.object({
+		ratePlans: z.object({
+			Annual: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
-				Monthly: z.object({
-					id: z.string(),
-					pricing: z.object({
-						USD: z.number(),
-						NZD: z.number(),
-						EUR: z.number(),
-						GBP: z.number(),
-						CAD: z.number(),
-						AUD: z.number(),
-					}),
-					charges: z.object({ Contribution: z.object({ id: z.string() }) }),
+				charges: z.object({ Contribution: z.object({ id: z.string() }) }),
+			}),
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
 				}),
+				charges: z.object({ Contribution: z.object({ id: z.string() }) }),
 			}),
 		}),
 	}),

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -2,609 +2,607 @@
 
 exports[`Generated product catalog matches snapshot 1`] = `
 {
-  "products": {
-    "Contribution": {
-      "ratePlans": {
-        "Annual": {
-          "charges": {
-            "Contribution": {
-              "id": "2c92a0fc5e1dc084015e37f58c7b0f34",
-            },
-          },
-          "id": "2c92a0fc5e1dc084015e37f58c200eea",
-          "pricing": {
-            "AUD": 100,
-            "CAD": 5,
-            "EUR": 60,
-            "GBP": 60,
-            "NZD": 60,
-            "USD": 60,
+  "Contribution": {
+    "ratePlans": {
+      "Annual": {
+        "charges": {
+          "Contribution": {
+            "id": "2c92a0fc5e1dc084015e37f58c7b0f34",
           },
         },
-        "Monthly": {
-          "charges": {
-            "Contribution": {
-              "id": "2c92a0fc5aacfadd015ad250bf2c6d38",
-            },
+        "id": "2c92a0fc5e1dc084015e37f58c200eea",
+        "pricing": {
+          "AUD": 100,
+          "CAD": 5,
+          "EUR": 60,
+          "GBP": 60,
+          "NZD": 60,
+          "USD": 60,
+        },
+      },
+      "Monthly": {
+        "charges": {
+          "Contribution": {
+            "id": "2c92a0fc5aacfadd015ad250bf2c6d38",
           },
-          "id": "2c92a0fc5aacfadd015ad24db4ff5e97",
-          "pricing": {
-            "AUD": 10,
-            "CAD": 5,
-            "EUR": 5,
-            "GBP": 5,
-            "NZD": 5,
-            "USD": 5,
-          },
+        },
+        "id": "2c92a0fc5aacfadd015ad24db4ff5e97",
+        "pricing": {
+          "AUD": 10,
+          "CAD": 5,
+          "EUR": 5,
+          "GBP": 5,
+          "NZD": 5,
+          "USD": 5,
         },
       },
     },
-    "DigitalSubscription": {
-      "ratePlans": {
-        "Annual": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0fb4edd70c9014edeaa5001218c",
-            },
-          },
-          "id": "2c92a0fb4edd70c8014edeaa4e972204",
-          "pricing": {
-            "AUD": 269.99,
-            "CAD": 274,
-            "EUR": 187,
-            "GBP": 149,
-            "NZD": 269.99,
-            "USD": 249,
+  },
+  "DigitalSubscription": {
+    "ratePlans": {
+      "Annual": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb4edd70c9014edeaa5001218c",
           },
         },
-        "Monthly": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0fb4edd70c9014edeaa50342192",
-            },
-          },
-          "id": "2c92a0fb4edd70c8014edeaa4eae220a",
-          "pricing": {
-            "AUD": 26.99,
-            "CAD": 27.44,
-            "EUR": 18.99,
-            "GBP": 14.99,
-            "NZD": 26.99,
-            "USD": 24.99,
+        "id": "2c92a0fb4edd70c8014edeaa4e972204",
+        "pricing": {
+          "AUD": 269.99,
+          "CAD": 274,
+          "EUR": 187,
+          "GBP": 149,
+          "NZD": 269.99,
+          "USD": 249,
+        },
+      },
+      "Monthly": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb4edd70c9014edeaa50342192",
           },
         },
-        "OneYearGift": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a011779932fd0177a670f43102aa",
-            },
-          },
-          "id": "2c92a00c77992ba70177a6596f710265",
-          "pricing": {
-            "AUD": 175,
-            "CAD": 175,
-            "EUR": 125,
-            "GBP": 99,
-            "NZD": 175,
-            "USD": 165,
+        "id": "2c92a0fb4edd70c8014edeaa4eae220a",
+        "pricing": {
+          "AUD": 26.99,
+          "CAD": 27.44,
+          "EUR": 18.99,
+          "GBP": 14.99,
+          "NZD": 26.99,
+          "USD": 24.99,
+        },
+      },
+      "OneYearGift": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a011779932fd0177a670f43102aa",
           },
         },
-        "ThreeMonthGift": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a00f779933030177a65881490325",
-            },
+        "id": "2c92a00c77992ba70177a6596f710265",
+        "pricing": {
+          "AUD": 175,
+          "CAD": 175,
+          "EUR": 125,
+          "GBP": 99,
+          "NZD": 175,
+          "USD": 165,
+        },
+      },
+      "ThreeMonthGift": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a00f779933030177a65881490325",
           },
-          "id": "2c92a00d779932ef0177a65430d30ac1",
-          "pricing": {
-            "AUD": 63,
-            "CAD": 63,
-            "EUR": 45,
-            "GBP": 36,
-            "NZD": 63,
-            "USD": 60,
-          },
+        },
+        "id": "2c92a00d779932ef0177a65430d30ac1",
+        "pricing": {
+          "AUD": 63,
+          "CAD": 63,
+          "EUR": 45,
+          "GBP": 36,
+          "NZD": 63,
+          "USD": 60,
         },
       },
     },
-    "GuardianWeeklyDomestic": {
-      "ratePlans": {
-        "Annual": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0fe6619b4b901661aa8e6811695",
-            },
-          },
-          "id": "2c92a0fe6619b4b901661aa8e66c1692",
-          "pricing": {
-            "AUD": 480,
-            "CAD": 396,
-            "EUR": 318,
-            "GBP": 180,
-            "NZD": 600,
-            "USD": 360,
+  },
+  "GuardianWeeklyDomestic": {
+    "ratePlans": {
+      "Annual": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fe6619b4b901661aa8e6811695",
           },
         },
-        "Monthly": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0fd79ac64b00179ae3f9d704962",
-            },
-          },
-          "id": "2c92a0fd79ac64b00179ae3f9d474960",
-          "pricing": {
-            "AUD": 40,
-            "CAD": 33,
-            "EUR": 26.5,
-            "GBP": 15,
-            "NZD": 50,
-            "USD": 30,
+        "id": "2c92a0fe6619b4b901661aa8e66c1692",
+        "pricing": {
+          "AUD": 480,
+          "CAD": 396,
+          "EUR": 318,
+          "GBP": 180,
+          "NZD": 600,
+          "USD": 360,
+        },
+      },
+      "Monthly": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fd79ac64b00179ae3f9d704962",
           },
         },
-        "OneYearGift": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0ff67cebd0d0167f0a1a85b2350",
-            },
-          },
-          "id": "2c92a0ff67cebd0d0167f0a1a834234e",
-          "pricing": {
-            "AUD": 480,
-            "CAD": 396,
-            "EUR": 318,
-            "GBP": 180,
-            "NZD": 600,
-            "USD": 360,
+        "id": "2c92a0fd79ac64b00179ae3f9d474960",
+        "pricing": {
+          "AUD": 40,
+          "CAD": 33,
+          "EUR": 26.5,
+          "GBP": 15,
+          "NZD": 50,
+          "USD": 30,
+        },
+      },
+      "OneYearGift": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0ff67cebd0d0167f0a1a85b2350",
           },
         },
-        "Quarterly": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0fe6619b4b601661aa8b74e623f",
-            },
-          },
-          "id": "2c92a0fe6619b4b301661aa494392ee2",
-          "pricing": {
-            "AUD": 120,
-            "CAD": 99,
-            "EUR": 79.5,
-            "GBP": 45,
-            "NZD": 150,
-            "USD": 90,
+        "id": "2c92a0ff67cebd0d0167f0a1a834234e",
+        "pricing": {
+          "AUD": 480,
+          "CAD": 396,
+          "EUR": 318,
+          "GBP": 180,
+          "NZD": 600,
+          "USD": 360,
+        },
+      },
+      "Quarterly": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fe6619b4b601661aa8b74e623f",
           },
         },
-        "SixWeekly": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0086619bf8901661aaac95d5800",
-            },
-          },
-          "id": "2c92a0086619bf8901661aaac94257fe",
-          "pricing": {
-            "AUD": 6,
-            "CAD": 6,
-            "EUR": 6,
-            "GBP": 6,
-            "NZD": 6,
-            "USD": 6,
+        "id": "2c92a0fe6619b4b301661aa494392ee2",
+        "pricing": {
+          "AUD": 120,
+          "CAD": 99,
+          "EUR": 79.5,
+          "GBP": 45,
+          "NZD": 150,
+          "USD": 90,
+        },
+      },
+      "SixWeekly": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0086619bf8901661aaac95d5800",
           },
         },
-        "ThreeMonthGift": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a00e6dd988e2016df853875d74c6",
-            },
+        "id": "2c92a0086619bf8901661aaac94257fe",
+        "pricing": {
+          "AUD": 6,
+          "CAD": 6,
+          "EUR": 6,
+          "GBP": 6,
+          "NZD": 6,
+          "USD": 6,
+        },
+      },
+      "ThreeMonthGift": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a00e6dd988e2016df853875d74c6",
           },
-          "id": "2c92a00e6dd988e2016df85387417498",
-          "pricing": {
-            "AUD": 120,
-            "CAD": 99,
-            "EUR": 79.5,
-            "GBP": 45,
-            "NZD": 150,
-            "USD": 90,
-          },
+        },
+        "id": "2c92a00e6dd988e2016df85387417498",
+        "pricing": {
+          "AUD": 120,
+          "CAD": 99,
+          "EUR": 79.5,
+          "GBP": 45,
+          "NZD": 150,
+          "USD": 90,
         },
       },
     },
-    "GuardianWeeklyRestOfWorld": {
-      "ratePlans": {
-        "Annual": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0fe6619b4b601661ab3002f2653",
-            },
-          },
-          "id": "2c92a0fe6619b4b601661ab300222651",
-          "pricing": {
-            "AUD": 424,
-            "CAD": 345,
-            "EUR": 270,
-            "GBP": 297.6,
-            "NZD": 530,
-            "USD": 396,
+  },
+  "GuardianWeeklyRestOfWorld": {
+    "ratePlans": {
+      "Annual": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fe6619b4b601661ab3002f2653",
           },
         },
-        "Monthly": {
-          "charges": {
-            "Monthly": {
-              "id": "2c92a0ff79ac64e30179ae4566cb3a86",
-            },
-          },
-          "id": "2c92a0ff79ac64e30179ae45669b3a83",
-          "pricing": {
-            "GBP": 24.8,
-            "USD": 33,
+        "id": "2c92a0fe6619b4b601661ab300222651",
+        "pricing": {
+          "AUD": 424,
+          "CAD": 345,
+          "EUR": 270,
+          "GBP": 297.6,
+          "NZD": 530,
+          "USD": 396,
+        },
+      },
+      "Monthly": {
+        "charges": {
+          "Monthly": {
+            "id": "2c92a0ff79ac64e30179ae4566cb3a86",
           },
         },
-        "OneYearGift": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0ff67cebd140167f0a2f68912ed",
-            },
-          },
-          "id": "2c92a0ff67cebd140167f0a2f66a12eb",
-          "pricing": {
-            "AUD": 424,
-            "CAD": 345,
-            "EUR": 270,
-            "GBP": 297.6,
-            "NZD": 530,
-            "USD": 396,
+        "id": "2c92a0ff79ac64e30179ae45669b3a83",
+        "pricing": {
+          "GBP": 24.8,
+          "USD": 33,
+        },
+      },
+      "OneYearGift": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0ff67cebd140167f0a2f68912ed",
           },
         },
-        "Quarterly": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0ff6619bf8b01661ab2d0396eb2",
-            },
-          },
-          "id": "2c92a0086619bf8901661ab02752722f",
-          "pricing": {
-            "AUD": 106,
-            "CAD": 86.25,
-            "EUR": 67.5,
-            "GBP": 74.4,
-            "NZD": 132.5,
-            "USD": 99,
+        "id": "2c92a0ff67cebd140167f0a2f66a12eb",
+        "pricing": {
+          "AUD": 424,
+          "CAD": 345,
+          "EUR": 270,
+          "GBP": 297.6,
+          "NZD": 530,
+          "USD": 396,
+        },
+      },
+      "Quarterly": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0ff6619bf8b01661ab2d0396eb2",
           },
         },
-        "SixWeekly": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0086619bf8901661ab546091b23",
-            },
-          },
-          "id": "2c92a0086619bf8901661ab545f51b21",
-          "pricing": {
-            "AUD": 6,
-            "CAD": 6,
-            "EUR": 6,
-            "GBP": 6,
-            "NZD": 6,
-            "USD": 6,
+        "id": "2c92a0086619bf8901661ab02752722f",
+        "pricing": {
+          "AUD": 106,
+          "CAD": 86.25,
+          "EUR": 67.5,
+          "GBP": 74.4,
+          "NZD": 132.5,
+          "USD": 99,
+        },
+      },
+      "SixWeekly": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0086619bf8901661ab546091b23",
           },
         },
-        "ThreeMonthGift": {
-          "charges": {
-            "Subscription": {
-              "id": "2c92a0076dd9892e016df8503e936c4a",
-            },
+        "id": "2c92a0086619bf8901661ab545f51b21",
+        "pricing": {
+          "AUD": 6,
+          "CAD": 6,
+          "EUR": 6,
+          "GBP": 6,
+          "NZD": 6,
+          "USD": 6,
+        },
+      },
+      "ThreeMonthGift": {
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0076dd9892e016df8503e936c4a",
           },
-          "id": "2c92a0076dd9892e016df8503e7c6c48",
-          "pricing": {
-            "AUD": 106,
-            "CAD": 86.25,
-            "EUR": 67.5,
-            "GBP": 74.4,
-            "NZD": 132.5,
-            "USD": 99,
-          },
+        },
+        "id": "2c92a0076dd9892e016df8503e7c6c48",
+        "pricing": {
+          "AUD": 106,
+          "CAD": 86.25,
+          "EUR": 67.5,
+          "GBP": 74.4,
+          "NZD": 132.5,
+          "USD": 99,
         },
       },
     },
-    "HomeDelivery": {
-      "ratePlans": {
-        "Everyday": {
-          "charges": {
-            "Friday": {
-              "id": "2c92a0fd560d13880156136b73770f1e",
-            },
-            "Monday": {
-              "id": "2c92a0fd560d13880156136b74340f36",
-            },
-            "Saturday": {
-              "id": "2c92a0fd560d13880156136b74b80f47",
-            },
-            "Sunday": {
-              "id": "2c92a0fd560d13230156137061435de7",
-            },
-            "Thursday": {
-              "id": "2c92a0fd560d13880156136b73b50f26",
-            },
-            "Tuesday": {
-              "id": "2c92a0fd560d13880156136b74780f3f",
-            },
-            "Wednesday": {
-              "id": "2c92a0fd560d13880156136b730d0f0e",
-            },
+  },
+  "HomeDelivery": {
+    "ratePlans": {
+      "Everyday": {
+        "charges": {
+          "Friday": {
+            "id": "2c92a0fd560d13880156136b73770f1e",
           },
-          "id": "2c92a0fd560d13880156136b72e50f0c",
-          "pricing": {
-            "GBP": 78.99,
+          "Monday": {
+            "id": "2c92a0fd560d13880156136b74340f36",
+          },
+          "Saturday": {
+            "id": "2c92a0fd560d13880156136b74b80f47",
+          },
+          "Sunday": {
+            "id": "2c92a0fd560d13230156137061435de7",
+          },
+          "Thursday": {
+            "id": "2c92a0fd560d13880156136b73b50f26",
+          },
+          "Tuesday": {
+            "id": "2c92a0fd560d13880156136b74780f3f",
+          },
+          "Wednesday": {
+            "id": "2c92a0fd560d13880156136b730d0f0e",
           },
         },
-        "Saturday": {
-          "charges": {
-            "Saturday": {
-              "id": "2c92a0fd5e1dcf0d015e3cb39d207ddf",
-            },
-          },
-          "id": "2c92a0fd5e1dcf0d015e3cb39d0a7ddb",
-          "pricing": {
-            "GBP": 19.99,
+        "id": "2c92a0fd560d13880156136b72e50f0c",
+        "pricing": {
+          "GBP": 78.99,
+        },
+      },
+      "Saturday": {
+        "charges": {
+          "Saturday": {
+            "id": "2c92a0fd5e1dcf0d015e3cb39d207ddf",
           },
         },
-        "Sixday": {
-          "charges": {
-            "Friday": {
-              "id": "2c92a0ff560d311b0156136f2b50531f",
-            },
-            "Monday": {
-              "id": "2c92a0ff560d311b0156136f2bc2532f",
-            },
-            "Saturday": {
-              "id": "2c92a0ff560d311b0156136f2c43533f",
-            },
-            "Thursday": {
-              "id": "2c92a0ff560d311b0156136f2b8c5327",
-            },
-            "Tuesday": {
-              "id": "2c92a0ff560d311b0156136f2c015337",
-            },
-            "Wednesday": {
-              "id": "2c92a0ff560d311b0156136f2b185317",
-            },
+        "id": "2c92a0fd5e1dcf0d015e3cb39d0a7ddb",
+        "pricing": {
+          "GBP": 19.99,
+        },
+      },
+      "Sixday": {
+        "charges": {
+          "Friday": {
+            "id": "2c92a0ff560d311b0156136f2b50531f",
           },
-          "id": "2c92a0ff560d311b0156136f2afe5315",
-          "pricing": {
-            "GBP": 68.99,
+          "Monday": {
+            "id": "2c92a0ff560d311b0156136f2bc2532f",
+          },
+          "Saturday": {
+            "id": "2c92a0ff560d311b0156136f2c43533f",
+          },
+          "Thursday": {
+            "id": "2c92a0ff560d311b0156136f2b8c5327",
+          },
+          "Tuesday": {
+            "id": "2c92a0ff560d311b0156136f2c015337",
+          },
+          "Wednesday": {
+            "id": "2c92a0ff560d311b0156136f2b185317",
           },
         },
-        "Sunday": {
-          "charges": {
-            "Sunday": {
-              "id": "2c92a0ff5af9b657015b0fea5bb83fa8",
-            },
-          },
-          "id": "2c92a0ff5af9b657015b0fea5b653f81",
-          "pricing": {
-            "GBP": 19.99,
+        "id": "2c92a0ff560d311b0156136f2afe5315",
+        "pricing": {
+          "GBP": 68.99,
+        },
+      },
+      "Sunday": {
+        "charges": {
+          "Sunday": {
+            "id": "2c92a0ff5af9b657015b0fea5bb83fa8",
           },
         },
-        "Weekend": {
-          "charges": {
-            "Saturday": {
-              "id": "2c92a0fd5614305c01561dc88fb875d0",
-            },
-            "Sunday": {
-              "id": "2c92a0fd5614305c01561dc88f8975c8",
-            },
+        "id": "2c92a0ff5af9b657015b0fea5b653f81",
+        "pricing": {
+          "GBP": 19.99,
+        },
+      },
+      "Weekend": {
+        "charges": {
+          "Saturday": {
+            "id": "2c92a0fd5614305c01561dc88fb875d0",
           },
-          "id": "2c92a0fd5614305c01561dc88f3275be",
-          "pricing": {
-            "GBP": 31.99,
+          "Sunday": {
+            "id": "2c92a0fd5614305c01561dc88f8975c8",
           },
+        },
+        "id": "2c92a0fd5614305c01561dc88f3275be",
+        "pricing": {
+          "GBP": 31.99,
         },
       },
     },
-    "NationalDelivery": {
-      "ratePlans": {
-        "Everyday": {
-          "charges": {
-            "Friday": {
-              "id": "8a12999f8a268c57018a27ebe44c14b6",
-            },
-            "Monday": {
-              "id": "8a12999f8a268c57018a27ebe55814ca",
-            },
-            "Saturday": {
-              "id": "8a12999f8a268c57018a27ebe65914de",
-            },
-            "Sunday": {
-              "id": "8a12999f8a268c57018a27ebe35114a6",
-            },
-            "Thursday": {
-              "id": "8a12999f8a268c57018a27ebe4d414bf",
-            },
-            "Tuesday": {
-              "id": "8a12999f8a268c57018a27ebe5d814d6",
-            },
-            "Wednesday": {
-              "id": "8a12999f8a268c57018a27ebe3ce14ae",
-            },
+  },
+  "NationalDelivery": {
+    "ratePlans": {
+      "Everyday": {
+        "charges": {
+          "Friday": {
+            "id": "8a12999f8a268c57018a27ebe44c14b6",
           },
-          "id": "8a12999f8a268c57018a27ebe31414a4",
-          "pricing": {
-            "GBP": 78.99,
+          "Monday": {
+            "id": "8a12999f8a268c57018a27ebe55814ca",
+          },
+          "Saturday": {
+            "id": "8a12999f8a268c57018a27ebe65914de",
+          },
+          "Sunday": {
+            "id": "8a12999f8a268c57018a27ebe35114a6",
+          },
+          "Thursday": {
+            "id": "8a12999f8a268c57018a27ebe4d414bf",
+          },
+          "Tuesday": {
+            "id": "8a12999f8a268c57018a27ebe5d814d6",
+          },
+          "Wednesday": {
+            "id": "8a12999f8a268c57018a27ebe3ce14ae",
           },
         },
-        "Sixday": {
-          "charges": {
-            "Friday": {
-              "id": "8a12999f8a268c57018a27ebfecb18c7",
-            },
-            "Monday": {
-              "id": "8a12999f8a268c57018a27ec00b418d9",
-            },
-            "Saturday": {
-              "id": "8a12999f8a268c57018a27ec029418ea",
-            },
-            "Thursday": {
-              "id": "8a12999f8a268c57018a27ebffb518cf",
-            },
-            "Tuesday": {
-              "id": "8a12999f8a268c57018a27ec01a918e2",
-            },
-            "Wednesday": {
-              "id": "8a12999f8a268c57018a27ebfde818ab",
-            },
+        "id": "8a12999f8a268c57018a27ebe31414a4",
+        "pricing": {
+          "GBP": 78.99,
+        },
+      },
+      "Sixday": {
+        "charges": {
+          "Friday": {
+            "id": "8a12999f8a268c57018a27ebfecb18c7",
           },
-          "id": "8a12999f8a268c57018a27ebfd721883",
-          "pricing": {
-            "GBP": 68.99,
+          "Monday": {
+            "id": "8a12999f8a268c57018a27ec00b418d9",
+          },
+          "Saturday": {
+            "id": "8a12999f8a268c57018a27ec029418ea",
+          },
+          "Thursday": {
+            "id": "8a12999f8a268c57018a27ebffb518cf",
+          },
+          "Tuesday": {
+            "id": "8a12999f8a268c57018a27ec01a918e2",
+          },
+          "Wednesday": {
+            "id": "8a12999f8a268c57018a27ebfde818ab",
           },
         },
-        "Weekend": {
-          "charges": {
-            "Saturday": {
-              "id": "8a12999f8a268c57018a27ebe949151d",
-            },
-            "Sunday": {
-              "id": "8a12999f8a268c57018a27ebe8b4150e",
-            },
+        "id": "8a12999f8a268c57018a27ebfd721883",
+        "pricing": {
+          "GBP": 68.99,
+        },
+      },
+      "Weekend": {
+        "charges": {
+          "Saturday": {
+            "id": "8a12999f8a268c57018a27ebe949151d",
           },
-          "id": "8a12999f8a268c57018a27ebe868150c",
-          "pricing": {
-            "GBP": 31.99,
+          "Sunday": {
+            "id": "8a12999f8a268c57018a27ebe8b4150e",
           },
+        },
+        "id": "8a12999f8a268c57018a27ebe868150c",
+        "pricing": {
+          "GBP": 31.99,
         },
       },
     },
-    "SubscriptionCard": {
-      "ratePlans": {
-        "Everyday": {
-          "charges": {
-            "Friday": {
-              "id": "2c92a00870ec598001710740c91d2f4d",
-            },
-            "Monday": {
-              "id": "2c92a00870ec598001710740c7b82f1c",
-            },
-            "Saturday": {
-              "id": "2c92a00870ec598001710740c8652f37",
-            },
-            "Sunday": {
-              "id": "2c92a00870ec598001710740c9d72f61",
-            },
-            "Thursday": {
-              "id": "2c92a00870ec598001710740c8c42f40",
-            },
-            "Tuesday": {
-              "id": "2c92a00870ec598001710740c80f2f26",
-            },
-            "Wednesday": {
-              "id": "2c92a00870ec598001710740c9802f59",
-            },
+  },
+  "SubscriptionCard": {
+    "ratePlans": {
+      "Everyday": {
+        "charges": {
+          "Friday": {
+            "id": "2c92a00870ec598001710740c91d2f4d",
           },
-          "id": "2c92a00870ec598001710740c78d2f13",
-          "pricing": {
-            "GBP": 64.99,
+          "Monday": {
+            "id": "2c92a00870ec598001710740c7b82f1c",
+          },
+          "Saturday": {
+            "id": "2c92a00870ec598001710740c8652f37",
+          },
+          "Sunday": {
+            "id": "2c92a00870ec598001710740c9d72f61",
+          },
+          "Thursday": {
+            "id": "2c92a00870ec598001710740c8c42f40",
+          },
+          "Tuesday": {
+            "id": "2c92a00870ec598001710740c80f2f26",
+          },
+          "Wednesday": {
+            "id": "2c92a00870ec598001710740c9802f59",
           },
         },
-        "Saturday": {
-          "charges": {
-            "Saturday": {
-              "id": "2c92a00870ec598001710740ce042fcb",
-            },
-          },
-          "id": "2c92a00870ec598001710740cdd02fbd",
-          "pricing": {
-            "GBP": 14.99,
+        "id": "2c92a00870ec598001710740c78d2f13",
+        "pricing": {
+          "GBP": 64.99,
+        },
+      },
+      "Saturday": {
+        "charges": {
+          "Saturday": {
+            "id": "2c92a00870ec598001710740ce042fcb",
           },
         },
-        "Sixday": {
-          "charges": {
-            "Friday": {
-              "id": "2c92a00870ec598001710740cb4e2f6b",
-            },
-            "Monday": {
-              "id": "2c92a00870ec598001710740cbb32f77",
-            },
-            "Saturday": {
-              "id": "2c92a00870ec598001710740cd6e2fa2",
-            },
-            "Thursday": {
-              "id": "2c92a00870ec598001710740cc9b2f88",
-            },
-            "Tuesday": {
-              "id": "2c92a00870ec598001710740cc2c2f80",
-            },
-            "Wednesday": {
-              "id": "2c92a00870ec598001710740cd012f90",
-            },
+        "id": "2c92a00870ec598001710740cdd02fbd",
+        "pricing": {
+          "GBP": 14.99,
+        },
+      },
+      "Sixday": {
+        "charges": {
+          "Friday": {
+            "id": "2c92a00870ec598001710740cb4e2f6b",
           },
-          "id": "2c92a00870ec598001710740ca532f69",
-          "pricing": {
-            "GBP": 56.99,
+          "Monday": {
+            "id": "2c92a00870ec598001710740cbb32f77",
+          },
+          "Saturday": {
+            "id": "2c92a00870ec598001710740cd6e2fa2",
+          },
+          "Thursday": {
+            "id": "2c92a00870ec598001710740cc9b2f88",
+          },
+          "Tuesday": {
+            "id": "2c92a00870ec598001710740cc2c2f80",
+          },
+          "Wednesday": {
+            "id": "2c92a00870ec598001710740cd012f90",
           },
         },
-        "Sunday": {
-          "charges": {
-            "Sunday": {
-              "id": "2c92a00870ec598001710740d1103019",
-            },
-          },
-          "id": "2c92a00870ec598001710740d0d83017",
-          "pricing": {
-            "GBP": 14.99,
+        "id": "2c92a00870ec598001710740ca532f69",
+        "pricing": {
+          "GBP": 56.99,
+        },
+      },
+      "Sunday": {
+        "charges": {
+          "Sunday": {
+            "id": "2c92a00870ec598001710740d1103019",
           },
         },
-        "Weekend": {
-          "charges": {
-            "Saturday": {
-              "id": "2c92a00870ec598001710740d28e3024",
-            },
-            "Sunday": {
-              "id": "2c92a00870ec598001710740d325302c",
-            },
+        "id": "2c92a00870ec598001710740d0d83017",
+        "pricing": {
+          "GBP": 14.99,
+        },
+      },
+      "Weekend": {
+        "charges": {
+          "Saturday": {
+            "id": "2c92a00870ec598001710740d28e3024",
           },
-          "id": "2c92a00870ec598001710740d24b3022",
-          "pricing": {
-            "GBP": 25.99,
+          "Sunday": {
+            "id": "2c92a00870ec598001710740d325302c",
           },
+        },
+        "id": "2c92a00870ec598001710740d24b3022",
+        "pricing": {
+          "GBP": 25.99,
         },
       },
     },
-    "SupporterPlus": {
-      "ratePlans": {
-        "Annual": {
-          "charges": {
-            "Contribution": {
-              "id": "8a12892d85fc6df4018602451322287f",
-            },
-            "Subscription": {
-              "id": "8a128ed885fc6ded01860228f7cb3d5f",
-            },
+  },
+  "SupporterPlus": {
+    "ratePlans": {
+      "Annual": {
+        "charges": {
+          "Contribution": {
+            "id": "8a12892d85fc6df4018602451322287f",
           },
-          "id": "8a128ed885fc6ded01860228f77e3d5a",
-          "pricing": {
-            "AUD": 160,
-            "CAD": 120,
-            "EUR": 95,
-            "GBP": 95,
-            "NZD": 160,
-            "USD": 120,
+          "Subscription": {
+            "id": "8a128ed885fc6ded01860228f7cb3d5f",
           },
         },
-        "Monthly": {
-          "charges": {
-            "Contribution": {
-              "id": "8a128d7085fc6dec01860234cd075270",
-            },
-            "Subscription": {
-              "id": "8a128ed885fc6ded018602296af13eba",
-            },
+        "id": "8a128ed885fc6ded01860228f77e3d5a",
+        "pricing": {
+          "AUD": 160,
+          "CAD": 120,
+          "EUR": 95,
+          "GBP": 95,
+          "NZD": 160,
+          "USD": 120,
+        },
+      },
+      "Monthly": {
+        "charges": {
+          "Contribution": {
+            "id": "8a128d7085fc6dec01860234cd075270",
           },
-          "id": "8a128ed885fc6ded018602296ace3eb8",
-          "pricing": {
-            "AUD": 17,
-            "CAD": 13,
-            "EUR": 10,
-            "GBP": 10,
-            "NZD": 17,
-            "USD": 13,
+          "Subscription": {
+            "id": "8a128ed885fc6ded018602296af13eba",
           },
+        },
+        "id": "8a128ed885fc6ded018602296ace3eb8",
+        "pricing": {
+          "AUD": 17,
+          "CAD": 13,
+          "EUR": 10,
+          "GBP": 10,
+          "NZD": 17,
+          "USD": 13,
         },
       },
     },

--- a/modules/product-catalog/test/getProductCatalogIntegration.test.ts
+++ b/modules/product-catalog/test/getProductCatalogIntegration.test.ts
@@ -8,7 +8,7 @@ import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 
 test('getCatalogFromApi', async () => {
 	const codeCatalog = await getProductCatalogFromApi('CODE');
-	expect(
-		codeCatalog.products.DigitalSubscription.ratePlans.Monthly.pricing.GBP,
-	).toEqual(14.99);
+	expect(codeCatalog.DigitalSubscription.ratePlans.Monthly.pricing.GBP).toEqual(
+		14.99,
+	);
 });

--- a/modules/product-catalog/test/productCatalogMapping.test.ts
+++ b/modules/product-catalog/test/productCatalogMapping.test.ts
@@ -1,8 +1,8 @@
 import { findDuplicates } from '@modules/arrayFunctions';
-import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
-import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
+import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
+import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import codeZuoraCatalog from '../../zuora-catalog/test/fixtures/catalog-code.json';
 import prodZuoraCatalog from '../../zuora-catalog/test/fixtures/catalog-prod.json';
 
@@ -11,22 +11,21 @@ const prodProductCatalog = generateProductCatalog(prodZuoraCatalog);
 const codeCatalogHelper = new ProductCatalogHelper(codeProductCatalog);
 const prodCatalogHelper = new ProductCatalogHelper(prodProductCatalog);
 test('We can find a product rate plan from product details', () => {
-	expect(codeProductCatalog.products.SupporterPlus.ratePlans.Monthly.id).toBe(
+	expect(codeProductCatalog.SupporterPlus.ratePlans.Monthly.id).toBe(
 		'8ad08cbd8586721c01858804e3275376',
 	);
 });
 
 test('We can find a product rate plan charge from product details', () => {
 	expect(
-		codeProductCatalog.products.NationalDelivery.ratePlans.Everyday.charges
-			.Monday.id,
+		codeProductCatalog.NationalDelivery.ratePlans.Everyday.charges.Monday.id,
 	).toBe('8ad096ca8992481d018992a3674c18da');
 });
 
 test('We can find the price of a product from product details', () => {
-	expect(
-		codeProductCatalog.products.HomeDelivery.ratePlans.Sixday.pricing.GBP,
-	).toBe(68.99);
+	expect(codeProductCatalog.HomeDelivery.ratePlans.Sixday.pricing.GBP).toBe(
+		68.99,
+	);
 });
 
 test('We can find product details from a productRatePlanId', () => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR removes the top level `products` array from the product catalog as it wasn't adding any benefits and was just making code which uses the catalog more verbose.