### PR TITLE
Update new-product-api SupporterPlusLimits

### DIFF
--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/addsubscription/validation/supporterplus/AmountLimits.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/addsubscription/validation/supporterplus/AmountLimits.scala
@@ -15,33 +15,33 @@ object AmountLimits {
   def fromMinorToMajor(value: Int) = value / 100
 
   val gbp = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 95, max = 2000),
-  )
-
-  val aud = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 17, max = 200),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 160, max = 2400),
-  )
-
-  val usd = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 13, max = 800),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 120, max = 10000),
-  )
-
-  val nzd = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 17, max = 200),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 160, max = 2400),
-  )
-
-  val cad = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 13, max = 166),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 12, max = 166),
     annual = AmountLimits.limitsFromMajorToMinorUnits(min = 120, max = 2000),
   )
 
+  val aud = SupporterPlusLimits(
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 20, max = 200),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 200, max = 2400),
+  )
+
+  val usd = SupporterPlusLimits(
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 15, max = 800),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 130, max = 10000),
+  )
+
+  val nzd = SupporterPlusLimits(
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 20, max = 200),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 200, max = 2400),
+  )
+
+  val cad = SupporterPlusLimits(
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 15, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 130, max = 2000),
+  )
+
   val eur = SupporterPlusLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 95, max = 2000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 12, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 120, max = 2000),
   )
 
   def limitsFor(planId: PlanId, currency: Currency): AmountLimits = {

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/addsubscription/validation/supporterplus/AmountLimits.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/addsubscription/validation/supporterplus/AmountLimits.scala
@@ -26,7 +26,7 @@ object AmountLimits {
 
   val usd = SupporterPlusLimits(
     monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 15, max = 800),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 130, max = 10000),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 150, max = 10000),
   )
 
   val nzd = SupporterPlusLimits(
@@ -36,7 +36,7 @@ object AmountLimits {
 
   val cad = SupporterPlusLimits(
     monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 15, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 130, max = 2000),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 150, max = 2000),
   )
 
   val eur = SupporterPlusLimits(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
new-product-api contains a list of minimum prices for Supporter Plus as a validation, these need to change to coincide with the Supporter Plus acquisition price rise which is happening shortly.