### PR TITLE
Add a `check-formatting` pnpm script

### DIFF
--- a/_templates/new-lambda/api-gateway/package.ejs.t
+++ b/_templates/new-lambda/api-gateway/package.ejs.t
@@ -12,7 +12,8 @@ sh: git add handlers/<%=lambdaName%>/package.json
     "type-check": "tsc --noEmit",
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr <%=lambdaName%>.zip ./*.js"
+    "package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr <%=lambdaName%>.zip ./*.js",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.129"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "test-update": "jest -u",
     "format": "prettier --write \"{lib,bin}/**/*.ts\"",
-    "check-formatting": "prettier --check \"{lib,bin}/**/*.ts\"",
+    "check-formatting": "prettier --check **/*.ts",
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
     "synth": "cdk synth --path-metadata false --version-reporting false",
     "diff": "cdk diff --path-metadata false --version-reporting false",

--- a/handlers/alarms-handler/package.json
+++ b/handlers/alarms-handler/package.json
@@ -6,7 +6,8 @@
 		"type-check": "tsc --noEmit",
 		"build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
 		"lint": "eslint src/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr alarms-handler.zip ./*.js"
+		"package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr alarms-handler.zip ./*.js",
+		"check-formatting": "prettier --check **/*.ts"
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "^3.556.0",

--- a/handlers/discount-api/package.json
+++ b/handlers/discount-api/package.json
@@ -6,7 +6,8 @@
     "type-check": "tsc --noEmit",
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr discount-api.zip ./*.js"
+    "package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr discount-api.zip ./*.js",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "dependencies": {
     "dayjs": "^1.11.11",

--- a/handlers/generate-product-catalog/package.json
+++ b/handlers/generate-product-catalog/package.json
@@ -6,7 +6,8 @@
     "type-check": "tsc --noEmit",
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr generate-product-catalog.zip ./*.js"
+    "package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr generate-product-catalog.zip ./*.js",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.129",

--- a/handlers/product-switch-api/package.json
+++ b/handlers/product-switch-api/package.json
@@ -6,7 +6,8 @@
     "type-check": "tsc --noEmit",
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm build && cd target; zip -qr product-switch-api.zip ./*.js"
+    "package": "pnpm type-check && pnpm lint && pnpm build && cd target; zip -qr product-switch-api.zip ./*.js",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "dependencies": {
     "dayjs": "^1.11.11",

--- a/handlers/salesforce-disaster-recovery-health-check/package.json
+++ b/handlers/salesforce-disaster-recovery-health-check/package.json
@@ -6,7 +6,8 @@
 		"type-check": "tsc --noEmit",
 		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
 		"lint": "eslint src/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr salesforce-disaster-recovery-health-check.zip ./*.js"
+		"package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr salesforce-disaster-recovery-health-check.zip ./*.js",
+		"check-formatting": "prettier --check **/*.ts"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.129"

--- a/handlers/salesforce-disaster-recovery/package.json
+++ b/handlers/salesforce-disaster-recovery/package.json
@@ -7,7 +7,8 @@
 		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
 		"lint": "eslint src/**/*.ts",
 		"package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr salesforce-disaster-recovery.zip ./*.js",
-		"type-check": "tsc --noEmit"
+		"type-check": "tsc --noEmit",
+		"check-formatting": "prettier --check **/*.ts"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.137",

--- a/handlers/update-supporter-plus-amount/package.json
+++ b/handlers/update-supporter-plus-amount/package.json
@@ -6,7 +6,8 @@
     "type-check": "tsc --noEmit",
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr update-supporter-plus-amount.zip ./*.js"
+    "package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr update-supporter-plus-amount.zip ./*.js",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "dependencies": {
     "dayjs": "^1.11.11",

--- a/modules/aws/package.json
+++ b/modules/aws/package.json
@@ -1,6 +1,9 @@
 {
   "name": "aws",
   "version": "1.0.0",
+  "scripts": {
+    "check-formatting": "prettier --check **/*.ts"
+  },
   "dependencies": {
     "@aws-sdk/credential-provider-node": "3.451.0"
   }

--- a/modules/email/package.json
+++ b/modules/email/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration"
+    "it-test": "jest --group=integration",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "3.451.0"

--- a/modules/package.json
+++ b/modules/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration"
+    "it-test": "jest --group=integration",
+    "check-formatting": "prettier --check **/*.ts"
   }
 }

--- a/modules/product-catalog/package.json
+++ b/modules/product-catalog/package.json
@@ -5,7 +5,8 @@
     "generateTypes": "ts-node src/generateTypeObjectCommand.ts",
     "updateSnapshots": "jest -u --group=-integration",
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration"
+    "it-test": "jest --group=integration",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/modules/test-users/package.json
+++ b/modules/test-users/package.json
@@ -7,7 +7,8 @@
     "createMonthlyContribution": "ts-node ./src/createMonthlyContribution.ts",
     "updateMonthlyContributionAmount": "ts-node ./src/updateMonthlyContributionAmount.ts",
     "cancelSubscription": "ts-node ./src/cancel.ts",
-    "deleteAccount": "ts-node ./src/deleteAccount.ts"
+    "deleteAccount": "ts-node ./src/deleteAccount.ts",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "devDependencies": {
     "dayjs": "^1.11.11",

--- a/modules/zuora-catalog/package.json
+++ b/modules/zuora-catalog/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration"
+    "it-test": "jest --group=integration",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.451.0",

--- a/modules/zuora/package.json
+++ b/modules/zuora/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration"
+    "it-test": "jest --group=integration",
+    "check-formatting": "prettier --check **/*.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.451.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"it-test": "pnpm --stream -r run it-test",
 		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && cd ./cdk && yarn lint --fix && yarn test -u && git add ./lib/__snapshots__/*.test.ts.snap",
 		"prepare": "husky",
-		"format": "prettier --write handlers/**/*.ts modules/**/*.ts"
+		"format": "prettier --write handlers/**/*.ts modules/**/*.ts",
+		"check-formatting": "pnpm -r run check-formatting"
 	},
 	"devDependencies": {
 		"@guardian/eslint-config-typescript": "8.0.1",


### PR DESCRIPTION
## What does this change?

I've noticed that sometimes the TS code formatting in this repo drifts from the prettier config so I'd like to start checking formatting in CI, failing the build if there are files which aren't formatting correctly.

This adds a script `check-formatting` which can be run for the whole project:

`$ pnpm check-formatting`

or for a specific workspace:

`$ pnpm --filter alarms-handler check-formatting`

In #2230 I added a script to format the codebase, but on reflection I don't think this was very `pnpm`-ish. I think delegating to individual workspace `package.json`s is the way to go (so you can run for a specific workspace). I'll follow up with a PR to move over to this approach for formatting.

Then two more PRs:

* Fix the current formatting for the project
* Enforce formatting in CI.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
