### PR TITLE
Add billing periods to product catalog type object

### DIFF
--- a/modules/product-catalog/src/generateTypeObject.ts
+++ b/modules/product-catalog/src/generateTypeObject.ts
@@ -33,7 +33,21 @@ const getCurrenciesForProduct = (productRatePlan: ZuoraProductRatePlan) =>
 			charge.pricing.map((price) => price.currency),
 		),
 	);
-
+const getBillingPeriodsForProduct = (
+	productRatePlans: ZuoraProductRatePlan[],
+) =>
+	distinct(
+		productRatePlans
+			.flatMap((productRatePlan) =>
+				productRatePlan.productRatePlanCharges.flatMap(
+					(charge) => charge.billingPeriod,
+				),
+			)
+			.filter(
+				(billingPeriod) =>
+					billingPeriod !== null && billingPeriod != 'Specific_Weeks',
+			) as string[],
+	);
 const getZuoraProduct = (productRatePlans: ZuoraProductRatePlan[]) => {
 	const currencies = getCurrenciesForProduct(
 		checkDefined(
@@ -41,8 +55,10 @@ const getZuoraProduct = (productRatePlans: ZuoraProductRatePlan[]) => {
 			'Undefined productRatePlan in getZuoraProductObjects',
 		),
 	);
+	const billingPeriods = getBillingPeriodsForProduct(productRatePlans);
 	return {
 		currencies,
+		billingPeriods,
 		productRatePlans: arrayToObject(
 			productRatePlans
 				.filter((productRatePlan) =>

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -16,6 +16,18 @@ type ProductRatePlanChargeKey<
 export type ProductCurrency<P extends ProductKey> =
 	TypeObject[P]['currencies'][number];
 
+export type ProductBillingPeriod<P extends ProductKey> =
+	TypeObject[P]['billingPeriods'][number];
+
+export const isProductBillingPeriod = <P extends ProductKey>(
+	product: P,
+	billingPeriod: unknown,
+): billingPeriod is ProductBillingPeriod<P> => {
+	return (typeObject[product].billingPeriods as readonly unknown[]).includes(
+		billingPeriod,
+	);
+};
+
 type ProductPrice<P extends ProductKey> = {
 	[PC in ProductCurrency<P>]: number;
 };

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -1,4 +1,3 @@
-import type { BillingPeriod } from '@modules/billingPeriod';
 import { typeObject } from '@modules/product-catalog/typeObject';
 
 type TypeObject = typeof typeObject;
@@ -45,7 +44,7 @@ type ProductRatePlan<
 	charges: {
 		[PRPC in ProductRatePlanChargeKey<P, PRP>]: ProductRatePlanCharge;
 	};
-	billingPeriod?: BillingPeriod;
+	billingPeriod?: ProductBillingPeriod<P>;
 };
 
 type Product<P extends ProductKey> = {

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -1,5 +1,5 @@
-import { BillingPeriodValues } from '@modules/billingPeriod';
 import { z } from 'zod';
+import { typeObject } from '@modules/product-catalog/typeObject';
 
 export const productCatalogSchema = z.object({
 	DigitalSubscription: z.object({
@@ -15,7 +15,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.DigitalSubscription.billingPeriods)
+					.optional(),
 			}),
 			ThreeMonthGift: z.object({
 				id: z.string(),
@@ -28,7 +30,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.DigitalSubscription.billingPeriods)
+					.optional(),
 			}),
 			OneYearGift: z.object({
 				id: z.string(),
@@ -41,7 +45,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.DigitalSubscription.billingPeriods)
+					.optional(),
 			}),
 			Monthly: z.object({
 				id: z.string(),
@@ -54,7 +60,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.DigitalSubscription.billingPeriods)
+					.optional(),
 			}),
 		}),
 	}),
