### PR TITLE
use arm64 runtime for all cloudformed lambdas

### DIFF
--- a/handlers/cancellation-sf-cases-api/cfn.yaml
+++ b/handlers/cancellation-sf-cases-api/cfn.yaml
@@ -85,6 +85,8 @@ Resources:
       MemorySize: 1536
       Runtime: java11
       Timeout: 300
+      Architectures:
+        - arm64
     DependsOn:
       - CancellationSFCasesApiRole
 

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -83,6 +83,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - CatalogServiceRole
 
@@ -138,6 +140,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - CatalogServiceRole
 

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -153,6 +153,8 @@ Resources:
       Tags:
         - Key: lambda:createdBy
           Value: SAM
+      Architectures:
+        - arm64
   ContactUsLambdaApiEventPermissionStage:
     Type: AWS::Lambda::Permission
     Properties:

--- a/handlers/delivery-problem-credit-processor/cfn.yaml
+++ b/handlers/delivery-problem-credit-processor/cfn.yaml
@@ -77,6 +77,8 @@ Resources:
       MemorySize: 1024
       Runtime: java11
       Timeout: 900
+      Architectures:
+        - arm64
     DependsOn:
       - DeliveryProblemCreditProcessorRole
 

--- a/handlers/delivery-records-api/cfn.yaml
+++ b/handlers/delivery-records-api/cfn.yaml
@@ -87,6 +87,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - DeliveryRecordsApiRole
 

--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -63,6 +63,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - DigitalSubscriptionExpiryRole
 

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -101,6 +101,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - DigitalVoucherApiRole
 

--- a/handlers/digital-voucher-cancellation-processor/cfn.yaml
+++ b/handlers/digital-voucher-cancellation-processor/cfn.yaml
@@ -128,6 +128,8 @@ Resources:
         - Key: Stack
           Value: membership
       Timeout: 300
+      Architectures:
+        - arm64
     DependsOn:
       - DigitalVoucherCancellationProcessorFnRoleDefaultPolicy0592FCB9
       - DigitalVoucherCancellationProcessorFnRole9BC677A8

--- a/handlers/fulfilment-date-calculator/cfn.yaml
+++ b/handlers/fulfilment-date-calculator/cfn.yaml
@@ -96,6 +96,8 @@ Resources:
       MemorySize: 1536
       Runtime: java11
       Timeout: 900
+      Architectures:
+        - arm64
     DependsOn:
       - FulfilmentDateCalculatorLambdaRole
 

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -96,6 +96,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - HolidayStopApiRole
 

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -86,6 +86,8 @@ Resources:
       MemorySize: 1024
       Runtime: java11
       Timeout: 900
+      Architectures:
+        - arm64
     DependsOn:
       - HolidayStopProcessorRole
 

--- a/handlers/identity-backfill/cfn.yaml
+++ b/handlers/identity-backfill/cfn.yaml
@@ -74,6 +74,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - "IdentityBackfillRole"
 

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -79,6 +79,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - "IdentityRetentionRole"
 

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -254,6 +254,8 @@ Resources:
       Tags:
         - Key: lambda:createdBy
           Value: SAM
+      Architectures:
+        - arm64
   ProductMoveApiGateway:
     Type: AWS::ApiGateway::RestApi
     Properties:
@@ -456,6 +458,8 @@ Resources:
       Tags:
         - Key: lambda:createdBy
           Value: SAM
+      Architectures:
+        - arm64
   ProductMoveApiGatewayApiKey:
     Type: AWS::ApiGateway::ApiKey
     DependsOn:

--- a/handlers/sf-api-user-credentials-setter/cfn.yaml
+++ b/handlers/sf-api-user-credentials-setter/cfn.yaml
@@ -66,5 +66,7 @@ Resources:
       MemorySize: 512
       Runtime: java11
       Timeout: 900
+      Architectures:
+        - arm64
     DependsOn:
       - SfApiUserCredentialsSetterRole

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -75,6 +75,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - "SfContactMergeRole"
 

--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -82,6 +82,8 @@ Resources:
       MemorySize: 1536
       Runtime: java11
       Timeout: 300
+      Architectures:
+        - arm64
     DependsOn:
     - StartJobRole
   BatchStateRole:
@@ -131,6 +133,8 @@ Resources:
       MemorySize: 1536
       Runtime: java11
       Timeout: 300
+      Architectures:
+        - arm64
     DependsOn:
     - BatchStateRole
   DownloadBatchRole:
@@ -225,6 +229,8 @@ Resources:
       MemorySize: 1792
       Runtime: java11
       Timeout: 900
+      Architectures:
+        - arm64
     DependsOn:
     - DownloadBatchRole
   EndJobRole:
@@ -282,6 +288,8 @@ Resources:
       MemorySize: 1536
       Runtime: java11
       Timeout: 900
+      Architectures:
+        - arm64
     DependsOn:
       - CleanBucketRole
   EndJob:
