### PR TITLE
Add cloud formation for digital-subscription-expiry lambda

### DIFF
--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -106,8 +106,8 @@ Resources:
         Integration:
           Type: AWS_PROXY
           IntegrationHttpMethod: POST
-          Uri:
-            Fn::ImportValue: !Sub "subscriptions-${Stage}-digital-subscription-expiry-DigitalSubscriptionExpiryLambdaUri"
+          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubscriptionExpiryLambda.Arn}/invocations
+
       DependsOn:
         - DigitalSubAuthApi
         - SubsApiResource
@@ -118,21 +118,21 @@ Resources:
         Description: Api to handle digital sub authorisation
         Name: !Sub digital-sub-auth-handler-${Stage}
 
-    AuthMethod:
-      Type: AWS::ApiGateway::Method
-      Properties:
-        AuthorizationType: NONE
-        RestApiId: !Ref DigitalSubAuthApi
-        ResourceId: !Ref DigitalSubAuthApiResource
-        HttpMethod: POST
-        Integration:
-          Type: AWS_PROXY
-          IntegrationHttpMethod: POST
-          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubAuthLambda.Arn}/invocations
-      DependsOn:
-        - DigitalSubAuthApi
-        - DigitalSubAuthLambda
-        - DigitalSubAuthApiResource
+#    AuthMethod:
+#      Type: AWS::ApiGateway::Method
+#      Properties:
+#        AuthorizationType: NONE
+#        RestApiId: !Ref DigitalSubAuthApi
+#        ResourceId: !Ref DigitalSubAuthApiResource
+#        HttpMethod: POST
+#        Integration:
+#          Type: AWS_PROXY
+#          IntegrationHttpMethod: POST
+#          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubAuthLambda.Arn}/invocations
+#      DependsOn:
+#        - DigitalSubAuthApi
+#        - DigitalSubAuthLambda
+#        - DigitalSubAuthApiResource
 
     DigitalSubAuthApiStage:
       Type: AWS::ApiGateway::Stage
@@ -141,14 +141,14 @@ Resources:
         RestApiId: !Ref DigitalSubAuthApi
         DeploymentId: !Ref DigitalSubAuthApiDeployment
         StageName: !Sub ${Stage}
-      DependsOn: AuthMethod
+      DependsOn: SubsMethod
 
     DigitalSubAuthApiDeployment:
       Type: AWS::ApiGateway::Deployment
       Properties:
         Description: Deploys the digital sub Auth API into an environment/stage
         RestApiId: !Ref DigitalSubAuthApi
-      DependsOn: AuthMethod
+      DependsOn: SubsMethod
 
     DigitalSubAuthDomainName:
       Type: "AWS::ApiGateway::DomainName"

--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -107,9 +107,9 @@ Resources:
           Type: AWS_PROXY
           IntegrationHttpMethod: POST
           Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubscriptionExpiryLambda.Arn}/invocations
-
       DependsOn:
         - DigitalSubAuthApi
+        - DigitalSubscriptionExpiryLambda
         - SubsApiResource
 
     DigitalSubAuthApi:

--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -2,13 +2,23 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: Gets expiry dates for digital subscriptions or emergency tokens
 
 Parameters:
-    Stage:
-        Description: Stage name
-        Type: String
-        AllowedValues:
-            - PROD
-            - CODE
-        Default: CODE
+  Stack:
+    Description: Stack name
+    Type: String
+    Default: subscriptions
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+        - PROD
+        - CODE
+    Default: CODE
+  App:
+    Description: App name
+    Type: String
+    AllowedValues:
+      - digital-subscription-authorisation
+    Default: digital-subscription-authorisation
 Mappings:
   StageVariables:
     PROD:
@@ -16,9 +26,9 @@ Mappings:
       ApiGatewayTargetDomainName: 'd-nhg1ruog5k.execute-api.eu-west-1.amazonaws.com'
     CODE:
       DomainName: 'digital-subscription-authorisation-code.subscriptions.guardianapis.com'
-      ApiGatewayTargetDomainName: 'd-axk4hzkvf8.execute-api.eu-west-1.amazonaws.com'
+      ApiGatewayTargetDomainName: 'd-erth6z0ptj.execute-api.eu-west-1.amazonaws.com'
 Resources:
