### PR TITLE
More Growth team alarms

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -7,6 +7,8 @@ const appToTeamMappings: Record<string, Team> = {
 	'dotcom-components': 'GROWTH',
 	'admin-console': 'GROWTH',
 	'promotions-tool': 'GROWTH',
+	'price-migration-engine-state-machine': 'GROWTH',
+	'support-reminders': 'GROWTH',
 
 	'gchat-test-app': 'SRE',
 	'holiday-stop-api': 'VALUE',


### PR DESCRIPTION
- `price-migration-engine-state-machine` - https://github.com/guardian/support-reminders/pull/174
- `support-reminders` - https://github.com/guardian/price-migration-engine/pull/1041