### PR TITLE
Remove missing charge from product catalog schema

### DIFF
--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -164,7 +164,6 @@ export const productCatalogSchema = z.object({
 				}),
 				charges: z.object({
 					Subscription: z.object({ id: z.string() }),
-					Contribution: z.object({ id: z.string() }),
 				}),
 				billingPeriod: z.enum(BillingPeriodValues).optional(),
 			}),
@@ -180,7 +179,6 @@ export const productCatalogSchema = z.object({
 				}),
 				charges: z.object({
 					Subscription: z.object({ id: z.string() }),
-					Contribution: z.object({ id: z.string() }),
 				}),
 				billingPeriod: z.enum(BillingPeriodValues).optional(),
 			}),

--- a/modules/product-catalog/test/getProductCatalogIntegration.test.ts
+++ b/modules/product-catalog/test/getProductCatalogIntegration.test.ts
@@ -12,3 +12,10 @@ test('getCatalogFromApi', async () => {
 		14.99,
 	);
 });
+
+test('getCatalogFromApi', async () => {
+	const catalog = await getProductCatalogFromApi('PROD');
+	expect(catalog.DigitalSubscription.ratePlans.Monthly.pricing.GBP).toEqual(
+		14.99,
+	);
+});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
#2275 had a bug where the product catalog schema for the supporter plus v1 rateplan had a contribution charge in it which does not exist in the catalog, causing parsing errors.
This PR fixes that.