### PR TITLE
Allow alarms from mobile AWS account

### DIFF
--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -8,6 +8,7 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuStringParameter",
       "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -34,6 +35,10 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
     },
     "alarmshandlerVALUEwebhook": {
       "Description": "VALUE Team Google Chat webhook URL",
+      "Type": "String",
+    },
+    "alarmshandlermobileawsaccount": {
+      "Description": "ARN of the mobile AWS account",
       "Type": "String",
     },
   },
@@ -471,6 +476,34 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SNS::Topic",
     },
+    "alarmshandlertopicPolicy7401CE24": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Ref": "alarmshandlermobileawsaccount",
+                },
+              },
+              "Resource": {
+                "Ref": "alarmshandlertopic003C974E",
+              },
+              "Sid": "0",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Topics": [
+          {
+            "Ref": "alarmshandlertopic003C974E",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::TopicPolicy",
+    },
     "deadlettersalarmshandlerqueueC7A67616": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -510,6 +543,7 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
       "GuStringParameter",
       "GuStringParameter",
       "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -536,6 +570,10 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
     },
     "alarmshandlerVALUEwebhook": {
       "Description": "VALUE Team Google Chat webhook URL",
+      "Type": "String",
+    },
+    "alarmshandlermobileawsaccount": {
+      "Description": "ARN of the mobile AWS account",
       "Type": "String",
     },
   },
@@ -972,6 +1010,34 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
         "TopicName": "alarms-handler-topic-PROD",
       },
       "Type": "AWS::SNS::Topic",
+    },
+    "alarmshandlertopicPolicy7401CE24": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Ref": "alarmshandlermobileawsaccount",
+                },
+              },
+              "Resource": {
+                "Ref": "alarmshandlertopic003C974E",
+              },
+              "Sid": "0",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Topics": [
+          {
+            "Ref": "alarmshandlertopic003C974E",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::TopicPolicy",
     },
     "deadlettersalarmshandlerqueueC7A67616": {
       "DeletionPolicy": "Delete",

--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -38,7 +38,7 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       "Type": "String",
     },
     "alarmshandlermobileawsaccount": {
-      "Description": "ARN of the mobile AWS account",
+      "Description": "ID of the mobile aws account",
       "Type": "String",
     },
   },
@@ -485,7 +485,20 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
               "Effect": "Allow",
               "Principal": {
                 "AWS": {
-                  "Ref": "alarmshandlermobileawsaccount",
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "alarmshandlermobileawsaccount",
+                      },
+                      ":root",
+                    ],
+                  ],
                 },
               },
               "Resource": {
@@ -573,7 +586,7 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
       "Type": "String",
     },
     "alarmshandlermobileawsaccount": {
-      "Description": "ARN of the mobile AWS account",
+      "Description": "ID of the mobile aws account",
       "Type": "String",
     },
   },
@@ -1020,7 +1033,20 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
               "Effect": "Allow",
               "Principal": {
                 "AWS": {
-                  "Ref": "alarmshandlermobileawsaccount",
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "alarmshandlermobileawsaccount",
+                      },
+                      ":root",
+                    ],
+                  ],
                 },
               },
               "Resource": {

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -5,7 +5,7 @@ import {GuLambdaFunction} from '@guardian/cdk/lib/constructs/lambda';
 import type {App} from 'aws-cdk-lib';
 import {Duration} from 'aws-cdk-lib';
 import {ComparisonOperator} from 'aws-cdk-lib/aws-cloudwatch';
-import {ArnPrincipal, Effect, Policy,PolicyStatement} from "aws-cdk-lib/aws-iam";
+import {AccountPrincipal, Effect, Policy, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Runtime} from 'aws-cdk-lib/aws-lambda';
 import {SqsEventSource} from 'aws-cdk-lib/aws-lambda-event-sources';
 import {Topic} from 'aws-cdk-lib/aws-sns';
@@ -36,8 +36,8 @@ export class AlarmsHandler extends GuStack {
 				description: `${team} Team Google Chat webhook URL`,
 			});
 
