### PR TITLE
Add email module

### DIFF
--- a/modules/email/README.md
+++ b/modules/email/README.md
@@ -1,0 +1,1 @@
+A module to enable sending of emails from Typescript code via Braze and [membership-workflow](https://github.com/guardian/membership-workflow/) 

--- a/modules/email/jest.config.js
+++ b/modules/email/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	runner: 'groups',
+	moduleNameMapper: {
+		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
+		'@modules/(.*)$': '<rootDir>/../../modules/$1',
+	},
+};

--- a/modules/email/package.json
+++ b/modules/email/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "zuora",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest --group=-integration",
+    "it-test": "jest --group=integration"
+  },
+  "dependencies": {
+    "@aws-sdk/client-sqs": "3.451.0",
+    "dayjs": "^1.11.10"
+  }
+}

--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -1,0 +1,39 @@
+import type { SendMessageCommandOutput } from '@aws-sdk/client-sqs';
+import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { awsConfig } from '@modules/aws/config';
+import type { Stage } from '@modules/stage';
+
+export type EmailPayload = {
+	Address: string; // email address
+	ContactAttributes: {
+		SubscriberAttributes: Record<string, string>;
+	};
+};
+
+export type DataExtensionName =
+	| 'SV_RCtoSP_Switch'
+	| 'subscription-cancelled-email';
+
+export type EmailMessage = {
+	To: EmailPayload;
+	DataExtensionName: DataExtensionName;
+	SfContactId: string;
+	IdentityUserId?: string;
+};
+
+export const sendEmail = async (
+	stage: Stage,
+	emailMessage: EmailMessage,
+): Promise<SendMessageCommandOutput> => {
+	const queueName = `braze-emails-${stage}`;
+	const client = new SQSClient(awsConfig);
+
+	const command = new SendMessageCommand({
+		QueueUrl: queueName,
+		MessageBody: JSON.stringify(emailMessage),
+	});
+
+	const response = await client.send(command);
+	console.log(response);
+	return response;
+};

--- a/modules/email/test/emailIntegrationTest.test.ts
+++ b/modules/email/test/emailIntegrationTest.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Integration test for the email module.
+ *
+ * @group integration
+ */
+import dayjs from 'dayjs';
+import type { EmailMessage } from '@modules/email/email';
+import { sendEmail } from '@modules/email/email';
+
+test('Email', async () => {
+	const emailMessage: EmailMessage = {
+		To: {
+			Address: 'rupert.bates@theguardian.com',
+			ContactAttributes: {
+				SubscriberAttributes: {
+					first_name: 'Support',
+					last_name: 'Service Lambdas',
+					currency: '£',
+					price: '10',
+					first_payment_amount: '7',
+					date_of_first_payment: dayjs().format('DD MMMM YYYY'),
+					payment_frequency: 'Monthly',
+					subscription_id: 'AS-123456',
+				},
+			},
+		},
+		DataExtensionName: 'SV_RCtoSP_Switch',
+		SfContactId: '0035I00000VUYThQAP',
+	};
+
+	const result = await sendEmail('PROD', emailMessage);
+	expect(result.MessageId?.length).toBeGreaterThan(0);
+});

--- a/modules/email/tsconfig.json
+++ b/modules/email/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,15 @@ importers:
         specifier: 3.451.0
         version: 3.451.0
 
+  modules/email:
+    dependencies:
+      '@aws-sdk/client-sqs':
+        specifier: 3.451.0
+        version: 3.451.0
+      dayjs:
+        specifier: ^1.11.10
+        version: 1.11.10
+
   modules/product-catalog:
     devDependencies:
       ts-node:
@@ -378,6 +387,55 @@ packages:
       '@smithy/util-utf8': 2.0.2
       tslib: 2.6.2
       uuid: 8.3.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sqs@3.451.0:
+    resolution: {integrity: sha512-xiDTC1iGMV+GZGLuudEMjJGhvjeMHmeTxvqJFEK78fzPxEUoUsTvA9i3qek2b4NM6fFWE7Ef0isYCAJW0jmdaA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.451.0
+      '@aws-sdk/core': 3.451.0
+      '@aws-sdk/credential-provider-node': 3.451.0
+      '@aws-sdk/middleware-host-header': 3.451.0
+      '@aws-sdk/middleware-logger': 3.451.0
+      '@aws-sdk/middleware-recursion-detection': 3.451.0
+      '@aws-sdk/middleware-sdk-sqs': 3.451.0
+      '@aws-sdk/middleware-signing': 3.451.0
+      '@aws-sdk/middleware-user-agent': 3.451.0
+      '@aws-sdk/region-config-resolver': 3.451.0
+      '@aws-sdk/types': 3.451.0
+      '@aws-sdk/util-endpoints': 3.451.0
+      '@aws-sdk/util-user-agent-browser': 3.451.0
+      '@aws-sdk/util-user-agent-node': 3.451.0
+      '@smithy/config-resolver': 2.0.19
+      '@smithy/fetch-http-handler': 2.2.7
+      '@smithy/hash-node': 2.0.16
+      '@smithy/invalid-dependency': 2.0.14
+      '@smithy/md5-js': 2.0.16
+      '@smithy/middleware-content-length': 2.0.16
+      '@smithy/middleware-endpoint': 2.2.1
+      '@smithy/middleware-retry': 2.0.21
+      '@smithy/middleware-serde': 2.0.14
+      '@smithy/middleware-stack': 2.0.8
+      '@smithy/node-config-provider': 2.1.6
+      '@smithy/node-http-handler': 2.1.10
+      '@smithy/protocol-http': 3.0.10
+      '@smithy/smithy-client': 2.1.16
+      '@smithy/types': 2.6.0
+      '@smithy/url-parser': 2.0.14
+      '@smithy/util-base64': 2.0.1
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.20
+      '@smithy/util-defaults-mode-node': 2.0.26
+      '@smithy/util-endpoints': 1.0.5
+      '@smithy/util-retry': 2.0.7
+      '@smithy/util-utf8': 2.0.2
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -634,6 +692,17 @@ packages:
       '@smithy/smithy-client': 2.1.16
       '@smithy/types': 2.6.0
       tslib: 2.6.2
+
+  /@aws-sdk/middleware-sdk-sqs@3.451.0:
+    resolution: {integrity: sha512-GXpFSc9Ji4IAT/OaTkmnDrxzZrrAsJctUAC9vihpgGDof79A1Oz4R+r2uBMTKGxCIFkqyYW5Se7y2ijjTNa3ZA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.451.0
+      '@smithy/types': 2.6.0
+      '@smithy/util-hex-encoding': 2.0.0
+      '@smithy/util-utf8': 2.0.2
+      tslib: 2.6.2
+    dev: false
 
   /@aws-sdk/middleware-sdk-sts@3.451.0:
     resolution: {integrity: sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
       "@modules/zuora/*": ["./modules/zuora/src/*"],
       "@modules/zuora-catalog/*": ["./modules/zuora-catalog/src/*"],
       "@modules/product-catalog/*": ["./modules/product-catalog/src/*"],
+      "@modules/email/*": ["./modules/email/src/*"],
       "@modules/*": ["./modules/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a module to enable sending of emails from Typescript code via Braze and [membership-workflow](https://github.com/guardian/membership-workflow/)

See the integration test for usage.