### PR TITLE
Run prettier over the codebase

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -3,31 +3,31 @@ import { checkDefined } from '@modules/nullAndUndefined';
 type Team = 'VALUE' | 'GROWTH' | 'PP' | 'SRE';
 
 const appToTeamMappings: Record<string, Team> = {
-    'apps-metering': 'GROWTH',
-    'gchat-test-app': 'SRE',
-}
+	'apps-metering': 'GROWTH',
+	'gchat-test-app': 'SRE',
+};
 
 export const getTeam = (appName: string): Team => {
-    const team = appToTeamMappings[appName];
-    if (!team) {
-        console.log(`No team found for app: ${appName}, defaulting to SRE`);
-        return 'SRE';
-    }
-    return team;
-}
+	const team = appToTeamMappings[appName];
+	if (!team) {
+		console.log(`No team found for app: ${appName}, defaulting to SRE`);
+		return 'SRE';
+	}
+	return team;
+};
 
 export const buildWebhookMappings = (): Record<Team, string> => {
-    const getEnvironmentVariable = (team: Team): string => {
-        const prefix = team.toUpperCase();
-        return checkDefined<string>(
-            process.env[`${prefix}_WEBHOOK`],
-            `${prefix}_WEBHOOK environment variable not set`,
-        );
-    }
-    return {
-        VALUE: getEnvironmentVariable('VALUE'),
-        GROWTH: getEnvironmentVariable('GROWTH'),
-        PP: getEnvironmentVariable('PP'),
-        SRE: getEnvironmentVariable('SRE'),
-    }
-}
+	const getEnvironmentVariable = (team: Team): string => {
+		const prefix = team.toUpperCase();
+		return checkDefined<string>(
+			process.env[`${prefix}_WEBHOOK`],
+			`${prefix}_WEBHOOK environment variable not set`,
+		);
+	};
+	return {
+		VALUE: getEnvironmentVariable('VALUE'),
+		GROWTH: getEnvironmentVariable('GROWTH'),
+		PP: getEnvironmentVariable('PP'),
+		SRE: getEnvironmentVariable('SRE'),
+	};
+};

--- a/handlers/alarms-handler/src/cloudwatch.ts
+++ b/handlers/alarms-handler/src/cloudwatch.ts
@@ -1,21 +1,26 @@
-import {CloudWatchClient, ListTagsForResourceCommand} from "@aws-sdk/client-cloudwatch";
-import type {
-    ListTagsForResourceCommandOutput
-} from "@aws-sdk/client-cloudwatch/dist-types/commands/ListTagsForResourceCommand";
-import type {Tag} from "@aws-sdk/client-cloudwatch/dist-types/models/models_0";
+import {
+	CloudWatchClient,
+	ListTagsForResourceCommand,
+} from '@aws-sdk/client-cloudwatch';
+import type { ListTagsForResourceCommandOutput } from '@aws-sdk/client-cloudwatch/dist-types/commands/ListTagsForResourceCommand';
+import type { Tag } from '@aws-sdk/client-cloudwatch/dist-types/models/models_0';
 
 const getTags = (alarmArn: string): Promise<Tag[]> => {
-    const client = new CloudWatchClient({ region: "eu-west-1" });
+	const client = new CloudWatchClient({ region: 'eu-west-1' });
 
-    const request = new ListTagsForResourceCommand({
-        ResourceARN: alarmArn
-    });
+	const request = new ListTagsForResourceCommand({
+		ResourceARN: alarmArn,
+	});
 
-    return client.send(request).then((response: ListTagsForResourceCommandOutput) => response.Tags ?? []);
-}
+	return client
+		.send(request)
+		.then((response: ListTagsForResourceCommandOutput) => response.Tags ?? []);
+};
 
