### PR TITLE
don't leak internal server error details

### DIFF
--- a/handlers/discount-api/src/index.ts
+++ b/handlers/discount-api/src/index.ts
@@ -44,7 +44,7 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 			};
 		} else {
 			return {
-				body: JSON.stringify(error),
+				body: 'Internal server error, check the logs for more information',
 				statusCode: 500,
 			};
 		}


### PR DESCRIPTION
I noticed that discount API returns full details of any internal server errors to the client!  unfortunately this is dangerous because we have no idea what kind of information might be in there, that could help an attacker.
https://owasp.org/www-community/Improper_Error_Handling#:~:text=The%20most%20common%20problem%20is%20when%20detailed%20internal%20error%20messages%20such%20as%20stack%20traces%2C%20database%20dumps%2C%20and%20error%20codes%20are%20displayed%20to%20the%20user%20(hacker)

This PR changes it so errors do not get returned to the end client.