### PR TITLE
Update Snyk workflow to specify Java version

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,5 +14,6 @@ jobs:
       ORG: the-guardian-cuu
       SKIP_NODE: true
       EXCLUDE: handlers
+      JAVA_VERSION: 21
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Co-authored by @johnduffell 

## What does this change?
This add the `JAVA_VERSION` option to the Snyk action as it was failing because it requires Java 21 and the default version is 11.


## How to test
The Snyk action should now succeed.