### PR TITLE
alarms-handler: app mappings

### DIFF
--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -5,6 +5,9 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -17,8 +20,20 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "alarmshandlerwebhook": {
-      "Description": "Google Chat webhook URL",
+    "alarmshandlerGROWTHwebhook": {
+      "Description": "GROWTH Team Google Chat webhook URL",
+      "Type": "String",
+    },
+    "alarmshandlerPEwebhook": {
+      "Description": "P&E Team Google Chat webhook URL",
+      "Type": "String",
+    },
+    "alarmshandlerSREwebhook": {
+      "Description": "SRE Team Google Chat webhook URL",
+      "Type": "String",
+    },
+    "alarmshandlerVALUEwebhook": {
+      "Description": "VALUE Team Google Chat webhook URL",
       "Type": "String",
     },
   },
@@ -88,10 +103,19 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "alarms-handler",
+            "GROWTH_WEBHOOK": {
+              "Ref": "alarmshandlerGROWTHwebhook",
+            },
+            "P&E_WEBHOOK": {
+              "Ref": "alarmshandlerPEwebhook",
+            },
+            "SRE_WEBHOOK": {
+              "Ref": "alarmshandlerSREwebhook",
+            },
             "STACK": "membership",
             "STAGE": "CODE",
-            "WEBHOOK": {
-              "Ref": "alarmshandlerwebhook",
+            "VALUE_WEBHOOK": {
+              "Ref": "alarmshandlerVALUEwebhook",
             },
           },
         },
@@ -462,6 +486,9 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -474,8 +501,20 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "alarmshandlerwebhook": {
-      "Description": "Google Chat webhook URL",
+    "alarmshandlerGROWTHwebhook": {
+      "Description": "GROWTH Team Google Chat webhook URL",
+      "Type": "String",
+    },
+    "alarmshandlerPEwebhook": {
+      "Description": "P&E Team Google Chat webhook URL",
+      "Type": "String",
+    },
+    "alarmshandlerSREwebhook": {
+      "Description": "SRE Team Google Chat webhook URL",
+      "Type": "String",
+    },
+    "alarmshandlerVALUEwebhook": {
+      "Description": "VALUE Team Google Chat webhook URL",
       "Type": "String",
     },
   },
@@ -545,10 +584,19 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "alarms-handler",
+            "GROWTH_WEBHOOK": {
+              "Ref": "alarmshandlerGROWTHwebhook",
+            },
+            "P&E_WEBHOOK": {
+              "Ref": "alarmshandlerPEwebhook",
+            },
+            "SRE_WEBHOOK": {
+              "Ref": "alarmshandlerSREwebhook",
+            },
             "STACK": "membership",
             "STAGE": "PROD",
-            "WEBHOOK": {
-              "Ref": "alarmshandlerwebhook",
+            "VALUE_WEBHOOK": {
+              "Ref": "alarmshandlerVALUEwebhook",
             },
           },
         },

