### PR TITLE
Add BadRequest as a possible response from SubscriptionCancelEndpoint

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -68,7 +68,7 @@ object SubscriptionCancelEndpoint {
     run(
       "A-S00878246",
       ExpectedInput(
-        "mma_value_for_money",// valid pick list value
+        "mma_value_for_money", // valid pick list value
       ),
       IdentityId("200235444"),
     ),
@@ -115,6 +115,11 @@ object SubscriptionCancelEndpoint {
               sttp.model.StatusCode.InternalServerError,
               jsonBody[InternalServerError]
                 .copy(info = EndpointIO.Info.empty.copy(description = Some("InternalServerError."))),
+            ),
+            oneOfVariant(
+              sttp.model.StatusCode.BadRequest,
+              jsonBody[BadRequest]
+                .copy(info = EndpointIO.Info.empty.copy(description = Some("Bad request."))),
             ),
           ),
         )


### PR DESCRIPTION
## What does this change?
I have noticed that there are a lot of errors in the logs caused by us returning a BadRequest response from the SubscriptionCancel endpoint of the product-move-api. This is because it has not been added as a valid response to the Tapir configuration, so an exception happens at that point and we ultimately return a 500.
There is an [example of this here](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmove-product-PROD/log-events/2024$252F06$252F03$252F$255B$2524LATEST$255D81597cc3ab8c417c83a671cf18cd7271)

This PR fixes that.