### PR TITLE
build: add pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+cd cdk && yarn test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,1 @@
 pnpm --filter cdk lint && pnpm --filter cdk test
-pnpm 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,2 @@
-cd cdk && yarn lint && yarn test
+pnpm --filter cdk lint && pnpm --filter cdk test
+pnpm 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-cd cdk && yarn test
+cd cdk && yarn lint && yarn test

--- a/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
@@ -1717,7 +1717,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
             ],
           },
         ],
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": {
           "Stack": "support",
           "Stage": "PROD",
@@ -1808,7 +1808,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
             ],
           },
         ],
-        "Runtime": "java11",
+        "Runtime": "java21",
         "Tags": {
           "Stack": "support",
           "Stage": "PROD",

--- a/cdk/lib/stripe-webhook-endpoints.ts
+++ b/cdk/lib/stripe-webhook-endpoints.ts
@@ -30,7 +30,7 @@ export class StripeWebhookEndpoints extends GuStack {
 
         // ---- Existing CFN template ---- //
         const yamlTemplateFilePath = path.join(__dirname, "../..", "handlers/stripe-webhook-endpoints/cfn.yaml");
-        const yamlDefinedResources =  new CfnInclude(this, "YamlTemplate", {
+        new CfnInclude(this, "YamlTemplate", {
             templateFile: yamlTemplateFilePath,
         });
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"clean": "rm -rf .parcel-cache && pnpm -r run clean",
 		"test": "pnpm --stream -r run test",
 		"it-test": "pnpm --stream -r run it-test",
-		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && cd ./cdk && yarn lint --fix && yarn test -u && git add ./lib/__snapshots__/*.test.ts.snap"
+		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && cd ./cdk && yarn lint --fix && yarn test -u && git add ./lib/__snapshots__/*.test.ts.snap",
+		"prepare": "husky"
 	},
 	"devDependencies": {
 		"@guardian/eslint-config-typescript": "8.0.1",
@@ -18,6 +19,7 @@
 		"eslint": "^8.57.0",
 		"eslint-import-resolver-typescript": "^3.6.1",
 		"eslint-plugin-import": "^2.29.1",
+		"husky": "^9.0.11",
 		"hygen": "^6.2.11",
 		"jest": "^29.7.0",
 		"jest-runner-groups": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.29.1
         version: 2.29.1(@typescript-eslint/parser@6.14.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      husky:
+        specifier: ^9.0.11
+        version: 9.0.11
       hygen:
         specifier: ^6.2.11
         version: 6.2.11
@@ -4389,6 +4392,12 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+    dev: true
+
+  /husky@9.0.11:
+    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
+    engines: {node: '>=18'}
+    hasBin: true
     dev: true
 
   /hygen@6.2.11:


### PR DESCRIPTION
## What does this change?

This adds a pre-push hook that runs the cdk lint & tests before push. 

This can hopefully shorten the feedback loop between development and deployment when we forget to update the snapshot tests or when there are linting errors.
