### PR TITLE
make the module tests run in the automated build

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -39,7 +39,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm --filter modules test
+      - run: pushd modules && pnpm test; popd
       - run: pnpm package
 
       - name: Configure AWS credentials

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -39,6 +39,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install
+      - run: pushd modules && pnpm test; popd
       - run: pnpm package
 
       - name: Configure AWS credentials

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -39,7 +39,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pushd modules && pnpm test; popd
+      - run: pnpm --filter modules test
       - run: pnpm package
 
       - name: Configure AWS credentials

--- a/modules/jest.config.js
+++ b/modules/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	runner: 'groups',
+	moduleNameMapper: {
+		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
+		'@modules/(.*)$': '<rootDir>/../../modules/$1',
+	},
+};

--- a/modules/jest.config.js
+++ b/modules/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
 	testEnvironment: 'node',
 	runner: 'groups',
 	moduleNameMapper: {
-		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
-		'@modules/(.*)$': '<rootDir>/../../modules/$1',
+		'@modules/(.*)/(.*)$': '<rootDir>/../modules/$1/src/$2',
+		'@modules/(.*)$': '<rootDir>/../modules/$1',
 	},
 };

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "modules",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest --group=-integration",
+    "it-test": "jest --group=integration"
+  }
+}

--- a/modules/zuora/test/billingPreview.test.ts
+++ b/modules/zuora/test/billingPreview.test.ts
@@ -1,10 +1,15 @@
-import { getNextInvoiceItems } from '../src/billingPreview';
+import {
+	billingPreviewToRecords,
+	getNextInvoiceTotal,
+} from '../src/billingPreview';
 import { billingPreviewSchema } from '../src/zuoraSchemas';
 import billingPreview from './fixtures/billing-preview-with-discount.json';
 
 test('getNextPayment', () => {
 	const parsedBillingPreview = billingPreviewSchema.parse(billingPreview);
-	const nextInvoiceItems = getNextInvoiceItems(parsedBillingPreview);
-	expect(nextInvoiceItems[0]?.serviceStartDate).toEqual(new Date('2023-12-19'));
-	expect(nextInvoiceItems.length).toEqual(3);
+	const nextInvoiceItems = getNextInvoiceTotal(
+		billingPreviewToRecords(parsedBillingPreview),
+	);
+	expect(nextInvoiceItems.date).toEqual(new Date('2023-12-19'));
+	expect(nextInvoiceItems.total).toBeCloseTo(14.05);
 });


### PR DESCRIPTION
I noticed that one of the tests was failing locally but there were no issues with the build.

After investigation it seemed that the build only runs "package" which doesn't exist on the modules so it's skipped.
The tsc and eslint at the root search out all files in both locations, so those checks were not skipped.

This PR updates it so that pnpm test is run at the root, which should exist on all modules as well as the handlers.

There is an efficiency issue where all the builds are doing everything, this would also mean an issue in one lambda would stop them all building, but that can be dealt with if/when it causes an issue.