@@ -302,6 +310,8 @@ Resources:
       MemorySize: 1536
       Runtime: java11
       Timeout: 300
+      Architectures:
+        - arm64
     DependsOn:
     - EndJobRole
   StatesExecutionRole:

--- a/handlers/sf-gocardless-sync/cfn.yaml
+++ b/handlers/sf-gocardless-sync/cfn.yaml
@@ -82,6 +82,8 @@ Resources:
       MemorySize: 1536 # TODO review this amount of memory is required
       Runtime: java11
       Timeout: 240 # kills if still running after 4mins to avoid clashes with next run
+      Architectures:
+        - arm64
 
 
   GoCardlessSalesForceSyncScheduleRule:

--- a/handlers/sf-move-subscriptions-api/cfn.yaml
+++ b/handlers/sf-move-subscriptions-api/cfn.yaml
@@ -133,6 +133,8 @@ Resources:
         - Key: Stack
           Value: membership
       Timeout: 300
+      Architectures:
+        - arm64
     DependsOn:
       - sfMoveSubscriptionsFnRoleDefaultPolicyBD9AFEB9
       - sfMoveSubscriptionsFnRole6D1AF23F

--- a/handlers/zuora-callout-apis/cfn.yaml
+++ b/handlers/zuora-callout-apis/cfn.yaml
@@ -85,6 +85,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - ZuoraAutoCancelRole
 

--- a/handlers/zuora-datalake-export/cfn.yaml
+++ b/handlers/zuora-datalake-export/cfn.yaml
@@ -73,6 +73,8 @@ Resources:
             MemorySize: 3008
             Runtime: java11
             Timeout: 900
+            Architectures:
+              - arm64
         DependsOn:
         - ExportLambdaRole
 

--- a/handlers/zuora-rer/cfn.yaml
+++ b/handlers/zuora-rer/cfn.yaml
@@ -136,6 +136,8 @@ Resources:
             Timeout: 120
             Role:
               !GetAtt ZuoraBatonRerLambdaRole.Arn
+            Architectures:
+              - arm64
 
     PerformZuoraRerLambda:
         Type: AWS::Lambda::Function
@@ -155,5 +157,7 @@ Resources:
             Timeout: 900
             Role:
               !GetAtt PerformZuoraRerLambdaRole.Arn
+            Architectures:
+              - arm64
         DependsOn:
         - PerformZuoraRerLambdaRole

--- a/handlers/zuora-retention/cfn.yaml
+++ b/handlers/zuora-retention/cfn.yaml
@@ -240,6 +240,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - ZuoraQuerierRole
     ZuoraRetentionJobResult:
@@ -260,6 +262,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - ZuoraResultsRole
     ZuoraRetentionFileFetcher:
@@ -280,6 +284,8 @@ Resources:
             MemorySize: 1536
             Runtime: java11
             Timeout: 300
+            Architectures:
+              - arm64
         DependsOn:
         - ZuoraFileFetcherRole
     ZuoraRetentionFilter:
@@ -300,6 +306,8 @@ Resources:
                 MemorySize: 1536
                 Runtime: java11
                 Timeout: 300
+                Architectures:
+                  - arm64
             DependsOn:
             - FilterRole
     ZuoraRetentionAccountUpdater:
@@ -320,6 +328,8 @@ Resources:
                 MemorySize: 1536
                 Runtime: java11
                 Timeout: 300
+                Architectures:
+                  - arm64
             DependsOn:
             - UpdaterRole
     StatesExecutionRole:

--- a/handlers/zuora-sar/cfn.yaml
+++ b/handlers/zuora-sar/cfn.yaml
@@ -184,6 +184,8 @@ Resources:
                 SubnetIds: !Ref VpcSubnets
             Role:
               !GetAtt ZuoraBatonSarLambdaRole.Arn
+            Architectures:
+              - arm64
 
     PerformZuoraSarLambda:
         Type: AWS::Lambda::Function
@@ -207,5 +209,7 @@ Resources:
                 SubnetIds: !Ref VpcSubnets
             Role:
               !GetAtt PerformZuoraSarLambdaRole.Arn
+            Architectures:
+              - arm64
         DependsOn:
         - PerformZuoraSarLambdaRole


### PR DESCRIPTION
ARM 64 is cheaper than x86, and similar speed.  It's well used and tested amongst our main servers for several years.  The product-move-api is the only one that uses it from the lambdas.
background info 
- https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html
- https://filia-aleks.medium.com/aws-lambda-battle-x86-vs-arm-graviton2-perfromance-3581aaef75d9

This PR switches all our lambdas over
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures

I will test a couple in CODE but I don't have any reservations.  I think any issues might show would be possible cases with memory usage, similar to what we had when switching java8 -> java8.al2

I also happened to notice that java17 and java21 is available, I will look into any benefits for scala code.