-		const mobileAccountArnParameter = new GuStringParameter(this, `${app}-mobile-aws-account`, {
-			description: 'ARN of the mobile AWS account',
+		const mobileAccountId = new GuStringParameter(this, `${app}-mobile-aws-account`, {
+			description: 'ID of the mobile aws account',
 		});
 
 		const lambda = new GuLambdaFunction(this, `${app}-lambda`, {
@@ -83,7 +83,7 @@ export class AlarmsHandler extends GuStack {
 		snsTopic.addToResourcePolicy(new PolicyStatement({
 			effect: Effect.ALLOW,
 			actions: ['sns:Publish'],
-			principals: [new ArnPrincipal(mobileAccountArnParameter.valueAsString)],
+			principals: [new AccountPrincipal(mobileAccountId.valueAsString)],
 			resources: [snsTopic.topicArn],
 		}));
 

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -1,16 +1,21 @@
-import {GuAlarm} from '@guardian/cdk/lib/constructs/cloudwatch';
-import type {GuStackProps} from '@guardian/cdk/lib/constructs/core';
-import {GuStack, GuStringParameter} from '@guardian/cdk/lib/constructs/core';
-import {GuLambdaFunction} from '@guardian/cdk/lib/constructs/lambda';
-import type {App} from 'aws-cdk-lib';
-import {Duration} from 'aws-cdk-lib';
-import {ComparisonOperator} from 'aws-cdk-lib/aws-cloudwatch';
-import {AccountPrincipal, Effect, Policy, PolicyStatement} from "aws-cdk-lib/aws-iam";
-import {Runtime} from 'aws-cdk-lib/aws-lambda';
-import {SqsEventSource} from 'aws-cdk-lib/aws-lambda-event-sources';
-import {Topic} from 'aws-cdk-lib/aws-sns';
-import {SqsSubscription} from 'aws-cdk-lib/aws-sns-subscriptions';
-import {Queue} from 'aws-cdk-lib/aws-sqs';
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
+import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
+import type { App } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
+import { ComparisonOperator } from 'aws-cdk-lib/aws-cloudwatch';
+import {
+	AccountPrincipal,
+	Effect,
+	Policy,
+	PolicyStatement,
+} from 'aws-cdk-lib/aws-iam';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { SqsSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 export class AlarmsHandler extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -36,9 +41,13 @@ export class AlarmsHandler extends GuStack {
 				description: `${team} Team Google Chat webhook URL`,
 			});
 
-		const mobileAccountId = new GuStringParameter(this, `${app}-mobile-aws-account`, {
-			description: 'ID of the mobile aws account',
-		});
+		const mobileAccountId = new GuStringParameter(
+			this,
+			`${app}-mobile-aws-account`,
+			{
+				description: 'ID of the mobile aws account',
+			},
+		);
 
 		const lambda = new GuLambdaFunction(this, `${app}-lambda`, {
 			app,
@@ -60,18 +69,16 @@ export class AlarmsHandler extends GuStack {
 			},
 		});
 
-		lambda.role?.attachInlinePolicy(new Policy(
-			this,
-			`${app}-cloudwatch-policy`,
-			{
+		lambda.role?.attachInlinePolicy(
+			new Policy(this, `${app}-cloudwatch-policy`, {
 				statements: [
 					new PolicyStatement({
 						actions: ['cloudwatch:ListTagsForResource'],
 						resources: ['*'],
 					}),
 				],
-			},
-		));
+			}),
+		);
 
 		const snsTopic = new Topic(this, `${app}-topic`, {
 			topicName: `${app}-topic-${this.stage}`,
@@ -80,12 +87,14 @@ export class AlarmsHandler extends GuStack {
 		snsTopic.addSubscription(new SqsSubscription(queue));
 
 		// Allow cross-account publishing to the topic
-		snsTopic.addToResourcePolicy(new PolicyStatement({
-			effect: Effect.ALLOW,
-			actions: ['sns:Publish'],
-			principals: [new AccountPrincipal(mobileAccountId.valueAsString)],
-			resources: [snsTopic.topicArn],
-		}));
+		snsTopic.addToResourcePolicy(
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: ['sns:Publish'],
+				principals: [new AccountPrincipal(mobileAccountId.valueAsString)],
+				resources: [snsTopic.topicArn],
+			}),
+		);
 
 		new GuAlarm(this, `${app}-alarm`, {
 			app: app,


### PR DESCRIPTION
We need alarms in the mobile aws account to publish messages to the SNS topic in the membership account