### PR TITLE
infra: create stack for CSBX environment

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -47,6 +47,7 @@ jobs:
           contentDirectories: |
             ${{ matrix.subproject }}-cloudformation:
               - ./cdk/cdk.out/${{ matrix.subproject }}-CODE.template.json
+              - ./cdk/cdk.out/${{ matrix.subproject }}-CSBX.template.json
               - ./cdk/cdk.out/${{ matrix.subproject }}-PROD.template.json
             ${{ matrix.subproject }}:
               - ./handlers/${{ matrix.subproject }}/target/${{ matrix.subproject }}.zip

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -46,8 +46,6 @@ jobs:
           configPath: ./handlers/${{ matrix.subproject }}/riff-raff.yaml
           contentDirectories: |
             ${{ matrix.subproject }}-cloudformation:
-              - ./cdk/cdk.out/${{ matrix.subproject }}-CODE.template.json
-              - ./cdk/cdk.out/${{ matrix.subproject }}-CSBX.template.json
-              - ./cdk/cdk.out/${{ matrix.subproject }}-PROD.template.json
+              - ./cdk/cdk.out
             ${{ matrix.subproject }}:
               - ./handlers/${{ matrix.subproject }}/target/${{ matrix.subproject }}.zip

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -47,7 +47,9 @@ jobs:
           contentDirectories: |
             ${{ matrix.subproject }}-cloudformation:
               - ./cdk/cdk.out/${{ matrix.subproject }}-CODE.template.json
+              {{ if env.ENABLE_CSBX_TEMPLATE }}
               - ./cdk/cdk.out/${{ matrix.subproject }}-CSBX.template.json
+              {{ endif }}
               - ./cdk/cdk.out/${{ matrix.subproject }}-PROD.template.json
             ${{ matrix.subproject }}:
               - ./handlers/${{ matrix.subproject }}/target/${{ matrix.subproject }}.zip

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -47,9 +47,7 @@ jobs:
           contentDirectories: |
             ${{ matrix.subproject }}-cloudformation:
               - ./cdk/cdk.out/${{ matrix.subproject }}-CODE.template.json
-              {{ if env.ENABLE_CSBX_TEMPLATE }}
               - ./cdk/cdk.out/${{ matrix.subproject }}-CSBX.template.json