-    DigitalSubscriptionExpiryRole:
+    LambdaRole:
         Type: AWS::IAM::Role
         Properties:
             AssumeRolePolicyDocument:
@@ -50,7 +60,7 @@ Resources:
                             - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}.*.json
                             - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/emergencyTokens-${Stage}.*.json
                             - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/trustedApi-${Stage}.*.json
-    DigitalSubscriptionExpiryLambda:
+    Lambda:
         Type: AWS::Lambda::Function
         Properties:
             Description: get digital subscription expiration dates
@@ -65,7 +75,7 @@ Resources:
                   Stage: !Ref Stage
             Role:
                 Fn::GetAtt:
-                - "DigitalSubscriptionExpiryRole"
+                - "LambdaRole"
                 - Arn
             MemorySize: 1536
             Runtime: java21
@@ -73,84 +83,63 @@ Resources:
             Architectures:
               - arm64
         DependsOn:
-        - DigitalSubscriptionExpiryRole
+        - LambdaRole
 
-    DigitalSubAuthApiPermission:
+    ApiGatewayLambdaPermission:
             Type: AWS::Lambda::Permission
             Properties:
                 Action: lambda:invokeFunction
                 FunctionName: !Sub digital-subscription-expiry-${Stage}
                 Principal: apigateway.amazonaws.com
-            DependsOn: DigitalSubscriptionExpiryLambda
-#Outputs:
-#  DigitalSubscriptionExpiryLambdaExport:
-#    Description: lambda that returns expiration date for digital pack subscriptions or emergency tokens
-#    Value: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubscriptionExpiryLambda.Arn}/invocations
-#    Export:
-#      Name: !Sub ${AWS::StackName}-DigitalSubscriptionExpiryLambdaUri
-    SubsApiResource:
+            DependsOn: Lambda
+
+    ApiResource:
       Type: AWS::ApiGateway::Resource
       Properties:
-        RestApiId: !Ref DigitalSubAuthApi
-        ParentId: !GetAtt [DigitalSubAuthApi, RootResourceId]
+        RestApiId: !Ref RestApi
+        ParentId: !GetAtt [RestApi, RootResourceId]
         PathPart: subs
-      DependsOn: DigitalSubAuthApi
+      DependsOn: RestApi
 
-    SubsMethod:
+    ApiMethod:
       Type: AWS::ApiGateway::Method
       Properties:
         AuthorizationType: NONE
-        RestApiId: !Ref DigitalSubAuthApi
-        ResourceId: !Ref SubsApiResource
+        RestApiId: !Ref RestApi
+        ResourceId: !Ref ApiResource
         HttpMethod: POST
         Integration:
           Type: AWS_PROXY
           IntegrationHttpMethod: POST
-          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubscriptionExpiryLambda.Arn}/invocations
+          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Lambda.Arn}/invocations
       DependsOn:
-        - DigitalSubAuthApi
-        - DigitalSubscriptionExpiryLambda
-        - SubsApiResource
+        - RestApi
+        - Lambda
+        - ApiResource
 
-    DigitalSubAuthApi:
+    RestApi:
       Type: "AWS::ApiGateway::RestApi"
       Properties:
         Description: Api to handle digital sub authorisation
         Name: !Sub digital-sub-auth-handler-${Stage}
 
-#    AuthMethod:
-#      Type: AWS::ApiGateway::Method
-#      Properties:
-#        AuthorizationType: NONE
-#        RestApiId: !Ref DigitalSubAuthApi
-#        ResourceId: !Ref DigitalSubAuthApiResource
-#        HttpMethod: POST
-#        Integration:
-#          Type: AWS_PROXY
-#          IntegrationHttpMethod: POST
-#          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubAuthLambda.Arn}/invocations
-#      DependsOn:
-#        - DigitalSubAuthApi
-#        - DigitalSubAuthLambda
-#        - DigitalSubAuthApiResource
-
-    DigitalSubAuthApiStage:
+    RestApiStage:
       Type: AWS::ApiGateway::Stage
       Properties:
         Description: Stage for digital sub auth  API
-        RestApiId: !Ref DigitalSubAuthApi
-        DeploymentId: !Ref DigitalSubAuthApiDeployment
+        RestApiId: !Ref RestApi
+        DeploymentId: !Ref RestApiDeployment
         StageName: !Sub ${Stage}
-      DependsOn: SubsMethod
+      DependsOn: ApiMethod
 
