### PR TITLE
compile and run against java 21 LTS

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '21'
           cache: 'sbt'
 
       - name: Build

--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '21'
           cache: 'sbt'
 
       - name: Run tests and build subproject JAR

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ val scala2Settings = Seq(
     "-encoding",
     "UTF-8",
     "-feature",
-    "-target:jvm-1.8",
     "-language:existentials",
     "-language:higherKinds",
     "-language:implicitConversions",
@@ -860,8 +859,8 @@ def genDocsImpl(makeDocsClassName: String): Def.Initialize[Task[Unit]] = {
 initialize := {
   val _ = initialize.value
   assert(
-    List("1.8", "11").contains(sys.props("java.specification.version")),
-    "Java 8 or 11 is required for this project.",
+    sys.props("java.specification.version") == "21",
+    "Java 21 is required for this project, download corretto-21 from File->Project structure.",
   )
 }
 

--- a/cdk/lib/__snapshots__/new-product-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/new-product-api.test.ts.snap
@@ -841,7 +841,7 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",
@@ -1121,7 +1121,7 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",
@@ -2256,7 +2256,7 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",
@@ -2536,7 +2536,7 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
+++ b/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
@@ -170,7 +170,7 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",
@@ -727,7 +727,7 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
@@ -119,7 +119,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": {
           "Stack": "membership",
           "Stage": "TEST",
@@ -193,7 +193,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": {
           "Stack": "membership",
           "Stage": "TEST",

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -32,7 +32,7 @@ export class BatchEmailSender extends GuStack {
             app,
             handler: "com.gu.batchemailsender.api.batchemail.Handler::apply",
             functionName: `batch-email-sender-${this.stage}`,
-            runtime: Runtime.JAVA_11,
+            runtime: Runtime.JAVA_21,
             fileName: "batch-email-sender.jar",
             memorySize: 1536,
             timeout: Duration.seconds(300),

--- a/cdk/lib/new-product-api.ts
+++ b/cdk/lib/new-product-api.ts
@@ -28,7 +28,7 @@ export class NewProductApi extends GuStack {
     // ---- Miscellaneous constants ---- //
     const isProd = this.stage === 'PROD';
     const app = "new-product-api";
-    const runtime = Runtime.JAVA_11;
+    const runtime = Runtime.JAVA_21;
     const fileName = "new-product-api.jar";
     const memorySize = 1536;
     const timeout = Duration.seconds(300);

--- a/cdk/lib/single-contribution-salesforce-writes.ts
+++ b/cdk/lib/single-contribution-salesforce-writes.ts
@@ -73,7 +73,7 @@ export class SingleContributionSalesforceWrites extends GuStack {
 
 		const lambda = new GuLambdaFunction(this, `${APP_NAME}-lambda`, {
 			app: APP_NAME,
-			runtime: Runtime.JAVA_11,
+			runtime: Runtime.JAVA_21,
 			fileName: `${APP_NAME}.jar`,
 			functionName: `${APP_NAME}-${props.stage}`,
 			handler:

--- a/handlers/cancellation-sf-cases-api/cfn.yaml
+++ b/handlers/cancellation-sf-cases-api/cfn.yaml
@@ -83,7 +83,7 @@ Resources:
           - CancellationSFCasesApiRole
           - Arn
       MemorySize: 1536
-      Runtime: java11
+      Runtime: java21
       Timeout: 300
       Architectures:
         - arm64

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -81,7 +81,7 @@ Resources:
             Role:
                 !GetAtt CatalogServiceRole.Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64
@@ -138,7 +138,7 @@ Resources:
             Role:
                 !GetAtt CatalogServiceRole.Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/contact-us-api/cfn.yaml
+++ b/handlers/contact-us-api/cfn.yaml
@@ -134,7 +134,7 @@ Resources:
         Fn::GetAtt:
           - ContactUsLambdaRole
           - Arn
-      Runtime: java11
+      Runtime: java21
       Timeout: 60
       Environment:
         Variables:

--- a/handlers/delivery-problem-credit-processor/cfn.yaml
+++ b/handlers/delivery-problem-credit-processor/cfn.yaml
@@ -75,7 +75,7 @@ Resources:
       Role:
         !GetAtt DeliveryProblemCreditProcessorRole.Arn
       MemorySize: 1024
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Architectures:
         - arm64

--- a/handlers/delivery-records-api/cfn.yaml
+++ b/handlers/delivery-records-api/cfn.yaml
@@ -85,7 +85,7 @@ Resources:
                 - DeliveryRecordsApiRole
                 - Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/dev-env-cleaner/cfn.yaml
+++ b/handlers/dev-env-cleaner/cfn.yaml
@@ -35,7 +35,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/dev-env-cleaner/dev-env-cleaner.jar
       MemorySize: 2048
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -61,7 +61,7 @@ Resources:
                 - "DigitalSubscriptionExpiryRole"
                 - Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/digital-voucher-api/cfn.yaml
+++ b/handlers/digital-voucher-api/cfn.yaml
@@ -99,7 +99,7 @@ Resources:
                 - DigitalVoucherApiRole
                 - Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/digital-voucher-cancellation-processor/cfn.yaml
+++ b/handlers/digital-voucher-cancellation-processor/cfn.yaml
@@ -106,7 +106,7 @@ Resources:
         Fn::GetAtt:
           - DigitalVoucherCancellationProcessorFnRole9BC677A8
           - Arn
-      Runtime: java11
+      Runtime: java21
       Environment:
         Variables:
           App: digital-voucher-cancellation-processor

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -82,7 +82,7 @@ Resources:
       Description: >
         Suspends fulfilment of digital voucher subscriptions.
         Source: https://github.com/guardian/support-service-lambdas/tree/main/handlers/digital-voucher-suspension-processor.
-      Runtime: java11
+      Runtime: java21
       MemorySize: 1536
       Timeout: 900
       CodeUri:

--- a/handlers/fulfilment-date-calculator/cfn.yaml
+++ b/handlers/fulfilment-date-calculator/cfn.yaml
@@ -94,7 +94,7 @@ Resources:
           Stage: !Ref Stage
       Role: !GetAtt FulfilmentDateCalculatorLambdaRole.Arn
       MemorySize: 1536
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Architectures:
         - arm64

--- a/handlers/holiday-stop-api/cfn.yaml
+++ b/handlers/holiday-stop-api/cfn.yaml
@@ -94,7 +94,7 @@ Resources:
                 - HolidayStopApiRole
                 - Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -84,7 +84,7 @@ Resources:
       Role:
         !GetAtt HolidayStopProcessorRole.Arn
       MemorySize: 1024
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Architectures:
         - arm64

--- a/handlers/identity-backfill/cfn.yaml
+++ b/handlers/identity-backfill/cfn.yaml
@@ -72,7 +72,7 @@ Resources:
                 - "IdentityBackfillRole"
                 - Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -77,7 +77,7 @@ Resources:
                 - "IdentityRetentionRole"
                 - Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -71,7 +71,7 @@ Resources:
         Fn::GetAtt:
           - ProductMoveApiLambdaRole
           - Arn
-      Runtime: java11
+      Runtime: java21
       Timeout: 300
       Environment:
         Variables:
@@ -242,7 +242,7 @@ Resources:
         Fn::GetAtt:
           - SalesforceTrackingLambdaRole
           - Arn
-      Runtime: java11
+      Runtime: java21
       Timeout: 300
       Environment:
         Variables:
@@ -446,7 +446,7 @@ Resources:
         Fn::GetAtt:
           - RefundLambdaRole
           - Arn
-      Runtime: java11
+      Runtime: java21
       Timeout: 300
       Environment:
         Variables:

--- a/handlers/revenue-recogniser-job/cfn.yaml
+++ b/handlers/revenue-recogniser-job/cfn.yaml
@@ -35,7 +35,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/revenue-recogniser-job/revenue-recogniser-job.jar
       MemorySize: 2048
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/sf-api-user-credentials-setter/cfn.yaml
+++ b/handlers/sf-api-user-credentials-setter/cfn.yaml
@@ -64,7 +64,7 @@ Resources:
       Role:
         !GetAtt SfApiUserCredentialsSetterRole.Arn
       MemorySize: 512
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Architectures:
         - arm64

--- a/handlers/sf-billing-account-remover/cfn.yaml
+++ b/handlers/sf-billing-account-remover/cfn.yaml
@@ -87,7 +87,7 @@ Resources:
       Role:
         !GetAtt SFBillingAccountRemoverRole.Arn
       MemorySize: 512
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - SFBillingAccountRemoverRole

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -73,7 +73,7 @@ Resources:
             Role:
                 !GetAtt SfContactMergeRole.Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -80,7 +80,7 @@ Resources:
       Role:
         !GetAtt StartJobRole.Arn
       MemorySize: 1536
-      Runtime: java11
+      Runtime: java21
       Timeout: 300
       Architectures:
         - arm64
@@ -131,7 +131,7 @@ Resources:
       Role:
         !GetAtt BatchStateRole.Arn
       MemorySize: 1536
-      Runtime: java11
+      Runtime: java21
       Timeout: 300
       Architectures:
         - arm64
@@ -227,7 +227,7 @@ Resources:
       Role:
         !GetAtt DownloadBatchRole.Arn
       MemorySize: 1792
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Architectures:
         - arm64
@@ -286,7 +286,7 @@ Resources:
       Role:
         !GetAtt CleanBucketRole.Arn
       MemorySize: 1536
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Architectures:
         - arm64
@@ -308,7 +308,7 @@ Resources:
       Role:
         !GetAtt EndJobRole.Arn
       MemorySize: 1536
-      Runtime: java11
+      Runtime: java21
       Timeout: 300
       Architectures:
         - arm64

--- a/handlers/sf-emails-to-s3-exporter/cfn.yaml
+++ b/handlers/sf-emails-to-s3-exporter/cfn.yaml
@@ -247,7 +247,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/sf-emails-to-s3-exporter/sf-emails-to-s3-exporter.jar
       MemorySize: 512
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Environment:
         Variables:

--- a/handlers/sf-gocardless-sync/cfn.yaml
+++ b/handlers/sf-gocardless-sync/cfn.yaml
@@ -80,7 +80,7 @@ Resources:
         - "GoCardlessSalesForceSyncRole"
         - Arn
       MemorySize: 1536 # TODO review this amount of memory is required
-      Runtime: java11
+      Runtime: java21
       Timeout: 240 # kills if still running after 4mins to avoid clashes with next run
       Architectures:
         - arm64

--- a/handlers/sf-move-subscriptions-api/cfn.yaml
+++ b/handlers/sf-move-subscriptions-api/cfn.yaml
@@ -111,7 +111,7 @@ Resources:
         Fn::GetAtt:
           - sfMoveSubscriptionsFnRole6D1AF23F
           - Arn
-      Runtime: java11
+      Runtime: java21
       Environment:
         Variables:
           App: sf-move-subscriptions-api

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -45,7 +45,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
       MemorySize: 512
-      Runtime: java11
+      Runtime: java21
       Timeout: 900
       Environment:
         Variables:
@@ -99,7 +99,7 @@ Resources:
         Bucket: support-service-lambdas-dist
         Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
       MemorySize: 512
-      Runtime: java11
+      Runtime: java21
       Timeout: 300
       Environment:
         Variables:

--- a/handlers/stripe-webhook-endpoints/cfn.yaml
+++ b/handlers/stripe-webhook-endpoints/cfn.yaml
@@ -31,7 +31,7 @@ Resources:
     Properties:
       FunctionName: !Sub stripe-payment-intent-issues-${Stage}
       Description: A lambda for handling payment intent issues (cancellation, failure, action required)
-      Runtime: java11
+      Runtime: java21
       Handler: com.gu.paymentIntentIssues.Lambda::handler
       MemorySize: 512
       Timeout: 300
@@ -67,7 +67,7 @@ Resources:
     Properties:
       FunctionName: !Sub stripe-customer-updated-${Stage}
       Description: A lambda for handling customer updates
-      Runtime: java11
+      Runtime: java21
       Handler: com.gu.stripeCardUpdated.Lambda::apply
       MemorySize: 1536
       Timeout: 900

--- a/handlers/zuora-callout-apis/cfn.yaml
+++ b/handlers/zuora-callout-apis/cfn.yaml
@@ -83,7 +83,7 @@ Resources:
                 - ZuoraAutoCancelRole
                 - Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64

--- a/handlers/zuora-datalake-export/cfn.yaml
+++ b/handlers/zuora-datalake-export/cfn.yaml
@@ -71,7 +71,7 @@ Resources:
                   Stage: !Ref Stage
             Role: !GetAtt ExportLambdaRole.Arn
             MemorySize: 3008
-            Runtime: java11
+            Runtime: java21
             Timeout: 900
             Architectures:
               - arm64

--- a/handlers/zuora-rer/cfn.yaml
+++ b/handlers/zuora-rer/cfn.yaml
@@ -132,7 +132,7 @@ Resources:
                 Variables:
                   Stage: !Ref Stage
             MemorySize: 1024
-            Runtime: java11
+            Runtime: java21
             Timeout: 120
             Role:
               !GetAtt ZuoraBatonRerLambdaRole.Arn
@@ -153,7 +153,7 @@ Resources:
                 Variables:
                     Stage: !Ref Stage
             MemorySize: 1024
-            Runtime: java11
+            Runtime: java21
             Timeout: 900
             Role:
               !GetAtt PerformZuoraRerLambdaRole.Arn

--- a/handlers/zuora-retention/cfn.yaml
+++ b/handlers/zuora-retention/cfn.yaml
@@ -238,7 +238,7 @@ Resources:
             Role:
                 !GetAtt ZuoraQuerierRole.Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64
@@ -260,7 +260,7 @@ Resources:
             Role:
                 !GetAtt ZuoraResultsRole.Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64
@@ -282,7 +282,7 @@ Resources:
             Role:
                 !GetAtt ZuoraFileFetcherRole.Arn
             MemorySize: 1536
-            Runtime: java11
+            Runtime: java21
             Timeout: 300
             Architectures:
               - arm64
@@ -304,7 +304,7 @@ Resources:
                 Role:
                     !GetAtt FilterRole.Arn
                 MemorySize: 1536
-                Runtime: java11
+                Runtime: java21
                 Timeout: 300
                 Architectures:
                   - arm64
@@ -326,7 +326,7 @@ Resources:
                 Role:
                     !GetAtt UpdaterRole.Arn
                 MemorySize: 1536
-                Runtime: java11
+                Runtime: java21
                 Timeout: 300
                 Architectures:
                   - arm64

--- a/handlers/zuora-sar/cfn.yaml
+++ b/handlers/zuora-sar/cfn.yaml
@@ -176,7 +176,7 @@ Resources:
                 Variables:
                   Stage: !Ref Stage
             MemorySize: 1024
-            Runtime: java11
+            Runtime: java21
             Timeout: 120
             VpcConfig:
                 SecurityGroupIds:
@@ -201,7 +201,7 @@ Resources:
                 Variables:
                     Stage: !Ref Stage
             MemorySize: 1024
-            Runtime: java11
+            Runtime: java21
             Timeout: 900
             VpcConfig:
                 SecurityGroupIds:


### PR DESCRIPTION
Further to updating to arm64 architecture https://github.com/guardian/support-service-lambdas/pull/2194

This PR updates to java 21 LTS.  This seems to have bumped performance significantly with support-workers https://github.com/guardian/support-frontend/pull/5792 , so I am replicating it here.

I have also bumped the version we compile with in GHA, in case that improves compilation performance.

I tested auto cancel in CODE and it seems to have improved the cold start noticably