### PR TITLE
feat: add support-workers to PP alarm handler

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -57,6 +57,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'stripe-intent',
 		'salesforce-disaster-recovery',
 		'salesforce-disaster-recovery-health-check',
+		'workers',
 	],
 };
 


### PR DESCRIPTION
Adds [support-workers](https://github.com/guardian/support-frontend/pull/6051) to the alarms handler for `PP`.