### PR TITLE
Ad/alarms mappings

### DIFF
--- a/cdk/lib/__snapshots__/salesforce-disaster-recovery-health-check.test.ts.snap
+++ b/cdk/lib/__snapshots__/salesforce-disaster-recovery-health-check.test.ts.snap
@@ -47,7 +47,7 @@ exports[`The Salesforce disaster recovery health check stack matches the snapsho
                   {
                     "Ref": "AWS::AccountId",
                   },
-                  ":salesforce-disaster-recovery-CODE",
+                  ":alarms-handler-topic-CODE",
                 ],
               ],
             },
@@ -223,7 +223,7 @@ exports[`The Salesforce disaster recovery health check stack matches the snapsho
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":salesforce-disaster-recovery-CODE",
+                    ":alarms-handler-topic-CODE",
                   ],
                 ],
               },
@@ -412,7 +412,7 @@ exports[`The Salesforce disaster recovery health check stack matches the snapsho
                   {
                     "Ref": "AWS::AccountId",
                   },
-                  ":salesforce-disaster-recovery-PROD",
+                  ":alarms-handler-topic-PROD",
                 ],
               ],
             },
@@ -588,7 +588,7 @@ exports[`The Salesforce disaster recovery health check stack matches the snapsho
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":salesforce-disaster-recovery-PROD",
+                    ":alarms-handler-topic-PROD",
                   ],
                 ],
               },

--- a/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
+++ b/cdk/lib/__snapshots__/salesforce-disaster-recovery.test.ts.snap
@@ -126,10 +126,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SsmParameterValueCODEmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/CODE/membership/salesforce-disaster-recovery/sns-topic-subscription-email",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
   },
   "Resources": {
     "Bucket83908E77": {
@@ -246,11 +242,15 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
               {
                 "Ref": "AWS::Region",
               },
-              "', $$.Execution.StartTime, 'failed-rows.csv')"},"Next":"SendCompletionNotification"},"SendCompletionNotification":{"Next":"HaveAllAccountsBeenResynced","Type":"Task","Resource":"arn:aws:states:::sns:publish","Parameters":{"TopicArn":"",
+              "', $$.Execution.StartTime, 'failed-rows.csv')"},"Next":"SendCompletionNotification"},"SendCompletionNotification":{"Next":"HaveAllAccountsBeenResynced","Type":"Task","Resource":"arn:aws:states:::sns:publish","Parameters":{"TopicArn":"arn:aws:sns:",
               {
-                "Ref": "SnsTopic2C1570A4",
+                "Ref": "AWS::Region",
               },
-              "","Subject":"Salesforce Disaster Recovery Re-syncing Procedure Completed For CODE","Message.$":"States.Format('This notification is part of the Salesforce Disaster Recovery procedure explained in the runbook below:\\n{}\\n\\nState machine execution details:\\n{}\\n\\nAccounts to sync:\\n{}\\n\\nAccounts that failed to update ({}):\\n{}\\n\\t\\t\\t\\t\\t\\t', 'https://docs.google.com/document/d/1_KxFtfKU3-3-PSzaAYG90uONa05AVgoBmyBDyu5SC5c/edit#heading=h.2r6eh2y6rjut', $.stateMachineExecutionDetailsUrl, $.queryResultFileUrl, $.failedRowsCount, $.failedRowsFileUrl)"},"ResultPath":"$.TaskResult"},"HaveAllAccountsBeenResynced":{"Type":"Choice","Choices":[{"Variable":"$.failedRowsCount","NumericEquals":0,"Next":"AllAccountsHaveBeenResynced"}],"Default":"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug"},"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug":{"Type":"Pass","End":true},"AllAccountsHaveBeenResynced":{"Type":"Pass","End":true},"HealthCheckSuccessful":{"Type":"Pass","End":true},"NoAccountsToResync":{"Type":"Pass","End":true}}}",
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":alarms-handler-topic-CODE","Subject":"Salesforce Disaster Recovery Re-syncing Procedure Completed For CODE","Message.$":"States.Format('This notification is part of the Salesforce Disaster Recovery procedure explained in the runbook below:\\n{}\\n\\nState machine execution details:\\n{}\\n\\nAccounts to sync:\\n{}\\n\\nAccounts that failed to update ({}):\\n{}\\n\\t\\t\\t\\t\\t\\t', 'https://docs.google.com/document/d/1_KxFtfKU3-3-PSzaAYG90uONa05AVgoBmyBDyu5SC5c/edit#heading=h.2r6eh2y6rjut', $.stateMachineExecutionDetailsUrl, $.queryResultFileUrl, $.failedRowsCount, $.failedRowsFileUrl)"},"ResultPath":"$.TaskResult"},"HaveAllAccountsBeenResynced":{"Type":"Choice","Choices":[{"Variable":"$.failedRowsCount","NumericEquals":0,"Next":"AllAccountsHaveBeenResynced"}],"Default":"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug"},"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug":{"Type":"Pass","End":true},"AllAccountsHaveBeenResynced":{"Type":"Pass","End":true},"HealthCheckSuccessful":{"Type":"Pass","End":true},"NoAccountsToResync":{"Type":"Pass","End":true}}}",
             ],
           ],
         },
