### PR TITLE
send confirmation email when suspending s+

### DIFF
--- a/handlers/discount-api/src/index.ts
+++ b/handlers/discount-api/src/index.ts
@@ -1,3 +1,4 @@
+import { sendEmail } from '@modules/email/email';
 import { ValidationError } from '@modules/errors';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import type { Stage } from '@modules/stage';
@@ -37,13 +38,16 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 				const subscriptionNumber = applyDiscountSchema.parse(
 					JSON.parse(getIfDefined(event.body, 'No body was provided')),
 				).subscriptionNumber;
-				const result = await applyDiscountEndpoint(
+				const { response, emailPayload } = await applyDiscountEndpoint(
 					stage,
 					event.headers,
 					subscriptionNumber,
 				);
+				if (emailPayload) {
+					await sendEmail(stage, emailPayload);
+				}
 				return {
-					body: stringify<ApplyDiscountResponseBody>(result),
+					body: stringify<ApplyDiscountResponseBody>(response),
 					statusCode: 200,
 				};
 			}

--- a/handlers/discount-api/src/productToDiscountMapping.ts
+++ b/handlers/discount-api/src/productToDiscountMapping.ts
@@ -37,6 +37,7 @@ export type Discount = {
 	name: string;
 	upToPeriods: number;
 	upToPeriodsType: string;
+	sendEmail: boolean;
 };
 
 export const catalog = {
@@ -71,18 +72,21 @@ const Discounts: {
 			name: 'Cancellation Save Discount - 25% off for 3 months',
 			upToPeriods: 3,
 			upToPeriodsType: 'Months',
+			sendEmail: false,
 		},
 		cancellation25pc12mo: {
 			productRatePlanId: '8ad08f068b5b9ca2018b5cadf0897ed3',
 			name: 'Cancellation Save Discount - 25% off for 12 months',
 			upToPeriods: 12,
 			upToPeriodsType: 'Months',
+			sendEmail: false,
 		},
 		cancellationFree2Mo: {
 			productRatePlanId: '8ad081dd8fd3d9df018fe2b6a7bc379d',
 			name: 'Cancellation Save Discount - Free for 2 months',
 			upToPeriods: 2,
 			upToPeriodsType: 'Months',
+			sendEmail: true,
 		},
 	},
 	PROD: {
@@ -91,18 +95,21 @@ const Discounts: {
 			name: 'Cancellation Save Discount - 25% off for 3 months',
 			upToPeriods: 3,
 			upToPeriodsType: 'Months',
+			sendEmail: false,
 		},
 		cancellation25pc12mo: {
 			productRatePlanId: '8a128adf8b64bcfd018b6b6fdc7674f5',
 			name: 'Cancellation Save Discount - 25% off for 12 months',
 			upToPeriods: 12,
 			upToPeriodsType: 'Months',
+			sendEmail: false,
 		},
 		cancellationFree2Mo: {
 			productRatePlanId: '8a1299c28fb956e8018fe2c0e12c3ae4',
 			name: 'Cancellation Save Discount - Free for 2 months',
 			upToPeriods: 2,
 			upToPeriodsType: 'Months',
+			sendEmail: true,
 		},
 	},
 };

--- a/handlers/discount-api/src/sendCancellationDiscountConfirmationEmail.ts
+++ b/handlers/discount-api/src/sendCancellationDiscountConfirmationEmail.ts
@@ -1,0 +1,41 @@
+import type { EmailMessageWithUserId } from '@modules/email/email';
+import { DataExtensionNames } from '@modules/email/email';
+import type dayjs from 'dayjs';
+
+export type EmailFields = {
+	firstDiscountedPaymentDate: dayjs.Dayjs;
+	nextNonDiscountedPaymentDate: dayjs.Dayjs;
+	emailAddress: string;
+	firstName: string;
+	lastName: string;
+	identityId: string;
+};
+
+export const sendCancellationDiscountEmail = ({
+	firstDiscountedPaymentDate,
+	nextNonDiscountedPaymentDate,
+	emailAddress,
+	firstName,
+	lastName,
+	identityId,
+}: EmailFields) => {
+	const emailMessage: EmailMessageWithUserId = {
+		To: {
+			Address: emailAddress,
+			ContactAttributes: {
+				SubscriberAttributes: {
+					first_name: firstName,
+					last_name: lastName,
+					first_discounted_payment_date:
+						firstDiscountedPaymentDate.format('DD MMMM YYYY'),
+					next_non_discounted_payment_date:
+						nextNonDiscountedPaymentDate.format('DD MMMM YYYY'),
+				},
+			},
+		},
+		DataExtensionName: DataExtensionNames.cancellationDiscountConfirmation,
+		IdentityUserId: identityId,
+	};
+
+	return emailMessage;
+};