-    DigitalSubAuthApiDeployment:
+    RestApiDeployment:
       Type: AWS::ApiGateway::Deployment
       Properties:
         Description: Deploys the digital sub Auth API into an environment/stage
-        RestApiId: !Ref DigitalSubAuthApi
-      DependsOn: SubsMethod
+        RestApiId: !Ref RestApi
+      DependsOn: ApiMethod
 
-    DigitalSubAuthDomainName:
+    DomainName:
       Type: "AWS::ApiGateway::DomainName"
       Properties:
         RegionalCertificateArn: !Sub arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/bece8c44-d92f-4661-a943-8b0b65e2ad6d
@@ -158,13 +147,16 @@ Resources:
         EndpointConfiguration:
           Types:
             - REGIONAL
-    DigitalSubBasePathMappings:
+
+    BasePathMapping:
       Type: "AWS::ApiGateway::BasePathMapping"
       Properties:
-        RestApiId: !Ref DigitalSubAuthApi
-        DomainName: !Ref DigitalSubAuthDomainName
+        RestApiId: !Ref RestApi
+        DomainName: !Ref DomainName
         Stage: !Sub ${Stage}
-    DigitalSubAuthDNSRecord:
+      DependsOn: RestApiStage
+
+    DNSRecord:
       Type: AWS::Route53::RecordSet
       Properties:
         HostedZoneName: subscriptions.guardianapis.com.

--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -9,7 +9,14 @@ Parameters:
             - PROD
             - CODE
         Default: CODE
-
+Mappings:
+  StageVariables:
+    PROD:
+      DomainName: 'digital-subscription-authorisation-prod.subscriptions.guardianapis.com'
+      ApiGatewayTargetDomainName: 'd-nhg1ruog5k.execute-api.eu-west-1.amazonaws.com'
+    CODE:
+      DomainName: 'digital-subscription-authorisation-code.subscriptions.guardianapis.com'
+      ApiGatewayTargetDomainName: 'd-axk4hzkvf8.execute-api.eu-west-1.amazonaws.com'
 Resources:
     DigitalSubscriptionExpiryRole:
         Type: AWS::IAM::Role
@@ -75,9 +82,96 @@ Resources:
                 FunctionName: !Sub digital-subscription-expiry-${Stage}
                 Principal: apigateway.amazonaws.com
             DependsOn: DigitalSubscriptionExpiryLambda
