### PR TITLE
Don't create a failed lambda alarm in code for generate-product-catalog

### DIFF
--- a/cdk/lib/__snapshots__/generate-product-catalog.test.ts.snap
+++ b/cdk/lib/__snapshots__/generate-product-catalog.test.ts.snap
@@ -7,7 +7,6 @@ exports[`The generate product catalog stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuCname",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -233,47 +232,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "FailedProductCatalogLambdaAlarm543E56AB": {
-      "Properties": {
-        "ActionsEnabled": false,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":retention-dev",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "This means the product catalog may not be up to date in S3. This lambda runs on a regular schedule so action will only be necessary if the alarm is triggered continuously",
-        "AlarmName": "The generate-product-catalog Lambda has failed",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": {
-              "Ref": "generateproductcataloglambda1E6192C7",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Errors",
-        "Namespace": "AWS/Lambda",
-        "Period": 300,
-        "Statistic": "Sum",
-        "Threshold": 1,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
     },
     "NS1DNSentry": {
       "Properties": {

--- a/cdk/lib/generate-product-catalog.ts
+++ b/cdk/lib/generate-product-catalog.ts
@@ -93,25 +93,27 @@ export class GenerateProductCatalog extends GuStack {
 			resourceRecord: 'guardian.map.fastly.net',
 		});
 
-		new GuAlarm(this, 'FailedProductCatalogLambdaAlarm', {
-			app,
-			alarmName: `The ${app} Lambda has failed`,
-			alarmDescription:
-				'This means the product catalog may not be up to date in S3. This lambda runs on a regular schedule so action will only be necessary if the alarm is triggered continuously',
-			evaluationPeriods: 1,
-			threshold: 1,
-			actionsEnabled: this.stage === 'PROD',
-			snsTopicName: 'retention-dev',
-			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-			metric: new Metric({
-				metricName: 'Errors',
-				namespace: 'AWS/Lambda',
-				statistic: 'Sum',
-				period: Duration.seconds(300),
-				dimensionsMap: {
-					FunctionName: lambda.functionName,
-				},
-			}),
-		});
+		if (this.stage === 'PROD') {
+			new GuAlarm(this, `FailedProductCatalogLambdaAlarm`, {
+				app,
+				alarmName: `The ${app} Lambda has failed`,
+				alarmDescription:
+					'This means the product catalog may not be up to date in S3. This lambda runs on a regular schedule so action will only be necessary if the alarm is triggered continuously',
+				evaluationPeriods: 1,
+				threshold: 1,
+				snsTopicName: 'retention-dev',
+				comparisonOperator:
+					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				metric: new Metric({
+					metricName: 'Errors',
+					namespace: 'AWS/Lambda',
+					statistic: 'Sum',
+					period: Duration.seconds(300),
+					dimensionsMap: {
+						FunctionName: lambda.functionName,
+					},
+				}),
+			});
+		}
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We don't want alarms when the CODE version of the generate-product-catalog lambda fails