### PR TITLE
Send requests to the invoicing api refund queue 

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/InvoicingApiRefundInput.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/InvoicingApiRefundInput.scala
@@ -1,0 +1,19 @@
+package com.gu.productmove.refund
+
+import com.gu.productmove.zuora.model.SubscriptionName
+import zio.ZIO
+import zio.json.*
+import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
+
+case class InvoicingApiRefundInput(
+    subscriptionName: SubscriptionName,
+    amount: BigDecimal,
+)
+
+object InvoicingApiRefundInput {
+
+  given JsonDecoder[InvoicingApiRefundInput] = DeriveJsonDecoder.gen[InvoicingApiRefundInput]
+
+  given JsonEncoder[InvoicingApiRefundInput] = DeriveJsonEncoder.gen[InvoicingApiRefundInput]
+
+}

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundHandler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundHandler.scala
@@ -3,7 +3,7 @@ package com.gu.productmove.refund
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
-import com.gu.productmove.SecretsLive
+import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, GuStageLive, SQSLive, SecretsLive, SttpClientLive}
 import com.gu.productmove.invoicingapi.InvoicingApiRefundLive
 import com.gu.productmove.refund.*
 import com.gu.productmove.zuora.{
@@ -15,7 +15,6 @@ import com.gu.productmove.zuora.{
   InvoiceItemAdjustmentLive,
 }
 import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGetLive}
-import com.gu.productmove.{AwsCredentialsLive, AwsS3Live, GuStageLive, SttpClientLive}
 import zio.json.*
 import zio.{Exit, Runtime, Unsafe, ZIO}
 
