### PR TITLE
Alarm mappings digital voucher suspension processor

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -79,12 +79,15 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'frontend',
 		'it-test-runner',
 		'stripe-intent',
+		'workers',
+
+		// support-service-lambdas
+		'digital-voucher-suspension-processor',
 
 		// other
 		'canonical-config',
 		'salesforce-disaster-recovery',
 		'salesforce-disaster-recovery-health-check',
-		'workers',
 	],
 };
 

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -123,7 +123,7 @@ Resources:
         For troubleshooting, see
         https://github.com/guardian/support-service-lambdas/blob/main/handlers/digital-voucher-suspension-processor/README.md.
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -128,9 +128,14 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref SuspensionLambda
-      EvaluationPeriods: 1
+      
       MetricName: Errors
       Namespace: AWS/Lambda
+      # We have the alarm only trigger after 2 evaluation periods
+      # We do expect intermittent failures from external APIs,
+      # but they should be fixed on the next run and we want to
+      # pick-up on any sustained issues
+      EvaluationPeriods: 2
       Period: 3600
       Statistic: Sum
       Threshold: 3

--- a/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmountIntegration.test.ts
+++ b/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmountIntegration.test.ts
@@ -1,4 +1,4 @@
-'workers',import console from 'console';
+import console from 'console';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';

--- a/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmountIntegration.test.ts
+++ b/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmountIntegration.test.ts
@@ -1,4 +1,4 @@
-import console from 'console';
+'workers',import console from 'console';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';


### PR DESCRIPTION
- Adds `digital-voucher-suspension-processor` to `PP` alarm mapping.
- Bumps the `EvaluationPeriods: 2` as we expect some runs to fail, and they should be picked up by the next run.