### PR TITLE
allow multiple discounts for the same frequency

### DIFF
--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -60,7 +60,10 @@ export const discountEndpoint = async (
 	]);
 
 	console.log('Working out the appropriate discount for the subscription');
-	const {discount, nonDiscountRatePlan} = getDiscountFromSubscription(stage, subscription);
+	const { discount, nonDiscountRatePlan } = getDiscountFromSubscription(
+		stage,
+		subscription,
+	);
 
 	console.log('Checking this subscription is eligible for the discount');
 	const dateToApply = eligibilityChecker.getNextBillingDateIfEligible(

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -60,13 +60,12 @@ export const discountEndpoint = async (
 	]);
 
 	console.log('Working out the appropriate discount for the subscription');
-	const discount = getDiscountFromSubscription(stage, subscription);
+	const {discount, nonDiscountRatePlan} = getDiscountFromSubscription(stage, subscription);
 
 	console.log('Checking this subscription is eligible for the discount');
-	const nextBillingDate = eligibilityChecker.getNextBillingDateIfEligible(
-		subscription,
+	const dateToApply = eligibilityChecker.getNextBillingDateIfEligible(
 		billingPreview,
-		discount.productRatePlanId,
+		nonDiscountRatePlan,
 	);
 
 	if (preview) {
@@ -74,7 +73,7 @@ export const discountEndpoint = async (
 		return getDiscountPreview(
 			zuoraClient,
 			requestBody.subscriptionNumber,
-			nextBillingDate,
+			dateToApply,
 			discount,
 		);
 	} else {
@@ -83,7 +82,7 @@ export const discountEndpoint = async (
 			requestBody.subscriptionNumber,
 			subscription.termStartDate,
 			subscription.termEndDate,
-			nextBillingDate,
+			dateToApply,
 			discount.productRatePlanId,
 		);
 	}

--- a/handlers/discount-api/src/eligibilityChecker.ts
+++ b/handlers/discount-api/src/eligibilityChecker.ts
@@ -1,9 +1,9 @@
-import {sum} from '@modules/arrayFunctions';
-import {ValidationError} from '@modules/errors';
-import {checkDefined} from '@modules/nullAndUndefined';
-import {getNextInvoiceItems} from '@modules/zuora/billingPreview';
-import type {BillingPreview, RatePlan,} from '@modules/zuora/zuoraSchemas';
-import type {ZuoraCatalogHelper} from '@modules/zuora-catalog/zuoraCatalog';
+import { sum } from '@modules/arrayFunctions';
+import { ValidationError } from '@modules/errors';
+import { checkDefined } from '@modules/nullAndUndefined';
+import { getNextInvoiceItems } from '@modules/zuora/billingPreview';
+import type { BillingPreview, RatePlan } from '@modules/zuora/zuoraSchemas';
+import type { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
 
 export class EligibilityChecker {
 	constructor(private catalog: ZuoraCatalogHelper) {}

--- a/handlers/discount-api/src/eligibilityChecker.ts
+++ b/handlers/discount-api/src/eligibilityChecker.ts
@@ -1,70 +1,27 @@
-import { sum } from '@modules/arrayFunctions';
-import { ValidationError } from '@modules/errors';
-import { checkDefined } from '@modules/nullAndUndefined';
-import { getNextInvoiceItems } from '@modules/zuora/billingPreview';
-import { isNotRemoved } from '@modules/zuora/rateplan';
-import type {
-	BillingPreview,
-	RatePlan,
-	ZuoraSubscription,
-} from '@modules/zuora/zuoraSchemas';
-import type { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
-import { getEligibleProductRatePlanIdsForDiscount } from './productToDiscountMapping';
+import {sum} from '@modules/arrayFunctions';
+import {ValidationError} from '@modules/errors';
+import {checkDefined} from '@modules/nullAndUndefined';
+import {getNextInvoiceItems} from '@modules/zuora/billingPreview';
+import type {BillingPreview, RatePlan,} from '@modules/zuora/zuoraSchemas';
+import type {ZuoraCatalogHelper} from '@modules/zuora-catalog/zuoraCatalog';
 
 export class EligibilityChecker {
 	constructor(private catalog: ZuoraCatalogHelper) {}
 
 	getNextBillingDateIfEligible = (
-		subscription: ZuoraSubscription,
 		billingPreview: BillingPreview,
-		discountProductRatePlanId: string,
+		ratePlan: RatePlan,
 	) => {
-		const eligibleRatePlan = this.getEligibleRatePlanFromSubscription(
-			subscription,
-			discountProductRatePlanId,
-		);
-
 		console.log(
 			'Checking that the next payment is at least at the catalog price',
 		);
 		const nextBillingDate = this.checkNextPaymentIsAtCatalogPrice(
 			billingPreview,
-			eligibleRatePlan,
+			ratePlan,
 		);
 
 		console.log('Subscription is eligible for the discount');
 		return nextBillingDate;
-	};
-
-	private getEligibleRatePlanFromSubscription = (
-		subscription: ZuoraSubscription,
-		discountProductRatePlanId: string,
-	): RatePlan => {
-		const eligibleProductRatePlans = getEligibleProductRatePlanIdsForDiscount(
-			discountProductRatePlanId,
-		);
-
-		const eligibleRatePlans: RatePlan[] = subscription.ratePlans.filter(
-			(ratePlan) =>
-				isNotRemoved(ratePlan) &&
-				eligibleProductRatePlans.includes(ratePlan.productRatePlanId),
-		);
-
-		if (eligibleRatePlans.length > 1) {
-			throw new Error(
-				`Subscription ${subscription.subscriptionNumber} has more than one eligible rate plan
-				 for ${discountProductRatePlanId}. I don't know whether this should be allowed so fail for now`,
-			);
-		}
-
-		if (eligibleRatePlans.length === 0 || !eligibleRatePlans[0]) {
-			throw new ValidationError(
-				`Subscription ${subscription.subscriptionNumber} is not eligible for discount 
-				${discountProductRatePlanId} as it does not contain any eligible rate plans`,
-			);
-		}
-
-		return eligibleRatePlans[0];
 	};
 
 	private checkNextPaymentIsAtCatalogPrice = (
@@ -74,7 +31,7 @@ export class EligibilityChecker {
 		// Work out the catalog price of the rate plan
 		const currency = checkDefined(
 			ratePlan.ratePlanCharges[0]?.currency,
-			'No currency found on rate plan charge',
+			'No charges found on rate plan',
 		);
 		const totalPrice = this.catalog.getCatalogPrice(
 			ratePlan.productRatePlanId,

--- a/handlers/discount-api/src/productToDiscountMapping.ts
+++ b/handlers/discount-api/src/productToDiscountMapping.ts
@@ -1,14 +1,17 @@
-import {getSingleOrThrow} from "@modules/arrayFunctions";
-import type {BillingPeriod} from '@modules/billingPeriod';
-import {ValidationError} from "@modules/errors";
-import type {Stage} from '@modules/stage';
-import {isNotRemovedOrDiscount} from "@modules/zuora/rateplan";
-import type {ZuoraSubscription} from "@modules/zuora/zuoraSchemas";
+import { getSingleOrThrow } from '@modules/arrayFunctions';
+import type { BillingPeriod } from '@modules/billingPeriod';
+import { ValidationError } from '@modules/errors';
+import type { Stage } from '@modules/stage';
+import { isNotRemovedOrDiscount } from '@modules/zuora/rateplan';
+import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
 
 export function getDiscountableRatePlan(subscription: ZuoraSubscription) {
 	return getSingleOrThrow(
 		subscription.ratePlans,
-		(msg) => new Error(`Subscription ${subscription.subscriptionNumber} has multiple discountable rateplans ${msg}`),
+		(msg) =>
+			new Error(
+				`Subscription ${subscription.subscriptionNumber} has multiple discountable rateplans ${msg}`,
+			),
 		isNotRemovedOrDiscount,
 	);
 }
@@ -18,16 +21,17 @@ export const getDiscountFromSubscription = (
 	subscription: ZuoraSubscription,
 ) => {
 	const nonDiscountRatePlan = getDiscountableRatePlan(subscription);
-	const discount = ProductToDiscountMapping[stage][nonDiscountRatePlan.productRatePlanId];
+	const discount =
+		ProductToDiscountMapping[stage][nonDiscountRatePlan.productRatePlanId];
 
 	if (discount == undefined) {
 		throw new ValidationError(
 			`Subscription ${subscription.subscriptionNumber} is not eligible for any discount`,
-		)
+		);
 	}
 
-	return {discount, nonDiscountRatePlan};
-}
+	return { discount, nonDiscountRatePlan };
+};
 
 export type Discount = {
 	productRatePlanId: string;
@@ -38,32 +42,32 @@ export type Discount = {
 	effectiveEndDate: string;
 };
 
-type Product = 'digiSub'
+type Product = 'digiSub';
 
 // TODO in future refactor "catalog" to use catalog service
 const catalog: {
-	[K in 'CODE'|'PROD']: {
-		[K in Product]: {[K in BillingPeriod]: string};
+	[K in 'CODE' | 'PROD']: {
+		[K in Product]: { [K in BillingPeriod]: string };
 	};
 } = {
-    CODE: {
+	CODE: {
 		digiSub: {
 			Month: '2c92c0f84bbfec8b014bc655f4852d9d',
 			Quarter: '2c92c0f84bbfec58014bc6a2d43a1f5b',
-			Annual: '2c92c0f94bbffaaa014bc6a4212e205b'
-		}
+			Annual: '2c92c0f94bbffaaa014bc6a4212e205b',
+		},
 	},
 	PROD: {
 		digiSub: {
 			Month: '2c92a0fb4edd70c8014edeaa4eae220a',
 			Quarter: '2c92a0fb4edd70c8014edeaa4e8521fe',
-			Annual: '2c92a0fb4edd70c8014edeaa4e972204'
-		}
-	}
-}
+			Annual: '2c92a0fb4edd70c8014edeaa4e972204',
+		},
+	},
+};
 
 const Discounts: {
-	[K in 'CODE'|'PROD']: {[K in string]: Discount};
+	[K in 'CODE' | 'PROD']: { [K in string]: Discount };
 } = {
 	CODE: {
 		cancellation25pc3mo: {

--- a/handlers/discount-api/src/productToDiscountMapping.ts
+++ b/handlers/discount-api/src/productToDiscountMapping.ts
@@ -1,33 +1,33 @@
-import { getSingleOrThrow } from '@modules/arrayFunctions';
-import type { BillingPeriod } from '@modules/billingPeriod';
-import { checkDefined } from '@modules/nullAndUndefined';
-import type { Stage } from '@modules/stage';
-import { isNotRemovedOrDiscount } from '@modules/zuora/rateplan';
-import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
+import {getSingleOrThrow} from "@modules/arrayFunctions";
+import type {BillingPeriod} from '@modules/billingPeriod';
+import {ValidationError} from "@modules/errors";
+import type {Stage} from '@modules/stage';
+import {isNotRemovedOrDiscount} from "@modules/zuora/rateplan";
+import type {ZuoraSubscription} from "@modules/zuora/zuoraSchemas";
+
+export function getDiscountableRatePlan(subscription: ZuoraSubscription) {
+	return getSingleOrThrow(
+		subscription.ratePlans,
+		(msg) => new Error(`Subscription ${subscription.subscriptionNumber} has multiple discountable rateplans ${msg}`),
+		isNotRemovedOrDiscount,
+	);
+}
 
 export const getDiscountFromSubscription = (
 	stage: Stage,
 	subscription: ZuoraSubscription,
 ) => {
-	const nonDiscountRatePlan = getSingleOrThrow(
-		subscription.ratePlans,
-		isNotRemovedOrDiscount,
-	);
-	const billingPeriod = checkDefined(
-		nonDiscountRatePlan.ratePlanCharges[0]?.billingPeriod,
-		`No billing period found on subscription ${subscription.subscriptionNumber}`,
-	);
-	return ProductToDiscountMapping[stage][billingPeriod];
-};
+	const nonDiscountRatePlan = getDiscountableRatePlan(subscription);
+	const discount = ProductToDiscountMapping[stage][nonDiscountRatePlan.productRatePlanId];
 
-export const getEligibleProductRatePlanIdsForDiscount = (
-	discountProductRatePlanId: string,
-) => {
-	return Object.values(ProductToDiscountMapping)
-		.flatMap((_) => Object.values(_))
-		.filter((_) => _.productRatePlanId === discountProductRatePlanId)
-		.flatMap((_) => _.eligibleProductRatePlanIds);
-};
+	if (discount == undefined) {
+		throw new ValidationError(
+			`Subscription ${subscription.subscriptionNumber} is not eligible for any discount`,
+		)
+	}
+
+	return {discount, nonDiscountRatePlan};
+}
 
 export type Discount = {
 	productRatePlanId: string;
@@ -36,12 +36,12 @@ export type Discount = {
 	upToPeriodsType: string;
 	effectiveStartDate: string;
 	effectiveEndDate: string;
-	eligibleProductRatePlanIds: string[];
 };
 
 type Product = 'digiSub'
 
-const productRatePlanIds: {
+// TODO in future refactor "catalog" to use catalog service
+const catalog: {
 	[K in 'CODE'|'PROD']: {
 		[K in Product]: {[K in BillingPeriod]: string};
 	};
@@ -62,114 +62,61 @@ const productRatePlanIds: {
 	}
 }
 
-const ProductToDiscountMapping: {
-	[K in Stage]: {
-		[K in BillingPeriod]: Discount;
-	};
+const Discounts: {
+	[K in 'CODE'|'PROD']: {[K in string]: Discount};
 } = {
 	CODE: {
-		Month: {
+		cancellation25pc3mo: {
 			productRatePlanId: '2c92c0f962cec7990162d3882afc52dd',
 			name: 'Cancellation Save Discount - 25% off for 3 months',
 			upToPeriods: 3,
 			upToPeriodsType: 'Months',
 			effectiveStartDate: '2018-04-01',
 			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [
-				productRatePlanIds.CODE.digiSub.Month,
-				productRatePlanIds.CODE.digiSub.Quarter,
-			],
 		},
-		Quarter: {
-			productRatePlanId: '2c92c0f962cec7990162d3882afc52dd',
-			name: 'Cancellation Save Discount - 25% off for 3 months',
-			upToPeriods: 3,
-			upToPeriodsType: 'Months',
-			effectiveStartDate: '2018-04-01',
-			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [
-				productRatePlanIds.CODE.digiSub.Month,
-				productRatePlanIds.CODE.digiSub.Quarter,
-			],
-		},
-		Annual: {
+		cancellation25pc12mo: {
 			productRatePlanId: '8ad08f068b5b9ca2018b5cadf0897ed3',
 			name: 'Cancellation Save Discount - 25% off for 12 months',
 			upToPeriods: 12,
 			upToPeriodsType: 'Months',
 			effectiveStartDate: '2023-10-23',
 			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [productRatePlanIds.CODE.digiSub.Annual],
-		},
-	},
-	CSBX: {
-		Month: {
-			productRatePlanId: '2c92a0ff64176cd40164232c8ec97661',
-			name: 'Cancellation Save Discount - 25% off for 3 months',
-			upToPeriods: 3,
-			upToPeriodsType: 'Months',
-			effectiveStartDate: '2018-06-22',
-			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [
-				productRatePlanIds.PROD.digiSub.Month,
-				productRatePlanIds.PROD.digiSub.Quarter,
-			],
-		},
-		Quarter: {
-			productRatePlanId: '2c92a0ff64176cd40164232c8ec97661',
-			name: 'Cancellation Save Discount - 25% off for 3 months',
-			upToPeriods: 3,
-			upToPeriodsType: 'Months',
-			effectiveStartDate: '2018-06-22',
-			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [
-				productRatePlanIds.PROD.digiSub.Month,
-				productRatePlanIds.PROD.digiSub.Quarter,
-			],
-		},
-		Annual: {
-			productRatePlanId: '8a128adf8b64bcfd018b6b6fdc7674f5',
-			name: 'Cancellation Save Discount - 25% off for 12 months',
-			upToPeriods: 12,
-			upToPeriodsType: 'Months',
-			effectiveStartDate: '2023-10-26',
-			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [productRatePlanIds.PROD.digiSub.Annual],
 		},
 	},
 	PROD: {
-		Month: {
+		cancellation25pc3mo: {
 			productRatePlanId: '2c92a0ff64176cd40164232c8ec97661',
 			name: 'Cancellation Save Discount - 25% off for 3 months',
 			upToPeriods: 3,
 			upToPeriodsType: 'Months',
 			effectiveStartDate: '2018-06-22',
 			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [
-				productRatePlanIds.PROD.digiSub.Month,
-				productRatePlanIds.PROD.digiSub.Quarter,
-			],
 		},
-		Quarter: {
-			productRatePlanId: '2c92a0ff64176cd40164232c8ec97661',
-			name: 'Cancellation Save Discount - 25% off for 3 months',
-			upToPeriods: 3,
-			upToPeriodsType: 'Months',
-			effectiveStartDate: '2018-06-22',
-			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [
-				productRatePlanIds.PROD.digiSub.Month,
-				productRatePlanIds.PROD.digiSub.Quarter,
-			],
-		},
-		Annual: {
+		cancellation25pc12mo: {
 			productRatePlanId: '8a128adf8b64bcfd018b6b6fdc7674f5',
 			name: 'Cancellation Save Discount - 25% off for 12 months',
 			upToPeriods: 12,
 			upToPeriodsType: 'Months',
 			effectiveStartDate: '2023-10-26',
 			effectiveEndDate: '2099-03-08',
-			eligibleProductRatePlanIds: [productRatePlanIds.PROD.digiSub.Annual],
 		},
+	},
+};
+
+const ProductToDiscountMapping = {
+	CODE: {
+		[catalog.CODE.digiSub.Month]: Discounts.CODE.cancellation25pc3mo,
+		[catalog.CODE.digiSub.Quarter]: Discounts.CODE.cancellation25pc3mo,
+		[catalog.CODE.digiSub.Annual]: Discounts.CODE.cancellation25pc12mo,
+	},
+	CSBX: {
+		[catalog.PROD.digiSub.Month]: Discounts.PROD.cancellation25pc3mo,
+		[catalog.PROD.digiSub.Quarter]: Discounts.PROD.cancellation25pc3mo,
+		[catalog.PROD.digiSub.Annual]: Discounts.PROD.cancellation25pc12mo,
+	},
+	PROD: {
+		[catalog.PROD.digiSub.Month]: Discounts.PROD.cancellation25pc3mo,
+		[catalog.PROD.digiSub.Quarter]: Discounts.PROD.cancellation25pc3mo,
+		[catalog.PROD.digiSub.Annual]: Discounts.PROD.cancellation25pc12mo,
 	},
 };

--- a/handlers/discount-api/src/productToDiscountMapping.ts
+++ b/handlers/discount-api/src/productToDiscountMapping.ts
@@ -44,7 +44,6 @@ export type Discount = {
 
 type Product = 'digiSub';
 
-// TODO in future refactor "catalog" to use catalog service
 const catalog: {
 	[K in 'CODE' | 'PROD']: {
 		[K in Product]: { [K in BillingPeriod]: string };

--- a/handlers/discount-api/test/eligibilityChecker.test.ts
+++ b/handlers/discount-api/test/eligibilityChecker.test.ts
@@ -14,6 +14,7 @@ import billingPreviewJson3 from './fixtures/billing-previews/eligibility-checker
 import subscriptionJson2 from './fixtures/digital-subscriptions/eligibility-checker-test2.json';
 import subscriptionJson3 from './fixtures/digital-subscriptions/eligibility-checker-test3.json';
 import subscriptionJson1 from './fixtures/digital-subscriptions/get-discount-test.json';
+import {getDiscountableRatePlan} from "../src/productToDiscountMapping";
 
 test('Eligibility check fails for a subscription which is on a reduced price', () => {
 	const sub = zuoraSubscriptionSchema.parse(subscriptionJson1);
@@ -24,9 +25,8 @@ test('Eligibility check fails for a subscription which is on a reduced price', (
 	const eligibilityChecker = new EligibilityChecker(catalog);
 	expect(() => {
 		eligibilityChecker.getNextBillingDateIfEligible(
-			sub,
 			billingPreview,
-			'8a128adf8b64bcfd018b6b6fdc7674f5',
+			getDiscountableRatePlan(sub),
 		);
 	}).toThrow('Amount payable for next invoice');
 });
@@ -40,9 +40,8 @@ test('Eligibility check works for a price risen subscription', () => {
 	expect(
 		dayjs(
 			eligibilityChecker.getNextBillingDateIfEligible(
-				sub,
 				billingPreview,
-				'2c92a0ff64176cd40164232c8ec97661',
+				getDiscountableRatePlan(sub),
 			),
 		),
 	).toEqual(dayjs('2024-02-07'));
@@ -57,9 +56,8 @@ test('error', () => {
 	const eligibilityChecker = new EligibilityChecker(catalog);
 	expect(() => {
 		eligibilityChecker.getNextBillingDateIfEligible(
-			sub,
 			billingPreview,
-			'8ad08f068b5b9ca2018b5cadf0897ed3',
+			getDiscountableRatePlan(sub),
 		);
 	}).toThrow('Amount payable for next invoice');
 });

--- a/handlers/discount-api/test/getDiscountFromSubscription.test.ts
+++ b/handlers/discount-api/test/getDiscountFromSubscription.test.ts
@@ -4,13 +4,12 @@ import json from './fixtures/digital-subscriptions/get-discount-test.json';
 
 test('getDiscountFromSubscription should return an annual discount for an annual sub', () => {
 	const sub = zuoraSubscriptionSchema.parse(json);
-	expect(getDiscountFromSubscription('PROD', sub)).toEqual({
+	expect(getDiscountFromSubscription('PROD', sub).discount).toEqual({
 		productRatePlanId: '8a128adf8b64bcfd018b6b6fdc7674f5',
 		name: 'Cancellation Save Discount - 25% off for 12 months',
 		upToPeriods: 12,
 		upToPeriodsType: 'Months',
 		effectiveStartDate: '2023-10-26',
 		effectiveEndDate: '2099-03-08',
-		eligibleProductRatePlanIds: ['2c92a0fb4edd70c8014edeaa4e972204'],
 	});
 });

--- a/modules/arrayFunctions.ts
+++ b/modules/arrayFunctions.ts
@@ -19,17 +19,18 @@ export const groupBy = <T>(
 
 export const getSingleOrThrow = <T>(
 	array: T[],
-	filter: (element: T) => boolean,
+	error: (msg: string) => Error,
+	filter?: (element: T) => boolean,
 ): T => {
-	const matchingElements = array.filter(filter);
+	const matchingElements = filter ? array.filter(filter) : array;
 	if (matchingElements.length > 1) {
-		throw new Error('Array had more than one matching element');
+		throw error('Array had more than one matching element');
 	}
 	if (matchingElements.length < 1) {
-		throw new Error('Array had no matching elements');
+		throw error('Array had no matching elements');
 	}
 	if (!matchingElements[0]) {
-		throw new ReferenceError('Matching element was null or undefined :-s');
+		throw error('Matching element was null or undefined');
 	}
 	return matchingElements[0];
 };

--- a/modules/zuora/src/cancelSubscription.ts
+++ b/modules/zuora/src/cancelSubscription.ts
@@ -15,7 +15,7 @@ export const cancelSubscription = async (
 	const body = JSON.stringify({
 		cancellationEffectiveDate: zuoraDateFormat(contractEffectiveDate),
 		cancellationPolicy: 'SpecificDate',
-		runBilling,
+		runBilling,// for some reason zuora chokes on this here but not when pasted into postman?
 		collect,
 	});
 	return zuoraClient.put(path, body, zuoraSuccessResponseSchema);

--- a/modules/zuora/src/cancelSubscription.ts
+++ b/modules/zuora/src/cancelSubscription.ts
@@ -15,8 +15,10 @@ export const cancelSubscription = async (
 	const body = JSON.stringify({
 		cancellationEffectiveDate: zuoraDateFormat(contractEffectiveDate),
 		cancellationPolicy: 'SpecificDate',
-		runBilling,// for some reason zuora chokes on this here but not when pasted into postman?
+		runBilling,
 		collect,
 	});
-	return zuoraClient.put(path, body, zuoraSuccessResponseSchema);
+	return zuoraClient.put(path, body, zuoraSuccessResponseSchema, {
+		'zuora-version': '211.0',
+	});
 };


### PR DESCRIPTION
The previous code would only allow one discount per frequency.
The eligible rate plans were sitting below the discount.

This PR flips it so each rate plan has an eligible discount attached.

--

There's an element of understanding typescript and the codebase so there may be some refactor that's either as good either way, or there's a reason I haven't noticed.