### PR TITLE
SOI consent setter - get SOI product from mobile-purchases response

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -191,11 +191,12 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       mobileSubscriptionsResponse <- getMobileSubscriptions(messageBody.identityId)
       activeSubs <- sfConnector.getActiveSubs(Seq(messageBody.identityId))
 
-      hasMobileSub = mobileSubscriptionsResponse.subscriptions
+      iapSOIs = mobileSubscriptionsResponse.subscriptions
         .filter(_.valid)
-        .headOption
-        .map(_ => "InAppPurchase")
-      productNames = activeSubs.records.map(_.Product__c) ++ hasMobileSub
+        .map(_.softOptInProductName)
+        .distinct
+
+      productNames = activeSubs.records.map(_.Product__c) ++ iapSOIs
 
       consentsBody <- buildProductSwitchConsents(
         previousProductName,
@@ -239,11 +240,11 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       mobileSubscriptionsResponse <- getMobileSubscriptions(messageBody.identityId)
       activeSubs <- sfConnector.getActiveSubs(Seq(messageBody.identityId))
 
-      hasMobileSub = mobileSubscriptionsResponse.subscriptions
+      iapSOIs = mobileSubscriptionsResponse.subscriptions
         .filter(_.valid)
-        .headOption
-        .map(_ => "InAppPurchase")
-      productNames = activeSubs.records.map(_.Product__c) ++ hasMobileSub
+        .map(_.softOptInProductName)
+        .distinct
+      productNames = activeSubs.records.map(_.Product__c) ++ iapSOIs
 
       consents <- consentsCalculator.getCancellationConsents(
         messageBody.productName,

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
@@ -9,7 +9,7 @@ import scalaj.http.{Http, HttpResponse}
 import scala.util.Try
 
 case class MobileSubscriptions(subscriptions: List[MobileSubscription])
-case class MobileSubscription(valid: Boolean)
+case class MobileSubscription(valid: Boolean, softOptInProductName: String)
 
 class MpapiConnector(config: MpapiConfig) {
 

--- a/handlers/soft-opt-in-consent-setter/src/test/resources/mobileSubscriptions.json
+++ b/handlers/soft-opt-in-consent-setter/src/test/resources/mobileSubscriptions.json
@@ -7,7 +7,8 @@
       "valid": false,
       "gracePeriod": false,
       "autoRenewing": false,
-      "productId": "uk.co.guardian.gla.1month.2018May.withFreeTrial"
+      "productId": "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+      "softOptInProductName": "InAppPurchase"
     }
   ]
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -228,7 +228,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
     Handler.buildProductSwitchConsents(
       "guardianweekly",
       "newspaper",
-      Set("newspaper", "mobilesubscription"),
+      Set("newspaper", "InAppPurchase"),
       calculator,
     ) shouldBe Right("""[
         |  {
@@ -246,7 +246,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
     HandlerIAP.buildProductSwitchConsents(
       "guardianweekly",
       "newspaper",
-      Set("newspaper", "mobilesubscription"),
+      Set("newspaper", "InAppPurchase"),
       calculator,
     ) shouldBe Right("""[
         |  {

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -26,7 +26,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
   test(testName = "processProductSwitchSub should handle product switch event correctly") {
     val mobileSubscriptions = MobileSubscriptions(
       List(
-        MobileSubscription(true),
+        MobileSubscription(true, "InAppPurchase"),
       ),
     )
 
@@ -72,7 +72,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
   test(testName = "processAcquiredSub should handle acquisition event correctly") {
     val mobileSubscriptions = MobileSubscriptions(
       List(
-        MobileSubscription(true),
+        MobileSubscription(true, "InAppPurchase"),
       ),
     )
 
@@ -103,7 +103,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
   test(testName = "processCancellation should handle supporter plus cancellation while owning an IAP") {
     val mobileSubscriptions = MobileSubscriptions(
       List(
-        MobileSubscription(true),
+        MobileSubscription(true, "InAppPurchase"),
       ),
     )
 

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -75,12 +75,6 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
   }
 
   test(testName = "processAcquiredSub should handle acquisition event correctly") {
-    val mobileSubscriptions = MobileSubscriptions(
-      List(
-        MobileSubscription(true, "InAppPurchase"),
-      ),
-    )
-
     mockSendConsentsReq
       .expects(
         "someIdentityId",

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -33,7 +33,12 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     mockSendConsentsReq
       .expects(
         identityId,
-        "[\n  {\n    \"id\" : \"digital_subscriber_preview\",\n    \"consented\" : true\n  }\n]",
+        """[
+          |  {
+          |    "id" : "digital_subscriber_preview",
+          |    "consented" : true
+          |  }
+          |]""".stripMargin,
       )
       .returning(Right(()))
     mockGetMobileSubscriptions.expects("someIdentityId").returning(Right(mobileSubscriptions))
@@ -79,7 +84,24 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     mockSendConsentsReq
       .expects(
         "someIdentityId",
-        "[\n  {\n    \"id\" : \"your_support_onboarding\",\n    \"consented\" : true\n  },\n  {\n    \"id\" : \"similar_guardian_products\",\n    \"consented\" : true\n  },\n  {\n    \"id\" : \"supporter_newsletter\",\n    \"consented\" : true\n  },\n  {\n    \"id\" : \"digital_subscriber_preview\",\n    \"consented\" : true\n  }\n]",
+        """[
+          |  {
+          |    "id" : "your_support_onboarding",
+          |    "consented" : true
+          |  },
+          |  {
+          |    "id" : "similar_guardian_products",
+          |    "consented" : true
+          |  },
+          |  {
+          |    "id" : "supporter_newsletter",
+          |    "consented" : true
+          |  },
+          |  {
+          |    "id" : "digital_subscriber_preview",
+          |    "consented" : true
+          |  }
+          |]""".stripMargin,
       )
       .returning(Right(()))
 
@@ -110,7 +132,12 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     mockSendConsentsReq
       .expects(
         "someIdentityId",
-        "[\n  {\n    \"id\" : \"digital_subscriber_preview\",\n    \"consented\" : false\n  }\n]",
+        """[
+          |  {
+          |    "id" : "digital_subscriber_preview",
+          |    "consented" : false
+          |  }
+          |]""".stripMargin,
       )
       .returning(Right(()))
     mockGetMobileSubscriptions.expects("someIdentityId").returning(Right(mobileSubscriptions))
@@ -147,7 +174,20 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     mockSendConsentsReq
       .expects(
         "someIdentityId",
-        "[\n  {\n    \"id\" : \"your_support_onboarding\",\n    \"consented\" : false\n  },\n  {\n    \"id\" : \"supporter_newsletter\",\n    \"consented\" : false\n  },\n  {\n    \"id\" : \"digital_subscriber_preview\",\n    \"consented\" : false\n  }\n]",
+        """[
+          |  {
+          |    "id" : "your_support_onboarding",
+          |    "consented" : false
+          |  },
+          |  {
+          |    "id" : "supporter_newsletter",
+          |    "consented" : false
+          |  },
+          |  {
+          |    "id" : "digital_subscriber_preview",
+          |    "consented" : false
+          |  }
+          |]""".stripMargin,
       )
       .returning(Right(()))
     mockGetMobileSubscriptions.expects("someIdentityId").returning(Right(mobileSubscriptions))

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -188,7 +188,16 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     mockSendConsentsReq
       .expects(
         "someIdentityId",
-        "[\n  {\n    \"id\" : \"supporter_newsletter\",\n    \"consented\" : false\n  },\n  {\n    \"id\" : \"digital_subscriber_preview\",\n    \"consented\" : false\n  }\n]",
+        """[
+          |  {
+          |    "id" : "supporter_newsletter",
+          |    "consented" : false
+          |  },
+          |  {
+          |    "id" : "digital_subscriber_preview",
+          |    "consented" : false
+          |  }
+          |]""".stripMargin,
       )
       .returning(Right(()))
     mockGetMobileSubscriptions.expects("someIdentityId").returning(Right(mobileSubscriptionsIncludingFeast))

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -178,7 +178,9 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     result shouldBe Right(())
   }
 
-  test(testName = "processCancellation should handle supporter plus cancellation while owning a Feast IAP") {
+  test(testName =
+    "when cancelling Supporter Plus, while also holding a Feast IAP, processCancellation should unset the Supporter Plus consents which are not shared with the Feast IAP",
+  ) {
     val mobileSubscriptionsIncludingFeast = MobileSubscriptions(
       List(
         MobileSubscription(true, "FeastInAppPurchase"),

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/JsonCodecSpec.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/JsonCodecSpec.scala
@@ -23,6 +23,6 @@ class JsonCodecSpec extends AnyFlatSpec with should.Matchers {
 
     val record = decode[MobileSubscriptions](json)
 
-    record shouldBe Right(MobileSubscriptions(List(MobileSubscription(false))))
+    record shouldBe Right(MobileSubscriptions(List(MobileSubscription(false, "InAppPurchase"))))
   }
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -9,8 +9,6 @@ object ConsentsCalculatorTestData {
     Set("your_support_onboarding", "similar_guardian_products", "subscriber_preview", "supporter_newsletter")
   val guWeeklyMapping = Set("your_support_onboarding", "guardian_weekly_newsletter")
   val testProductMapping = Set("unique_consent")
-  val testMobileSubscriptionMapping =
-    Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter")
 
   val testConsentMappings = Map(
     "membership" -> membershipMapping,
@@ -20,7 +18,6 @@ object ConsentsCalculatorTestData {
     "newspaper" -> newspaperMapping,
     "guardianweekly" -> guWeeklyMapping,
     "testproduct" -> testProductMapping,
-    "mobilesubscription" -> testMobileSubscriptionMapping,
   )
 
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -9,6 +9,7 @@ object ConsentsCalculatorTestData {
     Set("your_support_onboarding", "similar_guardian_products", "subscriber_preview", "supporter_newsletter")
   val guWeeklyMapping = Set("your_support_onboarding", "guardian_weekly_newsletter")
   val testProductMapping = Set("unique_consent")
+  val testFeastMobileSubscriptionMapping = Set("your_support_onboarding", "similar_guardian_products")
 
   val testConsentMappings = Map(
     "membership" -> membershipMapping,
@@ -18,6 +19,7 @@ object ConsentsCalculatorTestData {
     "newspaper" -> newspaperMapping,
     "guardianweekly" -> guWeeklyMapping,
     "testproduct" -> testProductMapping,
+    "FeastInAppPurchase" -> testFeastMobileSubscriptionMapping,
   )
 
 }


### PR DESCRIPTION
## What does this change?

Instead of assuming the product is `InAppPurchase`, get the SOI product name from the mobile-purchases response. We now have different products with different SOIs.