-              {{ endif }}
               - ./cdk/cdk.out/${{ matrix.subproject }}-PROD.template.json
             ${{ matrix.subproject }}:
               - ./handlers/${{ matrix.subproject }}/target/${{ matrix.subproject }}.zip

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -118,7 +118,7 @@ new SalesforceDisasterRecovery(app, 'salesforce-disaster-recovery-CSBX', {
 	salesforceApiConnectionResourceId:
 		'salesforce-disaster-recovery-CSBX-salesforce-api/c8d71d2e-9101-439d-a3e2-d8fa7e6b155f',
 	salesforceOauthSecretName:
-		'events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm',
+		'events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b',
 	salesforceQueryWaitSeconds: 1,
 });
 new SalesforceDisasterRecovery(app, 'salesforce-disaster-recovery-PROD', {

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -111,6 +111,16 @@ new SalesforceDisasterRecovery(app, 'salesforce-disaster-recovery-CODE', {
 		'events!connection/salesforce-disaster-recovery-CODE-salesforce-api/e2792d75-414a-48f3-89a1-5e8eac15f627',
 	salesforceQueryWaitSeconds: 1,
 });
+new SalesforceDisasterRecovery(app, 'salesforce-disaster-recovery-CSBX', {
+	stack: 'membership',
+	stage: 'CSBX',
+	salesforceApiDomain: 'https://gnmtouchpoint--dev1.sandbox.my.salesforce.com',
+	salesforceApiConnectionResourceId:
+		'salesforce-disaster-recovery-CSBX-salesforce-api/c8d71d2e-9101-439d-a3e2-d8fa7e6b155f',
+	salesforceOauthSecretName:
+		'events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm',
+	salesforceQueryWaitSeconds: 1,
+});
 new SalesforceDisasterRecovery(app, 'salesforce-disaster-recovery-PROD', {
 	stack: 'membership',
 	stage: 'PROD',
@@ -132,5 +142,11 @@ new GenerateProductCatalog(app, 'generate-product-catalog-PROD', {
 	domainName: 'product-catalog.guardianapis.com',
 });
 
-new StripeWebhookEndpoints(app, "stripe-webhook-endpoints-CODE", { stack: "membership", stage: "CODE" });
-new StripeWebhookEndpoints(app, "stripe-webhook-endpoints-PROD", { stack: "membership", stage: "PROD" });
+new StripeWebhookEndpoints(app, 'stripe-webhook-endpoints-CODE', {
+	stack: 'membership',
+	stage: 'CODE',
+});
+new StripeWebhookEndpoints(app, 'stripe-webhook-endpoints-PROD', {
+	stack: 'membership',
+	stage: 'PROD',
+});

--- a/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
+++ b/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
@@ -1437,7 +1437,7 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm",
+                    ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/c8d71d2e-9101-439d-a3e2-d8fa7e6b155f",
                   ],
                 ],
               },
@@ -1565,7 +1565,7 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
               {
                 "Ref": "AWS::AccountId",
               },
-              ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm"},"RequestBody":{"operation":"query","query.$":"$.query"}},"Retry":[{"ErrorEquals":["States.Http.StatusCode.400"],"MaxAttempts":0},{"ErrorEquals":["States.ALL"],"IntervalSeconds":5,"MaxAttempts":3,"BackoffRate":2}]},"WaitForSalesforceQueryJobToComplete":{"Type":"Wait","Seconds":1,"Next":"GetSalesforceQueryJobStatus"},"GetSalesforceQueryJobStatus":{"Next":"IsSalesforceQueryJobCompleted","Type":"Task","Resource":"arn:aws:states:::http:invoke","Parameters":{"ApiEndpoint.$":"States.Format('https://gnmtouchpoint--dev1.sandbox.my.salesforce.com/services/data/v59.0/jobs/query/{}', $.ResponseBody.id)","Method":"GET","Authentication":{"ConnectionArn":"arn:aws:events:",
+              ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/c8d71d2e-9101-439d-a3e2-d8fa7e6b155f"},"RequestBody":{"operation":"query","query.$":"$.query"}},"Retry":[{"ErrorEquals":["States.Http.StatusCode.400"],"MaxAttempts":0},{"ErrorEquals":["States.ALL"],"IntervalSeconds":5,"MaxAttempts":3,"BackoffRate":2}]},"WaitForSalesforceQueryJobToComplete":{"Type":"Wait","Seconds":1,"Next":"GetSalesforceQueryJobStatus"},"GetSalesforceQueryJobStatus":{"Next":"IsSalesforceQueryJobCompleted","Type":"Task","Resource":"arn:aws:states:::http:invoke","Parameters":{"ApiEndpoint.$":"States.Format('https://gnmtouchpoint--dev1.sandbox.my.salesforce.com/services/data/v59.0/jobs/query/{}', $.ResponseBody.id)","Method":"GET","Authentication":{"ConnectionArn":"arn:aws:events:",
               {
                 "Ref": "AWS::Region",
               },
@@ -1573,7 +1573,7 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
               {
                 "Ref": "AWS::AccountId",
               },
-              ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm"}}},"IsSalesforceQueryJobCompleted":{"Type":"Choice","Choices":[{"Variable":"$.ResponseBody.state","StringEquals":"JobComplete","Next":"SaveSalesforceQueryResultToS3"}],"Default":"WaitForSalesforceQueryJobToComplete"},"SaveSalesforceQueryResultToS3":{"Next":"ProcessCsvInDistributedMap","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"arn:",
+              ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/c8d71d2e-9101-439d-a3e2-d8fa7e6b155f"}}},"IsSalesforceQueryJobCompleted":{"Type":"Choice","Choices":[{"Variable":"$.ResponseBody.state","StringEquals":"JobComplete","Next":"SaveSalesforceQueryResultToS3"}],"Default":"WaitForSalesforceQueryJobToComplete"},"SaveSalesforceQueryResultToS3":{"Next":"ProcessCsvInDistributedMap","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2005,7 +2005,7 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
               "Ref": "Bucket83908E77",
             },
             "SALESFORCE_API_DOMAIN": "https://gnmtouchpoint--dev1.sandbox.my.salesforce.com",
-            "SALESFORCE_OAUTH_SECRET_NAME": "events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm",
+            "SALESFORCE_OAUTH_SECRET_NAME": "events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b",
             "STACK": "membership",
             "STAGE": "CSBX",
           },

