### PR TITLE
Update the snapshots 

### DIFF
--- a/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
@@ -995,7 +995,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",
@@ -1207,7 +1207,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",
@@ -2387,7 +2387,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",
@@ -2599,7 +2599,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
@@ -1717,7 +1717,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
             ],
           },
         ],
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": {
           "Stack": "support",
           "Stage": "PROD",
@@ -1808,7 +1808,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
             ],
           },
         ],
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": {
           "Stack": "support",
           "Stage": "PROD",

--- a/cdk/lib/stripe-webhook-endpoints.ts
+++ b/cdk/lib/stripe-webhook-endpoints.ts
@@ -30,7 +30,7 @@ export class StripeWebhookEndpoints extends GuStack {
 
         // ---- Existing CFN template ---- //
         const yamlTemplateFilePath = path.join(__dirname, "../..", "handlers/stripe-webhook-endpoints/cfn.yaml");
-        const yamlDefinedResources =  new CfnInclude(this, "YamlTemplate", {
+        new CfnInclude(this, "YamlTemplate", {
             templateFile: yamlTemplateFilePath,
         });
 

--- a/cdk/lib/stripe-webhook-endpoints.ts
+++ b/cdk/lib/stripe-webhook-endpoints.ts
@@ -43,7 +43,7 @@ export class StripeWebhookEndpoints extends GuStack {
                 functionName: `stripe-payment-intent-issues-cdk-${this.stage}`,
                 fileName: `${app}.jar`,
                 handler: "com.gu.paymentIntentIssues.Lambda::handler",
-                runtime: Runtime.JAVA_11,
+                runtime: Runtime.JAVA_21,
                 memorySize: 512,
                 timeout: Duration.seconds(300),
                 environment: {
@@ -61,7 +61,7 @@ export class StripeWebhookEndpoints extends GuStack {
                 functionName: `stripe-customer-updated-cdk-${this.stage}`,
                 fileName: `${app}.jar`,
                 handler: "com.gu.stripeCardUpdated.Lambda::apply",
-                runtime: Runtime.JAVA_11,
+                runtime: Runtime.JAVA_21,
                 memorySize: 1536,
                 timeout: Duration.seconds(900),
                 environment: {


### PR DESCRIPTION
## What does this change?

This is to update the cdk snapshots

This is because on merging the PR [Recreate existing CFN template using CDK constructs for stripe-webhook-endpoints](https://github.com/guardian/support-service-lambdas/pull/2174). the following jobs failed 

<img width="544" alt="image" src="https://github.com/guardian/support-service-lambdas/assets/73653255/175e2bec-f9cd-4464-8c42-34282f44af68">

[CI-Typescript](https://github.com/guardian/support-service-lambdas/actions/workflows/ci-typescript.yml)

<img width="873" alt="image" src="https://github.com/guardian/support-service-lambdas/assets/73653255/5f72c8a4-f513-4761-952a-ba785fc41f4d">


[CI-Scala](https://github.com/guardian/support-service-lambdas/actions/workflows/ci-scala.yml)


<img width="873" alt="image" src="https://github.com/guardian/support-service-lambdas/assets/73653255/b3c9e69b-9e3e-4dc6-8787-4b7324d30d6f">

