### PR TITLE
feat: add ownership for bigquery-acquisitions-publisher to Growth and PP

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -19,6 +19,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'admin-console',
 		'apps-metering',
 		'batch-email-sender',
+		'bigquery-acquisitions-publisher',
 		'component-event-stream',
 		'contributions-ticker-calculator',
 		'digital-voucher-api',
@@ -73,6 +74,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'zuora-retention',
 
 		// support-frontend
+		'bigquery-acquisitions-publisher',
 		'frontend',
 		'it-test-runner',
 		'stripe-intent',

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -74,7 +74,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'zuora-retention',
 
 		// support-frontend
-		'bigquery-acquisitions-publisher',
 		'frontend',
 		'it-test-runner',
 		'stripe-intent',


### PR DESCRIPTION
## What does this change?

Add ownership for `bigquery-acquisitions-publisher` to Growth.