### PR TITLE
Fix a rounding error whilst summing prices

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/PricesFromZuoraCatalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/PricesFromZuoraCatalog.scala
@@ -39,7 +39,7 @@ object ZuoraCatalogWireModel {
 
   def sumPrices(prices: Seq[Price]): Option[AmountMinorUnits] = {
 
-    def doubleToMinorUnitsInt(amount: Double): Int = (amount * 100).toInt
+    def doubleToMinorUnitsInt(amount: Double): Int = (BigDecimal(amount) * 100).toInt
     val optionalAmounts: Seq[Option[Double]] = prices.map(_.price)
     val allAmounts = optionalAmounts.flatten.map(doubleToMinorUnitsInt)
     if (allAmounts.isEmpty) None

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogTest.scala
@@ -3,8 +3,9 @@ package com.gu.newproduct.api
 import com.gu.effects.S3Location
 import com.gu.i18n.Currency.{EUR, GBP, USD}
 import com.gu.newproduct.api.productcatalog.PlanId._
+import com.gu.newproduct.api.productcatalog.ZuoraCatalogWireModel.Price
 import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
-import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PricesFromZuoraCatalog}
+import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PricesFromZuoraCatalog, ZuoraCatalogWireModel}
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.ZuoraEnvironment
 import com.gu.util.resthttp.Types.ClientSuccess
@@ -83,5 +84,18 @@ class PricesFromZuoraCatalogTest extends AnyFlatSpec with Matchers {
         ),
       ),
     )
+  }
+
+  it should "sum prices correctly" in {
+    val prices = List(
+      Price(Some(9.78), "GBP"),
+      Price(Some(9.79), "GBP"),
+      Price(Some(9.79), "GBP"),
+      Price(Some(9.79), "GBP"),
+      Price(Some(9.79), "GBP"),
+      Price(Some(13.05), "GBP"),
+
+    )
+    ZuoraCatalogWireModel.sumPrices(prices) shouldBe Some(AmountMinorUnits(6199))
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We noticed a bug in the new-product-api where it was returning the incorrect price for subscription card Sixday subs.
This was caused by the code which sums the charges on that particular product rate plan when converting fractional (Double) prices to minor units prices. 
The code 
```scala
def doubleToMinorUnitsInt(amount: Double): Int = (amount * 100).toInt
```
when given a value of 9.79 returns 978, not as you might reasonably expect 979 and this led to the incorrect prices.

To fix this issue, this PR converts the amount to be multiplied to a BigDecimal before multiplication.
<img width="614" alt="Screenshot 2024-04-05 at 15 48 06" src="https://github.com/guardian/support-service-lambdas/assets/181371/69c62796-20be-4201-9254-d35d5bcad831">

