### PR TITLE
Alarm chat integration for the `soft-opt-in-consent-setter` lambda

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -9,7 +9,9 @@ const appToTeamMappings: Record<string, Team> = {
 	'promotions-tool': 'GROWTH',
 
 	'gchat-test-app': 'SRE',
+
 	'holiday-stop-api': 'VALUE',
+	'soft-opt-in-consent-setter': 'VALUE',
 };
 
 export const getTeam = (appName: string): Team => {

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -238,7 +238,7 @@ Resources:
       - LambdaFunction
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to run
       AlarmDescription: >
         Five or more runs found an error and were unable to complete.
@@ -263,7 +263,7 @@ Resources:
       - LambdaFunctionIAP
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       AlarmName: !Sub soft-opt-in-consent-setter-IAP-${Stage} threw an exception
       AlarmDescription: >
         Five or more runs found an error and were unable to complete.
@@ -286,7 +286,7 @@ Resources:
     Condition: IsProd
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       AlarmName: !Sub soft-opt-in-consent-setter-IAP-${Stage} failed to run and sent the message to the dead letter queue.
       AlarmDescription: >
         Five or more runs found an error and were unable to complete.
@@ -311,7 +311,7 @@ Resources:
       - LambdaFunction
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
       AlarmDescription: >
         A run failed to update (some) records in Salesforce in the last hour.
@@ -336,7 +336,7 @@ Resources:
       - LambdaFunction
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update the Dynamo logging table.
       AlarmDescription: >
         A run failed to update (some) records in Salesforce in the last hour.


### PR DESCRIPTION
## What does this change?

Maps the `soft-opt-in-consent-setter` app to the value team.
Updates the topic for `soft-opt-in-consent-setter` alarms.

This lambda belongs to Value. We'd like alarms to show up in the Value team chat.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
