### PR TITLE
Make BillingPeriod an option in the GetSubscription response

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/RecurringContributionToSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/RecurringContributionToSupporterPlus.scala
@@ -78,13 +78,20 @@ class RecurringContributionToSupporterPlusImpl(
             s"Missing or unknown currency ${ratePlanCharge.currency} on rate plan charge in rate plan ${currentRatePlan.id} ",
           ),
         )
+      billingPeriod <- ZIO
+        .fromOption(ratePlanCharge.billingPeriod)
+        .orElseFail(
+          new Throwable(
+            s"Missing billing period on rate plan charge in rate plan $currentRatePlan ",
+          ),
+        )
 
       result <-
         if (postData.preview)
           doPreview(
             SubscriptionName(subscription.id),
             postData.price,
-            ratePlanCharge.billingPeriod,
+            billingPeriod,
             ratePlanCharge,
             currency,
             currentRatePlan.id,
@@ -159,6 +166,13 @@ class RecurringContributionToSupporterPlusImpl(
       )
 
       today <- Clock.currentDateTime.map(_.toLocalDate)
+      billingPeriod <- ZIO
+        .fromOption(ratePlanCharge.billingPeriod)
+        .orElseFail(
+          new Throwable(
+            s"Missing billing period on rate plan charge in rate plan $currentRatePlan ",
+          ),
+        )
       supporterPlusRatePlanIds <- getRatePlans.getSupporterPlusRatePlanIds(billingPeriod)
 
       // To avoid problems with charges not aligning correctly with the term and resulting in unpredictable

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
@@ -67,7 +67,9 @@ class ToRecurringContributionImpl(
 
       price = postData.price
       previousAmount = activeRatePlanCharge.price.get
-      billingPeriod = activeRatePlanCharge.billingPeriod
+      billingPeriod <- ZIO
+        .fromOption(activeRatePlanCharge.billingPeriod)
+        .orElseFail(new Throwable(s"billingPeriod is null for rate plan charge $activeRatePlanCharge"))
 
       updateRequestBody <- getRatePlans(
         billingPeriod,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetSubscription.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetSubscription.scala
@@ -62,7 +62,7 @@ object GetSubscription {
       number: String,
       price: Option[Double],
       currency: String,
-      billingPeriod: BillingPeriod,
+      billingPeriod: Option[BillingPeriod],
       effectiveStartDate: LocalDate,
       chargedThroughDate: Option[LocalDate],
   ) {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -47,7 +47,7 @@ val ratePlanCharge1 = RatePlanCharge(
   effectiveStartDate = LocalDate.of(2017, 12, 15),
   effectiveEndDate = LocalDate.of(2020, 11, 29),
   chargedThroughDate = Some(LocalDate.of(2022, 9, 29)),
-  billingPeriod = Monthly,
+  billingPeriod = Some(Monthly),
 )
 
 val ratePlanCharge2 = RatePlanCharge(
@@ -60,7 +60,7 @@ val ratePlanCharge2 = RatePlanCharge(
   effectiveStartDate = LocalDate.of(2021, 1, 15),
   effectiveEndDate = LocalDate.of(2022, 1, 15),
   chargedThroughDate = Some(LocalDate.of(2021, 2, 15)),
-  billingPeriod = Monthly,
+  billingPeriod = Some(Monthly),
 )
 
 val getSubscriptionResponse = GetSubscriptionResponse(
@@ -153,7 +153,7 @@ val getSubscriptionResponse2 = GetSubscriptionResponse(
           number = "C-00732721",
           price = Some(5.000000000),
           currency = "GBP",
-          billingPeriod = Monthly,
+          billingPeriod = Some(Monthly),
           effectiveStartDate = LocalDate.of(2022, 10, 28),
           effectiveEndDate = LocalDate.of(2022, 10, 28),
           chargedThroughDate = Some(LocalDate.of(2022, 10, 28)),
@@ -174,7 +174,7 @@ val getSubscriptionResponse2 = GetSubscriptionResponse(
           number = "C-00732747",
           price = Some(30.000000000),
           currency = "GBP",
-          billingPeriod = Monthly,
+          billingPeriod = Some(Monthly),
           chargedThroughDate = Some(LocalDate.of(2022, 11, 28)),
           effectiveStartDate = LocalDate.of(2022, 10, 28),
           effectiveEndDate = LocalDate.of(2023, 10, 28),
@@ -227,7 +227,7 @@ val getSubscriptionResponseNoChargedThroughDate = GetSubscriptionResponse(
           effectiveStartDate = LocalDate.of(2017, 12, 15),
           effectiveEndDate = LocalDate.of(2020, 11, 29),
           chargedThroughDate = None,
-          billingPeriod = Monthly,
+          billingPeriod = Some(Monthly),
         ),
       ),
     ),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The GetSubscriptionResponse model used by the product-move-api expects that all rateplan charge objects will have a billing period set, however some (for instance the old membership Friend rate plan) have a null billing period and this was causing crashes.

This PR makes billing period optional in the model