### PR TITLE
Add T3 into the DeliveryCreditProcessor

### DIFF
--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProcessor.scala
@@ -12,7 +12,7 @@ import com.gu.salesforce.{RecordsWrapperCaseClass, SFAuthConfig}
 import com.gu.util.Logging
 import com.gu.util.config.ConfigReads.ConfigFailure
 import com.gu.util.config.{ConfigLocation, LoadConfigModule, Stage}
-import com.gu.zuora.ZuoraProductTypes.{GuardianWeekly, NewspaperHomeDelivery, NewspaperNationalDelivery, ZuoraProductType}
+import com.gu.zuora.ZuoraProductTypes.{GuardianWeekly, NewspaperHomeDelivery, NewspaperNationalDelivery, TierThree, ZuoraProductType}
 import com.gu.zuora.subscription._
 import com.gu.zuora.{AccessToken, HolidayStopProcessorZuoraConfig, Zuora}
 import io.circe.generic.auto._
@@ -64,7 +64,7 @@ object DeliveryCreditProcessor extends Logging {
       }
 
   val processAllProducts: RIO[Clock, List[DeliveryCreditResult]] = {
-    val productTypes = List(NewspaperHomeDelivery, GuardianWeekly, NewspaperNationalDelivery)
+    val productTypes = List(NewspaperHomeDelivery, GuardianWeekly, NewspaperNationalDelivery, TierThree)
     for {
       sfAuthConfig <- sfConfig
       zConfig <- zuoraConfig

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProduct.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/DeliveryCreditProduct.scala
@@ -54,9 +54,11 @@ object DeliveryCreditProduct {
 
     def creditProduct(stage: Stage)(plan: RatePlan): Option[CreditProduct] = (stage, plan.productName) match {
       case (Stage.Prod, s"Guardian Weekly$_") => Some(DeliveryCreditProduct.Prod.GuardianWeekly)
+      case (Stage.Prod, s"Tier Three") => Some(DeliveryCreditProduct.Prod.GuardianWeekly)
       case (Stage.Prod, "Newspaper Delivery") => Some(DeliveryCreditProduct.Prod.HomeDelivery)
       case (Stage.Prod, "Newspaper - National Delivery") => Some(DeliveryCreditProduct.Prod.NationalDelivery)
       case (Stage.Code, s"Guardian Weekly$_") => Some(DeliveryCreditProduct.Code.GuardianWeekly)
+      case (Stage.Code, s"Tier Three") => Some(DeliveryCreditProduct.Code.GuardianWeekly)
       case (Stage.Code, "Newspaper Delivery") => Some(DeliveryCreditProduct.Code.HomeDelivery)
       case (Stage.Code, "Newspaper - National Delivery") => Some(DeliveryCreditProduct.Code.NationalDelivery)
       case _ => None

--- a/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/Handler.scala
+++ b/handlers/delivery-problem-credit-processor/src/main/scala/com/gu/deliveryproblemcreditprocessor/Handler.scala
@@ -1,19 +1,35 @@
 package com.gu.deliveryproblemcreditprocessor
 
-import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.{Context, LambdaRuntime}
 import io.circe.generic.auto._
 import io.github.mkotsur.aws.handler.Lambda
 import io.github.mkotsur.aws.handler.Lambda._
+import java.lang.{System => JavaSystem}
+
+import java.io.{OutputStream, PrintStream}
 
 object Handler extends Lambda[None.type, List[DeliveryCreditResult]] {
 
   private val runtime = zio.Runtime.default
+
+  val printStream = new PrintStream(new OutputStream() {
+    override def write(b: Int): Unit =
+      LambdaRuntime.getLogger.log(Array(b.toByte))
+
+    override def write(b: Array[Byte]): Unit =
+      LambdaRuntime.getLogger.log(b)
+
+    override def write(b: Array[Byte], off: Int, len: Int): Unit =
+      LambdaRuntime.getLogger.log(b.slice(off, off + len))
+  })
 
   override protected def handle(
       unused: None.type,
       context: Context,
   ): Either[Throwable, List[DeliveryCreditResult]] =
     runtime.unsafeRun {
+      JavaSystem.setOut(printStream)
+      JavaSystem.setErr(printStream)
       val program = DeliveryCreditProcessor.processAllProducts
       program.either
     }


### PR DESCRIPTION
## What does this change?
Similar to the holiday stop processor which was updated here: https://github.com/guardian/support-service-lambdas/pull/2350

the delivery credit processor also needs updating to take account of the new Tier Three product.