### PR TITLE
add a simple test for sortBy and groupBy

### DIFF
--- a/modules/arrayFunctions.test.ts
+++ b/modules/arrayFunctions.test.ts
@@ -1,0 +1,35 @@
+import { groupBy, sortBy } from './arrayFunctions';
+
+test('sortBy should sort by the relevant field', () => {
+	const data = [
+		{ l: 1, d: 102 },
+		{ l: 3, d: 103 },
+		{ l: 2, d: 101 },
+	];
+	const actual = sortBy(data, (item) => `${item.d}`);
+	expect(actual).toEqual([
+		{ l: 2, d: 1011 },
+		{ l: 1, d: 102 },
+		{ l: 3, d: 103 },
+	]);
+});
+
+test('groupBy should group correctly', () => {
+	const data = [
+		{ k: 1, d: 101 },
+		{ k: 2, d: 201 },
+		{ k: 1, d: 102 },
+		{ k: 2, d: 202 },
+	];
+	const actual = groupBy(data, (item) => `${item.k}`);
+	expect(actual).toEqual({
+		1: [
+			{ k: 1, d: 101 },
+			{ k: 1, d: 102 },
+		],
+		2: [
+			{ k: 2, d: 201 },
+			{ k: 2, d: 202 },
+		],
+	});
+});

--- a/modules/arrayFunctions.test.ts
+++ b/modules/arrayFunctions.test.ts
@@ -8,7 +8,7 @@ test('sortBy should sort by the relevant field', () => {
 	];
 	const actual = sortBy(data, (item) => `${item.d}`);
 	expect(actual).toEqual([
-		{ l: 2, d: 1011 },
+		{ l: 2, d: 101 },
 		{ l: 1, d: 102 },
 		{ l: 3, d: 103 },
 	]);


### PR DESCRIPTION
There were no tests for our self written groupBy and sortBy functions.  Tom noticed that was an omission in https://github.com/guardian/support-service-lambdas/pull/2317#discussion_r1638030650

This PR adds them.