@@ -72,7 +80,9 @@ export const productCatalogSchema = z.object({
 					Tuesday: z.object({ id: z.string() }),
 					Thursday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.HomeDelivery.billingPeriods)
+					.optional(),
 			}),
 			Sixday: z.object({
 				id: z.string(),
@@ -85,7 +95,9 @@ export const productCatalogSchema = z.object({
 					Monday: z.object({ id: z.string() }),
 					Saturday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.HomeDelivery.billingPeriods)
+					.optional(),
 			}),
 			Weekend: z.object({
 				id: z.string(),
@@ -94,19 +106,25 @@ export const productCatalogSchema = z.object({
 					Saturday: z.object({ id: z.string() }),
 					Sunday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.HomeDelivery.billingPeriods)
+					.optional(),
 			}),
 			Saturday: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({ Saturday: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.HomeDelivery.billingPeriods)
+					.optional(),
 			}),
 			Sunday: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({ Sunday: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.HomeDelivery.billingPeriods)
+					.optional(),
 			}),
 		}),
 	}),
@@ -124,7 +142,9 @@ export const productCatalogSchema = z.object({
 					Saturday: z.object({ id: z.string() }),
 					Sunday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.NationalDelivery.billingPeriods)
+					.optional(),
 			}),
 			Weekend: z.object({
 				id: z.string(),
@@ -133,7 +153,9 @@ export const productCatalogSchema = z.object({
 					Saturday: z.object({ id: z.string() }),
 					Sunday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.NationalDelivery.billingPeriods)
+					.optional(),
 			}),
 			Sixday: z.object({
 				id: z.string(),
@@ -146,7 +168,9 @@ export const productCatalogSchema = z.object({
 					Friday: z.object({ id: z.string() }),
 					Saturday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.NationalDelivery.billingPeriods)
+					.optional(),
 			}),
 		}),
 	}),
@@ -196,7 +220,9 @@ export const productCatalogSchema = z.object({
 					Subscription: z.object({ id: z.string() }),
 					Contribution: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SupporterPlus.billingPeriods)
+					.optional(),
 			}),
 			Annual: z.object({
 				id: z.string(),
@@ -212,7 +238,9 @@ export const productCatalogSchema = z.object({
 					Subscription: z.object({ id: z.string() }),
 					Contribution: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SupporterPlus.billingPeriods)
+					.optional(),
 			}),
 			GuardianWeeklyRestOfWorldMonthly: z.object({
 				id: z.string(),
@@ -228,7 +256,9 @@ export const productCatalogSchema = z.object({
 					SupporterPlus: z.object({ id: z.string() }),
 					GuardianWeekly: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SupporterPlus.billingPeriods)
+					.optional(),
 			}),
 			GuardianWeeklyDomesticMonthly: z.object({
 				id: z.string(),
@@ -244,7 +274,9 @@ export const productCatalogSchema = z.object({
 					SupporterPlus: z.object({ id: z.string() }),
 					GuardianWeekly: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SupporterPlus.billingPeriods)
+					.optional(),
 			}),
 			GuardianWeeklyRestOfWorldAnnual: z.object({
 				id: z.string(),
@@ -260,7 +292,9 @@ export const productCatalogSchema = z.object({
 					SupporterPlus: z.object({ id: z.string() }),
 					GuardianWeekly: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SupporterPlus.billingPeriods)
+					.optional(),
 			}),
 			GuardianWeeklyDomesticAnnual: z.object({
 				id: z.string(),
@@ -276,7 +310,9 @@ export const productCatalogSchema = z.object({
 					SupporterPlus: z.object({ id: z.string() }),
 					GuardianWeekly: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SupporterPlus.billingPeriods)
+					.optional(),
 			}),
 		}),
 	}),
@@ -286,31 +322,41 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ USD: z.number(), GBP: z.number() }),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyRestOfWorld.billingPeriods)
+					.optional(),
 			}),
 			OneYearGift: z.object({
 				id: z.string(),
 				pricing: z.object({ USD: z.number(), GBP: z.number() }),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyRestOfWorld.billingPeriods)
+					.optional(),
 			}),
 			Quarterly: z.object({
 				id: z.string(),
 				pricing: z.object({ USD: z.number(), GBP: z.number() }),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyRestOfWorld.billingPeriods)
+					.optional(),
 			}),
 			Annual: z.object({
 				id: z.string(),
 				pricing: z.object({ USD: z.number(), GBP: z.number() }),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyRestOfWorld.billingPeriods)
+					.optional(),
 			}),
 			Monthly: z.object({
 				id: z.string(),
 				pricing: z.object({ USD: z.number(), GBP: z.number() }),
 				charges: z.object({ Monthly: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyRestOfWorld.billingPeriods)
+					.optional(),
 			}),
 		}),
 	}),
