### PR TITLE
Remove time portion from dates before comparing in product-switch-api

### DIFF
--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -151,7 +151,9 @@ export const getSwitchInformationWithOwnerCheck = (
 		billingPeriod,
 	};
 
-	const startNewTerm = dayjs(subscription.termStartDate).isBefore(today);
+	const termStartDate = dayjs(subscription.termStartDate).startOf('day');
+	const startOfToday = today.startOf('day');
+	const startNewTerm = termStartDate.isBefore(startOfToday);
 
 	return {
 		stage,

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -62,7 +62,7 @@ test('url parsing', () => {
 });
 
 test('startNewTerm is only true when the termStartDate is before today', () => {
-	const today = dayjs('2024-05-09');
+	const today = dayjs('2024-05-09T23:10:10.663+01:00');
 	const subscription = zuoraSubscriptionSchema.parse(subscriptionJson);
 	const account = zuoraAccountSchema.parse(accountJson);
 	const productCatalog = productCatalogSchema.parse(catalogJson);
@@ -73,7 +73,7 @@ test('startNewTerm is only true when the termStartDate is before today', () => {
 		subscription,
 		account,
 		productCatalog,
-		'105368983',
+		'999999999999',
 		today,
 	);
 	expect(switchInformation.startNewTerm).toEqual(false);

--- a/handlers/product-switch-api/test/fixtures/account.json
+++ b/handlers/product-switch-api/test/fixtures/account.json
@@ -13,7 +13,7 @@
     "purchaseOrderNumber": null,
     "customerServiceRepName": null,
     "ScrubbedOn__c": null,
-    "IdentityId__c": "105368983",
+    "IdentityId__c": "999999999999",
     "sfContactId__c": "0035I00000CvU9EQAV",
     "CCURN__c": null,
     "SpecialDeliveryInstructions__c": null,

--- a/handlers/product-switch-api/test/fixtures/product-catalog.json
+++ b/handlers/product-switch-api/test/fixtures/product-catalog.json
@@ -147,7 +147,7 @@
   },
   "SupporterPlus": {
     "ratePlans": {
-      "SupporterPlusAndGuardianWeeklyRowMonthly": {
+      "GuardianWeeklyRestOfWorldMonthly": {
         "id": "8a1281f38f518d11018f52a599806a65",
         "pricing": {
           "USD": 46,
@@ -167,7 +167,7 @@
         },
         "billingPeriod": "Month"
       },
-      "SupporterPlusAndGuardianWeeklyRowAnnual": {
+      "GuardianWeeklyRestOfWorldAnnual": {
         "id": "8a1292628f51a923018f52a324e45710",
         "pricing": {
           "USD": 516,
@@ -187,7 +187,7 @@
         },
         "billingPeriod": "Annual"
       },
-      "SupporterPlusAndGuardianWeeklyDomesticAnnual": {
+      "GuardianWeeklyDomesticAnnual": {
         "id": "8a1282048f518d08018f529ead0f3d91",
         "pricing": {
           "USD": 480,
@@ -207,7 +207,7 @@
         },
         "billingPeriod": "Annual"
       },
-      "SupporterPlusAndGuardianWeeklyDomesticMonthly": {
+      "GuardianWeeklyDomesticMonthly": {
         "id": "8a1288a38f518d01018f529a04443172",
         "pricing": {
           "USD": 43,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
#2240 didn't properly take account of the time portion of a Dayjs object when comparing dates, this PR fixes that.