--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -88,6 +88,27 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "alarmshandlercloudwatchpolicy7746710B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:ListTagsForResource",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "alarmshandlercloudwatchpolicy7746710B",
+        "Roles": [
+          {
+            "Ref": "alarmshandlerlambdaServiceRole3953DF7F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "alarmshandlerlambda383D2BAA": {
       "DependsOn": [
         "alarmshandlerlambdaServiceRoleDefaultPolicyFEF447F6",
@@ -568,6 +589,27 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
         "Threshold": 0,
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "alarmshandlercloudwatchpolicy7746710B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:ListTagsForResource",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "alarmshandlercloudwatchpolicy7746710B",
+        "Roles": [
+          {
+            "Ref": "alarmshandlerlambdaServiceRole3953DF7F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "alarmshandlerlambda383D2BAA": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -24,8 +24,8 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       "Description": "GROWTH Team Google Chat webhook URL",
       "Type": "String",
     },
-    "alarmshandlerPEwebhook": {
-      "Description": "P&E Team Google Chat webhook URL",
+    "alarmshandlerPPwebhook": {
+      "Description": "PP Team Google Chat webhook URL",
       "Type": "String",
     },
     "alarmshandlerSREwebhook": {
@@ -106,8 +106,8 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
             "GROWTH_WEBHOOK": {
               "Ref": "alarmshandlerGROWTHwebhook",
             },
-            "P&E_WEBHOOK": {
-              "Ref": "alarmshandlerPEwebhook",
+            "PP_WEBHOOK": {
+              "Ref": "alarmshandlerPPwebhook",
             },
             "SRE_WEBHOOK": {
               "Ref": "alarmshandlerSREwebhook",
@@ -505,8 +505,8 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
       "Description": "GROWTH Team Google Chat webhook URL",
       "Type": "String",
     },
-    "alarmshandlerPEwebhook": {
-      "Description": "P&E Team Google Chat webhook URL",
+    "alarmshandlerPPwebhook": {
+      "Description": "PP Team Google Chat webhook URL",
       "Type": "String",
     },
     "alarmshandlerSREwebhook": {
@@ -587,8 +587,8 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
             "GROWTH_WEBHOOK": {
               "Ref": "alarmshandlerGROWTHwebhook",
             },
-            "P&E_WEBHOOK": {
-              "Ref": "alarmshandlerPEwebhook",
+            "PP_WEBHOOK": {
+              "Ref": "alarmshandlerPPwebhook",
             },
             "SRE_WEBHOOK": {
               "Ref": "alarmshandlerSREwebhook",

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -49,7 +49,7 @@ export class AlarmsHandler extends GuStack {
 				STACK: this.stack,
 				STAGE: this.stage,
 				GROWTH_WEBHOOK: buildWebhookParameter('GROWTH').valueAsString,
-				'P&E_WEBHOOK': buildWebhookParameter('P&E').valueAsString,
+				'PP_WEBHOOK': buildWebhookParameter('PP').valueAsString,
 				VALUE_WEBHOOK: buildWebhookParameter('VALUE').valueAsString,
 				SRE_WEBHOOK: buildWebhookParameter('SRE').valueAsString,
 			},

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -49,7 +49,7 @@ export class AlarmsHandler extends GuStack {
 				STACK: this.stack,
 				STAGE: this.stage,
 				GROWTH_WEBHOOK: buildWebhookParameter('GROWTH').valueAsString,
-				'PP_WEBHOOK': buildWebhookParameter('PP').valueAsString,
+				PP_WEBHOOK: buildWebhookParameter('PP').valueAsString,
 				VALUE_WEBHOOK: buildWebhookParameter('VALUE').valueAsString,
 				SRE_WEBHOOK: buildWebhookParameter('SRE').valueAsString,
 			},

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -30,11 +30,10 @@ export class AlarmsHandler extends GuStack {
 			},
 		});
 
-		const parameters = {
-			webhook: new GuStringParameter(this, `${app}-webhook`, {
-				description: 'Google Chat webhook URL',
-			}),
-		};
+		const buildWebhookParameter = (team: string): GuStringParameter =>
+			new GuStringParameter(this, `${app}-${team}-webhook`, {
+				description: `${team} Team Google Chat webhook URL`,
+			});
 
 		new GuLambdaFunction(this, `${app}-lambda`, {
 			app,
@@ -49,7 +48,10 @@ export class AlarmsHandler extends GuStack {
 				APP: app,
 				STACK: this.stack,
 				STAGE: this.stage,
-				WEBHOOK: parameters.webhook.valueAsString,
+				GROWTH_WEBHOOK: buildWebhookParameter('GROWTH').valueAsString,
+				'P&E_WEBHOOK': buildWebhookParameter('P&E').valueAsString,
+				VALUE_WEBHOOK: buildWebhookParameter('VALUE').valueAsString,
+				SRE_WEBHOOK: buildWebhookParameter('SRE').valueAsString,
 			},
 		});
 

--- a/handlers/alarms-handler/package.json
+++ b/handlers/alarms-handler/package.json
@@ -9,7 +9,8 @@
 		"package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr alarms-handler.zip ./*.js"
 	},
 	"dependencies": {
-		"@aws-sdk/client-cloudwatch": "^3.556.0"
+		"@aws-sdk/client-cloudwatch": "^3.556.0",
+		"zod": "^3.23.4"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.132"

--- a/handlers/alarms-handler/package.json
+++ b/handlers/alarms-handler/package.json
@@ -8,6 +8,9 @@
 		"lint": "eslint src/**/*.ts",
 		"package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr alarms-handler.zip ./*.js"
 	},
+	"dependencies": {
+		"@aws-sdk/client-cloudwatch": "^3.556.0"
+	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.132"
 	}

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -1,6 +1,6 @@
 import { checkDefined } from '@modules/nullAndUndefined';
 
-type Team = 'Value' | 'Growth' | 'P&P' | 'SRE';
+type Team = 'Value' | 'Growth' | 'PP' | 'SRE';
 
 const appToTeamMappings: Record<string, Team> = {
     'apps-metering: ': 'Growth',

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -1,9 +1,9 @@
 import { checkDefined } from '@modules/nullAndUndefined';
 
-type Team = 'Value' | 'Growth' | 'PP' | 'SRE';
+type Team = 'VALUE' | 'GROWTH' | 'PP' | 'SRE';
 
 const appToTeamMappings: Record<string, Team> = {
-    'apps-metering: ': 'Growth',
+    'apps-metering: ': 'GROWTH',
     'gchat-test-app': 'SRE',
 }
 
@@ -25,8 +25,8 @@ export const buildWebhookMappings = (): Record<Team, string> => {
         );
     }
     return {
-        Value: getEnvironmentVariable('Value'),
-        Growth: getEnvironmentVariable('Growth'),
+        VALUE: getEnvironmentVariable('VALUE'),
+        GROWTH: getEnvironmentVariable('GROWTH'),
         PP: getEnvironmentVariable('PP'),
         SRE: getEnvironmentVariable('SRE'),
     }

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -3,7 +3,7 @@ import { checkDefined } from '@modules/nullAndUndefined';
 type Team = 'VALUE' | 'GROWTH' | 'PP' | 'SRE';
 
 const appToTeamMappings: Record<string, Team> = {
-    'apps-metering: ': 'GROWTH',
+    'apps-metering': 'GROWTH',
     'gchat-test-app': 'SRE',
 }
 

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -1,13 +1,19 @@
 import { checkDefined } from '@modules/nullAndUndefined';
 
-type Team = 'Value' | 'Growth' | 'P&P';
+type Team = 'Value' | 'Growth' | 'P&P' | 'SRE';
 
 const appToTeamMappings: Record<string, Team> = {
     'apps-metering: ': 'Growth',
+    'gchat-test-app': 'SRE',
 }
 
-export const getTeam = (appName: string): Team | undefined => {
-    return appToTeamMappings[appName];
+export const getTeam = (appName: string): Team => {
+    const team = appToTeamMappings[appName];
+    if (!team) {
+        console.log(`No team found for app: ${appName}, defaulting to SRE`);
+        return 'SRE';
+    }
+    return team;
 }
 
 export const buildWebhookMappings = (): Record<Team, string> => {
@@ -19,5 +25,6 @@ export const buildWebhookMappings = (): Record<Team, string> => {
         Value: getEnvironmentVariable('Value'),
         Growth: getEnvironmentVariable('Growth'),
         'P&P': getEnvironmentVariable('P&P'),
+        SRE: getEnvironmentVariable('SRE'),
     }
 }

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -17,10 +17,13 @@ export const getTeam = (appName: string): Team => {
 }
 
 export const buildWebhookMappings = (): Record<Team, string> => {
-    const getEnvironmentVariable = (team: Team): string => checkDefined<string>(
-        process.env[`${team}_WEBHOOK`],
-        'WEBHOOK environment variable not set',
-    );
+    const getEnvironmentVariable = (team: Team): string => {
+        const prefix = team.toUpperCase();
+        return checkDefined<string>(
+            process.env[`${prefix}_WEBHOOK`],
+            `${prefix}_WEBHOOK environment variable not set`,
+        );
+    }
     return {
         Value: getEnvironmentVariable('Value'),
         Growth: getEnvironmentVariable('Growth'),

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -24,7 +24,7 @@ export const buildWebhookMappings = (): Record<Team, string> => {
     return {
         Value: getEnvironmentVariable('Value'),
         Growth: getEnvironmentVariable('Growth'),
-        'P&P': getEnvironmentVariable('P&P'),
+        PP: getEnvironmentVariable('PP'),
         SRE: getEnvironmentVariable('SRE'),
     }
 }

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -1,0 +1,23 @@
+import { checkDefined } from '@modules/nullAndUndefined';
+
+type Team = 'Value' | 'Growth' | 'P&P';
+
+const appToTeamMappings: Record<string, Team> = {
+    'apps-metering: ': 'Growth',
+}
+
+export const getTeam = (appName: string): Team | undefined => {
+    return appToTeamMappings[appName];
+}
+
+export const buildWebhookMappings = (): Record<Team, string> => {
+    const getEnvironmentVariable = (team: Team): string => checkDefined<string>(
+        process.env[`${team}_WEBHOOK`],
+        'WEBHOOK environment variable not set',
+    );
+    return {
+        Value: getEnvironmentVariable('Value'),
+        Growth: getEnvironmentVariable('Growth'),
+        'P&P': getEnvironmentVariable('P&P'),
+    }
+}

--- a/handlers/alarms-handler/src/cloudwatch.ts
+++ b/handlers/alarms-handler/src/cloudwatch.ts
@@ -1,8 +1,8 @@
 import {CloudWatchClient, ListTagsForResourceCommand} from "@aws-sdk/client-cloudwatch";
-import {Tag} from "@aws-sdk/client-cloudwatch/dist-types/models/models_0";
-import {
+import type {
     ListTagsForResourceCommandOutput
 } from "@aws-sdk/client-cloudwatch/dist-types/commands/ListTagsForResourceCommand";
+import type {Tag} from "@aws-sdk/client-cloudwatch/dist-types/models/models_0";
 
 const getTags = (alarmArn: string): Promise<Tag[]> => {
     const client = new CloudWatchClient({ region: "eu-west-1" });

--- a/handlers/alarms-handler/src/cloudwatch.ts
+++ b/handlers/alarms-handler/src/cloudwatch.ts
@@ -1,0 +1,21 @@
+import {CloudWatchClient, ListTagsForResourceCommand} from "@aws-sdk/client-cloudwatch";
+import {Tag} from "@aws-sdk/client-cloudwatch/dist-types/models/models_0";
+import {
+    ListTagsForResourceCommandOutput
+} from "@aws-sdk/client-cloudwatch/dist-types/commands/ListTagsForResourceCommand";
+
+const getTags = (alarmArn: string): Promise<Tag[]> => {
+    const client = new CloudWatchClient({ region: "eu-west-1" });
+
+    const request = new ListTagsForResourceCommand({
+        ResourceARN: alarmArn
+    });
+
+    return client.send(request).then((response: ListTagsForResourceCommandOutput) => response.Tags ?? []);
+}
+
+export const getAppNameTag = (alarmArn: string): Promise<string | undefined> => {
+    return getTags(alarmArn).then((tags: Tag[]) => {
+        return tags.find((tag: Tag) => tag.Key === 'App')?.Value;
+    });
+};

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -56,7 +56,7 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 			console.log(record);
 			const recordBody = JSON.parse(record.body) as SNSEventRecord['Sns'];
 
-			const alarmMessage = alarmMessageSchema.safeParse(recordBody.Message);
+			const alarmMessage = alarmMessageSchema.safeParse(JSON.parse(recordBody.Message));
 			if (alarmMessage.success) {
 				await processCloudwatchMessage(alarmMessage.data);
 			} else {

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -45,7 +45,8 @@ const processCloudwatchMessage = async (message: AlarmMessage): Promise<void> =>
 const processOtherMessage = async (message: string): Promise<void> => {
 	await fetch(webhookMappings['SRE'], {
 		method: 'POST',
-		body: message,
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ text: message }),
 	});
 }
 

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -1,5 +1,5 @@
-import { checkDefined } from '@modules/nullAndUndefined';
 import type { SNSEventRecord, SQSEvent } from 'aws-lambda';
+import {buildWebhookMappings} from "./alarmMappings";
 
 interface AlarmMessage {
 	AlarmName: string;
@@ -9,16 +9,15 @@ interface AlarmMessage {
 
 export const handler = async (event: SQSEvent): Promise<void> => {
 	try {
-		const webhookUrl = checkDefined<string>(
-			process.env.WEBHOOK,
-			'WEBHOOK environment variable not set',
-		);
+		const webhookMappings = buildWebhookMappings();
 
 		for (const record of event.Records) {
 			console.log(record);
 			const recordBody = JSON.parse(record.body) as SNSEventRecord['Sns'];
 
 			let text: string;
+
+			// TODO - get alarm ARN from the message, fetch the alarm's tags from AWS, and lookup the correct webhook based on the app
 
 			try {
 				const message = JSON.parse(recordBody.Message) as AlarmMessage;

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -45,7 +45,6 @@ const processCloudwatchMessage = async (message: AlarmMessage): Promise<void> =>
 const processOtherMessage = async (message: string): Promise<void> => {
 	await fetch(webhookMappings['SRE'], {
 		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
 		body: message,
 	});
 }

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -1,41 +1,52 @@
 import type { SNSEventRecord, SQSEvent } from 'aws-lambda';
-import {buildWebhookMappings} from "./alarmMappings";
+import {buildWebhookMappings, getTeam} from "./alarmMappings";
+import {getAppNameTag} from "./cloudwatch";
+
+const webhookMappings = buildWebhookMappings();
 
 interface AlarmMessage {
+	AlarmArn: string;
 	AlarmName: string;
 	AlarmDescription?: string;
 	NewStateReason: string;
 }
 
+const getWebhookUrl = async (message: AlarmMessage): Promise<string> => {
+	const appName = await getAppNameTag(message.AlarmArn);
+	if (!appName) {
+		console.log(`Unable to find App tag for alarm ARN: ${message.AlarmArn}, defaulting to SRE`);
+		return webhookMappings['SRE'];
+	} else {
+		const teamName = getTeam(appName);
+		return webhookMappings[teamName];
+	}
+}
+
+const processMessage = async (rawMessage: string): Promise<void> => {
+	const message = JSON.parse(rawMessage) as AlarmMessage;
+
+	const webhookUrl = await getWebhookUrl(message);
+
+	const text = `*ALARM:* ${
+		message.AlarmName
+	} has triggered!\n\n*Description:* ${
+		message.AlarmDescription ?? ''
+	}\n\n*Reason:* ${message.NewStateReason}`;
+
+	await fetch(webhookUrl, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ text }),
+	});
+}
+
 export const handler = async (event: SQSEvent): Promise<void> => {
 	try {
-		const webhookMappings = buildWebhookMappings();
-
 		for (const record of event.Records) {
 			console.log(record);
 			const recordBody = JSON.parse(record.body) as SNSEventRecord['Sns'];
 
-			let text: string;
-
-			// TODO - get alarm ARN from the message, fetch the alarm's tags from AWS, and lookup the correct webhook based on the app
-
-			try {
-				const message = JSON.parse(recordBody.Message) as AlarmMessage;
-
-				text = `*ALARM:* ${
-					message.AlarmName
-				} has triggered!\n\n*Description:* ${
-					message.AlarmDescription ?? ''
-				}\n\n*Reason:* ${message.NewStateReason}`;
-			} catch (error) {
-				text = recordBody.Message;
-			}
-
-			await fetch(webhookUrl, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ text }),
-			});
+			await processMessage(recordBody.Message);
 		}
 	} catch (error) {
 		console.error(error);

--- a/handlers/salesforce-disaster-recovery/package.json
+++ b/handlers/salesforce-disaster-recovery/package.json
@@ -10,12 +10,12 @@
 		"type-check": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@types/aws-lambda": "^8.10.129",
+		"@types/aws-lambda": "^8.10.137",
 		"aws-sdk-client-mock": "^3.0.1"
 	},
 	"dependencies": {
-		"@aws-sdk/client-s3": "3.451.0",
-		"@aws-sdk/client-secrets-manager": "3.451.0",
+		"@aws-sdk/client-s3": "3.556.0",
+		"@aws-sdk/client-secrets-manager": "3.556.0",
 		"csv-parse": "^5.5.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,10 @@ importers:
         version: 10.9.2(@types/node@20.11.27)(typescript@5.3.3)
 
   handlers/alarms-handler:
+    dependencies:
+      '@aws-sdk/client-cloudwatch':
+        specifier: ^3.556.0
+        version: 3.556.0
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.132
@@ -288,6 +292,56 @@ packages:
       '@aws-sdk/types': 3.451.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
+
+  /@aws-sdk/client-cloudwatch@3.556.0:
+    resolution: {integrity: sha512-ZaOzvfiskGMdeUglzvjvddXfl37NpzV5kGbn+C8mkM8HD4wg1hJoDw14pelz+j2JOfEaK/iwRirMxIv/z+OWgw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-compression': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
 
   /@aws-sdk/client-s3@3.451.0:
     resolution: {integrity: sha512-wDQjG/5jEswus1JclfcWeTIwrAXfAFSPz1tvwo7mRrfDNH8UPFjKKBI9ArBBwwaWUj4ou++56CHFKhKX4ytaQw==}
@@ -597,6 +651,56 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/client-sso-oidc@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-AXKd2TB6nNrksu+OfmHl8uI07PdgzOo4o8AxoRO8SHlwoMAGvcT9optDGVSYoVfgOKTymCoE7h8/UoUfPc11wQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': ^3.556.0
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/client-sso@3.451.0:
     resolution: {integrity: sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==}
     engines: {node: '>=14.0.0'}
@@ -647,6 +751,52 @@ packages:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-sdk/core': 3.552.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sso@3.556.0:
+    resolution: {integrity: sha512-unXdWS7uvHqCcOyC1de+Fr8m3F2vMg2m24GPea0bg7rVGTYmiyn9mhUX11VCt+ozydrw+F50FQwL6OqoqPocmw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/core': 3.556.0
       '@aws-sdk/middleware-host-header': 3.535.0
       '@aws-sdk/middleware-logger': 3.535.0
       '@aws-sdk/middleware-recursion-detection': 3.535.0
@@ -782,6 +932,55 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/client-sts@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-TsK3js7Suh9xEmC886aY+bv0KdLLYtzrcmVt6sJ/W6EnDXYQhBuKYFhp03NrN2+vSvMGpqJwR62DyfKe1G0QzQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': ^3.556.0
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/core@3.451.0:
     resolution: {integrity: sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==}
     engines: {node: '>=14.0.0'}
@@ -796,6 +995,19 @@ packages:
       '@smithy/core': 1.4.2
       '@smithy/protocol-http': 3.3.0
       '@smithy/signature-v4': 2.2.1
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      fast-xml-parser: 4.2.5
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/core@3.556.0:
+    resolution: {integrity: sha512-vJaSaHw2kPQlo11j/Rzuz0gk1tEaKdz+2ser0f0qZ5vwFlANjt08m/frU17ctnVKC1s58bxpctO/1P894fHLrA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/core': 1.4.2
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       fast-xml-parser: 4.2.5
@@ -873,6 +1085,26 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/credential-provider-ini@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-0Nz4ErOlXhe3muxWYMbPwRMgfKmVbBp36BAE2uv/z5wTbfdBkcgUwaflEvlKCLUTdHzuZsQk+BFS/gVyaUeOuA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-env': 3.535.0
+      '@aws-sdk/credential-provider-process': 3.535.0
+      '@aws-sdk/credential-provider-sso': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-web-identity': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
   /@aws-sdk/credential-provider-node@3.451.0:
     resolution: {integrity: sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==}
     engines: {node: '>=14.0.0'}
@@ -901,6 +1133,26 @@ packages:
       '@aws-sdk/credential-provider-process': 3.535.0
       '@aws-sdk/credential-provider-sso': 3.552.0(@aws-sdk/credential-provider-node@3.552.0)
       '@aws-sdk/credential-provider-web-identity': 3.552.0(@aws-sdk/credential-provider-node@3.552.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-node@3.556.0:
+    resolution: {integrity: sha512-s1xVtKjyGc60O8qcNIzS1X3H+pWEwEfZ7TgNznVDNyuXvLrlNWiAcigPWGl2aAkc8tGcsSG0Qpyw2KYC939LFg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.535.0
+      '@aws-sdk/credential-provider-http': 3.552.0
+      '@aws-sdk/credential-provider-ini': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-process': 3.535.0
+      '@aws-sdk/credential-provider-sso': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-web-identity': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
       '@aws-sdk/types': 3.535.0
       '@smithy/credential-provider-imds': 2.3.0
       '@smithy/property-provider': 2.2.0
@@ -962,6 +1214,22 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/credential-provider-sso@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-ETuBgcnpfxqadEAqhQFWpKoV1C/NAgvs5CbBc5EJbelJ8f4prTdErIHjrRtVT8c02MXj92QwczsiNYd5IoOqyw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.556.0
+      '@aws-sdk/token-providers': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
   /@aws-sdk/credential-provider-web-identity@3.451.0:
     resolution: {integrity: sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==}
     engines: {node: '>=14.0.0'}
@@ -976,6 +1244,20 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/client-sts': 3.552.0(@aws-sdk/credential-provider-node@3.552.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-R/YAL8Uh8i+dzVjzMnbcWLIGeeRi2mioHVGnVF+minmaIkCiQMZg2HPrdlKm49El+RljT28Nl5YHRuiqzEIwMA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
       '@aws-sdk/types': 3.535.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
@@ -1235,6 +1517,21 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/client-sso-oidc': 3.552.0(@aws-sdk/credential-provider-node@3.552.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/token-providers@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-tvIiugNF0/+2wfuImMrpKjXMx4nCnFWQjQvouObny+wrif/PGqqQYrybwxPJDvzbd965bu1I+QuSv85/ug7xsg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso-oidc': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
       '@aws-sdk/types': 3.535.0
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
@@ -2801,6 +3098,21 @@ packages:
       '@smithy/util-utf8': 2.0.2
       tslib: 2.6.2
 
+  /@smithy/middleware-compression@2.2.0:
+    resolution: {integrity: sha512-4NHl84M/Yz9fIQH+NckoAExUOr0D8tZ5ng6rtr5eMzHwa8/bRTg4kUnpZW7S4yw7jT1NXDZ66M8r04uFiT4Ccw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-config-provider': 2.3.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      fflate: 0.8.1
+      tslib: 2.6.2
+    dev: false
+
   /@smithy/middleware-content-length@2.0.16:
     resolution: {integrity: sha512-9ddDia3pp1d3XzLXKcm7QebGxLq9iwKf+J1LapvlSOhpF8EM9SjMeSrMOOFgG+2TfW5K3+qz4IAJYYm7INYCng==}
     engines: {node: '>=14.0.0'}
@@ -3046,6 +3358,19 @@ packages:
 
   /@smithy/signature-v4@2.2.1:
     resolution: {integrity: sha512-j5fHgL1iqKTsKJ1mTcw88p0RUcidDu95AWSeZTgiYJb+QcfwWU/UpBnaqiB59FNH5MiAZuSbOBnZlwzeeY2tIw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-uri-escape': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/signature-v4@2.3.0:
+    resolution: {integrity: sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
@@ -3343,6 +3668,15 @@ packages:
       '@smithy/abort-controller': 2.0.14
       '@smithy/types': 2.6.0
       tslib: 2.6.2
+
+  /@smithy/util-waiter@2.2.0:
+    resolution: {integrity: sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/abort-controller': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
 
   /@tsconfig/node10@1.0.9:
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
@@ -4977,6 +5311,10 @@ packages:
     dependencies:
       bser: 2.1.1
     dev: true
+
+  /fflate@0.8.1:
+    resolution: {integrity: sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==}
+    dev: false
 
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@aws-sdk/client-cloudwatch':
         specifier: ^3.556.0
         version: 3.556.0
+      zod:
+        specifier: ^3.23.4
+        version: 3.23.4
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.132
@@ -8532,3 +8535,7 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
+  /zod@3.23.4:
+    resolution: {integrity: sha512-/AtWOKbBgjzEYYQRNfoGKHObgfAZag6qUJX1VbHo2PRBgS+wfWagEY2mizjfyAPcGesrJOcx/wcl0L9WnVrHFw==}
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,18 +116,18 @@ importers:
   handlers/salesforce-disaster-recovery:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: 3.451.0
-        version: 3.451.0
+        specifier: 3.556.0
+        version: 3.556.0
       '@aws-sdk/client-secrets-manager':
-        specifier: 3.451.0
-        version: 3.451.0
+        specifier: 3.556.0
+        version: 3.556.0
       csv-parse:
         specifier: ^5.5.3
         version: 5.5.5
     devDependencies:
       '@types/aws-lambda':
-        specifier: ^8.10.129
-        version: 8.10.129
+        specifier: ^8.10.137
+        version: 8.10.137
       aws-sdk-client-mock:
         specifier: ^3.0.1
         version: 3.0.1
@@ -257,7 +257,7 @@ packages:
       '@aws-crypto/ie11-detection': 3.0.0
       '@aws-crypto/supports-web-crypto': 3.0.0
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.451.0
+      '@aws-sdk/types': 3.535.0
       '@aws-sdk/util-locate-window': 3.310.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
@@ -407,6 +407,71 @@ packages:
     transitivePeerDependencies:
       - aws-crt
 
+  /@aws-sdk/client-s3@3.556.0:
+    resolution: {integrity: sha512-6WF9Kuzz1/8zqX8hKBpqj9+FYwQ5uTsVcOKpTW94AMX2qtIeVRlwlnNnYyywWo61yqD3g59CMNHcqSsaqAwglg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha1-browser': 3.0.0
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-bucket-endpoint': 3.535.0
+      '@aws-sdk/middleware-expect-continue': 3.535.0
+      '@aws-sdk/middleware-flexible-checksums': 3.535.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-location-constraint': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-sdk-s3': 3.556.0
+      '@aws-sdk/middleware-signing': 3.556.0
+      '@aws-sdk/middleware-ssec': 3.537.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/signature-v4-multi-region': 3.556.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@aws-sdk/xml-builder': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/eventstream-serde-browser': 2.2.0
+      '@smithy/eventstream-serde-config-resolver': 2.2.0
+      '@smithy/eventstream-serde-node': 2.2.0
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-blob-browser': 2.2.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/hash-stream-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/md5-js': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-stream': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/client-secrets-manager@3.451.0:
     resolution: {integrity: sha512-TNuYOXoALEhdaqxiBE4H+XA35BH2pekBXP594LGlmXgon3Ca+G2wx1EjVMRpo1K9GrzhwZSEWZsUyji4RwTs2w==}
     engines: {node: '>=14.0.0'}
@@ -451,6 +516,55 @@ packages:
       '@smithy/util-utf8': 2.0.2
       tslib: 2.6.2
       uuid: 8.3.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-secrets-manager@3.556.0:
+    resolution: {integrity: sha512-mTnoP3xAMb/uKVqomCr+Gvsu2UsT3cQr2ehpjiZwy/afaWxuF16dN76OBJAp3iK9/xf24i6smajzwS4z6rs+MA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+      uuid: 9.0.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -1279,6 +1393,19 @@ packages:
       '@smithy/util-config-provider': 2.0.0
       tslib: 2.6.2
 
+  /@aws-sdk/middleware-bucket-endpoint@3.535.0:
+    resolution: {integrity: sha512-7sijlfQsc4UO9Fsl11mU26Y5f9E7g6UoNg/iJUBpC5pgvvmdBRO5UEhbB/gnqvOEPsBXyhmfzbstebq23Qdz7A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-arn-parser': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-config-provider': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
   /@aws-sdk/middleware-expect-continue@3.451.0:
     resolution: {integrity: sha512-vwG8o2Uk6biLDlOZnqXemsO4dS2HvrprUdxyouwu6hlzLFskg8nL122butn19JqXJKgcVLuSSLzT+xwqBWy2Rg==}
     engines: {node: '>=14.0.0'}
@@ -1287,6 +1414,16 @@ packages:
       '@smithy/protocol-http': 3.0.10
       '@smithy/types': 2.6.0
       tslib: 2.6.2
+
+  /@aws-sdk/middleware-expect-continue@3.535.0:
+    resolution: {integrity: sha512-hFKyqUBky0NWCVku8iZ9+PACehx0p6vuMw5YnZf8FVgHP0fode0b/NwQY6UY7oor/GftvRsAlRUAWGNFEGUpwA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
 
   /@aws-sdk/middleware-flexible-checksums@3.451.0:
     resolution: {integrity: sha512-eOkpcC2zgAvqs1w7Yp5nsk9LBIj6qLU5kaZuZEBOiFbNKIrTnPo6dQuhgvDcKHD6Y5W/cUjSBiFMs/ROb5aoug==}
@@ -1300,6 +1437,20 @@ packages:
       '@smithy/types': 2.6.0
       '@smithy/util-utf8': 2.0.2
       tslib: 2.6.2
+
+  /@aws-sdk/middleware-flexible-checksums@3.535.0:
+    resolution: {integrity: sha512-rBIzldY9jjRATxICDX7t77aW6ctqmVDgnuAOgbVT5xgHftt4o7PGWKoMvl/45hYqoQgxVFnCBof9bxkqSBebVA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/crc32': 3.0.0
+      '@aws-crypto/crc32c': 3.0.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/is-array-buffer': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    dev: false
 
   /@aws-sdk/middleware-host-header@3.451.0:
     resolution: {integrity: sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==}
@@ -1327,6 +1478,15 @@ packages:
       '@aws-sdk/types': 3.451.0
       '@smithy/types': 2.6.0
       tslib: 2.6.2
+
+  /@aws-sdk/middleware-location-constraint@3.535.0:
+    resolution: {integrity: sha512-SxfS9wfidUZZ+WnlKRTCRn3h+XTsymXRXPJj8VV6hNRNeOwzNweoG3YhQbTowuuNfXf89m9v6meYkBBtkdacKw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
 
   /@aws-sdk/middleware-logger@3.451.0:
     resolution: {integrity: sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==}
@@ -1375,6 +1535,21 @@ packages:
       '@smithy/types': 2.6.0
       tslib: 2.6.2
 
+  /@aws-sdk/middleware-sdk-s3@3.556.0:
+    resolution: {integrity: sha512-4W/dnxqj1B6/uS/5Z+3UHaqDDGjNPgEVlqf5d3ToOFZ31ZfpANwhcCmyX39JklC4aolCEi9renQ5wHnTCC8K8g==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-arn-parser': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-config-provider': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
   /@aws-sdk/middleware-sdk-sqs@3.451.0:
     resolution: {integrity: sha512-GXpFSc9Ji4IAT/OaTkmnDrxzZrrAsJctUAC9vihpgGDof79A1Oz4R+r2uBMTKGxCIFkqyYW5Se7y2ijjTNa3ZA==}
     engines: {node: '>=14.0.0'}
@@ -1407,6 +1582,19 @@ packages:
       '@smithy/util-middleware': 2.0.7
       tslib: 2.6.2
 
+  /@aws-sdk/middleware-signing@3.556.0:
+    resolution: {integrity: sha512-kWrPmU8qd3gI5qzpuW9LtWFaH80cOz1ZJDavXx6PRpYZJ5JaKdUHghwfDlVTzzFYAeJmVsWIkPcLT5d5mY5ZTQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-middleware': 2.2.0
+      tslib: 2.6.2
+    dev: false
+
   /@aws-sdk/middleware-ssec@3.451.0:
     resolution: {integrity: sha512-hDkeBUiRsvuDbvsPha0/uJHE680WDzjAOoE6ZnLBoWsw7ry+Bw1ULMj0sCmpBVrQ7Gpivi/6zbezhClVmt3ITw==}
     engines: {node: '>=14.0.0'}
@@ -1414,6 +1602,15 @@ packages:
       '@aws-sdk/types': 3.451.0
       '@smithy/types': 2.6.0
       tslib: 2.6.2
+
+  /@aws-sdk/middleware-ssec@3.537.0:
+    resolution: {integrity: sha512-2QWMrbwd5eBy5KCYn9a15JEWBgrK2qFEKQN2lqb/6z0bhtevIOxIRfC99tzvRuPt6nixFQ+ynKuBjcfT4ZFrdQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
 
   /@aws-sdk/middleware-user-agent@3.451.0:
     resolution: {integrity: sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==}
@@ -1467,6 +1664,18 @@ packages:
       '@smithy/signature-v4': 2.0.16
       '@smithy/types': 2.6.0
       tslib: 2.6.2
+
+  /@aws-sdk/signature-v4-multi-region@3.556.0:
+    resolution: {integrity: sha512-bWDSK0ggK7QzAOmPZGv29UAIZocL1MNY7XyOvm3P3P1U3tFMoIBilQQBLabXyHoZ9J3Ik0Vv4n95htUhRQ35ow==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.556.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
 
   /@aws-sdk/token-providers@3.451.0:
     resolution: {integrity: sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==}
@@ -1562,6 +1771,13 @@ packages:
     dependencies:
       tslib: 2.6.2
 
+  /@aws-sdk/util-arn-parser@3.535.0:
+    resolution: {integrity: sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
   /@aws-sdk/util-endpoints@3.451.0:
     resolution: {integrity: sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==}
     engines: {node: '>=14.0.0'}
@@ -1642,6 +1858,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
+
+  /@aws-sdk/xml-builder@3.535.0:
+    resolution: {integrity: sha512-VXAq/Jz8KIrU84+HqsOJhIKZqG0PNTdi6n6PFQ4xJf44ZQHD/5C7ouH4qCFX5XgZXcgbRIcMVVYGC6Jye0dRng==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
 
   /@babel/code-frame@7.23.4:
     resolution: {integrity: sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==}
@@ -2911,10 +3135,23 @@ packages:
       '@smithy/util-base64': 2.0.1
       tslib: 2.6.2
 
+  /@smithy/chunked-blob-reader-native@2.2.0:
+    resolution: {integrity: sha512-VNB5+1oCgX3Fzs072yuRsUoC2N4Zg/LJ11DTxX3+Qu+Paa6AmbIF0E9sc2wthz9Psrk/zcOlTCyuposlIhPjZQ==}
+    dependencies:
+      '@smithy/util-base64': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
   /@smithy/chunked-blob-reader@2.0.0:
     resolution: {integrity: sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==}
     dependencies:
       tslib: 2.6.2
+
+  /@smithy/chunked-blob-reader@2.2.0:
+    resolution: {integrity: sha512-3GJNvRwXBGdkDZZOGiziVYzDpn4j6zfyULHMDKAGIUo72yHALpE9CbhfQp/XcLNVoc1byfMpn6uW5H2BqPjgaQ==}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /@smithy/config-resolver@2.0.19:
     resolution: {integrity: sha512-JsghnQ5zjWmjEVY8TFOulLdEOCj09SjRLugrHlkPZTIBBm7PQitCFVLThbsKPZQOP7N3ME1DU1nKUc1UaVnBog==}
@@ -2980,6 +3217,15 @@ packages:
       '@smithy/util-hex-encoding': 2.0.0
       tslib: 2.6.2
 
+  /@smithy/eventstream-codec@2.2.0:
+    resolution: {integrity: sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==}
+    dependencies:
+      '@aws-crypto/crc32': 3.0.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
+      tslib: 2.6.2
+    dev: false
+
   /@smithy/eventstream-serde-browser@2.0.14:
     resolution: {integrity: sha512-41wmYE9smDGJi1ZXp+LogH6BR7MkSsQD91wneIFISF/mupKULvoOJUkv/Nf0NMRxWlM3Bf1Vvi9FlR2oV4KU8Q==}
     engines: {node: '>=14.0.0'}
@@ -2988,12 +3234,29 @@ packages:
       '@smithy/types': 2.6.0
       tslib: 2.6.2
 
+  /@smithy/eventstream-serde-browser@2.2.0:
+    resolution: {integrity: sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/eventstream-serde-universal': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
   /@smithy/eventstream-serde-config-resolver@2.0.14:
     resolution: {integrity: sha512-43IyRIzQ82s+5X+t/3Ood00CcWtAXQdmUIUKMed2Qg9REPk8SVIHhpm3rwewLwg+3G2Nh8NOxXlEQu6DsPUcMw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.6.0
       tslib: 2.6.2
+
+  /@smithy/eventstream-serde-config-resolver@2.2.0:
+    resolution: {integrity: sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
 
   /@smithy/eventstream-serde-node@2.0.14:
     resolution: {integrity: sha512-jVh9E2qAr6DxH5tWfCAl9HV6tI0pEQ3JVmu85JknDvYTC66djcjDdhctPV2EHuKWf2kjRiFJcMIn0eercW4THA==}
@@ -3003,6 +3266,15 @@ packages:
       '@smithy/types': 2.6.0
       tslib: 2.6.2
 
+  /@smithy/eventstream-serde-node@2.2.0:
+    resolution: {integrity: sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/eventstream-serde-universal': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
   /@smithy/eventstream-serde-universal@2.0.14:
     resolution: {integrity: sha512-Ie35+AISNn1NmEjn5b2SchIE49pvKp4Q74bE9ME5RULWI1MgXyGkQUajWd5E6OBSr/sqGcs+rD3IjPErXnCm9g==}
     engines: {node: '>=14.0.0'}
@@ -3010,6 +3282,15 @@ packages:
       '@smithy/eventstream-codec': 2.0.14
       '@smithy/types': 2.6.0
       tslib: 2.6.2
+
+  /@smithy/eventstream-serde-universal@2.2.0:
+    resolution: {integrity: sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/eventstream-codec': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
 
   /@smithy/fetch-http-handler@2.2.7:
     resolution: {integrity: sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==}
@@ -3038,6 +3319,15 @@ packages:
       '@smithy/types': 2.6.0
       tslib: 2.6.2
 
+  /@smithy/hash-blob-browser@2.2.0:
+    resolution: {integrity: sha512-SGPoVH8mdXBqrkVCJ1Hd1X7vh1zDXojNN1yZyZTZsCno99hVue9+IYzWDjq/EQDDXxmITB0gBmuyPh8oAZSTcg==}
+    dependencies:
+      '@smithy/chunked-blob-reader': 2.2.0
+      '@smithy/chunked-blob-reader-native': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
   /@smithy/hash-node@2.0.16:
     resolution: {integrity: sha512-Wbi9A0PacMYUOwjAulQP90Wl3mQ6NDwnyrZQzFjDz+UzjXOSyQMgBrTkUBz+pVoYVlX3DUu24gWMZBcit+wOGg==}
     engines: {node: '>=14.0.0'}
@@ -3064,6 +3354,15 @@ packages:
       '@smithy/types': 2.6.0
       '@smithy/util-utf8': 2.0.2
       tslib: 2.6.2
+
+  /@smithy/hash-stream-node@2.2.0:
+    resolution: {integrity: sha512-aT+HCATOSRMGpPI7bi7NSsTNVZE/La9IaxLXWoVAYMxHT5hGO3ZOGEMZQg8A6nNL+pdFGtZQtND1eoY084HgHQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    dev: false
 
   /@smithy/invalid-dependency@2.0.14:
     resolution: {integrity: sha512-d8ohpwZo9RzTpGlAfsWtfm1SHBSU7+N4iuZ6MzR10xDTujJJWtmXYHK1uzcr7rggbpUTaWyHpPFgnf91q0EFqQ==}
@@ -3097,6 +3396,14 @@ packages:
       '@smithy/types': 2.6.0
       '@smithy/util-utf8': 2.0.2
       tslib: 2.6.2
+
+  /@smithy/md5-js@2.2.0:
+    resolution: {integrity: sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==}
+    dependencies:
+      '@smithy/types': 2.12.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    dev: false
 
   /@smithy/middleware-compression@2.2.0:
     resolution: {integrity: sha512-4NHl84M/Yz9fIQH+NckoAExUOr0D8tZ5ng6rtr5eMzHwa8/bRTg4kUnpZW7S4yw7jT1NXDZ66M8r04uFiT4Ccw==}
@@ -3700,6 +4007,10 @@ packages:
 
   /@types/aws-lambda@8.10.134:
     resolution: {integrity: sha512-cfv422ivDMO+EeA3N4YcshbTHBL+5lLXe+Uz+4HXvIcsCuWvqNFpOs28ZprL8NA3qRCzt95ETiNAJDn4IcC/PA==}
+    dev: true
+
+  /@types/aws-lambda@8.10.137:
+    resolution: {integrity: sha512-YNFwzVarXAOXkjuFxONyDw1vgRNzyH8AuyN19s0bM+ChSu/bzxb5XPxYFLXoqoM+tvgzwR3k7fXcEOW125yJxg==}
     dev: true
 
   /@types/babel__core@7.20.5:


### PR DESCRIPTION
Adds support for sending alarms to different google chat channels based on the app name.

- When a message is received, get the ARN of the alarm and fetch the tags for that alarm
- If an `App` tag is present then we attempt to resolve that to a team
- The team is then mapped to a webhook url

If we cannot resolve to a webhook url then the SRE channel is used by default.