### PR TITLE
checkUndefined should not throw on falsey values

### DIFF
--- a/modules/nullAndUndefined.ts
+++ b/modules/nullAndUndefined.ts
@@ -3,7 +3,7 @@ export const checkDefined = <T>(
 	value: T | undefined | null,
 	errorMessage: string,
 ): T => {
-	if (!value) {
+	if (value === undefined || value === null) {
 		throw new ReferenceError(errorMessage);
 	}
 	return value;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The current version of the `checkUndefined` function is too sensitive, it throws on falsey values such as zero when it should only throw on undefined or null.