### PR TITLE
Allow the targeting AWS account to publish to the alarms SNS topic

### DIFF
--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -10,6 +10,7 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuStringParameter",
       "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -44,6 +45,10 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
     },
     "alarmshandlermobileawsaccount": {
       "Description": "ID of the mobile aws account",
+      "Type": "String",
+    },
+    "alarmshandlertargetingawsaccount": {
+      "Description": "ID of the targeting aws account",
       "Type": "String",
     },
   },
@@ -521,6 +526,18 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
                         [
                           "arn:aws:cloudwatch:eu-west-1:",
                           {
+                            "Ref": "alarmshandlertargetingawsaccount",
+                          },
+                          ":alarm:*",
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:cloudwatch:eu-west-1:",
+                          {
                             "Ref": "AWS::AccountId",
                           },
                           ":alarm:*",
@@ -591,6 +608,7 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
       "GuStringParameter",
       "GuStringParameter",
       "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -625,6 +643,10 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
     },
     "alarmshandlermobileawsaccount": {
       "Description": "ID of the mobile aws account",
+      "Type": "String",
+    },
+    "alarmshandlertargetingawsaccount": {
+      "Description": "ID of the targeting aws account",
       "Type": "String",
     },
   },
@@ -1091,6 +1113,18 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
                           "arn:aws:cloudwatch:eu-west-1:",
                           {
                             "Ref": "alarmshandlermobileawsaccount",
+                          },
+                          ":alarm:*",
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:cloudwatch:eu-west-1:",
+                          {
+                            "Ref": "alarmshandlertargetingawsaccount",
                           },
                           ":alarm:*",
                         ],

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -56,6 +56,13 @@ export class AlarmsHandler extends GuStack {
 					'ARN of role in the mobile account which allows cloudwatch:ListTagsForResource',
 			},
 		);
+		const targetingAccountId = new GuStringParameter(
+			this,
+			`${app}-targeting-aws-account`,
+			{
+				description: 'ID of the targeting aws account',
+			},
+		);
 
 		const lambda = new GuLambdaFunction(this, `${app}-lambda`, {
 			app,
@@ -118,6 +125,7 @@ export class AlarmsHandler extends GuStack {
 					ArnLike: {
 						'aws:SourceArn': [
 							`arn:aws:cloudwatch:eu-west-1:${mobileAccountId.valueAsString}:alarm:*`,
+							`arn:aws:cloudwatch:eu-west-1:${targetingAccountId.valueAsString}:alarm:*`,
 							`arn:aws:cloudwatch:eu-west-1:${this.account}:alarm:*`,
 						],
 					},


### PR DESCRIPTION
## What does this change?

Allows the targeting AWS account to publish to the alarms SNS topic. I'm in the process of migrating alarms for projects in targeting over to chat. This is a first step.

The account ID is provided via a cloudformation stack parameter, so I'll need to apply the update manually in order to set it as there is no default.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
