### PR TITLE
Make dependabot run on all the js dependencies, not just cdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,9 @@ updates:
       prefix: "chore(deps): "
   
   - package-ecosystem: 'npm'
-    directory: '/cdk'
+    directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
     commit-message:
       prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Currently we only have dependabot scanning our cdk directory for dependencies to update, this PR changes that so that it will scan the whole repo moving forward. It also increases the update frequency to weekly.