--- a/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
+++ b/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
@@ -1367,6 +1367,1242 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
     "Bucket83908E77": {
       "DeletionPolicy": "Retain",
       "Properties": {
+        "BucketName": "salesforce-disaster-recovery-csbx",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "SalesforceApiHttpInvoke9D82CE85": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:InvokeHTTPEndpoint",
+              "Condition": {
+                "StringEquals": {
+                  "states:HTTPEndpoint": "https://gnmtouchpoint--dev1.sandbox.my.salesforce.com/services/data/v59.0/jobs/query",
+                  "states:HTTPMethod": "POST",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SalesforceDisasterRecoveryStateMachine6185B29D",
+              },
+            },
+            {
+              "Action": "states:InvokeHTTPEndpoint",
+              "Condition": {
+                "StringEquals": {
+                  "states:HTTPMethod": "GET",
+                },
+                "StringLike": {
+                  "states:HTTPEndpoint": "https://gnmtouchpoint--dev1.sandbox.my.salesforce.com/services/data/v59.0/jobs/query/*",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SalesforceDisasterRecoveryStateMachine6185B29D",
+              },
+            },
+            {
+              "Action": "events:RetrieveConnectionCredentials",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:events:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SalesforceDisasterRecoveryStateMachine6185B29D",
+              },
+            },
+            {
+              "Action": [
+                "states:RedriveExecution",
+                "states:DescribeExecution",
+                "states:StopExecution",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:states:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":execution:",
+                    {
+                      "Fn::GetAtt": [
+                        "SalesforceDisasterRecoveryStateMachine6185B29D",
+                        "Name",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "UpdateZuoraAccountsLambda64E51B2A",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SalesforceApiHttpInvoke9D82CE85",
+        "Roles": [
+          {
+            "Ref": "SalesforceDisasterRecoveryStateMachineRole2E3F61EB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SalesforceDisasterRecoveryStateMachine6185B29D": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "SalesforceDisasterRecoveryStateMachineRoleDefaultPolicyDF13C71B",
+        "SalesforceDisasterRecoveryStateMachineRole2E3F61EB",
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "",
+            [
+              "{"StartAt":"CreateSalesforceQueryJob","States":{"CreateSalesforceQueryJob":{"Next":"WaitForSalesforceQueryJobToComplete","Type":"Task","Resource":"arn:aws:states:::http:invoke","Parameters":{"ApiEndpoint":"https://gnmtouchpoint--dev1.sandbox.my.salesforce.com/services/data/v59.0/jobs/query","Method":"POST","Authentication":{"ConnectionArn":"arn:aws:events:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm"},"RequestBody":{"operation":"query","query.$":"$.query"}},"Retry":[{"ErrorEquals":["States.Http.StatusCode.400"],"MaxAttempts":0},{"ErrorEquals":["States.ALL"],"IntervalSeconds":5,"MaxAttempts":3,"BackoffRate":2}]},"WaitForSalesforceQueryJobToComplete":{"Type":"Wait","Seconds":1,"Next":"GetSalesforceQueryJobStatus"},"GetSalesforceQueryJobStatus":{"Next":"IsSalesforceQueryJobCompleted","Type":"Task","Resource":"arn:aws:states:::http:invoke","Parameters":{"ApiEndpoint.$":"States.Format('https://gnmtouchpoint--dev1.sandbox.my.salesforce.com/services/data/v59.0/jobs/query/{}', $.ResponseBody.id)","Method":"GET","Authentication":{"ConnectionArn":"arn:aws:events:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm"}}},"IsSalesforceQueryJobCompleted":{"Type":"Choice","Choices":[{"Variable":"$.ResponseBody.state","StringEquals":"JobComplete","Next":"SaveSalesforceQueryResultToS3"}],"Default":"WaitForSalesforceQueryJobToComplete"},"SaveSalesforceQueryResultToS3":{"Next":"ProcessCsvInDistributedMap","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "SaveSalesforceQueryResultToS3Lambda65311A6F",
+                  "Arn",
+                ],
+              },
+              "","Payload":{"queryJobId.$":"$.ResponseBody.id","filePath.$":"States.Format('{}/query-result.csv', $$.Execution.StartTime)"}}},"ProcessCsvInDistributedMap":{"Next":"GetMapResult","Type":"Map","MaxConcurrency":10,"ItemReader":{"Resource":"arn:aws:states:::s3:getObject","ReaderConfig":{"InputType":"CSV","CSVHeaderLocation":"FIRST_ROW"},"Parameters":{"Bucket":"",
+              {
+                "Ref": "Bucket83908E77",
+              },
+              "","Key.$":"States.Format('{}/query-result.csv', $$.Execution.StartTime)"}},"ItemBatcher":{"MaxItemsPerBatch":50},"ItemProcessor":{"ProcessorConfig":{"Mode":"DISTRIBUTED","ExecutionType":"STANDARD"},"StartAt":"UpdateZuoraAccounts","States":{"UpdateZuoraAccounts":{"Type":"Task","Resource":"arn:aws:states:::lambda:invoke","OutputPath":"$.Payload","Parameters":{"Payload.$":"$","FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "UpdateZuoraAccountsLambda64E51B2A",
+                  "Arn",
+                ],
+              },
+              ""},"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException","Lambda.TooManyRequestsException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["ZuoraError"],"IntervalSeconds":10,"MaxAttempts":5,"BackoffRate":5}],"End":true}}},"ResultWriter":{"Resource":"arn:aws:states:::s3:putObject","Parameters":{"Bucket":"",
+              {
+                "Ref": "Bucket83908E77",
+              },
+              "","Prefix.$":"$$.Execution.StartTime"}}},"GetMapResult":{"Next":"SaveFailedRowsToS3","Type":"Task","Resource":"arn:aws:states:::aws-sdk:s3:getObject","Parameters":{"Bucket.$":"$.ResultWriterDetails.Bucket","Key.$":"$.ResultWriterDetails.Key"},"ResultSelector":{"Payload.$":"States.StringToJson($.Body)"},"OutputPath":"$.Payload"},"SaveFailedRowsToS3":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "SaveFailedRowsToS3LambdaCBDFFBA6",
+                  "Arn",
+                ],
+              },
+              "","Payload":{"resultFiles.$":"$.ResultFiles.SUCCEEDED","filePath.$":"States.Format('{}/failed-rows.csv', $$.Execution.StartTime)"}}}}}",
+            ],
+          ],
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "SalesforceDisasterRecoveryStateMachineRole2E3F61EB",
+            "Arn",
+          ],
+        },
+        "StateMachineName": "salesforce-disaster-recovery-CSBX",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+      },
+      "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "SalesforceDisasterRecoveryStateMachineRole2E3F61EB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": {
+                  "Fn::FindInMap": [
+                    "ServiceprincipalMap",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "states",
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SalesforceDisasterRecoveryStateMachineRoleDefaultPolicyDF13C71B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SaveSalesforceQueryResultToS3Lambda65311A6F",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "SaveSalesforceQueryResultToS3Lambda65311A6F",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SaveFailedRowsToS3LambdaCBDFFBA6",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "SaveFailedRowsToS3LambdaCBDFFBA6",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SalesforceDisasterRecoveryStateMachineRoleDefaultPolicyDF13C71B",
+        "Roles": [
+          {
+            "Ref": "SalesforceDisasterRecoveryStateMachineRole2E3F61EB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SaveFailedRowsToS3LambdaCBDFFBA6": {
+      "DependsOn": [
+        "SaveFailedRowsToS3LambdaServiceRoleDefaultPolicy1999A22D",
+        "SaveFailedRowsToS3LambdaServiceRole27F3CEDA",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/CSBX/salesforce-disaster-recovery/salesforce-disaster-recovery.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "salesforce-disaster-recovery",
+            "S3_BUCKET": {
+              "Ref": "Bucket83908E77",
+            },
+            "STACK": "membership",
+            "STAGE": "CSBX",
+          },
+        },
+        "FunctionName": "save-failed-rows-to-s3-CSBX",
+        "Handler": "saveFailedRowsToS3.handler",
+        "MemorySize": 10240,
+        "Role": {
+          "Fn::GetAtt": [
+            "SaveFailedRowsToS3LambdaServiceRole27F3CEDA",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "salesforce-disaster-recovery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "SaveFailedRowsToS3LambdaServiceRole27F3CEDA": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "salesforce-disaster-recovery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SaveFailedRowsToS3LambdaServiceRoleDefaultPolicy1999A22D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/CSBX/salesforce-disaster-recovery/salesforce-disaster-recovery.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CSBX/membership/salesforce-disaster-recovery",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CSBX/membership/salesforce-disaster-recovery/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SaveFailedRowsToS3LambdaServiceRoleDefaultPolicy1999A22D",
+        "Roles": [
+          {
+            "Ref": "SaveFailedRowsToS3LambdaServiceRole27F3CEDA",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SaveSalesforceQueryResultToS3Lambda65311A6F": {
+      "DependsOn": [
+        "SaveSalesforceQueryResultToS3LambdaServiceRoleDefaultPolicyA0D4E7AC",
+        "SaveSalesforceQueryResultToS3LambdaServiceRole8B0CC327",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/CSBX/salesforce-disaster-recovery/salesforce-disaster-recovery.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "salesforce-disaster-recovery",
+            "S3_BUCKET": {
+              "Ref": "Bucket83908E77",
+            },
+            "SALESFORCE_API_DOMAIN": "https://gnmtouchpoint--dev1.sandbox.my.salesforce.com",
+            "SALESFORCE_OAUTH_SECRET_NAME": "events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm",
+            "STACK": "membership",
+            "STAGE": "CSBX",
+          },
+        },
+        "FunctionName": "save-salesforce-query-result-to-s3-CSBX",
+        "Handler": "saveSalesforceQueryResultToS3.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "SaveSalesforceQueryResultToS3LambdaServiceRole8B0CC327",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "salesforce-disaster-recovery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "SaveSalesforceQueryResultToS3LambdaServiceRole8B0CC327": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "salesforce-disaster-recovery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SaveSalesforceQueryResultToS3LambdaServiceRoleDefaultPolicyA0D4E7AC": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/CSBX/salesforce-disaster-recovery/salesforce-disaster-recovery.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CSBX/membership/salesforce-disaster-recovery",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CSBX/membership/salesforce-disaster-recovery/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SaveSalesforceQueryResultToS3LambdaServiceRoleDefaultPolicyA0D4E7AC",
+        "Roles": [
+          {
+            "Ref": "SaveSalesforceQueryResultToS3LambdaServiceRole8B0CC327",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "UpdateZuoraAccountsLambda64E51B2A": {
+      "DependsOn": [
+        "UpdateZuoraAccountsLambdaServiceRoleDefaultPolicy98EA0786",
+        "UpdateZuoraAccountsLambdaServiceRole31E9D1CD",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/CSBX/salesforce-disaster-recovery/salesforce-disaster-recovery.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "salesforce-disaster-recovery",
+            "STACK": "membership",
+            "STAGE": "CSBX",
+          },
+        },
+        "FunctionName": "update-zuora-accounts-CSBX",
+        "Handler": "updateZuoraAccounts.handler",
+        "MemorySize": 10240,
+        "Role": {
+          "Fn::GetAtt": [
+            "UpdateZuoraAccountsLambdaServiceRole31E9D1CD",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "salesforce-disaster-recovery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "UpdateZuoraAccountsLambdaServiceRole31E9D1CD": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "salesforce-disaster-recovery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CSBX",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "UpdateZuoraAccountsLambdaServiceRoleDefaultPolicy98EA0786": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:CSBX/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/CSBX/salesforce-disaster-recovery/salesforce-disaster-recovery.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CSBX/membership/salesforce-disaster-recovery",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CSBX/membership/salesforce-disaster-recovery/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "UpdateZuoraAccountsLambdaServiceRoleDefaultPolicy98EA0786",
+        "Roles": [
+          {
+            "Ref": "UpdateZuoraAccountsLambdaServiceRole31E9D1CD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+  },
+}
+`;
+
+exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
+{
+  "Mappings": {
+    "ServiceprincipalMap": {
+      "af-south-1": {
+        "states": "states.af-south-1.amazonaws.com",
+      },
+      "ap-east-1": {
+        "states": "states.ap-east-1.amazonaws.com",
+      },
+      "ap-northeast-1": {
+        "states": "states.ap-northeast-1.amazonaws.com",
+      },
+      "ap-northeast-2": {
+        "states": "states.ap-northeast-2.amazonaws.com",
+      },
+      "ap-northeast-3": {
+        "states": "states.ap-northeast-3.amazonaws.com",
+      },
+      "ap-south-1": {
+        "states": "states.ap-south-1.amazonaws.com",
+      },
+      "ap-south-2": {
+        "states": "states.ap-south-2.amazonaws.com",
+      },
+      "ap-southeast-1": {
+        "states": "states.ap-southeast-1.amazonaws.com",
+      },
+      "ap-southeast-2": {
+        "states": "states.ap-southeast-2.amazonaws.com",
+      },
+      "ap-southeast-3": {
+        "states": "states.ap-southeast-3.amazonaws.com",
+      },
+      "ap-southeast-4": {
+        "states": "states.ap-southeast-4.amazonaws.com",
+      },
+      "ca-central-1": {
+        "states": "states.ca-central-1.amazonaws.com",
+      },
+      "cn-north-1": {
+        "states": "states.cn-north-1.amazonaws.com",
+      },
+      "cn-northwest-1": {
+        "states": "states.cn-northwest-1.amazonaws.com",
+      },
+      "eu-central-1": {
+        "states": "states.eu-central-1.amazonaws.com",
+      },
+      "eu-central-2": {
+        "states": "states.eu-central-2.amazonaws.com",
+      },
+      "eu-north-1": {
+        "states": "states.eu-north-1.amazonaws.com",
+      },
+      "eu-south-1": {
+        "states": "states.eu-south-1.amazonaws.com",
+      },
+      "eu-south-2": {
+        "states": "states.eu-south-2.amazonaws.com",
+      },
+      "eu-west-1": {
+        "states": "states.eu-west-1.amazonaws.com",
+      },
+      "eu-west-2": {
+        "states": "states.eu-west-2.amazonaws.com",
+      },
+      "eu-west-3": {
+        "states": "states.eu-west-3.amazonaws.com",
+      },
+      "il-central-1": {
+        "states": "states.il-central-1.amazonaws.com",
+      },
+      "me-central-1": {
+        "states": "states.me-central-1.amazonaws.com",
+      },
+      "me-south-1": {
+        "states": "states.me-south-1.amazonaws.com",
+      },
+      "sa-east-1": {
+        "states": "states.sa-east-1.amazonaws.com",
+      },
+      "us-east-1": {
+        "states": "states.us-east-1.amazonaws.com",
+      },
+      "us-east-2": {
+        "states": "states.us-east-2.amazonaws.com",
+      },
+      "us-gov-east-1": {
+        "states": "states.us-gov-east-1.amazonaws.com",
+      },
+      "us-gov-west-1": {
+        "states": "states.us-gov-west-1.amazonaws.com",
+      },
+      "us-iso-east-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-iso-west-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-isob-east-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-west-1": {
+        "states": "states.us-west-1.amazonaws.com",
+      },
+      "us-west-2": {
+        "states": "states.us-west-2.amazonaws.com",
+      },
+    },
+  },
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuLambdaFunction",
+      "GuLambdaFunction",
+      "GuLambdaFunction",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "Bucket83908E77": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
         "BucketName": "salesforce-disaster-recovery-prod",
         "Tags": [
           {

--- a/cdk/lib/salesforce-disaster-recovery.test.ts
+++ b/cdk/lib/salesforce-disaster-recovery.test.ts
@@ -20,6 +20,21 @@ describe('The SalesforceDisasterRecovery stack', () => {
 				salesforceQueryWaitSeconds: 1,
 			},
 		);
+		const csbxStack = new SalesforceDisasterRecovery(
+			app,
+			`salesforce-disaster-recovery-CSBX`,
+			{
+				stack: 'membership',
+				stage: 'CSBX',
+				salesforceApiDomain:
+					'https://gnmtouchpoint--dev1.sandbox.my.salesforce.com',
+				salesforceApiConnectionResourceId:
+					'salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm',
+				salesforceOauthSecretName:
+					'events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm',
+				salesforceQueryWaitSeconds: 1,
+			},
+		);
 		const prodStack = new SalesforceDisasterRecovery(
 			app,
 			`salesforce-disaster-recovery-PROD`,
@@ -35,6 +50,7 @@ describe('The SalesforceDisasterRecovery stack', () => {
 			},
 		);
 		expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
+		expect(Template.fromStack(csbxStack).toJSON()).toMatchSnapshot();
 		expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();
 	});
 });

--- a/cdk/lib/salesforce-disaster-recovery.test.ts
+++ b/cdk/lib/salesforce-disaster-recovery.test.ts
@@ -29,9 +29,9 @@ describe('The SalesforceDisasterRecovery stack', () => {
 				salesforceApiDomain:
 					'https://gnmtouchpoint--dev1.sandbox.my.salesforce.com',
 				salesforceApiConnectionResourceId:
-					'salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm',
+					'salesforce-disaster-recovery-CSBX-salesforce-api/c8d71d2e-9101-439d-a3e2-d8fa7e6b155f',
 				salesforceOauthSecretName:
-					'events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b-8CFMdm',
+					'events!connection/salesforce-disaster-recovery-CSBX-salesforce-api/56d7692d-e186-4b5a-9745-9d0a7ce33f1b',
 				salesforceQueryWaitSeconds: 1,
 			},
 		);

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -271,6 +271,7 @@ export class SalesforceDisasterRecovery extends GuStack {
 				OutputPath: '$.Payload',
 			},
 		});
+		// trigger change
 
 		const saveFailedRowsToS3 = new LambdaInvoke(this, 'SaveFailedRowsToS3', {
 			lambdaFunction: new GuLambdaFunction(this, 'SaveFailedRowsToS3Lambda', {

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -271,7 +271,6 @@ export class SalesforceDisasterRecovery extends GuStack {
 				OutputPath: '$.Payload',
 			},
 		});
-		// trigger change
 
 		const saveFailedRowsToS3 = new LambdaInvoke(this, 'SaveFailedRowsToS3', {
 			lambdaFunction: new GuLambdaFunction(this, 'SaveFailedRowsToS3Lambda', {

--- a/handlers/discount-api/src/productToDiscountMapping.ts
+++ b/handlers/discount-api/src/productToDiscountMapping.ts
@@ -38,6 +38,7 @@ export type Discount = {
 	effectiveEndDate: string;
 	eligibleProductRatePlanIds: string[];
 };
+
 const ProductToDiscountMapping: {
 	[K in Stage]: {
 		[K in BillingPeriod]: Discount;
@@ -76,6 +77,41 @@ const ProductToDiscountMapping: {
 			effectiveStartDate: '2023-10-23',
 			effectiveEndDate: '2099-03-08',
 			eligibleProductRatePlanIds: ['2c92c0f94bbffaaa014bc6a4212e205b'],
+		},
+	},
+	CSBX: {
+		Month: {
+			productRatePlanId: '2c92a0ff64176cd40164232c8ec97661',
+			name: 'Cancellation Save Discount - 25% off for 3 months',
+			upToPeriods: 3,
+			upToPeriodsType: 'Months',
+			effectiveStartDate: '2018-06-22',
+			effectiveEndDate: '2099-03-08',
+			eligibleProductRatePlanIds: [
+				'2c92a0fb4edd70c8014edeaa4eae220a',
+				'2c92a0fb4edd70c8014edeaa4e8521fe',
+			],
+		},
+		Quarter: {
+			productRatePlanId: '2c92a0ff64176cd40164232c8ec97661',
+			name: 'Cancellation Save Discount - 25% off for 3 months',
+			upToPeriods: 3,
+			upToPeriodsType: 'Months',
+			effectiveStartDate: '2018-06-22',
+			effectiveEndDate: '2099-03-08',
+			eligibleProductRatePlanIds: [
+				'2c92a0fb4edd70c8014edeaa4eae220a',
+				'2c92a0fb4edd70c8014edeaa4e8521fe',
+			],
+		},
+		Annual: {
+			productRatePlanId: '8a128adf8b64bcfd018b6b6fdc7674f5',
+			name: 'Cancellation Save Discount - 25% off for 12 months',
+			upToPeriods: 12,
+			upToPeriodsType: 'Months',
+			effectiveStartDate: '2023-10-26',
+			effectiveEndDate: '2099-03-08',
+			eligibleProductRatePlanIds: ['2c92a0fb4edd70c8014edeaa4e972204'],
 		},
 	},
 	PROD: {

--- a/handlers/salesforce-disaster-recovery/riff-raff.yaml
+++ b/handlers/salesforce-disaster-recovery/riff-raff.yaml
@@ -4,6 +4,7 @@ regions:
   - eu-west-1
 allowedStages:
   - CODE
+  - CSBX
   - PROD
 deployments:
   salesforce-disaster-recovery-cloudformation:

--- a/handlers/salesforce-disaster-recovery/riff-raff.yaml
+++ b/handlers/salesforce-disaster-recovery/riff-raff.yaml
@@ -13,6 +13,7 @@ deployments:
     parameters:
       templateStagePaths:
         CODE: salesforce-disaster-recovery-CODE.template.json
+        CSBX: salesforce-disaster-recovery-CSBX.template.json
         PROD: salesforce-disaster-recovery-PROD.template.json
   salesforce-disaster-recovery:
     type: aws-lambda

--- a/modules/stage.ts
+++ b/modules/stage.ts
@@ -1,4 +1,4 @@
-export type Stage = 'CODE' | 'PROD';
+export type Stage = 'CODE' | 'CSBX' | 'PROD';
 
 export const stageFromEnvironment = (): Stage => {
 	const stage = process.env.Stage;

--- a/modules/zuora/src/common.ts
+++ b/modules/zuora/src/common.ts
@@ -1,10 +1,14 @@
 import type { Dayjs } from 'dayjs';
 
 export const zuoraServerUrl = (stage: string) => {
-	if (stage === 'PROD') {
-		return 'https://rest.zuora.com';
+	switch (stage) {
+		case 'PROD':
+			return 'https://rest.zuora.com';
+		case 'CSBX':
+			return 'https://rest.test.zuora.com';
+		default:
+			return 'https://rest.apisandbox.zuora.com';
 	}
-	return 'https://rest.apisandbox.zuora.com';
 };
 
 export const zuoraDateFormat = (date: Dayjs) => date.format('YYYY-MM-DD');


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/YpVKcGar/635-create-stack-for-csbx-environment)

- Create stack for the CSBX environment
- Modify the CI yaml file for TypeScript projects to allow for CSBX stage as well
- Upload the whole `cdk.out` directory and rely on Riff Raff to pick the correct files
- Add key for CSBX for discount-api `ProductToDiscountMapping` for type-checking validity

## Why are you doing this?

This is the 8th PR for the KR1 of the [Q4 FY 23/24 OKR - Disaster Recovery for Salesforce](https://docs.google.com/document/d/1UFDM33Yhl0cgHcIDIfWIkq8V7ZiYNc32wy0SGdfmILo/edit#heading=h.d6f3idk6a29j).

For context, this application is the implementation of the "Salesforce Disaster Recovery" system below.

![landscape](https://github.com/guardian/support-service-lambdas/assets/39066365/f9d8da65-d30c-4620-b11d-3a21ecf74a48)

## Design document

This PR implements point 9 of the solution outlined in this [document](https://docs.google.com/document/d/1_KxFtfKU3-3-PSzaAYG90uONa05AVgoBmyBDyu5SC5c/edit#heading=h.jyzfkcwrdmx7).

## How to test

You can test the CODE state machine from the AWS console [here](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-1%3A865473395570%3AstateMachine%3Asalesforce-disaster-recovery-CODE).

You can run unit tests with `pnpm test` inside `handlers/salesforce-disaster-recovery`.

## Previous

- [https://github.com/guardian/support-service-lambdas/pull/2153](https://github.com/guardian/support-service-lambdas/pull/2153)
- [https://github.com/guardian/support-service-lambdas/pull/2157](https://github.com/guardian/support-service-lambdas/pull/2157)
- [https://github.com/guardian/support-service-lambdas/pull/2158](https://github.com/guardian/support-service-lambdas/pull/2158)
- [https://github.com/guardian/support-service-lambdas/pull/2159](https://github.com/guardian/support-service-lambdas/pull/2159)
- [https://github.com/guardian/support-service-lambdas/pull/2160](https://github.com/guardian/support-service-lambdas/pull/2160)
- [https://github.com/guardian/support-service-lambdas/pull/2163](https://github.com/guardian/support-service-lambdas/pull/2163)
- [https://github.com/guardian/support-service-lambdas/pull/2185](https://github.com/guardian/support-service-lambdas/pull/2185)

## Next

Handle edge case when an ID is invalid and the whole batch of 50 is discarded.

