### PR TITLE
Add new fields to discount-api responses

### DIFF
--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -19,16 +19,12 @@ import dayjs from 'dayjs';
 import { EligibilityChecker } from './eligibilityChecker';
 import type { Discount } from './productToDiscountMapping';
 import { getDiscountFromSubscription } from './productToDiscountMapping';
-import type {
-	ApplyDiscountResponseBody,
-	EligibilityCheckResponseBody,
-} from './responseSchema';
 
 export const previewDiscountEndpoint = async (
 	stage: Stage,
 	headers: APIGatewayProxyEventHeaders,
 	subscriptionNumber: string,
-): Promise<EligibilityCheckResponseBody> => {
+) => {
 	const zuoraClient = await ZuoraClient.create(stage);
 
 	const { discount, dateToApply } = await getDiscountToApply(
@@ -51,7 +47,7 @@ export const applyDiscountEndpoint = async (
 	stage: Stage,
 	headers: APIGatewayProxyEventHeaders,
 	subscriptionNumber: string,
-): Promise<ApplyDiscountResponseBody> => {
+) => {
 	const zuoraClient = await ZuoraClient.create(stage);
 
 	const { subscription, discount, dateToApply } = await getDiscountToApply(

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -15,7 +15,6 @@ import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
 import { getZuoraCatalog } from '@modules/zuora-catalog/S3';
 import type { APIGatewayProxyEventHeaders } from 'aws-lambda';
-import type { ManipulateType } from 'dayjs';
 import dayjs from 'dayjs';
 import { EligibilityChecker } from './eligibilityChecker';
 import { getDiscountFromSubscription } from './productToDiscountMapping';
@@ -64,9 +63,8 @@ export const previewDiscountEndpoint = async (
 			'only discounts measured in months are supported in this version of discount-api',
 		);
 	}
-	const unit: ManipulateType = 'month';
 	const nextNonDiscountedPaymentDate = zuoraDateFormat(
-		dayjs(dateToApply).add(discount.upToPeriods, unit),
+		dayjs(dateToApply).add(discount.upToPeriods, 'month'),
 	);
 
 	return {

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -130,7 +130,7 @@ const getDiscountPreview = async (
 	const firstDiscountedPaymentDate = zuoraDateFormat(dayjs(nextBillingDate));
 	if (discount.upToPeriodsType !== 'Months') {
 		throw new Error(
-			'only month discount is supported, consider using a billing preview',
+			'only discounts measured in months are supported in this version of discount-api',
 		);
 	}
 	const unit: ManipulateType = 'month';

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -17,10 +17,8 @@ import { getZuoraCatalog } from '@modules/zuora-catalog/S3';
 import type { APIGatewayProxyEventHeaders } from 'aws-lambda';
 import dayjs from 'dayjs';
 import { EligibilityChecker } from './eligibilityChecker';
-import {
-	Discount,
-	getDiscountFromSubscription,
-} from './productToDiscountMapping';
+import type { Discount } from './productToDiscountMapping';
+import { getDiscountFromSubscription } from './productToDiscountMapping';
 import type {
 	ApplyDiscountResponseBody,
 	EligibilityCheckResponseBody,

--- a/handlers/discount-api/src/eligibilityChecker.ts
+++ b/handlers/discount-api/src/eligibilityChecker.ts
@@ -1,7 +1,9 @@
-import { sum } from '@modules/arrayFunctions';
 import { ValidationError } from '@modules/errors';
 import { checkDefined } from '@modules/nullAndUndefined';
-import { getNextInvoiceItems } from '@modules/zuora/billingPreview';
+import {
+	billingPreviewToRecords,
+	getNextInvoiceTotal,
+} from '@modules/zuora/billingPreview';
 import type { BillingPreview, RatePlan } from '@modules/zuora/zuoraSchemas';
 import type { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
 
@@ -39,23 +41,19 @@ export class EligibilityChecker {
 		);
 
 		// Work out how much the cost of the next invoice will be
-		const nextInvoiceItems = checkDefined(
-			getNextInvoiceItems(billingPreview),
+		const nextInvoiceTotal = checkDefined(
+			getNextInvoiceTotal(billingPreviewToRecords(billingPreview)),
 			`No next invoice found for account ${billingPreview.accountId}`,
 		);
-		const nextInvoiceTotal = sum(
-			nextInvoiceItems,
-			(item) => item.chargeAmount + item.taxAmount,
-		);
 
-		if (nextInvoiceTotal < totalPrice) {
+		if (nextInvoiceTotal.total < totalPrice) {
 			throw new ValidationError(
-				`Amount payable for next invoice (${nextInvoiceTotal} ${currency}) is less than the current 
+				`Amount payable for next invoice (${nextInvoiceTotal.total} ${currency}) is less than the current 
 				catalog price of the subscription (${totalPrice} ${currency}), so it is not eligible for a discount`,
 			);
 		}
 		return checkDefined(
-			nextInvoiceItems[0]?.serviceStartDate,
+			nextInvoiceTotal.date,
 			'No next invoice date found in next invoice items',
 		);
 	};

--- a/handlers/discount-api/src/index.ts
+++ b/handlers/discount-api/src/index.ts
@@ -22,11 +22,29 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 		switch (true) {
 			case event.path === '/apply-discount' && event.httpMethod === 'POST': {
 				console.log('Applying a discount');
-				return await discountEndpoint(stage, false, event.headers, event.body);
+				const result = await discountEndpoint(
+					stage,
+					false,
+					event.headers,
+					event.body,
+				);
+				return {
+					body: JSON.stringify(result),
+					statusCode: 200,
+				};
 			}
 			case event.path === '/preview-discount' && event.httpMethod === 'POST': {
 				console.log('Previewing discount');
-				return await discountEndpoint(stage, true, event.headers, event.body);
+				const result = await discountEndpoint(
+					stage,
+					true,
+					event.headers,
+					event.body,
+				);
+				return {
+					body: JSON.stringify(result),
+					statusCode: 200,
+				};
 			}
 			default:
 				return {

--- a/handlers/discount-api/src/index.ts
+++ b/handlers/discount-api/src/index.ts
@@ -26,6 +26,9 @@ export const handler: Handler = async (
 	return response;
 };
 
+// this is a type safe version of stringify
+const stringify = <T>(t: T): string => JSON.stringify(t);
+
 const routeRequest = async (event: APIGatewayProxyEvent) => {
 	try {
 		switch (true) {
@@ -34,13 +37,13 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 				const subscriptionNumber = applyDiscountSchema.parse(
 					JSON.parse(getIfDefined(event.body, 'No body was provided')),
 				).subscriptionNumber;
-				const result: ApplyDiscountResponseBody = await applyDiscountEndpoint(
+				const result = await applyDiscountEndpoint(
 					stage,
 					event.headers,
 					subscriptionNumber,
 				);
 				return {
-					body: JSON.stringify(result),
+					body: stringify<ApplyDiscountResponseBody>(result),
 					statusCode: 200,
 				};
 			}
@@ -49,14 +52,13 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 				const subscriptionNumber = applyDiscountSchema.parse(
 					JSON.parse(getIfDefined(event.body, 'No body was provided')),
 				).subscriptionNumber;
-				const result: EligibilityCheckResponseBody =
-					await previewDiscountEndpoint(
-						stage,
-						event.headers,
-						subscriptionNumber,
-					);
+				const result = await previewDiscountEndpoint(
+					stage,
+					event.headers,
+					subscriptionNumber,
+				);
 				return {
-					body: JSON.stringify(result),
+					body: stringify<EligibilityCheckResponseBody>(result),
 					statusCode: 200,
 				};
 			}

--- a/handlers/discount-api/src/responseSchema.ts
+++ b/handlers/discount-api/src/responseSchema.ts
@@ -4,8 +4,16 @@ export const previewDiscountSchema = z.object({
 	discountedPrice: z.number(),
 	upToPeriods: z.number(),
 	upToPeriodsType: z.string(),
+	firstDiscountedPaymentDate: z.string(),
+	nextNonDiscountedPaymentDate: z.string(),
 });
 
 export type EligibilityCheckResponseBody = z.infer<
 	typeof previewDiscountSchema
 >;
+
+export const applyDiscountSchema = z.object({
+	nextPaymentDate: z.string(),
+});
+
+export type ApplyDiscountResponseBody = z.infer<typeof applyDiscountSchema>;

--- a/handlers/discount-api/test/addDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/addDiscountIntegration.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Creates test subscriptions in various state to test the price rise logic
+ *
+ * @group integration
+ */
+
+import type { Stage } from '@modules/stage';
+import { addDiscount } from '@modules/zuora/addDiscount';
+import { getSubscription } from '@modules/zuora/getSubscription';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import dayjs from 'dayjs';
+import { createDigitalSubscription, doPriceRise } from './helpers';
+
+const stage: Stage = 'CODE';
+const subscribeDate = dayjs();
+const nextBillingDate = subscribeDate.add(1, 'month');
+
+test('createDigitalSubscription', async () => {
+	const zuoraClient = await ZuoraClient.create(stage);
+
+	console.log('Creating a new digital subscription');
+	const subscriptionNumber = await createDigitalSubscription(
+		zuoraClient,
+		false,
+	);
+
+	console.log('Getting the subscription details from Zuora');
+	const subscription = await getSubscription(zuoraClient, subscriptionNumber);
+
+	expect(subscription.subscriptionNumber).toEqual(subscriptionNumber);
+}, 30000);
+
+test('createPriceRiseSubscription', async () => {
+	const zuoraClient = await ZuoraClient.create(stage);
+
+	console.log('Creating a new digital subscription');
+	const subscriptionNumber = await createDigitalSubscription(zuoraClient, true);
+
+	console.log('Getting the subscription details from Zuora');
+	const subscription = await getSubscription(zuoraClient, subscriptionNumber);
+
+	console.log('Updating the subscription to trigger a price rise');
+	const priceRisen = await doPriceRise(
+		zuoraClient,
+		subscription,
+		nextBillingDate,
+	);
+
+	expect(priceRisen.success).toEqual(true);
+
+	console.log('Apply a discount to the subscription');
+	const discounted = await addDiscount(
+		zuoraClient,
+		subscriptionNumber,
+		dayjs(subscription.termStartDate),
+		dayjs(subscription.termEndDate),
+		nextBillingDate,
+		'8ad09be48b23d33f018b23e53afd522d',
+	);
+
+	expect(discounted.success).toEqual(true);
+}, 30000);

--- a/handlers/discount-api/test/applyDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/applyDiscountIntegration.test.ts
@@ -7,8 +7,7 @@ import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
 import { applyDiscountEndpoint } from '../src/discountEndpoint';
 import { ApplyDiscountResponseBody } from '../src/responseSchema';
-import { createSubscription } from './helpers';
-import { supporterPlusSubscribeBody } from './fixtures/request-bodies/supporterplus-subscribe-body-tier2';
+import { createSupporterPlusSubscription } from './helpers';
 import { zuoraDateFormat } from '@modules/zuora/common';
 
 const stage: Stage = 'CODE';
@@ -21,10 +20,7 @@ test('Supporter Plus subscriptions can have a discount', async () => {
 	const paymentDate = today.add(16, 'day');
 
 	console.log('Creating a new S+ subscription');
-	const subscriptionNumber = await createSubscription(
-		zuoraClient,
-		supporterPlusSubscribeBody(today),
-	);
+	const subscriptionNumber = await createSupporterPlusSubscription(zuoraClient);
 
 	const result = await applyDiscountEndpoint(
 		stage,

--- a/handlers/discount-api/test/applyDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/applyDiscountIntegration.test.ts
@@ -5,7 +5,7 @@ import type { Stage } from '@modules/stage';
 import { cancelSubscription } from '@modules/zuora/cancelSubscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
-import { discountEndpoint } from '../src/discountEndpoint';
+import { applyDiscountEndpoint } from '../src/discountEndpoint';
 import { ApplyDiscountResponseBody } from '../src/responseSchema';
 import { createSubscription } from './helpers';
 import { supporterPlusSubscribeBody } from './fixtures/request-bodies/supporterplus-subscribe-body-tier2';
@@ -26,16 +26,10 @@ test('Supporter Plus subscriptions can have a discount', async () => {
 		supporterPlusSubscribeBody(today),
 	);
 
-	const requestBody = {
-		subscriptionNumber: subscriptionNumber,
-		preview: true,
-	};
-
-	const result = await discountEndpoint(
+	const result = await applyDiscountEndpoint(
 		stage,
-		false,
 		{ 'x-identity-id': validIdentityId },
-		JSON.stringify(requestBody),
+		subscriptionNumber,
 	);
 	const eligibilityCheckResult = result as ApplyDiscountResponseBody;
 

--- a/handlers/discount-api/test/getNextPaymentDate.test.ts
+++ b/handlers/discount-api/test/getNextPaymentDate.test.ts
@@ -1,6 +1,6 @@
 import { getNextNonFreePaymentDate } from '@modules/zuora/billingPreview';
 
-test('getNextPaymentDate fails if there are no payments in the preview', () => {
+test('getNextNonFreePaymentDate fails if all payments are free', () => {
 	const items = [
 		{ date: new Date('2020-02-01'), amount: 0 },
 		{ date: new Date('2020-01-01'), amount: 0 },
@@ -14,7 +14,7 @@ test('getNextPaymentDate fails if there are no payments in the preview', () => {
 	);
 });
 
-test('getNextPaymentDate finds the relevant payment', () => {
+test('getNextNonFreePaymentDate finds the relevant payment', () => {
 	const items = [
 		{ date: new Date('2020-01-01'), amount: 0 },
 		{ date: new Date('2020-02-01'), amount: 10 },
@@ -26,7 +26,7 @@ test('getNextPaymentDate finds the relevant payment', () => {
 	expect(actual).toEqual('2020-02-01');
 });
 
-test('getNextPaymentDate finds the relevant payment in reverse order', () => {
+test('getNextNonFreePaymentDate finds the relevant payment in reverse order', () => {
 	const items = [
 		{ date: new Date('2020-03-01'), amount: 10 },
 		{ date: new Date('2020-02-01'), amount: 10 },
@@ -38,7 +38,7 @@ test('getNextPaymentDate finds the relevant payment in reverse order', () => {
 	expect(actual).toEqual('2020-02-01');
 });
 
-test('getNextPaymentDate finds the relevant payment even if theres duplicates', () => {
+test('getNextNonFreePaymentDate finds the relevant payment even if theres duplicates', () => {
 	const items = [
 		{ date: new Date('2020-01-01'), amount: 0 },
 		{ date: new Date('2020-02-01'), amount: 0 },
@@ -51,7 +51,7 @@ test('getNextPaymentDate finds the relevant payment even if theres duplicates', 
 	expect(actual).toEqual('2020-02-01');
 });
 
-test('getNextPaymentDate finds the relevant payment in reverse order even if theres duplicates', () => {
+test('getNextNonFreePaymentDate finds the relevant payment in reverse order even if theres duplicates', () => {
 	const items = [
 		{ date: new Date('2020-03-01'), amount: 10 },
 		{ date: new Date('2020-02-01'), amount: 10 },

--- a/handlers/discount-api/test/getNextPaymentDate.test.ts
+++ b/handlers/discount-api/test/getNextPaymentDate.test.ts
@@ -1,0 +1,63 @@
+import { getNextNonFreePaymentDate } from '../src/discountEndpoint';
+
+test('getNextPaymentDate fails if there are no payments in the preview', () => {
+	const items = [
+		{ date: new Date('2020-02-01'), amount: 0 },
+		{ date: new Date('2020-01-01'), amount: 0 },
+		{ date: new Date('2020-01-01'), amount: 0 },
+	];
+
+	const actual = () => getNextNonFreePaymentDate(items);
+
+	expect(actual).toThrow('could not find a non free payment in the preview');
+});
+
+test('getNextPaymentDate finds the relevant payment', () => {
+	const items = [
+		{ date: new Date('2020-01-01'), amount: 0 },
+		{ date: new Date('2020-02-01'), amount: 10 },
+		{ date: new Date('2020-03-01'), amount: 10 },
+	];
+
+	const actual = getNextNonFreePaymentDate(items);
+
+	expect(actual).toEqual('2020-02-01');
+});
+
+test('getNextPaymentDate finds the relevant payment in reverse order', () => {
+	const items = [
+		{ date: new Date('2020-03-01'), amount: 10 },
+		{ date: new Date('2020-02-01'), amount: 10 },
+		{ date: new Date('2020-01-01'), amount: 0 },
+	];
+
+	const actual = getNextNonFreePaymentDate(items);
+
+	expect(actual).toEqual('2020-02-01');
+});
+
+test('getNextPaymentDate finds the relevant payment even if theres duplicates', () => {
+	const items = [
+		{ date: new Date('2020-01-01'), amount: 0 },
+		{ date: new Date('2020-02-01'), amount: 0 },
+		{ date: new Date('2020-02-01'), amount: 10 },
+		{ date: new Date('2020-03-01'), amount: 10 },
+	];
+
+	const actual = getNextNonFreePaymentDate(items);
+
+	expect(actual).toEqual('2020-02-01');
+});
+
+test('getNextPaymentDate finds the relevant payment in reverse order even if theres duplicates', () => {
+	const items = [
+		{ date: new Date('2020-03-01'), amount: 10 },
+		{ date: new Date('2020-02-01'), amount: 10 },
+		{ date: new Date('2020-02-01'), amount: 0 },
+		{ date: new Date('2020-01-01'), amount: 0 },
+	];
+
+	const actual = getNextNonFreePaymentDate(items);
+
+	expect(actual).toEqual('2020-02-01');
+});

--- a/handlers/discount-api/test/getNextPaymentDate.test.ts
+++ b/handlers/discount-api/test/getNextPaymentDate.test.ts
@@ -1,4 +1,4 @@
-import { getNextNonFreePaymentDate } from '../src/discountEndpoint';
+import { getNextNonFreePaymentDate } from '@modules/zuora/billingPreview';
 
 test('getNextPaymentDate fails if there are no payments in the preview', () => {
 	const items = [
@@ -9,7 +9,9 @@ test('getNextPaymentDate fails if there are no payments in the preview', () => {
 
 	const actual = () => getNextNonFreePaymentDate(items);
 
-	expect(actual).toThrow('could not find a non free payment in the preview');
+	expect(actual).toThrow(
+		'could not find a non free payment in the invoice preview',
+	);
 });
 
 test('getNextPaymentDate finds the relevant payment', () => {

--- a/handlers/discount-api/test/helpers.ts
+++ b/handlers/discount-api/test/helpers.ts
@@ -12,11 +12,12 @@ import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 import { digiSubSubscribeBody } from './fixtures/request-bodies/digitalSub-subscribe-body-old-price';
 import { updateSubscriptionBody } from './fixtures/request-bodies/update-subscription-body';
+import { checkDefined } from '@modules/nullAndUndefined';
 
 export const createDigitalSubscription = async (
 	zuoraClient: ZuoraClient,
 	createWithOldPrice: boolean,
-): Promise<ZuoraSubscribeResponse> => {
+): Promise<string> => {
 	return await createSubscription(
 		zuoraClient,
 		digiSubSubscribeBody(dayjs(), createWithOldPrice),
@@ -80,11 +81,20 @@ export const createSubscription = async (
 			};
 		}[];
 	},
-): Promise<ZuoraSubscribeResponse> => {
+): Promise<string> => {
 	const path = `/v1/action/subscribe`;
 	const body = JSON.stringify(subscribeBody);
 
-	return zuoraClient.post(path, body, zuoraSubscribeResponseSchema);
+	const subscribeResponse: ZuoraSubscribeResponse = await zuoraClient.post(
+		path,
+		body,
+		zuoraSubscribeResponseSchema,
+	);
+
+	return checkDefined(
+		subscribeResponse[0]?.SubscriptionNumber,
+		'SubscriptionNumber was undefined in response from Zuora',
+	);
 };
 
 export const doPriceRise = async (

--- a/handlers/discount-api/test/helpers.ts
+++ b/handlers/discount-api/test/helpers.ts
@@ -13,18 +13,37 @@ import type { Dayjs } from 'dayjs';
 import { digiSubSubscribeBody } from './fixtures/request-bodies/digitalSub-subscribe-body-old-price';
 import { updateSubscriptionBody } from './fixtures/request-bodies/update-subscription-body';
 import { checkDefined } from '@modules/nullAndUndefined';
+import { supporterPlusSubscribeBody } from './fixtures/request-bodies/supporterplus-subscribe-body-tier2';
 
 export const createDigitalSubscription = async (
 	zuoraClient: ZuoraClient,
 	createWithOldPrice: boolean,
 ): Promise<string> => {
-	return await createSubscription(
+	const subscribeResponse = await subscribe(
 		zuoraClient,
 		digiSubSubscribeBody(dayjs(), createWithOldPrice),
 	);
+	return checkDefined(
+		subscribeResponse[0]?.SubscriptionNumber,
+		'SubscriptionNumber was undefined in response from Zuora',
+	);
 };
 
-export const createSubscription = async (
+export const createSupporterPlusSubscription = async (
+	zuoraClient: ZuoraClient,
+): Promise<string> => {
+	const subscribeResponse = await subscribe(
+		zuoraClient,
+		supporterPlusSubscribeBody(dayjs()),
+	);
+
+	return checkDefined(
+		subscribeResponse[0]?.SubscriptionNumber,
+		'SubscriptionNumber was undefined in response from Zuora',
+	);
+};
+
+async function subscribe(
 	zuoraClient: ZuoraClient,
 	subscribeBody: {
 		subscribes: {
@@ -81,7 +100,7 @@ export const createSubscription = async (
 			};
 		}[];
 	},
-): Promise<string> => {
+) {
 	const path = `/v1/action/subscribe`;
 	const body = JSON.stringify(subscribeBody);
 
@@ -90,12 +109,8 @@ export const createSubscription = async (
 		body,
 		zuoraSubscribeResponseSchema,
 	);
-
-	return checkDefined(
-		subscribeResponse[0]?.SubscriptionNumber,
-		'SubscriptionNumber was undefined in response from Zuora',
-	);
-};
+	return subscribeResponse;
+}
 
 export const doPriceRise = async (
 	zuoraClient: ZuoraClient,

--- a/handlers/discount-api/test/previewDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/previewDiscountIntegration.test.ts
@@ -7,8 +7,10 @@ import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
 import { previewDiscountEndpoint } from '../src/discountEndpoint';
 import { EligibilityCheckResponseBody } from '../src/responseSchema';
-import { createDigitalSubscription, createSubscription } from './helpers';
-import { supporterPlusSubscribeBody } from './fixtures/request-bodies/supporterplus-subscribe-body-tier2';
+import {
+	createDigitalSubscription,
+	createSupporterPlusSubscription,
+} from './helpers';
 import { zuoraDateFormat } from '@modules/zuora/common';
 
 const stage: Stage = 'CODE';
@@ -107,10 +109,7 @@ test('Supporter Plus subscriptions are eligible', async () => {
 	const paymentDate = today.add(16, 'day');
 
 	console.log('Creating a new S+ subscription');
-	const subscriptionNumber = await createSubscription(
-		zuoraClient,
-		supporterPlusSubscribeBody(today),
-	);
+	const subscriptionNumber = await createSupporterPlusSubscription(zuoraClient);
 
 	const result = await previewDiscountEndpoint(
 		stage,

--- a/handlers/discount-api/test/previewDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/previewDiscountIntegration.test.ts
@@ -5,7 +5,7 @@ import type { Stage } from '@modules/stage';
 import { cancelSubscription } from '@modules/zuora/cancelSubscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
-import { discountEndpoint } from '../src/discountEndpoint';
+import { previewDiscountEndpoint } from '../src/discountEndpoint';
 import { EligibilityCheckResponseBody } from '../src/responseSchema';
 import { createDigitalSubscription, createSubscription } from './helpers';
 import { supporterPlusSubscribeBody } from './fixtures/request-bodies/supporterplus-subscribe-body-tier2';
@@ -21,17 +21,11 @@ test("Subscriptions which don't belong to the provided identity Id are not eligi
 	console.log('Creating a new digital subscription');
 	const subscriptionNumber = await createDigitalSubscription(zuoraClient, true);
 
-	const requestBody = {
-		subscriptionNumber: subscriptionNumber,
-		preview: true,
-	};
-
 	await expect(async () => {
-		await discountEndpoint(
+		await previewDiscountEndpoint(
 			stage,
-			true,
 			{ 'x-identity-id': invalidIdentityId },
-			JSON.stringify(requestBody),
+			subscriptionNumber,
 		);
 	}).rejects.toThrow('does not belong to identity ID');
 
@@ -50,17 +44,11 @@ test('Subscriptions on the old price are not eligible', async () => {
 	console.log('Creating a new digital subscription');
 	const subscriptionNumber = await createDigitalSubscription(zuoraClient, true);
 
-	const requestBody = {
-		subscriptionNumber: subscriptionNumber,
-		preview: true,
-	};
-
 	await expect(async () => {
-		await discountEndpoint(
+		await previewDiscountEndpoint(
 			stage,
-			true,
 			{ 'x-identity-id': validIdentityId },
-			JSON.stringify(requestBody),
+			subscriptionNumber,
 		);
 	}).rejects.toThrow('it is not eligible for a discount');
 
@@ -86,16 +74,10 @@ test('Subscriptions on the new price are eligible', async () => {
 		false,
 	);
 
-	const requestBody = {
-		subscriptionNumber: subscriptionNumber,
-		preview: true,
-	};
-
-	const result = await discountEndpoint(
+	const result = await previewDiscountEndpoint(
 		stage,
-		true,
 		{ 'x-identity-id': validIdentityId },
-		JSON.stringify(requestBody),
+		subscriptionNumber,
 	);
 	const eligibilityCheckResult = result as EligibilityCheckResponseBody;
 
@@ -130,16 +112,10 @@ test('Supporter Plus subscriptions are eligible', async () => {
 		supporterPlusSubscribeBody(today),
 	);
 
-	const requestBody = {
-		subscriptionNumber: subscriptionNumber,
-		preview: true,
-	};
-
-	const result = await discountEndpoint(
+	const result = await previewDiscountEndpoint(
 		stage,
-		true,
 		{ 'x-identity-id': validIdentityId },
-		JSON.stringify(requestBody),
+		subscriptionNumber,
 	);
 	const eligibilityCheckResult = result as EligibilityCheckResponseBody;
 

--- a/modules/arrayFunctions.ts
+++ b/modules/arrayFunctions.ts
@@ -17,6 +17,16 @@ export const groupBy = <T>(
 	}, {});
 };
 
+export const sortBy = <T>(array: T[], fn: (item: T) => string): T[] => {
+	return array.sort((posGT, negGT) => {
+		const posGTKey = fn(posGT);
+		const negGTKey = fn(negGT);
+		if (posGTKey > negGTKey) return 1;
+		else if (posGTKey < negGTKey) return -1;
+		else return 0;
+	});
+};
+
 export const getSingleOrThrow = <T>(
 	array: T[],
 	error: (msg: string) => Error,

--- a/modules/zuora/src/billingPreview.ts
+++ b/modules/zuora/src/billingPreview.ts
@@ -66,10 +66,8 @@ function getOrderedInvoiceData(
 }
 
 export function billingPreviewToRecords(billingPreviewAfter: BillingPreview) {
-	return billingPreviewAfter.invoiceItems.map((entry) => {
-		return {
-			date: entry.serviceStartDate,
-			amount: entry.chargeAmount + entry.taxAmount,
-		};
-	});
+	return billingPreviewAfter.invoiceItems.map((entry) => ({
+		date: entry.serviceStartDate,
+		amount: entry.chargeAmount + entry.taxAmount,
+	}));
 }

--- a/modules/zuora/src/billingPreview.ts
+++ b/modules/zuora/src/billingPreview.ts
@@ -50,8 +50,8 @@ export function getNextNonFreePaymentDate(
 function getOrderedInvoiceData(
 	invoiceItems: Array<{ date: Date; amount: number }>,
 ) {
-	const grouped = groupBy(invoiceItems, (ii) => {
-		return zuoraDateFormat(dayjs(ii.date));
+	const grouped = groupBy(invoiceItems, (invoiceItem) => {
+		return zuoraDateFormat(dayjs(invoiceItem.date));
 	});
 
 	const ordered = sortBy(Object.entries(grouped), (item) => item[0]).map(


### PR DESCRIPTION
This PR adds the new fields needed in discount-api preview and apply discount responses.  cc @rBangay 

The idea is to display more information in the flow about the actual dates involved, so that the user can understand what they are agreeing to.

As always I'm a TS novice so no comment is too small to make!

Tested and working in CODE on a new supporter plus.
```
{
    "nextPaymentDate": "2024-09-11"
}
```