### PR TITLE
feat: add fixations to alarms-mappings

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -51,10 +51,16 @@ const teamToAppMappings: Record<Team, string[]> = {
 	],
 	SRE: ['gchat-test-app'],
 	PP: [
-		'canonical-config',
+		// contributions-platform
+		'fixation',
+		
+		// support-frontend
 		'frontend',
 		'it-test-runner',
 		'stripe-intent',
+		
+		// other
+		'canonical-config',
 		'salesforce-disaster-recovery',
 		'salesforce-disaster-recovery-health-check',
 	],


### PR DESCRIPTION
Captures alarms from `contributions-platform`.