### PR TITLE
feat: add payment-api to alarmMappings

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -80,6 +80,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'it-test-runner',
 		'stripe-intent',
 		'workers',
+		'payment-api',
 
 		// support-service-lambdas
 		'digital-voucher-suspension-processor',


### PR DESCRIPTION
Adds [`payment-api`](https://github.com/guardian/support-frontend/pull/6076) to `PP` alarms mappings