-export const getAppNameTag = (alarmArn: string): Promise<string | undefined> => {
-    return getTags(alarmArn).then((tags: Tag[]) => {
-        return tags.find((tag: Tag) => tag.Key === 'App')?.Value;
-    });
+export const getAppNameTag = (
+	alarmArn: string,
+): Promise<string | undefined> => {
+	return getTags(alarmArn).then((tags: Tag[]) => {
+		return tags.find((tag: Tag) => tag.Key === 'App')?.Value;
+	});
 };

--- a/modules/billingPeriod.ts
+++ b/modules/billingPeriod.ts
@@ -1,5 +1,7 @@
 export const BillingPeriodValues = ['Month', 'Quarter', 'Annual'] as const;
 export type BillingPeriod = (typeof BillingPeriodValues)[number];
-export const isBillingPeriod = (billingPeriod: unknown): billingPeriod is BillingPeriod => {
-    return (BillingPeriodValues as readonly unknown[]).includes(billingPeriod);
-}
+export const isBillingPeriod = (
+	billingPeriod: unknown,
+): billingPeriod is BillingPeriod => {
+	return (BillingPeriodValues as readonly unknown[]).includes(billingPeriod);
+};

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -1,210 +1,173 @@
 export const typeObject = {
-  "DigitalSubscription": {
-    "currencies": [
-      "USD",
-      "NZD",
-      "EUR",
-      "GBP",
-      "CAD",
-      "AUD"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      },
-      "OneYearGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "NationalDelivery": {
-    "currencies": [
-      "GBP"
-    ],
-    "productRatePlans": {
-      "Sixday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Saturday": {}
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Everyday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Saturday": {},
-        "Sunday": {}
-      }
-    }
-  },
-  "SupporterPlus": {
-    "currencies": [
-      "USD",
-      "NZD",
-      "EUR",
-      "GBP",
-      "CAD",
-      "AUD"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {},
-        "Contribution": {}
-      },
-      "Annual": {
-        "Contribution": {},
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyRestOfWorld": {
-    "currencies": [
-      "USD",
-      "GBP"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Monthly": {}
-      },
-      "OneYearGift": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "Quarterly": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyDomestic": {
-    "currencies": [
-      "USD",
-      "NZD",
-      "EUR",
-      "GBP",
-      "CAD",
-      "AUD"
-    ],
-    "productRatePlans": {
-      "OneYearGift": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "Quarterly": {
-        "Subscription": {}
-      },
-      "Monthly": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "SubscriptionCard": {
-    "currencies": [
-      "GBP"
-    ],
-    "productRatePlans": {
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Thursday": {},
-        "Wednesday": {},
-        "Saturday": {}
-      },
-      "Everyday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Wednesday": {},
-        "Sunday": {}
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Sunday": {
-        "Sunday": {}
-      },
-      "Saturday": {
-        "Saturday": {}
-      }
-    }
-  },
-  "Contribution": {
-    "currencies": [
-      "USD",
-      "NZD",
-      "EUR",
-      "GBP",
-      "CAD",
-      "AUD"
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Contribution": {}
-      },
-      "Monthly": {
-        "Contribution": {}
-      }
-    }
-  },
-  "HomeDelivery": {
-    "currencies": [
-      "GBP"
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Sunday": {},
-        "Wednesday": {},
-        "Friday": {},
-        "Thursday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {}
-      },
-      "Sunday": {
-        "Sunday": {}
-      },
-      "Sixday": {
-        "Wednesday": {},
-        "Friday": {},
-        "Thursday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {}
-      },
-      "Weekend": {
-        "Sunday": {},
-        "Saturday": {}
-      },
-      "Saturday": {
-        "Saturday": {}
-      }
-    }
-  }
+	DigitalSubscription: {
+		currencies: ['USD', 'NZD', 'EUR', 'GBP', 'CAD', 'AUD'],
+		productRatePlans: {
+			Monthly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+			OneYearGift: {
+				Subscription: {},
+			},
+		},
+	},
+	NationalDelivery: {
+		currencies: ['GBP'],
+		productRatePlans: {
+			Sixday: {
+				Monday: {},
+				Tuesday: {},
+				Wednesday: {},
+				Thursday: {},
+				Friday: {},
+				Saturday: {},
+			},
+			Weekend: {
+				Saturday: {},
+				Sunday: {},
+			},
+			Everyday: {
+				Monday: {},
+				Tuesday: {},
+				Wednesday: {},
+				Thursday: {},
+				Friday: {},
+				Saturday: {},
+				Sunday: {},
+			},
+		},
+	},
+	SupporterPlus: {
+		currencies: ['USD', 'NZD', 'EUR', 'GBP', 'CAD', 'AUD'],
+		productRatePlans: {
+			Monthly: {
+				Subscription: {},
+				Contribution: {},
+			},
+			Annual: {
+				Contribution: {},
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyRestOfWorld: {
+		currencies: ['USD', 'GBP'],
+		productRatePlans: {
+			Monthly: {
+				Monthly: {},
+			},
+			OneYearGift: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			Quarterly: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyDomestic: {
+		currencies: ['USD', 'NZD', 'EUR', 'GBP', 'CAD', 'AUD'],
+		productRatePlans: {
+			OneYearGift: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			Quarterly: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+		},
+	},
+	SubscriptionCard: {
+		currencies: ['GBP'],
+		productRatePlans: {
+			Sixday: {
+				Friday: {},
+				Monday: {},
+				Tuesday: {},
+				Thursday: {},
+				Wednesday: {},
+				Saturday: {},
+			},
+			Everyday: {
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+				Thursday: {},
+				Friday: {},
+				Wednesday: {},
+				Sunday: {},
+			},
+			Weekend: {
+				Saturday: {},
+				Sunday: {},
+			},
+			Sunday: {
+				Sunday: {},
+			},
+			Saturday: {
+				Saturday: {},
+			},
+		},
+	},
+	Contribution: {
+		currencies: ['USD', 'NZD', 'EUR', 'GBP', 'CAD', 'AUD'],
+		productRatePlans: {
+			Annual: {
+				Contribution: {},
+			},
+			Monthly: {
+				Contribution: {},
+			},
+		},
+	},
+	HomeDelivery: {
+		currencies: ['GBP'],
+		productRatePlans: {
+			Everyday: {
+				Sunday: {},
+				Wednesday: {},
+				Friday: {},
+				Thursday: {},
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+			},
+			Sunday: {
+				Sunday: {},
+			},
+			Sixday: {
+				Wednesday: {},
+				Friday: {},
+				Thursday: {},
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+			},
+			Weekend: {
+				Sunday: {},
+				Saturday: {},
+			},
+			Saturday: {
+				Saturday: {},
+			},
+		},
+	},
 } as const;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"test": "pnpm --stream -r run test",
 		"it-test": "pnpm --stream -r run it-test",
 		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && cd ./cdk && yarn lint --fix && yarn test -u && git add ./lib/__snapshots__/*.test.ts.snap",
-		"prepare": "husky"
+		"prepare": "husky",
+		"format": "prettier --write handlers/**/*.ts modules/**/*.ts"
 	},
 	"devDependencies": {
 		"@guardian/eslint-config-typescript": "8.0.1",


### PR DESCRIPTION
## What does this change?

Runs prettier across the codebase for consistent formatting. There were just a handful of files which weren't formatted to standard (I'm working on the `alarms-handler` but it only increased the scope slightly to format everything).

There's also a script in the package.json now so we can format with:

`$ pnpm format`