@@ -56,6 +55,7 @@ class RefundHandler extends RequestHandler[SQSEvent, Unit] {
             GetInvoiceLive.layer,
             InvoiceItemAdjustmentLive.layer,
             SecretsLive.layer,
+            SQSLive.layer,
           ),
       ) match
         case Exit.Success(value) => value

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -30,7 +30,7 @@ import com.gu.productmove.endpoint.cancel.{SubscriptionCancelEndpoint, Subscript
 import com.gu.productmove.invoicingapi.InvoicingApiRefund
 import com.gu.productmove.invoicingapi.InvoicingApiRefund.RefundResponse
 import com.gu.productmove.mocks.MockInvoicingApiRefund
-import com.gu.productmove.refund.RefundInput
+import com.gu.productmove.refund.{RefundInput,InvoicingApiRefundInput}
 import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.zuora.GetAccount.{
   AccountSubscription,
@@ -107,7 +107,7 @@ object HandlerSpec extends ZIOSpecDefault {
     val termRenewalStubs = Map(termRenewalInputsShouldBe -> termRenewalResponse)
     val getAccountStubs = Map(AccountNumber("accountNumber") -> getAccountResponse)
     val getAccountStubs2 = Map(AccountNumber("accountNumber") -> getAccountResponse2)
-    val sqsStubs: Map[EmailMessage | RefundInput | SalesforceRecordInput, Unit] =
+    val sqsStubs: Map[EmailMessage | RefundInput | InvoicingApiRefundInput | SalesforceRecordInput, Unit] =
       Map(emailMessageBody -> (), salesforceRecordInput2 -> ())
     val dynamoStubs = Map(supporterRatePlanItem1 -> ())
     val getPaymentMethodResponse = PaymentMethodResponse(
@@ -131,7 +131,7 @@ object HandlerSpec extends ZIOSpecDefault {
         val subscriptionUpdateInputsShouldBe: (SubscriptionName, SubscriptionUpdateRequest) =
           (subscriptionName, expectedRequestBodyLowCharge)
         val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse)
-        val sqsStubs: Map[EmailMessage | RefundInput | SalesforceRecordInput, Unit] =
+        val sqsStubs: Map[EmailMessage | RefundInput | InvoicingApiRefundInput | SalesforceRecordInput, Unit] =
           Map(emailMessageLowCharge -> (), salesforceRecordInput4 -> ())
         val dynamoStubs = Map(supporterRatePlanItem2 -> ())
 
@@ -212,7 +212,7 @@ object HandlerSpec extends ZIOSpecDefault {
         val expectedOutput = ProductMoveEndpointTypes.Success(
           "Product move completed successfully with subscription number A-S00339056 and switch type recurring-contribution-to-supporter-plus",
         )
-        val sqsStubs: Map[EmailMessage | RefundInput | SalesforceRecordInput, Unit] =
+        val sqsStubs: Map[EmailMessage | RefundInput |InvoicingApiRefundInput | SalesforceRecordInput, Unit] =
           Map(emailMessageBodyNoPaymentOrRefund -> (), salesforceRecordInput3 -> ())
 
         val layers = ZLayer.succeed(new MockGetSubscription(getSubscriptionStubs())) ++
@@ -292,7 +292,7 @@ object HandlerSpec extends ZIOSpecDefault {
         val expectedOutput = ProductMoveEndpointTypes.Success(
           "Product move completed successfully with subscription number A-S00339056 and switch type to-recurring-contribution",
         )
-        val sqsStubs: Map[EmailMessage | RefundInput | SalesforceRecordInput, Unit] =
+        val sqsStubs: Map[EmailMessage | RefundInput | InvoicingApiRefundInput | SalesforceRecordInput, Unit] =
           Map(emailMessageBody2 -> (), salesforceRecordInput1 -> ())
 
         val layers = ZLayer.succeed(new MockGetSubscription(getSubscriptionStubs())) ++

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSQS.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSQS.scala
@@ -35,6 +35,13 @@ class MockSQS(responses: Map[EmailMessage | RefundInput | SalesforceRecordInput,
       case None => ZIO.fail(InternalServerError(s"wrong input, refund input was $refundInput"))
   }
 
+  override def queueInvoicingApiRefund(invoicingApiRefundInput : InvoicingApiRefundInput): ZIO[Any, ErrorResponse, Unit] = {
+    addRequest(invoicingApiRefundInput)
+
+    responses.get(invoicingApiRefundInput) match
+      case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
+      case None => ZIO.fail(InternalServerError(s"wrong input, refund input was $invoicingApiRefundInput"))
+  }
   override def queueSalesforceTracking(salesforceRecordInput: SalesforceRecordInput): ZIO[Any, ErrorResponse, Unit] = {
     addRequest(salesforceRecordInput)
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSQS.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSQS.scala
@@ -1,7 +1,7 @@
 package com.gu.productmove.zuora
 
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError}
-import com.gu.productmove.refund.{RefundInput, InvoicingApiRefundInput}
+import com.gu.productmove.refund.RefundInput
 import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.{EmailMessage, SQS}
 import com.gu.productmove.zuora.GetSubscription
@@ -33,14 +33,6 @@ class MockSQS(responses: Map[EmailMessage | RefundInput | SalesforceRecordInput,
     responses.get(refundInput) match
       case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
       case None => ZIO.fail(InternalServerError(s"wrong input, refund input was $refundInput"))
-  }
-
-  override def queueInvoicingApiRefund(invoicingApiRefundInput : InvoicingApiRefundInput): ZIO[Any, ErrorResponse, Unit] = {
-    addRequest(invoicingApiRefundInput)
-
-    responses.get(invoicingApiRefundInput) match
-      case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
-      case None => ZIO.fail(InternalServerError(s"wrong input, refund input was $invoicingApiRefundInput"))
   }
   override def queueSalesforceTracking(salesforceRecordInput: SalesforceRecordInput): ZIO[Any, ErrorResponse, Unit] = {
     addRequest(salesforceRecordInput)

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSQS.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockSQS.scala
@@ -1,7 +1,7 @@
 package com.gu.productmove.zuora
 
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError}
-import com.gu.productmove.refund.RefundInput
+import com.gu.productmove.refund.{RefundInput, InvoicingApiRefundInput}
 import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.{EmailMessage, SQS}
 import com.gu.productmove.zuora.GetSubscription

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/RefundSupporterPlusSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/RefundSupporterPlusSpec.scala
@@ -41,6 +41,7 @@ object RefundSupporterPlusSpec extends ZIOSpecDefault {
               GetInvoiceLive.layer,
               InvoiceItemAdjustmentLive.layer,
               SecretsLive.layer,
+              SQSLive.layer,
             )
         } yield assert(true)(equalTo(true))
       } @@ TestAspect.ignore,
@@ -65,6 +66,7 @@ object RefundSupporterPlusSpec extends ZIOSpecDefault {
               GetInvoiceLive.layer,
               InvoiceItemAdjustmentLive.layer,
               SecretsLive.layer,
+              SQSLive.layer,
             )
         } yield assert(true)(equalTo(true))
       } @@ TestAspect.ignore,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
