### PR TITLE
Restructure alarm mappings

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -2,19 +2,29 @@ import { checkDefined } from '@modules/nullAndUndefined';
 
 type Team = 'VALUE' | 'GROWTH' | 'PP' | 'SRE';
 
-const appToTeamMappings: Record<string, Team> = {
-	'apps-metering': 'GROWTH',
-	'dotcom-components': 'GROWTH',
-	'admin-console': 'GROWTH',
-	'promotions-tool': 'GROWTH',
-	'price-migration-engine-state-machine': 'GROWTH',
-	'support-reminders': 'GROWTH',
-
-	'gchat-test-app': 'SRE',
-
-	'holiday-stop-api': 'VALUE',
-	'soft-opt-in-consent-setter': 'VALUE',
+const teamToAppMappings: Record<Team, string[]> = {
+	GROWTH: [
+		'apps-metering',
+		'dotcom-components',
+		'admin-console',
+		'promotions-tool',
+		'price-migration-engine-state-machine',
+		'support-reminders',
+	],
+	VALUE: ['holiday-stop-api', 'soft-opt-in-consent-setter'],
+	SRE: ['gchat-test-app'],
+	PP: [],
 };
+
+const appToTeamMappings: Record<string, Team> = Object.entries(
+	teamToAppMappings,
+).reduce(
+	(mappings, [team, apps]) => ({
+		...mappings,
+		...apps.reduce((acc, app) => ({ ...acc, [app]: team }), {}),
+	}),
+	{},
+);
 
 export const getTeam = (appName: string): Team => {
 	const team = appToTeamMappings[appName];

--- a/handlers/alarms-handler/test/alarmMappings.test.ts
+++ b/handlers/alarms-handler/test/alarmMappings.test.ts
@@ -1,0 +1,19 @@
+import { getTeam } from '../src/alarmMappings';
+
+describe('getTeam', () => {
+	it('returns the correct team for a given app', () => {
+		const app = 'apps-metering';
+
+		const team = getTeam(app);
+
+		expect(team).toEqual('GROWTH');
+	});
+
+	it('returns SRE if the app is not found', () => {
+		const app = 'foo';
+
+		const team = getTeam(app);
+
+		expect(team).toEqual('SRE');
+	});
+});


### PR DESCRIPTION
## What does this change?

Instead of mapping apps to teams, invert the data structure to be an object with teams as keys and arrays of apps as values. I think this is a nice data structure to work with when adding apps. Then we transform this back to the original format to do the lookup from app to team.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