@@ -474,7 +474,20 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
               "Action": "sns:Publish",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SnsTopic2C1570A4",
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sns:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":alarms-handler-topic-CODE",
+                  ],
+                ],
               },
             },
           ],
@@ -1043,42 +1056,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "SnsTopic2C1570A4": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "TopicName": "salesforce-disaster-recovery-CODE",
-      },
-      "Type": "AWS::SNS::Topic",
-    },
-    "SnsTopicTokenSubscription1D5A46B4F": {
-      "Properties": {
-        "Endpoint": {
-          "Ref": "SsmParameterValueCODEmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter",
-        },
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "SnsTopic2C1570A4",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
     "UpdateZuoraAccountsLambda64E51B2A": {
       "DependsOn": [
         "UpdateZuoraAccountsLambdaServiceRoleDefaultPolicy98EA0786",
@@ -1437,10 +1414,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SsmParameterValueCSBXmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/CSBX/membership/salesforce-disaster-recovery/sns-topic-subscription-email",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
   },
   "Resources": {
     "Bucket83908E77": {
@@ -1557,11 +1530,15 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
               {
                 "Ref": "AWS::Region",
               },
-              "', $$.Execution.StartTime, 'failed-rows.csv')"},"Next":"SendCompletionNotification"},"SendCompletionNotification":{"Next":"HaveAllAccountsBeenResynced","Type":"Task","Resource":"arn:aws:states:::sns:publish","Parameters":{"TopicArn":"",
+              "', $$.Execution.StartTime, 'failed-rows.csv')"},"Next":"SendCompletionNotification"},"SendCompletionNotification":{"Next":"HaveAllAccountsBeenResynced","Type":"Task","Resource":"arn:aws:states:::sns:publish","Parameters":{"TopicArn":"arn:aws:sns:",
               {
-                "Ref": "SnsTopic2C1570A4",
+                "Ref": "AWS::Region",
               },
-              "","Subject":"Salesforce Disaster Recovery Re-syncing Procedure Completed For CSBX","Message.$":"States.Format('This notification is part of the Salesforce Disaster Recovery procedure explained in the runbook below:\\n{}\\n\\nState machine execution details:\\n{}\\n\\nAccounts to sync:\\n{}\\n\\nAccounts that failed to update ({}):\\n{}\\n\\t\\t\\t\\t\\t\\t', 'https://docs.google.com/document/d/1_KxFtfKU3-3-PSzaAYG90uONa05AVgoBmyBDyu5SC5c/edit#heading=h.2r6eh2y6rjut', $.stateMachineExecutionDetailsUrl, $.queryResultFileUrl, $.failedRowsCount, $.failedRowsFileUrl)"},"ResultPath":"$.TaskResult"},"HaveAllAccountsBeenResynced":{"Type":"Choice","Choices":[{"Variable":"$.failedRowsCount","NumericEquals":0,"Next":"AllAccountsHaveBeenResynced"}],"Default":"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug"},"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug":{"Type":"Pass","End":true},"AllAccountsHaveBeenResynced":{"Type":"Pass","End":true},"HealthCheckSuccessful":{"Type":"Pass","End":true},"NoAccountsToResync":{"Type":"Pass","End":true}}}",
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":alarms-handler-topic-CSBX","Subject":"Salesforce Disaster Recovery Re-syncing Procedure Completed For CSBX","Message.$":"States.Format('This notification is part of the Salesforce Disaster Recovery procedure explained in the runbook below:\\n{}\\n\\nState machine execution details:\\n{}\\n\\nAccounts to sync:\\n{}\\n\\nAccounts that failed to update ({}):\\n{}\\n\\t\\t\\t\\t\\t\\t', 'https://docs.google.com/document/d/1_KxFtfKU3-3-PSzaAYG90uONa05AVgoBmyBDyu5SC5c/edit#heading=h.2r6eh2y6rjut', $.stateMachineExecutionDetailsUrl, $.queryResultFileUrl, $.failedRowsCount, $.failedRowsFileUrl)"},"ResultPath":"$.TaskResult"},"HaveAllAccountsBeenResynced":{"Type":"Choice","Choices":[{"Variable":"$.failedRowsCount","NumericEquals":0,"Next":"AllAccountsHaveBeenResynced"}],"Default":"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug"},"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug":{"Type":"Pass","End":true},"AllAccountsHaveBeenResynced":{"Type":"Pass","End":true},"HealthCheckSuccessful":{"Type":"Pass","End":true},"NoAccountsToResync":{"Type":"Pass","End":true}}}",
             ],
           ],
         },