@@ -327,7 +373,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
+					.optional(),
 			}),
 			Quarterly: z.object({
 				id: z.string(),
@@ -340,7 +388,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
+					.optional(),
 			}),
 			Annual: z.object({
 				id: z.string(),
@@ -353,7 +403,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
+					.optional(),
 			}),
 			Monthly: z.object({
 				id: z.string(),
@@ -366,7 +418,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
+					.optional(),
 			}),
 			OneYearGift: z.object({
 				id: z.string(),
@@ -379,7 +433,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
+					.optional(),
 			}),
 		}),
 	}),
@@ -397,7 +453,9 @@ export const productCatalogSchema = z.object({
 					Saturday: z.object({ id: z.string() }),
 					Sunday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SubscriptionCard.billingPeriods)
+					.optional(),
 			}),
 			Weekend: z.object({
 				id: z.string(),
@@ -406,7 +464,9 @@ export const productCatalogSchema = z.object({
 					Saturday: z.object({ id: z.string() }),
 					Sunday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SubscriptionCard.billingPeriods)
+					.optional(),
 			}),
 			Sixday: z.object({
 				id: z.string(),
@@ -419,19 +479,25 @@ export const productCatalogSchema = z.object({
 					Tuesday: z.object({ id: z.string() }),
 					Monday: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SubscriptionCard.billingPeriods)
+					.optional(),
 			}),
 			Sunday: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({ Sunday: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SubscriptionCard.billingPeriods)
+					.optional(),
 			}),
 			Saturday: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({ Saturday: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SubscriptionCard.billingPeriods)
+					.optional(),
 			}),
 		}),
 	}),
