### PR TITLE
Add more logging to the product-move-api

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraClient.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraClient.scala
@@ -127,7 +127,7 @@ object ZuoraRestBody {
       case ZuoraSuccessCheck.None => Right(())
     }
 
-    isSuccessful.flatMap(_ => body.fromJson[A].left.map(errorMessage => new Throwable("json parse" + errorMessage)))
+    isSuccessful.flatMap(_ => body.fromJson[A].left.map(errorMessage => new Throwable(s"json parsing error $errorMessage with body $body")))
   }
 
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraGet.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraGet.scala
@@ -18,7 +18,9 @@ class ZuoraGetLive(zuoraClient: ZuoraClient) extends ZuoraGet {
       zuoraSuccessCheck: ZuoraSuccessCheck = ZuoraSuccessCheck.SuccessCheckLowercase,
   ): Task[Response] =
     for {
+      _ <- ZIO.log(s"Sending GET to $relativeUrl")
       response <- zuoraClient.send(basicRequest.get(relativeUrl))
+      _ <- ZIO.log(s"Response is $response")
       parsedBody <- ZIO.fromEither(ZuoraRestBody.parseIfSuccessful[Response](response, zuoraSuccessCheck))
     } yield parsedBody
 
@@ -40,7 +42,9 @@ class ZuoraGetLive(zuoraClient: ZuoraClient) extends ZuoraGet {
       zuoraSuccessCheck: ZuoraSuccessCheck = ZuoraSuccessCheck.SuccessCheckLowercase,
   ): Task[Response] =
     for {
+      _ <- ZIO.log(s"Sending PUT to $relativeUrl with body ${input.toJson}")
       response <- zuoraClient.send(basicRequest.contentType("application/json").body(input.toJson).put(relativeUrl))
+      _ <- ZIO.log(s"Response is $response")
       parsedBody <- ZIO.fromEither(
         ZuoraRestBody.parseIfSuccessful[Response](response, zuoraSuccessCheck),
       )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
There are a number of parsing errors in the product-move-api (not product-switch-api!) this PR adds some more debug logging to help diagnose what the issue is.