@@ -1785,7 +1762,20 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
               "Action": "sns:Publish",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SnsTopic2C1570A4",
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sns:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":alarms-handler-topic-CSBX",
+                  ],
+                ],
               },
             },
           ],
@@ -2354,42 +2344,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "SnsTopic2C1570A4": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CSBX",
-          },
-        ],
-        "TopicName": "salesforce-disaster-recovery-CSBX",
-      },
-      "Type": "AWS::SNS::Topic",
-    },
-    "SnsTopicTokenSubscription1D5A46B4F": {
-      "Properties": {
-        "Endpoint": {
-          "Ref": "SsmParameterValueCSBXmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter",
-        },
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "SnsTopic2C1570A4",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
     "UpdateZuoraAccountsLambda64E51B2A": {
       "DependsOn": [
         "UpdateZuoraAccountsLambdaServiceRoleDefaultPolicy98EA0786",
@@ -2748,10 +2702,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/PROD/membership/salesforce-disaster-recovery/sns-topic-subscription-email",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
   },
   "Resources": {
     "Bucket83908E77": {
@@ -2868,11 +2818,15 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
               {
                 "Ref": "AWS::Region",
               },
-              "', $$.Execution.StartTime, 'failed-rows.csv')"},"Next":"SendCompletionNotification"},"SendCompletionNotification":{"Next":"HaveAllAccountsBeenResynced","Type":"Task","Resource":"arn:aws:states:::sns:publish","Parameters":{"TopicArn":"",
+              "', $$.Execution.StartTime, 'failed-rows.csv')"},"Next":"SendCompletionNotification"},"SendCompletionNotification":{"Next":"HaveAllAccountsBeenResynced","Type":"Task","Resource":"arn:aws:states:::sns:publish","Parameters":{"TopicArn":"arn:aws:sns:",
               {
-                "Ref": "SnsTopic2C1570A4",
+                "Ref": "AWS::Region",
               },
-              "","Subject":"Salesforce Disaster Recovery Re-syncing Procedure Completed For PROD","Message.$":"States.Format('This notification is part of the Salesforce Disaster Recovery procedure explained in the runbook below:\\n{}\\n\\nState machine execution details:\\n{}\\n\\nAccounts to sync:\\n{}\\n\\nAccounts that failed to update ({}):\\n{}\\n\\t\\t\\t\\t\\t\\t', 'https://docs.google.com/document/d/1_KxFtfKU3-3-PSzaAYG90uONa05AVgoBmyBDyu5SC5c/edit#heading=h.2r6eh2y6rjut', $.stateMachineExecutionDetailsUrl, $.queryResultFileUrl, $.failedRowsCount, $.failedRowsFileUrl)"},"ResultPath":"$.TaskResult"},"HaveAllAccountsBeenResynced":{"Type":"Choice","Choices":[{"Variable":"$.failedRowsCount","NumericEquals":0,"Next":"AllAccountsHaveBeenResynced"}],"Default":"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug"},"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug":{"Type":"Pass","End":true},"AllAccountsHaveBeenResynced":{"Type":"Pass","End":true},"HealthCheckSuccessful":{"Type":"Pass","End":true},"NoAccountsToResync":{"Type":"Pass","End":true}}}",
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":alarms-handler-topic-PROD","Subject":"Salesforce Disaster Recovery Re-syncing Procedure Completed For PROD","Message.$":"States.Format('This notification is part of the Salesforce Disaster Recovery procedure explained in the runbook below:\\n{}\\n\\nState machine execution details:\\n{}\\n\\nAccounts to sync:\\n{}\\n\\nAccounts that failed to update ({}):\\n{}\\n\\t\\t\\t\\t\\t\\t', 'https://docs.google.com/document/d/1_KxFtfKU3-3-PSzaAYG90uONa05AVgoBmyBDyu5SC5c/edit#heading=h.2r6eh2y6rjut', $.stateMachineExecutionDetailsUrl, $.queryResultFileUrl, $.failedRowsCount, $.failedRowsFileUrl)"},"ResultPath":"$.TaskResult"},"HaveAllAccountsBeenResynced":{"Type":"Choice","Choices":[{"Variable":"$.failedRowsCount","NumericEquals":0,"Next":"AllAccountsHaveBeenResynced"}],"Default":"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug"},"SomeAccountsHaveFailedToUpdate - Open state input 'failedRowsFileUrl' to debug":{"Type":"Pass","End":true},"AllAccountsHaveBeenResynced":{"Type":"Pass","End":true},"HealthCheckSuccessful":{"Type":"Pass","End":true},"NoAccountsToResync":{"Type":"Pass","End":true}}}",
             ],
           ],
         },
