### PR TITLE
Don't try to adjust invoice with zero value

### DIFF
--- a/handlers/product-switch-api/src/payment.ts
+++ b/handlers/product-switch-api/src/payment.ts
@@ -54,7 +54,10 @@ export const takePaymentOrAdjustInvoice = async (
 	const amountPayableToday = invoice.amount;
 	const invoiceId = invoice.id;
 
-	if (amountPayableToday < 0.5) {
+	if (amountPayableToday === 0) {
+		// Nothing to do, we don't need to take a payment and the account balance will be correct
+		return 0;
+	} else if (amountPayableToday < 0.5) {
 		await adjustNonCollectedInvoice(
 			zuoraClient,
 			invoiceId,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The product-switch-api has some logic which will either take payment for a recurring contribution to supporter plus product switch, or, if the amount is less than 50p/cents it will write that amount off but adjusting the Zuora invoice amount down to zero. This is because 50p is the minimum amount that we can charge through Stripe.

However this logic currently doesn't take account of the case where the payment amount is exactly zero, so when we try to adjust the invoice, Zuora returns an error as it doesn't make sense to reduce an invoice by £0.

This PR fixes that issue.