### PR TITLE
revert to java 11 due to JWT issue

### DIFF
--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -77,7 +77,7 @@ Resources:
                 - "IdentityRetentionRole"
                 - Arn
             MemorySize: 1536
-            Runtime: java21
+            Runtime: java11
             Timeout: 300
             Architectures:
               - arm64


### PR DESCRIPTION
we are seeing "Invalid JWT Signature" errors when this is called when it's trying to connect to google.

This is causing 5xx errors to our client (identity)

Reverting the JVM so that we can investigate/write more tests before we move forward.