@@ -3096,7 +3050,20 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
               "Action": "sns:Publish",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SnsTopic2C1570A4",
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sns:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":alarms-handler-topic-PROD",
+                  ],
+                ],
               },
             },
           ],
@@ -3664,42 +3631,6 @@ exports[`The SalesforceDisasterRecovery stack matches the snapshot 3`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "SnsTopic2C1570A4": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "TopicName": "salesforce-disaster-recovery-PROD",
-      },
-      "Type": "AWS::SNS::Topic",
-    },
-    "SnsTopicTokenSubscription1D5A46B4F": {
-      "Properties": {
-        "Endpoint": {
-          "Ref": "SsmParameterValuePRODmembershipsalesforcedisasterrecoverysnstopicsubscriptionemailC96584B6F00A464EAD1953AFF4B05118Parameter",
-        },
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "SnsTopic2C1570A4",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
     },
     "UpdateZuoraAccountsLambda64E51B2A": {
       "DependsOn": [

--- a/cdk/lib/salesforce-disaster-recovery-health-check.ts
+++ b/cdk/lib/salesforce-disaster-recovery-health-check.ts
@@ -14,7 +14,7 @@ export class SalesforceDisasterRecoveryHealthCheck extends GuStack {
 
 		const app = 'salesforce-disaster-recovery-health-check';
 
-		const snsTopicArn = `arn:aws:sns:${this.region}:${this.account}:salesforce-disaster-recovery-${this.stage}`;
+		const snsTopicArn = `arn:aws:sns:${this.region}:${this.account}:alarms-handler-topic-${this.stage}`;
 
 		const stateMachine = StateMachine.fromStateMachineName(
 			this,

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -4,13 +4,10 @@ import {
 	type GuFunctionProps,
 	GuLambdaFunction,
 } from '@guardian/cdk/lib/constructs/lambda';
-import { type App, Duration, Fn } from 'aws-cdk-lib';
+import { type App, Duration } from 'aws-cdk-lib';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { Topic } from 'aws-cdk-lib/aws-sns';
-import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
-import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import {
 	Choice,
 	Condition,

--- a/cdk/lib/salesforce-disaster-recovery.ts
+++ b/cdk/lib/salesforce-disaster-recovery.ts
@@ -4,7 +4,7 @@ import {
 	type GuFunctionProps,
 	GuLambdaFunction,
 } from '@guardian/cdk/lib/constructs/lambda';
-import { type App, Duration } from 'aws-cdk-lib';
+import { type App, Duration, Fn } from 'aws-cdk-lib';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
@@ -47,16 +47,7 @@ export class SalesforceDisasterRecovery extends GuStack {
 		const queryResultFileName = 'query-result.csv';
 		const failedRowsFileName = 'failed-rows.csv';
 
-		const snsTopic = new Topic(this, 'SnsTopic', {
-			topicName: `${app}-${this.stage}`,
-		});
-
-		const snsTopicSubscriptionEmail = StringParameter.valueForStringParameter(
-			this,
-			`/${this.stage}/membership/salesforce-disaster-recovery/sns-topic-subscription-email`,
-		);
-
-		snsTopic.addSubscription(new EmailSubscription(snsTopicSubscriptionEmail));
+		const snsTopicArn = `arn:aws:sns:${this.region}:${this.account}:alarms-handler-topic-${this.stage}`;
 
 		const lambdaDefaultConfig: Pick<
 			GuFunctionProps,
@@ -356,7 +347,7 @@ export class SalesforceDisasterRecovery extends GuStack {
 					Type: 'Task',
 					Resource: 'arn:aws:states:::sns:publish',
 					Parameters: {
-						TopicArn: snsTopic.topicArn,
+						TopicArn: snsTopicArn,
 						Subject: `Salesforce Disaster Recovery Re-syncing Procedure Completed For ${this.stage}`,
 						'Message.$': JsonPath.format(
 							`This notification is part of the Salesforce Disaster Recovery procedure explained in the runbook below:\n{}\n\nState machine execution details:\n{}\n\nAccounts to sync:\n{}\n\nAccounts that failed to update ({}):\n{}
@@ -513,7 +504,7 @@ export class SalesforceDisasterRecovery extends GuStack {
 						}),
 						new PolicyStatement({
 							actions: ['sns:Publish'],
-							resources: [snsTopic.topicArn],
+							resources: [snsTopicArn],
 						}),
 					],
 				},

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -28,7 +28,10 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'soft-opt-in-consent-setter',
 	],
 	SRE: ['gchat-test-app'],
-	PP: [],
+	PP: [
+		'salesforce-disaster-recovery',
+		'salesforce-disaster-recovery-health-check',
+	],
 };
 
 const appToTeamMappings: Record<string, Team> = Object.entries(


### PR DESCRIPTION
## What does this change?

This migrates alarm notifications to the new alarms handler SNS topic for the following P&P applications:
- salesforce-disaster-recovery
- salesforce-disaster-recovery-health-check