### PR TITLE
refactor: remove sns subscription emails from version control

### DIFF
--- a/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
+++ b/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
@@ -126,6 +126,10 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "SsmParameterValueCODEmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/CODE/membership/salesforce-disaster-recovery/sns-topic-subscription-emails-csv",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
   },
   "Resources": {
     "Bucket83908E77": {
@@ -1063,6 +1067,18 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SNS::Topic",
     },
+    "SnsTopicTokenSubscription1D5A46B4F": {
+      "Properties": {
+        "Endpoint": {
+          "Ref": "SsmParameterValueCODEmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter",
+        },
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "SnsTopic2C1570A4",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "SnsTopicandreadiotalleviguardiancouk14E3B4F6": {
       "Properties": {
         "Endpoint": "andrea.diotallevi@guardian.co.uk",
@@ -1429,6 +1445,10 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "SsmParameterValueCSBXmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/CSBX/membership/salesforce-disaster-recovery/sns-topic-subscription-emails-csv",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
@@ -2368,6 +2388,18 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
       },
       "Type": "AWS::SNS::Topic",
     },
+    "SnsTopicTokenSubscription1D5A46B4F": {
+      "Properties": {
+        "Endpoint": {
+          "Ref": "SsmParameterValueCSBXmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter",
+        },
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "SnsTopic2C1570A4",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "SnsTopicandreadiotalleviguardiancouk14E3B4F6": {
       "Properties": {
         "Endpoint": "andrea.diotallevi@guardian.co.uk",
@@ -2734,6 +2766,10 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/PROD/membership/salesforce-disaster-recovery/sns-topic-subscription-emails-csv",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
@@ -3672,6 +3708,18 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
         "TopicName": "salesforce-disaster-recovery-PROD",
       },
       "Type": "AWS::SNS::Topic",
+    },
+    "SnsTopicTokenSubscription1D5A46B4F": {
+      "Properties": {
+        "Endpoint": {
+          "Ref": "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter",
+        },
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "SnsTopic2C1570A4",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
     },
     "SnsTopicreaderrevenuedevguardiancoukD20937B5": {
       "Properties": {

--- a/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
+++ b/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
@@ -1079,16 +1079,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "SnsTopicandreadiotalleviguardiancouk14E3B4F6": {
-      "Properties": {
-        "Endpoint": "andrea.diotallevi@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "SnsTopic2C1570A4",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
     "UpdateZuoraAccountsLambda64E51B2A": {
       "DependsOn": [
         "UpdateZuoraAccountsLambdaServiceRoleDefaultPolicy98EA0786",
@@ -2400,16 +2390,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "SnsTopicandreadiotalleviguardiancouk14E3B4F6": {
-      "Properties": {
-        "Endpoint": "andrea.diotallevi@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "SnsTopic2C1570A4",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
     "UpdateZuoraAccountsLambda64E51B2A": {
       "DependsOn": [
         "UpdateZuoraAccountsLambdaServiceRoleDefaultPolicy98EA0786",
@@ -3714,16 +3694,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
         "Endpoint": {
           "Ref": "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter",
         },
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "SnsTopic2C1570A4",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
-    "SnsTopicreaderrevenuedevguardiancoukD20937B5": {
-      "Properties": {
-        "Endpoint": "reader.revenue.dev@guardian.co.uk",
         "Protocol": "email",
         "TopicArn": {
           "Ref": "SnsTopic2C1570A4",

--- a/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
+++ b/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
@@ -126,8 +126,8 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SsmParameterValueCODEmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/CODE/membership/salesforce-disaster-recovery/sns-topic-subscription-emails-csv",
+    "SsmParameterValueCODEmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/CODE/membership/salesforce-disaster-recovery/sns-topic-subscription-email",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
@@ -1070,7 +1070,7 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
     "SnsTopicTokenSubscription1D5A46B4F": {
       "Properties": {
         "Endpoint": {
-          "Ref": "SsmParameterValueCODEmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter",
+          "Ref": "SsmParameterValueCODEmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter",
         },
         "Protocol": "email",
         "TopicArn": {
@@ -1437,8 +1437,8 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SsmParameterValueCSBXmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/CSBX/membership/salesforce-disaster-recovery/sns-topic-subscription-emails-csv",
+    "SsmParameterValueCSBXmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/CSBX/membership/salesforce-disaster-recovery/sns-topic-subscription-email",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
@@ -2381,7 +2381,7 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
     "SnsTopicTokenSubscription1D5A46B4F": {
       "Properties": {
         "Endpoint": {
-          "Ref": "SsmParameterValueCSBXmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter",
+          "Ref": "SsmParameterValueCSBXmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter",
         },
         "Protocol": "email",
         "TopicArn": {
@@ -2748,8 +2748,8 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/PROD/membership/salesforce-disaster-recovery/sns-topic-subscription-emails-csv",
+    "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/PROD/membership/salesforce-disaster-recovery/sns-topic-subscription-email",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
@@ -3692,7 +3692,7 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
     "SnsTopicTokenSubscription1D5A46B4F": {
       "Properties": {
         "Endpoint": {
-          "Ref": "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailscsvC96584B6F00A464EAD1953AFF4B05118Parameter",
+          "Ref": "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter",
         },
         "Protocol": "email",
         "TopicArn": {

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -62,12 +62,6 @@ export class SalesforceDisasterRecovery extends GuStack {
 				snsTopic.addSubscription(new EmailSubscription(email));
 			});
 
-		snsTopic.addSubscription(
-			this.stage === 'PROD'
-				? new EmailSubscription('reader.revenue.dev@guardian.co.uk')
-				: new EmailSubscription('andrea.diotallevi@guardian.co.uk'),
-		);
-
 		const lambdaDefaultConfig: Pick<
 			GuFunctionProps,
 			'app' | 'memorySize' | 'fileName' | 'runtime' | 'timeout' | 'environment'

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -53,14 +53,12 @@ export class SalesforceDisasterRecovery extends GuStack {
 			topicName: `${app}-${this.stage}`,
 		});
 
-		StringParameter.valueForStringParameter(
+		const snsTopicSubscriptionEmail = StringParameter.valueForStringParameter(
 			this,
-			`/${this.stage}/membership/salesforce-disaster-recovery/sns-topic-subscription-emails-csv`,
-		)
-			.split(',')
-			.forEach((email) => {
-				snsTopic.addSubscription(new EmailSubscription(email));
-			});
+			`/${this.stage}/membership/salesforce-disaster-recovery/sns-topic-subscription-email`,
+		);
+
+		snsTopic.addSubscription(new EmailSubscription(snsTopicSubscriptionEmail));
 
 		const lambdaDefaultConfig: Pick<
 			GuFunctionProps,

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -59,8 +59,6 @@ export class SalesforceDisasterRecovery extends GuStack {
 		)
 			.split(',')
 			.forEach((email) => {
-				console.log('LOGGGGG');
-				console.log(email);
 				snsTopic.addSubscription(new EmailSubscription(email));
 			});
 

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -10,6 +10,7 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import {
 	Choice,
 	Condition,
@@ -51,6 +52,15 @@ export class SalesforceDisasterRecovery extends GuStack {
 		const snsTopic = new Topic(this, 'SnsTopic', {
 			topicName: `${app}-${this.stage}`,
 		});
+
+		StringParameter.valueForStringParameter(
+			this,
+			`/${this.stage}/membership/salesforce-disaster-recovery/sns-topic-subscription-emails-csv`,
+		)
+			.split(',')
+			.forEach((email) => {
+				snsTopic.addSubscription(new EmailSubscription(email));
+			});
 
 		snsTopic.addSubscription(
 			this.stage === 'PROD'

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -59,6 +59,8 @@ export class SalesforceDisasterRecovery extends GuStack {
 		)
 			.split(',')
 			.forEach((email) => {
+				console.log('LOGGGGG');
+				console.log(email);
 				snsTopic.addSubscription(new EmailSubscription(email));
 			});
 


### PR DESCRIPTION
## What does this change?

This removes emails from version control.

SNS topic subscription email for each stage is now retrieved from Parameter Store.