--- a/handlers/discount-api/test/applyDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/applyDiscountIntegration.test.ts
@@ -7,32 +7,87 @@ import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
 import { applyDiscountEndpoint } from '../src/discountEndpoint';
 import { ApplyDiscountResponseBody } from '../src/responseSchema';
-import { createSupporterPlusSubscription } from './helpers';
+import {
+	createDigitalSubscription,
+	createSupporterPlusSubscription,
+} from './helpers';
 import { zuoraDateFormat } from '@modules/zuora/common';
+import { EmailMessageWithUserId } from '@modules/email/email';
 
 const stage: Stage = 'CODE';
 const validIdentityId = '200175946';
 
-test('Supporter Plus subscriptions can have a discount', async () => {
+test('Supporter Plus subscriptions can have a discount and get an email', async () => {
 	const zuoraClient = await ZuoraClient.create(stage);
-
 	const today = dayjs();
+
 	const paymentDate = today.add(16, 'day');
 
 	console.log('Creating a new S+ subscription');
 	const subscriptionNumber = await createSupporterPlusSubscription(zuoraClient);
 
-	const result = await applyDiscountEndpoint(
+	const { response, emailPayload } = await applyDiscountEndpoint(
 		stage,
 		{ 'x-identity-id': validIdentityId },
 		subscriptionNumber,
 	);
-	const eligibilityCheckResult = result as ApplyDiscountResponseBody;
 
 	const expected: ApplyDiscountResponseBody = {
 		nextPaymentDate: zuoraDateFormat(paymentDate.add(2, 'months')),
 	};
-	expect(eligibilityCheckResult).toEqual(expected);
+	const expectedEmail: EmailMessageWithUserId = {
+		To: {
+			Address: 'test.user@thegulocal.com',
+			ContactAttributes: {
+				SubscriberAttributes: {
+					first_name: 'Test',
+					last_name: 'User',
+					first_discounted_payment_date: paymentDate.format('DD MMMM YYYY'),
+					next_non_discounted_payment_date: paymentDate
+						.add(2, 'months')
+						.format('DD MMMM YYYY'),
+				},
+			},
+		},
+		DataExtensionName: 'cancellation-discount-confirmation-email',
+		IdentityUserId: '200175946',
+	};
+
+	expect(response as ApplyDiscountResponseBody).toEqual(expected);
+	expect(emailPayload).toEqual(expectedEmail);
+
+	console.log('Cancelling the subscription');
+	const cancellationResult = await cancelSubscription(
+		zuoraClient,
+		subscriptionNumber,
+		dayjs().add(1, 'month'),
+		true,
+	);
+	expect(cancellationResult.success).toEqual(true);
+}, 30000);
+
+test('digi subs can have a discount but dont get an email', async () => {
+	const zuoraClient = await ZuoraClient.create(stage);
+	const today = dayjs();
+
+	console.log('Creating a new digital subscription');
+	const subscriptionNumber = await createDigitalSubscription(
+		zuoraClient,
+		false,
+	);
+
+	const { response, emailPayload } = await applyDiscountEndpoint(
+		stage,
+		{ 'x-identity-id': validIdentityId },
+		subscriptionNumber,
+	);
+
+	const expected: ApplyDiscountResponseBody = {
+		nextPaymentDate: zuoraDateFormat(today.add(16, 'day')),
+	};
+
+	expect(response as ApplyDiscountResponseBody).toEqual(expected);
+	expect(emailPayload).toEqual(undefined);
 
 	console.log('Cancelling the subscription');
 	const cancellationResult = await cancelSubscription(

--- a/handlers/discount-api/test/getDiscountFromSubscription.test.ts
+++ b/handlers/discount-api/test/getDiscountFromSubscription.test.ts
@@ -1,13 +1,18 @@
 import { zuoraSubscriptionSchema } from '@modules/zuora/zuoraSchemas';
-import { getDiscountFromSubscription } from '../src/productToDiscountMapping';
+import {
+	Discount,
+	getDiscountFromSubscription,
+} from '../src/productToDiscountMapping';
 import json from './fixtures/digital-subscriptions/get-discount-test.json';
 
 test('getDiscountFromSubscription should return an annual discount for an annual sub', () => {
 	const sub = zuoraSubscriptionSchema.parse(json);
-	expect(getDiscountFromSubscription('PROD', sub).discount).toEqual({
+	const expected: Discount = {
 		productRatePlanId: '8a128adf8b64bcfd018b6b6fdc7674f5',
 		name: 'Cancellation Save Discount - 25% off for 12 months',
 		upToPeriods: 12,
 		upToPeriodsType: 'Months',
-	});
+		sendEmail: false,
+	};
+	expect(getDiscountFromSubscription('PROD', sub).discount).toEqual(expected);
 });

--- a/handlers/discount-api/test/getNextPaymentDate.test.ts
+++ b/handlers/discount-api/test/getNextPaymentDate.test.ts
@@ -1,4 +1,6 @@
 import { getNextNonFreePaymentDate } from '@modules/zuora/billingPreview';
+import { zuoraDateFormat } from '@modules/zuora/common';
+import dayjs from 'dayjs';
 
 test('getNextPaymentDate fails if there are no payments in the preview', () => {
 	const items = [
@@ -23,7 +25,7 @@ test('getNextPaymentDate finds the relevant payment', () => {
 
 	const actual = getNextNonFreePaymentDate(items);
 
-	expect(actual).toEqual('2020-02-01');
+	expect(zuoraDateFormat(dayjs(actual))).toEqual('2020-02-01');
 });
 
 test('getNextPaymentDate finds the relevant payment in reverse order', () => {
@@ -35,7 +37,7 @@ test('getNextPaymentDate finds the relevant payment in reverse order', () => {
 
 	const actual = getNextNonFreePaymentDate(items);
 
-	expect(actual).toEqual('2020-02-01');
+	expect(zuoraDateFormat(dayjs(actual))).toEqual('2020-02-01');
 });
 
 test('getNextPaymentDate finds the relevant payment even if theres duplicates', () => {
@@ -48,7 +50,7 @@ test('getNextPaymentDate finds the relevant payment even if theres duplicates', 
 
 	const actual = getNextNonFreePaymentDate(items);
 
-	expect(actual).toEqual('2020-02-01');
+	expect(zuoraDateFormat(dayjs(actual))).toEqual('2020-02-01');
 });
 
 test('getNextPaymentDate finds the relevant payment in reverse order even if theres duplicates', () => {
@@ -61,5 +63,5 @@ test('getNextPaymentDate finds the relevant payment in reverse order even if the
 
 	const actual = getNextNonFreePaymentDate(items);
 
-	expect(actual).toEqual('2020-02-01');
+	expect(zuoraDateFormat(dayjs(actual))).toEqual('2020-02-01');
 });

--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -31,6 +31,7 @@ export const DataExtensionNames = {
 	recurringContributionToSupporterPlusSwitch: 'SV_RCtoSP_Switch',
 	subscriptionCancelledEmail: 'subscription-cancelled-email',
 	updateSupporterPlusAmount: 'payment-amount-changed-email',
+	cancellationDiscountConfirmation: 'cancellation-discount-confirmation-email',
 } as const;
 
 export type DataExtensionName =

--- a/modules/zuora/src/billingPreview.ts
+++ b/modules/zuora/src/billingPreview.ts
@@ -42,7 +42,7 @@ export function getNextNonFreePaymentDate(
 		'could not find a non free payment in the invoice preview',
 	);
 
-	const nextPaymentDate = zuoraDateFormat(dayjs(firstNonFree.date));
+	const nextPaymentDate = firstNonFree.date;
 
 	return nextPaymentDate;
 }


### PR DESCRIPTION
This PR is part of the cancellation saves work.

As part of this we need to send out an email to confirm what the user should expect.

This PR adds the code to send the email with the suitable fields.

This is a rough wireframe of what the email has, although it will also use their first name at least
![image](https://github.com/guardian/support-service-lambdas/assets/7304387/b4f9e34c-4118-4eb8-ab2a-65e0a3c113d5)