-Outputs:
-  DigitalSubscriptionExpiryLambdaExport:
-    Description: lambda that returns expiration date for digital pack subscriptions or emergency tokens
-    Value: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubscriptionExpiryLambda.Arn}/invocations
-    Export:
-      Name: !Sub ${AWS::StackName}-DigitalSubscriptionExpiryLambdaUri
+#Outputs:
+#  DigitalSubscriptionExpiryLambdaExport:
+#    Description: lambda that returns expiration date for digital pack subscriptions or emergency tokens
+#    Value: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubscriptionExpiryLambda.Arn}/invocations
+#    Export:
+#      Name: !Sub ${AWS::StackName}-DigitalSubscriptionExpiryLambdaUri
+    SubsApiResource:
+      Type: AWS::ApiGateway::Resource
+      Properties:
+        RestApiId: !Ref DigitalSubAuthApi
+        ParentId: !GetAtt [DigitalSubAuthApi, RootResourceId]
+        PathPart: subs
+      DependsOn: DigitalSubAuthApi
+
+    SubsMethod:
+      Type: AWS::ApiGateway::Method
+      Properties:
+        AuthorizationType: NONE
+        RestApiId: !Ref DigitalSubAuthApi
+        ResourceId: !Ref SubsApiResource
+        HttpMethod: POST
+        Integration:
+          Type: AWS_PROXY
+          IntegrationHttpMethod: POST
+          Uri:
+            Fn::ImportValue: !Sub "subscriptions-${Stage}-digital-subscription-expiry-DigitalSubscriptionExpiryLambdaUri"
+      DependsOn:
+        - DigitalSubAuthApi
+        - SubsApiResource
+
+    DigitalSubAuthApi:
+      Type: "AWS::ApiGateway::RestApi"
+      Properties:
+        Description: Api to handle digital sub authorisation
+        Name: !Sub digital-sub-auth-handler-${Stage}
+
+    AuthMethod:
+      Type: AWS::ApiGateway::Method
+      Properties:
+        AuthorizationType: NONE
+        RestApiId: !Ref DigitalSubAuthApi
+        ResourceId: !Ref DigitalSubAuthApiResource
+        HttpMethod: POST
+        Integration:
+          Type: AWS_PROXY
+          IntegrationHttpMethod: POST
+          Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DigitalSubAuthLambda.Arn}/invocations
+      DependsOn:
+        - DigitalSubAuthApi
+        - DigitalSubAuthLambda
+        - DigitalSubAuthApiResource
+
+    DigitalSubAuthApiStage:
+      Type: AWS::ApiGateway::Stage
+      Properties:
+        Description: Stage for digital sub auth  API
+        RestApiId: !Ref DigitalSubAuthApi
+        DeploymentId: !Ref DigitalSubAuthApiDeployment
+        StageName: !Sub ${Stage}
+      DependsOn: AuthMethod
+
+    DigitalSubAuthApiDeployment:
+      Type: AWS::ApiGateway::Deployment
+      Properties:
+        Description: Deploys the digital sub Auth API into an environment/stage
+        RestApiId: !Ref DigitalSubAuthApi
+      DependsOn: AuthMethod
+
+    DigitalSubAuthDomainName:
+      Type: "AWS::ApiGateway::DomainName"
+      Properties:
+        RegionalCertificateArn: !Sub arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/bece8c44-d92f-4661-a943-8b0b65e2ad6d
+        DomainName: !FindInMap [StageVariables, !Ref 'Stage', DomainName]
+        EndpointConfiguration:
+          Types:
+            - REGIONAL
+    DigitalSubBasePathMappings:
+      Type: "AWS::ApiGateway::BasePathMapping"
+      Properties:
+        RestApiId: !Ref DigitalSubAuthApi
+        DomainName: !Ref DigitalSubAuthDomainName
+        Stage: !Sub ${Stage}
+    DigitalSubAuthDNSRecord:
+      Type: AWS::Route53::RecordSet
+      Properties:
+        HostedZoneName: subscriptions.guardianapis.com.
+        Name: !Sub digital-subscription-authorisation-${Stage}.subscriptions.guardianapis.com.
+        Comment: !Sub CNAME for digital subscription auth ${Stage}
+        Type: CNAME
+        TTL: '120'
+        ResourceRecords:
+          - !FindInMap [StageVariables, !Ref 'Stage', ApiGatewayTargetDomainName]
+

--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -26,7 +26,7 @@ Mappings:
       ApiGatewayTargetDomainName: 'd-nhg1ruog5k.execute-api.eu-west-1.amazonaws.com'
     CODE:
       DomainName: 'digital-subscription-authorisation-code.subscriptions.guardianapis.com'
-      ApiGatewayTargetDomainName: 'd-erth6z0ptj.execute-api.eu-west-1.amazonaws.com'
+      ApiGatewayTargetDomainName: 'd-9hsw86gre3.execute-api.eu-west-1.amazonaws.com'
 Resources:
     LambdaRole:
         Type: AWS::IAM::Role

--- a/handlers/digital-subscription-expiry/cfn.yaml
+++ b/handlers/digital-subscription-expiry/cfn.yaml
@@ -23,7 +23,7 @@ Mappings:
   StageVariables:
     PROD:
       DomainName: 'digital-subscription-authorisation-prod.subscriptions.guardianapis.com'
-      ApiGatewayTargetDomainName: 'd-nhg1ruog5k.execute-api.eu-west-1.amazonaws.com'
+      ApiGatewayTargetDomainName: 'd-6c6fh16i42.execute-api.eu-west-1.amazonaws.com'
     CODE:
       DomainName: 'digital-subscription-authorisation-code.subscriptions.guardianapis.com'
       ApiGatewayTargetDomainName: 'd-9hsw86gre3.execute-api.eu-west-1.amazonaws.com'


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The digital-subscription-expiry API gateway and lambda is used by the apps to check whether users have a valid print subscription. 

Up until now the lambda was defined in support-service-lambdas but all the other infrastructure was defined in the now unused [digital-subscription-authorisation repo](https://github.com/guardian/digital-subscription-authorisation). 

This PR moves the infrastructure for the API gateway and DNS mappings into support-service-lambas so that the other repo can be archived.