### PR TITLE
feat: add product rate plans & charges for three tier bundles

### DIFF
--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -68,6 +68,22 @@ export const typeObject = {
       "Annual": {
         "Subscription": {},
         "Contribution": {}
+      },
+      "SupporterPlusAndGuardianWeeklyRowMonthly": {
+        "SupporterPlusSubscription": {},
+        "GuardianWeeklySubscription": {}
+      },
+      "SupporterPlusAndGuardianWeeklyRowAnnual": {
+        "SupporterPlusSubscription": {},
+        "GuardianWeeklySubscription": {}
+      },
+      "SupporterPlusAndGuardianWeeklyDomesticAnnual": {
+        "SupporterPlusSubscription": {},
+        "GuardianWeeklySubscription": {}
+      },
+      "SupporterPlusAndGuardianWeeklyDomesticMonthly": {
+        "SupporterPlusSubscription": {},
+        "GuardianWeeklySubscription": {}
       }
     }
   },

--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -18,6 +18,14 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	'Digital Subscription Three Month Fixed - One Time Charge': 'ThreeMonthGift',
 	'Supporter Plus V2 - Monthly': 'Monthly',
 	'Supporter Plus V2 - Annual': 'Annual',
+	'Supporter Plus V2 & Guardian Weekly ROW - Monthly':
+		'SupporterPlusAndGuardianWeeklyRowMonthly',
+	'Supporter Plus V2 & Guardian Weekly ROW - Annual':
+		'SupporterPlusAndGuardianWeeklyRowAnnual',
+	'Supporter Plus V2 & Guardian Weekly Domestic - Monthly':
+		'SupporterPlusAndGuardianWeeklyDomesticMonthly',
+	'Supporter Plus V2 & Guardian Weekly Domestic - Annual':
+		'SupporterPlusAndGuardianWeeklyDomesticAnnual',
 	'GW Oct 18 - Annual - ROW': 'Annual',
 	'GW Oct 18 - Monthly - ROW': 'Monthly',
 	'GW Oct 18 - Quarterly - ROW': 'Quarterly',

--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -20,10 +20,10 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	'Supporter Plus V2 - Annual': 'Annual',
 	'Supporter Plus V2 & Guardian Weekly ROW - Monthly':
 		'SupporterPlusAndGuardianWeeklyRowMonthly',
-	'Supporter Plus V2 & Guardian Weekly ROW - Annual':
-		'SupporterPlusAndGuardianWeeklyRowAnnual',
 	'Supporter Plus V2 & Guardian Weekly Domestic - Monthly':
 		'SupporterPlusAndGuardianWeeklyDomesticMonthly',
+	'Supporter Plus V2 & Guardian Weekly ROW - Annual':
+		'SupporterPlusAndGuardianWeeklyRowAnnual',
 	'Supporter Plus V2 & Guardian Weekly Domestic - Annual':
 		'SupporterPlusAndGuardianWeeklyDomesticAnnual',
 	'GW Oct 18 - Annual - ROW': 'Annual',
@@ -78,6 +78,12 @@ const zuoraCatalogToProductRatePlanChargeKey: Record<string, string> = {
 	Wednesday: 'Wednesday',
 	Thursday: 'Thursday',
 	Friday: 'Friday',
+	'Bundle - Supporter Plus V2 - Monthly': 'SupporterPlusSubscription',
+	'Bundle - Supporter Plus V2 - Annual': 'SupporterPlusSubscription',
+	'Bundle - GW Oct 18 - Monthly - ROW': 'GuardianWeeklySubscription',
+	'Bundle - GW Oct 18 - Monthly - Domestic': 'GuardianWeeklySubscription',
+	'Bundle - GW Oct 18 - Annual - ROW': 'GuardianWeeklySubscription',
+	'Bundle - GW Oct 18 - Annual - Domestic': 'GuardianWeeklySubscription',
 } as const;
 export const getZuoraProductKey = (product: string): string => {
 	return checkDefined(


### PR DESCRIPTION
## What does this change?

This adds the following bundle products to the product catalog api:

- Supporter Plus V2 & Guardian Weekly Domestic - Monthly
  - Bundle - Supporter Plus V2 - Monthly
  - Bundle - GW Oct 18 - Monthly - Domestic

- Supporter Plus V2 & Guardian Weekly Domestic - Annual
  - Bundle - Supporter Plus V2 - Annual
  - Bundle - GW Oct 18 - Annual - Domestic

- Supporter Plus V2 & Guardian Weekly ROW - Monthly
  - Bundle - Supporter Plus V2 - Monthly
  - Bundle - GW Oct 18 - Monthly - ROW

- Supporter Plus V2 & Guardian Weekly ROW - Annual
  - Bundle - Supporter Plus V2 - Annual
  - Bundle - GW Oct 18 - Annual - ROW