@@ -448,7 +514,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Contribution: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.Contribution.billingPeriods)
+					.optional(),
 			}),
 			Monthly: z.object({
 				id: z.string(),
@@ -461,7 +529,9 @@ export const productCatalogSchema = z.object({
 					AUD: z.number(),
 				}),
 				charges: z.object({ Contribution: z.object({ id: z.string() }) }),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.Contribution.billingPeriods)
+					.optional(),
 			}),
 		}),
 	}),

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -189,7 +189,9 @@ export const productCatalogSchema = z.object({
 				charges: z.object({
 					Subscription: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SupporterPlus.billingPeriods)
+					.optional(),
 			}),
 			V1DeprecatedAnnual: z.object({
 				id: z.string(),
@@ -204,7 +206,9 @@ export const productCatalogSchema = z.object({
 				charges: z.object({
 					Subscription: z.object({ id: z.string() }),
 				}),
-				billingPeriod: z.enum(BillingPeriodValues).optional(),
+				billingPeriod: z
+					.enum(typeObject.SupporterPlus.billingPeriods)
+					.optional(),
 			}),
 			Monthly: z.object({
 				id: z.string(),

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -1,6 +1,7 @@
 export const typeObject = {
 	DigitalSubscription: {
 		currencies: ['USD', 'NZD', 'EUR', 'GBP', 'CAD', 'AUD'],
+		billingPeriods: ['Quarter', 'Month', 'Annual'],
 		productRatePlans: {
 			Monthly: {
 				Subscription: {},
@@ -18,6 +19,7 @@ export const typeObject = {
 	},
 	NationalDelivery: {
 		currencies: ['GBP'],
+		billingPeriods: ['Month'],
 		productRatePlans: {
 			Sixday: {
 				Monday: {},
@@ -44,6 +46,7 @@ export const typeObject = {
 	},
 	SupporterPlus: {
 		currencies: ['USD', 'NZD', 'EUR', 'GBP', 'CAD', 'AUD'],
+		billingPeriods: ['Month', 'Annual'],
 		productRatePlans: {
 			GuardianWeeklyRestOfWorldMonthly: {
 				SupporterPlus: {},
@@ -79,6 +82,7 @@ export const typeObject = {
 	},
 	GuardianWeeklyRestOfWorld: {
 		currencies: ['USD', 'GBP'],
+		billingPeriods: ['Month', 'Annual', 'Quarter'],
 		productRatePlans: {
 			Monthly: {
 				Monthly: {},
@@ -99,6 +103,7 @@ export const typeObject = {
 	},
 	GuardianWeeklyDomestic: {
 		currencies: ['USD', 'NZD', 'EUR', 'GBP', 'CAD', 'AUD'],
+		billingPeriods: ['Annual', 'Quarter', 'Month'],
 		productRatePlans: {
 			OneYearGift: {
 				Subscription: {},
@@ -119,6 +124,7 @@ export const typeObject = {
 	},
 	SubscriptionCard: {
 		currencies: ['GBP'],
+		billingPeriods: ['Month'],
 		productRatePlans: {
 			Sixday: {
 				Friday: {},
@@ -151,6 +157,7 @@ export const typeObject = {
 	},
 	Contribution: {
 		currencies: ['USD', 'NZD', 'EUR', 'GBP', 'CAD', 'AUD'],
+		billingPeriods: ['Annual', 'Month'],
 		productRatePlans: {
 			Annual: {
 				Contribution: {},
@@ -162,6 +169,7 @@ export const typeObject = {
 	},
 	HomeDelivery: {
 		currencies: ['GBP'],
+		billingPeriods: ['Month'],
 		productRatePlans: {
 			Everyday: {
 				Sunday: {},

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -724,6 +724,10 @@ exports[`Generated product catalog matches snapshot 1`] = `
 exports[`Generated product catalog types match snapshot 1`] = `
 {
   "Contribution": {
+    "billingPeriods": [
+      "Annual",
+      "Month",
+    ],
     "currencies": [
       "USD",
       "NZD",
@@ -742,6 +746,11 @@ exports[`Generated product catalog types match snapshot 1`] = `
     },
   },
   "DigitalSubscription": {
+    "billingPeriods": [
+      "Quarter",
+      "Month",
+      "Annual",
+    ],
     "currencies": [
       "USD",
       "NZD",
@@ -766,6 +775,11 @@ exports[`Generated product catalog types match snapshot 1`] = `
     },
   },
   "GuardianWeeklyDomestic": {
+    "billingPeriods": [
+      "Annual",
+      "Quarter",
+      "Month",
+    ],
     "currencies": [
       "USD",
       "NZD",
@@ -793,6 +807,11 @@ exports[`Generated product catalog types match snapshot 1`] = `
     },
   },
   "GuardianWeeklyRestOfWorld": {
+    "billingPeriods": [
+      "Month",
+      "Annual",
+      "Quarter",
+    ],
     "currencies": [
       "USD",
       "GBP",
@@ -816,6 +835,9 @@ exports[`Generated product catalog types match snapshot 1`] = `
     },
   },
   "HomeDelivery": {
+    "billingPeriods": [
+      "Month",
+    ],
     "currencies": [
       "GBP",
     ],
@@ -850,6 +872,9 @@ exports[`Generated product catalog types match snapshot 1`] = `
     },
   },
   "NationalDelivery": {
+    "billingPeriods": [
+      "Month",
+    ],
     "currencies": [
       "GBP",
     ],
@@ -878,6 +903,9 @@ exports[`Generated product catalog types match snapshot 1`] = `
     },
   },
   "SubscriptionCard": {
+    "billingPeriods": [
+      "Month",
+    ],
     "currencies": [
       "GBP",
     ],
@@ -912,6 +940,10 @@ exports[`Generated product catalog types match snapshot 1`] = `
     },
   },
   "SupporterPlus": {
+    "billingPeriods": [
+      "Month",
+      "Annual",
+    ],
     "currencies": [
       "USD",
       "NZD",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds the supported billing periods for each product to the product catalog type object. This gives us a new type ` ProductBillingPeriod<P extends ProductKey>` and allow us to write code such as:

```typescript
const billingPeriod: ProductBillingPeriod<'SupporterPlus'> = 'Month'; // Valid billing period
const billingPeriod: ProductBillingPeriod<'SupporterPlus'> = 'Quarter'; // Compile error, supporter plus does not support Quarterly billing
```