### PR TITLE
Fetch tags for alarms from the targeting account

### DIFF
--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -11,6 +11,7 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuStringParameter",
       "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -45,6 +46,10 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
     },
     "alarmshandlermobileawsaccount": {
       "Description": "ID of the mobile aws account",
+      "Type": "String",
+    },
+    "alarmshandlertargetingaccountrolearn": {
+      "Description": "ARN of role in the targeting account which allows cloudwatch:ListTagsForResource",
       "Type": "String",
     },
     "alarmshandlertargetingawsaccount": {
@@ -156,6 +161,12 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
             },
             "STACK": "membership",
             "STAGE": "CODE",
+            "TARGETING_AWS_ACCOUNT_ID": {
+              "Ref": "alarmshandlertargetingawsaccount",
+            },
+            "TARGETING_ROLE_ARN": {
+              "Ref": "alarmshandlertargetingaccountrolearn",
+            },
             "VALUE_WEBHOOK": {
               "Ref": "alarmshandlerVALUEwebhook",
             },
@@ -357,9 +368,14 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
             {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
-              "Resource": {
-                "Ref": "alarmshandlermobileaccountrolearn",
-              },
+              "Resource": [
+                {
+                  "Ref": "alarmshandlermobileaccountrolearn",
+                },
+                {
+                  "Ref": "alarmshandlertargetingaccountrolearn",
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -609,6 +625,7 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
       "GuStringParameter",
       "GuStringParameter",
       "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -643,6 +660,10 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
     },
     "alarmshandlermobileawsaccount": {
       "Description": "ID of the mobile aws account",
+      "Type": "String",
+    },
+    "alarmshandlertargetingaccountrolearn": {
+      "Description": "ARN of role in the targeting account which allows cloudwatch:ListTagsForResource",
       "Type": "String",
     },
     "alarmshandlertargetingawsaccount": {
@@ -754,6 +775,12 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
             },
             "STACK": "membership",
             "STAGE": "PROD",
+            "TARGETING_AWS_ACCOUNT_ID": {
+              "Ref": "alarmshandlertargetingawsaccount",
+            },
+            "TARGETING_ROLE_ARN": {
+              "Ref": "alarmshandlertargetingaccountrolearn",
+            },
             "VALUE_WEBHOOK": {
               "Ref": "alarmshandlerVALUEwebhook",
             },
@@ -955,9 +982,14 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
             {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
-              "Resource": {
-                "Ref": "alarmshandlermobileaccountrolearn",
-              },
+              "Resource": [
+                {
+                  "Ref": "alarmshandlermobileaccountrolearn",
+                },
+                {
+                  "Ref": "alarmshandlertargetingaccountrolearn",
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -113,7 +113,10 @@ export class AlarmsHandler extends GuStack {
 			new PolicyStatement({
 				actions: ['sts:AssumeRole'],
 				effect: Effect.ALLOW,
-				resources: [mobileAccountRoleArn.valueAsString, targetingAccountRoleArn.valueAsString],
+				resources: [
+					mobileAccountRoleArn.valueAsString,
+					targetingAccountRoleArn.valueAsString,
+				],
 			}),
 		);
 

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -63,6 +63,14 @@ export class AlarmsHandler extends GuStack {
 				description: 'ID of the targeting aws account',
 			},
 		);
+		const targetingAccountRoleArn = new GuStringParameter(
+			this,
+			`${app}-targeting-account-role-arn`,
+			{
+				description:
+					'ARN of role in the targeting account which allows cloudwatch:ListTagsForResource',
+			},
+		);
 
 		const lambda = new GuLambdaFunction(this, `${app}-lambda`, {
 			app,
@@ -84,6 +92,8 @@ export class AlarmsHandler extends GuStack {
 				// The lambda uses the mobile account role if it needs to fetch tags cross-account
 				MOBILE_AWS_ACCOUNT_ID: mobileAccountId.valueAsString,
 				MOBILE_ROLE_ARN: mobileAccountRoleArn.valueAsString,
+				TARGETING_AWS_ACCOUNT_ID: targetingAccountId.valueAsString,
+				TARGETING_ROLE_ARN: targetingAccountRoleArn.valueAsString,
 			},
 		});
 
@@ -98,12 +108,12 @@ export class AlarmsHandler extends GuStack {
 			}),
 		);
 
-		// Allow the lambda to assume the role that allows cross-account fetching of tags
+		// Allow the lambda to assume the roles that allow cross-account fetching of tags
 		lambda.addToRolePolicy(
 			new PolicyStatement({
 				actions: ['sts:AssumeRole'],
 				effect: Effect.ALLOW,
-				resources: [mobileAccountRoleArn.valueAsString],
+				resources: [mobileAccountRoleArn.valueAsString, targetingAccountRoleArn.valueAsString],
 			}),
 		);
 


### PR DESCRIPTION
## What does this change?

If an alarm notifications is received which originates from the targeting AWS account, assume the targeting role to fetch its tags.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
