### PR TITLE
Zuora <-> salesforce link remover - create state machine

### DIFF
--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -889,7 +889,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
           "Fn::Join": [
             "",
             [
-              "{"StartAt":"Get Salesforce Billing Accounts","States":{"Get Salesforce Billing Accounts":{"Next":"Update Zuora Billing Accounts","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "{"StartAt":"Get Salesforce Billing Accounts","States":{"Get Salesforce Billing Accounts":{"Next":"Billing Accounts Processor Map","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -900,7 +900,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Billing Accounts Processor Map":{"Type":"Map","ResultPath":"$.billingAccountProcessingAttempts","End":true,"Parameters":{"item.$":"$$.Map.Item.Value"},"Iterator":{"StartAt":"Update Zuora Billing Accounts","States":{"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -911,7 +911,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}}",
+              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1}}}",
             ],
           ],
         },
@@ -1947,7 +1947,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
           "Fn::Join": [
             "",
             [
-              "{"StartAt":"Get Salesforce Billing Accounts","States":{"Get Salesforce Billing Accounts":{"Next":"Update Zuora Billing Accounts","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "{"StartAt":"Get Salesforce Billing Accounts","States":{"Get Salesforce Billing Accounts":{"Next":"Billing Accounts Processor Map","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -1958,7 +1958,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Billing Accounts Processor Map":{"Type":"Map","ResultPath":"$.billingAccountProcessingAttempts","End":true,"Parameters":{"item.$":"$$.Map.Item.Value"},"Iterator":{"StartAt":"Update Zuora Billing Accounts","States":{"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -1969,7 +1969,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}}",
+              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1}}}",
             ],
           ],
         },

--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -2,6 +2,115 @@
 
 exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
 {
+  "Mappings": {
+    "ServiceprincipalMap": {
+      "af-south-1": {
+        "states": "states.af-south-1.amazonaws.com",
+      },
+      "ap-east-1": {
+        "states": "states.ap-east-1.amazonaws.com",
+      },
+      "ap-northeast-1": {
+        "states": "states.ap-northeast-1.amazonaws.com",
+      },
+      "ap-northeast-2": {
+        "states": "states.ap-northeast-2.amazonaws.com",
+      },
+      "ap-northeast-3": {
+        "states": "states.ap-northeast-3.amazonaws.com",
+      },
+      "ap-south-1": {
+        "states": "states.ap-south-1.amazonaws.com",
+      },
+      "ap-south-2": {
+        "states": "states.ap-south-2.amazonaws.com",
+      },
+      "ap-southeast-1": {
+        "states": "states.ap-southeast-1.amazonaws.com",
+      },
+      "ap-southeast-2": {
+        "states": "states.ap-southeast-2.amazonaws.com",
+      },
+      "ap-southeast-3": {
+        "states": "states.ap-southeast-3.amazonaws.com",
+      },
+      "ap-southeast-4": {
+        "states": "states.ap-southeast-4.amazonaws.com",
+      },
+      "ca-central-1": {
+        "states": "states.ca-central-1.amazonaws.com",
+      },
+      "cn-north-1": {
+        "states": "states.cn-north-1.amazonaws.com",
+      },
+      "cn-northwest-1": {
+        "states": "states.cn-northwest-1.amazonaws.com",
+      },
+      "eu-central-1": {
+        "states": "states.eu-central-1.amazonaws.com",
+      },
+      "eu-central-2": {
+        "states": "states.eu-central-2.amazonaws.com",
+      },
+      "eu-north-1": {
+        "states": "states.eu-north-1.amazonaws.com",
+      },
+      "eu-south-1": {
+        "states": "states.eu-south-1.amazonaws.com",
+      },
+      "eu-south-2": {
+        "states": "states.eu-south-2.amazonaws.com",
+      },
+      "eu-west-1": {
+        "states": "states.eu-west-1.amazonaws.com",
+      },
+      "eu-west-2": {
+        "states": "states.eu-west-2.amazonaws.com",
+      },
+      "eu-west-3": {
+        "states": "states.eu-west-3.amazonaws.com",
+      },
+      "il-central-1": {
+        "states": "states.il-central-1.amazonaws.com",
+      },
+      "me-central-1": {
+        "states": "states.me-central-1.amazonaws.com",
+      },
+      "me-south-1": {
+        "states": "states.me-south-1.amazonaws.com",
+      },
+      "sa-east-1": {
+        "states": "states.sa-east-1.amazonaws.com",
+      },
+      "us-east-1": {
+        "states": "states.us-east-1.amazonaws.com",
+      },
+      "us-east-2": {
+        "states": "states.us-east-2.amazonaws.com",
+      },
+      "us-gov-east-1": {
+        "states": "states.us-gov-east-1.amazonaws.com",
+      },
+      "us-gov-west-1": {
+        "states": "states.us-gov-west-1.amazonaws.com",
+      },
+      "us-iso-east-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-iso-west-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-isob-east-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-west-1": {
+        "states": "states.us-west-1.amazonaws.com",
+      },
+      "us-west-2": {
+        "states": "states.us-west-2.amazonaws.com",
+      },
+    },
+  },
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
@@ -769,12 +878,297 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "zuorasalesforcelinkremoverstatemachineCODED6EAF6A2": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "zuorasalesforcelinkremoverstatemachineCODERoleDefaultPolicy93A58851",
+        "zuorasalesforcelinkremoverstatemachineCODERole2BDCFB38",
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "",
+            [
+              "{"StartAt":"Get Salesforce Billing Accounts","States":{"Get Salesforce Billing Accounts":{"Next":"Update Zuora Billing Accounts","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "getbillingaccountslambdaEDDA46BF",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "updatezuorabillingaccountlambda6EF8BCFE",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}}}}",
+            ],
+          ],
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "zuorasalesforcelinkremoverstatemachineCODERole2BDCFB38",
+            "Arn",
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "zuorasalesforcelinkremoverstatemachineCODERole2BDCFB38": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": {
+                  "Fn::FindInMap": [
+                    "ServiceprincipalMap",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "states",
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "zuorasalesforcelinkremoverstatemachineCODERoleDefaultPolicy93A58851": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "getbillingaccountslambdaEDDA46BF",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "getbillingaccountslambdaEDDA46BF",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "updatezuorabillingaccountlambda6EF8BCFE",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "updatezuorabillingaccountlambda6EF8BCFE",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "zuorasalesforcelinkremoverstatemachineCODERoleDefaultPolicy93A58851",
+        "Roles": [
+          {
+            "Ref": "zuorasalesforcelinkremoverstatemachineCODERole2BDCFB38",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
   },
 }
 `;
 
 exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
 {
+  "Mappings": {
+    "ServiceprincipalMap": {
+      "af-south-1": {
+        "states": "states.af-south-1.amazonaws.com",
+      },
+      "ap-east-1": {
+        "states": "states.ap-east-1.amazonaws.com",
+      },
+      "ap-northeast-1": {
+        "states": "states.ap-northeast-1.amazonaws.com",
+      },
+      "ap-northeast-2": {
+        "states": "states.ap-northeast-2.amazonaws.com",
+      },
+      "ap-northeast-3": {
+        "states": "states.ap-northeast-3.amazonaws.com",
+      },
+      "ap-south-1": {
+        "states": "states.ap-south-1.amazonaws.com",
+      },
+      "ap-south-2": {
+        "states": "states.ap-south-2.amazonaws.com",
+      },
+      "ap-southeast-1": {
+        "states": "states.ap-southeast-1.amazonaws.com",
+      },
+      "ap-southeast-2": {
+        "states": "states.ap-southeast-2.amazonaws.com",
+      },
+      "ap-southeast-3": {
+        "states": "states.ap-southeast-3.amazonaws.com",
+      },
+      "ap-southeast-4": {
+        "states": "states.ap-southeast-4.amazonaws.com",
+      },
+      "ca-central-1": {
+        "states": "states.ca-central-1.amazonaws.com",
+      },
+      "cn-north-1": {
+        "states": "states.cn-north-1.amazonaws.com",
+      },
+      "cn-northwest-1": {
+        "states": "states.cn-northwest-1.amazonaws.com",
+      },
+      "eu-central-1": {
+        "states": "states.eu-central-1.amazonaws.com",
+      },
+      "eu-central-2": {
+        "states": "states.eu-central-2.amazonaws.com",
+      },
+      "eu-north-1": {
+        "states": "states.eu-north-1.amazonaws.com",
+      },
+      "eu-south-1": {
+        "states": "states.eu-south-1.amazonaws.com",
+      },
+      "eu-south-2": {
+        "states": "states.eu-south-2.amazonaws.com",
+      },
+      "eu-west-1": {
+        "states": "states.eu-west-1.amazonaws.com",
+      },
+      "eu-west-2": {
+        "states": "states.eu-west-2.amazonaws.com",
+      },
+      "eu-west-3": {
+        "states": "states.eu-west-3.amazonaws.com",
+      },
+      "il-central-1": {
+        "states": "states.il-central-1.amazonaws.com",
+      },
+      "me-central-1": {
+        "states": "states.me-central-1.amazonaws.com",
+      },
+      "me-south-1": {
+        "states": "states.me-south-1.amazonaws.com",
+      },
+      "sa-east-1": {
+        "states": "states.sa-east-1.amazonaws.com",
+      },
+      "us-east-1": {
+        "states": "states.us-east-1.amazonaws.com",
+      },
+      "us-east-2": {
+        "states": "states.us-east-2.amazonaws.com",
+      },
+      "us-gov-east-1": {
+        "states": "states.us-gov-east-1.amazonaws.com",
+      },
+      "us-gov-west-1": {
+        "states": "states.us-gov-west-1.amazonaws.com",
+      },
+      "us-iso-east-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-iso-west-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-isob-east-1": {
+        "states": "states.amazonaws.com",
+      },
+      "us-west-1": {
+        "states": "states.us-west-1.amazonaws.com",
+      },
+      "us-west-2": {
+        "states": "states.us-west-2.amazonaws.com",
+      },
+    },
+  },
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
@@ -1537,6 +1931,182 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
         "Roles": [
           {
             "Ref": "updatezuorabillingaccountlambdaServiceRole91046AA4",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "zuorasalesforcelinkremoverstatemachinePRODCBC395DA": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "zuorasalesforcelinkremoverstatemachinePRODRoleDefaultPolicy857F0650",
+        "zuorasalesforcelinkremoverstatemachinePRODRole70C6CF2B",
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "",
+            [
+              "{"StartAt":"Get Salesforce Billing Accounts","States":{"Get Salesforce Billing Accounts":{"Next":"Update Zuora Billing Accounts","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "getbillingaccountslambdaEDDA46BF",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "updatezuorabillingaccountlambda6EF8BCFE",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}}}}",
+            ],
+          ],
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "zuorasalesforcelinkremoverstatemachinePRODRole70C6CF2B",
+            "Arn",
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "zuorasalesforcelinkremoverstatemachinePRODRole70C6CF2B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": {
+                  "Fn::FindInMap": [
+                    "ServiceprincipalMap",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "states",
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "zuorasalesforcelinkremoverstatemachinePRODRoleDefaultPolicy857F0650": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "getbillingaccountslambdaEDDA46BF",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "getbillingaccountslambdaEDDA46BF",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "updatezuorabillingaccountlambda6EF8BCFE",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "updatezuorabillingaccountlambda6EF8BCFE",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "zuorasalesforcelinkremoverstatemachinePRODRoleDefaultPolicy857F0650",
+        "Roles": [
+          {
+            "Ref": "zuorasalesforcelinkremoverstatemachinePRODRole70C6CF2B",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -900,7 +900,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Billing Accounts Processor Map":{"Type":"Map","ResultPath":"$.billingAccountProcessingAttempts","End":true,"Parameters":{"item.$":"$$.Map.Item.Value"},"Iterator":{"StartAt":"Update Zuora Billing Accounts","States":{"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Billing Accounts Processor Map":{"Type":"Map","ResultPath":"$.billingAccountProcessingAttempts","Next":"Update Salesforce Billing Accounts","Parameters":{"item.$":"$$.Map.Item.Value"},"Iterator":{"StartAt":"Update Zuora Billing Accounts","States":{"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -911,7 +911,18 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1}}}",
+              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "updatesfbillingaccountslambda98285844",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}}}}",
             ],
           ],
         },
@@ -1007,6 +1018,32 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                       {
                         "Fn::GetAtt": [
                           "getbillingaccountslambdaEDDA46BF",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "updatesfbillingaccountslambda98285844",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "updatesfbillingaccountslambda98285844",
                           "Arn",
                         ],
                       },
@@ -1958,7 +1995,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Billing Accounts Processor Map":{"Type":"Map","ResultPath":"$.billingAccountProcessingAttempts","End":true,"Parameters":{"item.$":"$$.Map.Item.Value"},"Iterator":{"StartAt":"Update Zuora Billing Accounts","States":{"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Billing Accounts Processor Map":{"Type":"Map","ResultPath":"$.billingAccountProcessingAttempts","Next":"Update Salesforce Billing Accounts","Parameters":{"item.$":"$$.Map.Item.Value"},"Iterator":{"StartAt":"Update Zuora Billing Accounts","States":{"Update Zuora Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -1969,7 +2006,18 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1}}}",
+              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "updatesfbillingaccountslambda98285844",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}}}}",
             ],
           ],
         },
@@ -2065,6 +2113,32 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                       {
                         "Fn::GetAtt": [
                           "getbillingaccountslambdaEDDA46BF",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "updatesfbillingaccountslambda98285844",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "updatesfbillingaccountslambda98285844",
                           "Arn",
                         ],
                       },

--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -911,7 +911,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","InputPath":"$.billingAccountProcessingAttempts","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2006,7 +2006,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","InputPath":"$.billingAccountProcessingAttempts","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -102,18 +102,25 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			},
 		);
 
-		const billingAccountsProcessingMap = new Map(this, 'Billing Accounts Processor Map', {
-			maxConcurrency: 1,
-			itemsPath: JsonPath.stringAt('$.billingAccountsToProcess'),
-			parameters: {
-			  item: JsonPath.stringAt('$$.Map.Item.Value'),
+		const billingAccountsProcessingMap = new Map(
+			this,
+			'Billing Accounts Processor Map',
+			{
+				maxConcurrency: 1,
+				itemsPath: JsonPath.stringAt('$.billingAccountsToProcess'),
+				parameters: {
+					item: JsonPath.stringAt('$$.Map.Item.Value'),
+				},
+				resultPath: '$.billingAccountProcessingAttempts',
 			},
-			resultPath: '$.billingAccountProcessingAttempts',
-		  });
-	  
-		  const billingAccountsProcessingMapDefinition = updateZuoraBillingAccountsLambdaTask;
-		  
-		  billingAccountsProcessingMap.iterator(billingAccountsProcessingMapDefinition);
+		);
+
+		const billingAccountsProcessingMapDefinition =
+			updateZuoraBillingAccountsLambdaTask;
+
+		billingAccountsProcessingMap.iterator(
+			billingAccountsProcessingMapDefinition,
+		);
 
 		const definition = getSalesforceBillingAccountsFromLambdaTask.next(
 			billingAccountsProcessingMap,

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -85,7 +85,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 		});
 
 		const getSalesforceBillingAccountsFromLambdaTask = new LambdaInvoke(
-			this, 
+			this,
 			'Get Salesforce Billing Accounts',
 			{
 				lambdaFunction: getSalesforceBillingAccountsLambda,

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -4,6 +4,7 @@ import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { type App } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { StateMachine } from 'aws-cdk-lib/aws-stepfunctions';
 import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 
 export class ZuoraSalesforceLinkRemover extends GuStack {
@@ -101,16 +102,16 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			},
 		);
 
-		const stateMachineDefinition =
+		const definition =
 			getSalesforceBillingAccountsFromLambdaTask.next(
 				updateZuoraBillingAccountsLambdaTask,
 			);
 
-		const stateMachine = new StateMachine(
+		new StateMachine(
 			this,
 			`zuora-salesforce-link-remover-state-machine-${this.stage}`,
 			{
-				stateMachineDefinition,
+				definition,
 			},
 		);
 	}

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -85,7 +85,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 		});
 
 		const getSalesforceBillingAccountsFromLambdaTask = new LambdaInvoke(
-			this,
+			this, 
 			'Get Salesforce Billing Accounts',
 			{
 				lambdaFunction: getSalesforceBillingAccountsLambda,

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -12,47 +12,55 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 
 		const appName = 'zuora-salesforce-link-remover';
 
-		const getSalesforceBillingAccountsLambda = new GuLambdaFunction(this, 'get-billing-accounts-lambda', {
-			app: appName,
-			functionName: `${appName}-get-billing-accounts-${this.stage}`,
-			runtime: Runtime.NODEJS_20_X,
-			environment: {
-				Stage: this.stage,
+		const getSalesforceBillingAccountsLambda = new GuLambdaFunction(
+			this,
+			'get-billing-accounts-lambda',
+			{
+				app: appName,
+				functionName: `${appName}-get-billing-accounts-${this.stage}`,
+				runtime: Runtime.NODEJS_20_X,
+				environment: {
+					Stage: this.stage,
+				},
+				handler: 'getBillingAccounts.handler',
+				fileName: `${appName}.zip`,
+				architecture: Architecture.ARM_64,
+				initialPolicy: [
+					new PolicyStatement({
+						actions: ['secretsmanager:GetSecretValue'],
+						resources: [
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:DEV/Salesforce/ConnectedApp/AwsConnectorSandbox-oO8Phf`,
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:DEV/Salesforce/User/integrationapiuser-rvxxrG`,
+						],
+					}),
+				],
 			},
-			handler: 'getBillingAccounts.handler',
-			fileName: `${appName}.zip`,
-			architecture: Architecture.ARM_64,
-			initialPolicy: [
-				new PolicyStatement({
-					actions: ['secretsmanager:GetSecretValue'],
-					resources: [
-						`arn:aws:secretsmanager:${this.region}:${this.account}:secret:DEV/Salesforce/ConnectedApp/AwsConnectorSandbox-oO8Phf`,
-						`arn:aws:secretsmanager:${this.region}:${this.account}:secret:DEV/Salesforce/User/integrationapiuser-rvxxrG`,
-					],
-				}),
-			],
-		});
+		);
 
-		const updateZuoraBillingAccountsLambda = new GuLambdaFunction(this, 'update-zuora-billing-account-lambda', {
-			app: appName,
-			functionName: `${appName}-update-zuora-billing-account-${this.stage}`,
-			runtime: Runtime.NODEJS_20_X,
-			environment: {
-				Stage: this.stage,
+		const updateZuoraBillingAccountsLambda = new GuLambdaFunction(
+			this,
+			'update-zuora-billing-account-lambda',
+			{
+				app: appName,
+				functionName: `${appName}-update-zuora-billing-account-${this.stage}`,
+				runtime: Runtime.NODEJS_20_X,
+				environment: {
+					Stage: this.stage,
+				},
+				handler: 'updateZuoraBillingAccount.handler',
+				fileName: `${appName}.zip`,
+				architecture: Architecture.ARM_64,
+				initialPolicy: [
+					new PolicyStatement({
+						actions: ['secretsmanager:GetSecretValue'],
+						resources: [
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:CODE/Zuora-OAuth/SupportServiceLambdas-S8QM4l`,
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:PROD/Zuora/SupportServiceLambdas-WeibUa`,
+						],
+					}),
+				],
 			},
-			handler: 'updateZuoraBillingAccount.handler',
-			fileName: `${appName}.zip`,
-			architecture: Architecture.ARM_64,
-			initialPolicy: [
-				new PolicyStatement({
-					actions: ['secretsmanager:GetSecretValue'],
-					resources: [
-						`arn:aws:secretsmanager:${this.region}:${this.account}:secret:CODE/Zuora-OAuth/SupportServiceLambdas-S8QM4l`,
-						`arn:aws:secretsmanager:${this.region}:${this.account}:secret:PROD/Zuora/SupportServiceLambdas-WeibUa`,
-					],
-				}),
-			],
-		});
+		);
 
 		new GuLambdaFunction(this, 'update-sf-billing-accounts-lambda', {
 			app: appName,
@@ -74,22 +82,36 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 				}),
 			],
 		});
-		
-		const getSalesforceBillingAccountsFromLambdaTask = new LambdaInvoke(this, 'Get Salesforce Billing Accounts', {
-			lambdaFunction: getSalesforceBillingAccountsLambda,
-			outputPath: '$.Payload',
-		});
-		
-		const updateZuoraBillingAccountsLambdaTask = new LambdaInvoke(this, 'Update Zuora Billing Accounts', {
-			lambdaFunction: updateZuoraBillingAccountsLambda,
-			outputPath: '$.Payload',
-		});
 
-		const stateMachineDefinition = getSalesforceBillingAccountsFromLambdaTask
-		.next(updateZuoraBillingAccountsLambdaTask);
-		
-		const stateMachine = new StateMachine(this, `zuora-salesforce-link-remover-state-machine-${this.stage}`, {
-			stateMachineDefinition,
-		});
+		const getSalesforceBillingAccountsFromLambdaTask = new LambdaInvoke(
+			this,
+			'Get Salesforce Billing Accounts',
+			{
+				lambdaFunction: getSalesforceBillingAccountsLambda,
+				outputPath: '$.Payload',
+			},
+		);
+
+		const updateZuoraBillingAccountsLambdaTask = new LambdaInvoke(
+			this,
+			'Update Zuora Billing Accounts',
+			{
+				lambdaFunction: updateZuoraBillingAccountsLambda,
+				outputPath: '$.Payload',
+			},
+		);
+
+		const stateMachineDefinition =
+			getSalesforceBillingAccountsFromLambdaTask.next(
+				updateZuoraBillingAccountsLambdaTask,
+			);
+
+		const stateMachine = new StateMachine(
+			this,
+			`zuora-salesforce-link-remover-state-machine-${this.stage}`,
+			{
+				stateMachineDefinition,
+			},
+		);
 	}
 }

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -63,7 +63,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			},
 		);
 
-		new GuLambdaFunction(this, 'update-sf-billing-accounts-lambda', {
+		const updateSfBillingAccountsLambda = new GuLambdaFunction(this, 'update-sf-billing-accounts-lambda', {
 			app: appName,
 			functionName: `${appName}-update-sf-billing-accounts-${this.stage}`,
 			runtime: Runtime.NODEJS_20_X,
@@ -102,6 +102,15 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			},
 		);
 
+		const updateSfBillingAccountsLambdaTask = new LambdaInvoke(
+			this,
+			'Update Salesforce Billing Accounts',
+			{
+				lambdaFunction: updateSfBillingAccountsLambda,
+				outputPath: '$.Payload',
+			},
+		);
+
 		const billingAccountsProcessingMap = new Map(
 			this,
 			'Billing Accounts Processor Map',
@@ -124,6 +133,8 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 
 		const definition = getSalesforceBillingAccountsFromLambdaTask.next(
 			billingAccountsProcessingMap,
+		).next(
+			updateSfBillingAccountsLambdaTask,
 		);
 
 		new StateMachine(

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -102,10 +102,9 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			},
 		);
 
-		const definition =
-			getSalesforceBillingAccountsFromLambdaTask.next(
-				updateZuoraBillingAccountsLambdaTask,
-			);
+		const definition = getSalesforceBillingAccountsFromLambdaTask.next(
+			updateZuoraBillingAccountsLambdaTask,
+		);
 
 		new StateMachine(
 			this,

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -111,6 +111,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			'Update Salesforce Billing Accounts',
 			{
 				lambdaFunction: updateSfBillingAccountsLambda,
+				inputPath: '$.billingAccountProcessingAttempts',
 				outputPath: '$.Payload',
 			},
 		);

--- a/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
@@ -47,7 +47,7 @@ export async function handler() {
 	// const prodQuery = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit`
 
 	const testQuery =
-		"select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where name like 'unlink account.testing%'  and GDPR_Removal_Attempts__c = 0 order by createddate asc LIMIT 2";
+		"select Id, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where name like 'unlink account.testing%'  and GDPR_Removal_Attempts__c = 0 order by createddate asc LIMIT 2";
 	const response: SalesforceQueryResponse = await executeSalesforceQuery(
 		sfAuthResponse,
 		testQuery,

--- a/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
@@ -46,7 +46,7 @@ export async function handler() {
 	// const prodQuery = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit`
 
 	const testQuery =
-		'select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c LIMIT 10';
+		'select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where name like \'unlink account.testing%\'  and GDPR_Removal_Attempts__c = 0 LIMIT 2';
 	const response: SalesforceQueryResponse = await executeSalesforceQuery(
 		sfAuthResponse,
 		testQuery,

--- a/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
@@ -1,5 +1,6 @@
 import { doSfAuth, executeSalesforceQuery } from './salesforceHttp';
 import type {
+	BillingAccountRecord,
 	SalesforceQueryResponse,
 	SfApiUserAuth,
 	SfConnectedAppAuth,
@@ -52,8 +53,10 @@ export async function handler() {
 		testQuery,
 	);
 
+	const billingAccountsToProcess: BillingAccountRecord[] = response.records;
+	console.log('billingAccountsToProcess:',billingAccountsToProcess)
 	return {
-		billingAccountsToProcess: response.records,
+		billingAccountsToProcess,
 	};
 }
 

--- a/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
@@ -46,7 +46,7 @@ export async function handler() {
 	// const prodQuery = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit`
 
 	const testQuery =
-		'select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where name like \'unlink account.testing%\'  and GDPR_Removal_Attempts__c = 0 order by createddate asc LIMIT 2';
+		"select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where name like 'unlink account.testing%'  and GDPR_Removal_Attempts__c = 0 order by createddate asc LIMIT 2";
 	const response: SalesforceQueryResponse = await executeSalesforceQuery(
 		sfAuthResponse,
 		testQuery,

--- a/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
@@ -46,7 +46,7 @@ export async function handler() {
 	// const prodQuery = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit`
 
 	const testQuery =
-		'select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where name like \'unlink account.testing%\'  and GDPR_Removal_Attempts__c = 0 LIMIT 2';
+		'select Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where name like \'unlink account.testing%\'  and GDPR_Removal_Attempts__c = 0 order by createddate asc LIMIT 2';
 	const response: SalesforceQueryResponse = await executeSalesforceQuery(
 		sfAuthResponse,
 		testQuery,

--- a/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
@@ -53,7 +53,7 @@ export async function handler() {
 	);
 
 	return {
-		billingAccountsToProcess: response.records
+		billingAccountsToProcess: response.records,
 	};
 }
 

--- a/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
@@ -1,6 +1,5 @@
 import { doSfAuth, executeSalesforceQuery } from './salesforceHttp';
 import type {
-	BillingAccountRecord,
 	SalesforceQueryResponse,
 	SfApiUserAuth,
 	SfConnectedAppAuth,
@@ -53,10 +52,8 @@ export async function handler() {
 		testQuery,
 	);
 
-	const billingAccountsToProcess: BillingAccountRecord[] = response.records;
-	console.log('billingAccountsToProcess:',billingAccountsToProcess)
 	return {
-		billingAccountsToProcess,
+		billingAccountsToProcess: response.records,
 	};
 }
 

--- a/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/getBillingAccounts.ts
@@ -51,7 +51,10 @@ export async function handler() {
 		sfAuthResponse,
 		testQuery,
 	);
-	return response.records;
+
+	return {
+		billingAccountsToProcess: response.records
+	};
 }
 
 function isValidStage(value: unknown): value is 'CODE' | 'PROD' {

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -135,6 +135,11 @@ export const BillingAccountRecordSchema = z.object({
 export const BillingAccountRecordsSchema = z.array(BillingAccountRecordSchema);
 export type BillingAccountRecord = z.infer<typeof BillingAccountRecordSchema>;
 
+export const BillingAccountRecordWithSuccessSchema = BillingAccountRecordSchema.extend({
+	crmIdRemovedSuccessfully: z.boolean(),
+});
+export type BillingAccountRecordWithSuccess = z.infer<typeof BillingAccountRecordWithSuccessSchema>;
+
 const SalesforceQueryResponseSchema = z.object({
 	totalSize: z.number(),
 	done: z.boolean(),
@@ -242,3 +247,6 @@ export type SalesforceUpdateResponse = z.infer<
 const SalesforceUpdateResponseArraySchema = z.array(
 	SalesforceUpdateResponseSchema,
 );
+export type SalesforceUpdateResponseArray = z.infer<
+typeof SalesforceUpdateResponseArraySchema
+>;

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -131,6 +131,8 @@ export const BillingAccountRecordSchema = z.object({
 	GDPR_Removal_Attempts__c: z.number(),
 	Zuora__External_Id__c: z.string(),
 });
+
+export const BillingAccountRecordsSchema = z.array(BillingAccountRecordSchema);
 export type BillingAccountRecord = z.infer<typeof BillingAccountRecordSchema>;
 
 const SalesforceQueryResponseSchema = z.object({

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -29,7 +29,9 @@ export async function doSfAuth(
 			SalesforceAuthResponseSchema.safeParse(sfAuthResponse);
 
 		if (!parseResponse.success) {
-			throw new Error(`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`);
+			throw new Error(
+				`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`,
+			);
 		}
 
 		return parseResponse.data;
@@ -101,7 +103,9 @@ export async function executeSalesforceQuery(
 		SalesforceQueryResponseSchema.safeParse(sfQueryResponse);
 
 	if (!parseResponse.success) {
-		throw new Error(`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`);
+		throw new Error(
+			`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`,
+		);
 	}
 
 	return parseResponse.data;
@@ -141,13 +145,13 @@ export type SalesforceQueryResponse = z.infer<
 
 export async function updateSfBillingAccounts(
 	sfAuthResponse: SfAuthResponse,
-	records: SalesforceUpdateRecord[]
+	records: SalesforceUpdateRecord[],
 ): Promise<SalesforceUpdateResponse[]> {
 	const url = `${sfAuthResponse.instance_url}/services/data/${sfApiVersion()}/composite/sobjects`;
 
 	const body = JSON.stringify({
 		allOrNone: false,
-		records
+		records,
 	});
 	const sfUpdateResponse = await doCompositeCallout(
 		url,
@@ -185,7 +189,9 @@ export async function doCompositeCallout(
 		SalesforceUpdateResponseArraySchema.safeParse(sfUpdateResponse);
 
 	if (!parseResponse.success) {
-		throw new Error(`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`);
+		throw new Error(
+			`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`,
+		);
 	}
 
 	return parseResponse.data;

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -18,7 +18,6 @@ export async function doSfAuth(
 		if (!response.ok) {
 			const errorText = await response.text();
 			const errorMessage = `Error response from Salesforce: ${errorText}`;
-			console.error(errorMessage);
 			throw new Error(errorMessage);
 		}
 
@@ -30,16 +29,13 @@ export async function doSfAuth(
 			SalesforceAuthResponseSchema.safeParse(sfAuthResponse);
 
 		if (!parseResponse.success) {
-			const parseError = `Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`;
-			console.error(parseError);
-			throw new Error(parseError);
+			throw new Error(`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`);
 		}
 
 		return parseResponse.data;
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		const errorText = `Error authenticating with Salesforce: ${errorMessage}`;
-		console.error(errorText);
 		throw new Error(errorText);
 	}
 }
@@ -105,9 +101,7 @@ export async function executeSalesforceQuery(
 		SalesforceQueryResponseSchema.safeParse(sfQueryResponse);
 
 	if (!parseResponse.success) {
-		const parseError = `Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`;
-		console.error(parseError);
-		throw new Error(parseError);
+		throw new Error(`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`);
 	}
 
 	return parseResponse.data;
@@ -191,9 +185,7 @@ export async function doCompositeCallout(
 		SalesforceUpdateResponseArraySchema.safeParse(sfUpdateResponse);
 
 	if (!parseResponse.success) {
-		const parseError = `Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`;
-		console.error(parseError);
-		throw new Error(parseError);
+		throw new Error(`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`);
 	}
 
 	return parseResponse.data;

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -128,7 +128,6 @@ const SalesforceAttributesSchema = z.object({
 export const BillingAccountRecordSchema = z.object({
 	attributes: SalesforceAttributesSchema,
 	Id: z.string(),
-	Zuora__Account__c: z.string(),
 	GDPR_Removal_Attempts__c: z.number(),
 	Zuora__External_Id__c: z.string(),
 });

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -122,10 +122,10 @@ const sfApiVersion = (): string => {
 
 const SalesforceAttributesSchema = z.object({
 	type: z.string(),
-	url: z.string(),
+	url: z.string().optional(),
 });
 
-const BillingAccountRecordSchema = z.object({
+export const BillingAccountRecordSchema = z.object({
 	attributes: SalesforceAttributesSchema,
 	Id: z.string(),
 	Zuora__Account__c: z.string(),
@@ -145,7 +145,7 @@ export type SalesforceQueryResponse = z.infer<
 
 export async function updateSfBillingAccounts(
 	sfAuthResponse: SfAuthResponse,
-	records: SalesforceUpdateRecord[],
+	records: BillingAccountRecord[],
 ): Promise<SalesforceUpdateResponse[]> {
 	const url = `${sfAuthResponse.instance_url}/services/data/${sfApiVersion()}/composite/sobjects`;
 

--- a/handlers/zuora-salesforce-link-remover/src/secrets.ts
+++ b/handlers/zuora-salesforce-link-remover/src/secrets.ts
@@ -55,7 +55,6 @@ export async function getSecretValue<T>(secretName: string): Promise<T> {
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		const errorText = `error getting secret: ${errorMessage}`;
-		console.error(errorText);
 		throw new Error(errorText);
 	}
 }

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -1,6 +1,10 @@
 import { stageFromEnvironment } from '@modules/stage';
 import { doSfAuth, updateSfBillingAccounts } from './salesforceHttp';
-import type { SalesforceUpdateRecord, SfApiUserAuth, SfConnectedAppAuth } from './salesforceHttp';
+import type {
+	SalesforceUpdateRecord,
+	SfApiUserAuth,
+	SfConnectedAppAuth,
+} from './salesforceHttp';
 import { getSalesforceSecretNames, getSecretValue } from './secrets';
 import type { ApiUserSecret, ConnectedAppSecret } from './secrets';
 
@@ -48,15 +52,17 @@ export async function handler() {
 	const incrementedRecords = incrementRemovalAttempts(mockedRecordsToUpdate);
 	const sfUpdateResponse = await updateSfBillingAccounts(
 		sfAuthResponse,
-		incrementedRecords
+		incrementedRecords,
 	);
 
 	return sfUpdateResponse;
 }
 
-function incrementRemovalAttempts(recordsToIncrement: SalesforceUpdateRecord[]): SalesforceUpdateRecord[]{
-	return recordsToIncrement.map(record => ({
-        ...record,
-        GDPR_Removal_Attempts__c: record.GDPR_Removal_Attempts__c + 1,
-    }));
+function incrementRemovalAttempts(
+	recordsToIncrement: SalesforceUpdateRecord[],
+): SalesforceUpdateRecord[] {
+	return recordsToIncrement.map((record) => ({
+		...record,
+		GDPR_Removal_Attempts__c: record.GDPR_Removal_Attempts__c + 1,
+	}));
 }

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -10,16 +10,8 @@ import { getSalesforceSecretNames, getSecretValue } from './secrets';
 import type { ApiUserSecret, ConnectedAppSecret } from './secrets';
 
 export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) => {
-	console.log('billingAccounts:',billingAccounts);
-	// const abc: OriginalRecords = billingAccounts.map(record => ({
-	// 	...record.billingAccountItem,
-	// 	success: record.success,
-	//   }));
-
-	//   console.log('abc:',abc);
 
 	const parseResponse = BillingAccountRecordsSchema.safeParse(billingAccounts);
-	console.log('parseResponse:',parseResponse);
 
 	if (!parseResponse.success) {
 		throw new Error(
@@ -48,36 +40,7 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 	};
 
 	const sfAuthResponse = await doSfAuth(sfApiUserAuth, sfConnectedAppAuth);
-
-	//mocked records to update will come from input event. Need to create state machine before we will know the exact format of the object.
-	// const mockedRecordsToUpdate: BillingAccountRecord[] = billingAccountsList;
-	
-	// [
-	// 	{
-	// 		id: 'a029E00000OEdL9QAL',
-	// 		GDPR_Removal_Attempts__c: 1,
-	// 		attributes: {
-	// 			type: 'Zuora__CustomerAccount__c',
-	// 		},
-	// 	},
-	// 	{
-	// 		id: 'a029E00000OEdMWQA1',
-	// 		GDPR_Removal_Attempts__c: 2,
-	// 		attributes: {
-	// 			type: 'Zuora__CustomerAccount__c',
-	// 		},
-	// 	},
-	// ];
-
-	// const incrementedRecords = incrementRemovalAttempts(billingAccountsList);
-	// const sfUpdateResponse = await updateSfBillingAccounts(
-	// 	sfAuthResponse,
-	// 	incrementedRecords,
-	// );
-
-
 	const billingAccountsToUpdate: BillingAccountRecord[] = incrementRemovalAttempts(parseResponse.data);
-	console.log('billingAccountsList:',billingAccountsToUpdate)
 
 	const sfUpdateResponse = await updateSfBillingAccounts(
 		sfAuthResponse,

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -1,6 +1,6 @@
 import { stageFromEnvironment } from '@modules/stage';
 import type { Handler } from 'aws-lambda';
-import { BillingAccountRecordSchema, doSfAuth, updateSfBillingAccounts } from './salesforceHttp';
+import { BillingAccountRecordsSchema, doSfAuth, updateSfBillingAccounts } from './salesforceHttp';
 import type {
 	BillingAccountRecord,
 	SfApiUserAuth,
@@ -11,7 +11,7 @@ import type { ApiUserSecret, ConnectedAppSecret } from './secrets';
 
 export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) => {
 	console.log('billingAccounts:',billingAccounts);
-	const parseResponse = BillingAccountRecordSchema.safeParse(billingAccounts);
+	const parseResponse = BillingAccountRecordsSchema.safeParse(billingAccounts);
 	console.log('parseResponse:',parseResponse);
 
 	if (!parseResponse.success) {
@@ -20,7 +20,7 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 		);
 	}
 
-	const billingAccountsList: BillingAccountRecord = parseResponse.data;
+	const billingAccountsList: BillingAccountRecord[] = parseResponse.data;
 	// const sfBillingAccountIds = parseResponse.data.map(record => record.sfBillingAccountId);
 	console.log('billingAccountsList:',billingAccountsList)
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -1,5 +1,6 @@
 import { stageFromEnvironment } from '@modules/stage';
 import type { Handler } from 'aws-lambda';
+import { z } from 'zod';
 import { BillingAccountRecordsSchema, doSfAuth, updateSfBillingAccounts } from './salesforceHttp';
 import type {
 	BillingAccountRecord,
@@ -11,6 +12,13 @@ import type { ApiUserSecret, ConnectedAppSecret } from './secrets';
 
 export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) => {
 	console.log('billingAccounts:',billingAccounts);
+	// const abc: OriginalRecords = billingAccounts.map(record => ({
+	// 	...record.billingAccountItem,
+	// 	success: record.success,
+	//   }));
+
+	//   console.log('abc:',abc);
+
 	const parseResponse = BillingAccountRecordsSchema.safeParse(billingAccounts);
 	console.log('parseResponse:',parseResponse);
 
@@ -21,7 +29,6 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 	}
 
 	const billingAccountsList: BillingAccountRecord[] = parseResponse.data;
-	// const sfBillingAccountIds = parseResponse.data.map(record => record.sfBillingAccountId);
 	console.log('billingAccountsList:',billingAccountsList)
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 
@@ -96,3 +103,16 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 
 // const EventSchema = z.array(DataSchema);
 // export type Event = z.infer<typeof EventSchema>;
+
+// const BillingAccountItemSchema = z.object({
+// 	GDPR_Removal_Attempts__c: z.number(),
+// 	Zuora__External_Id__c: z.string(),
+// 	Id: z.string(),
+//   });
+  
+//   const OriginalRecordSchema = z.object({
+// 	billingAccountItem: BillingAccountItemSchema,
+// 	success: z.boolean(),
+//   });
+//   export const OriginalRecordsSchema = z.array(OriginalRecordSchema);
+//   export type OriginalRecords = z.infer<typeof OriginalRecordsSchema>;

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -19,7 +19,18 @@ export const handler: Handler<BillingAccountRecord[], SalesforceUpdateResponseAr
 			`Error parsing data from input: ${JSON.stringify(parseResponse.error.format())}`,
 		);
 	}
-	const billingAccountsToUpdate: BillingAccountRecord[] = parseResponse.data;
+	//const billingAccountsToUpdate: BillingAccountRecord[] = parseResponse.data;
+
+	const billingAccountsToUpdate: BillingAccountRecord[] = [{
+			"Id" : "a02UD000003DBdnYAG",
+			"Zuora__External_Id__c":"",
+			"GDPR_Removal_Attempts__c" : 1,
+			"attributes" : {
+			  "url": "/services/data/v54.0/sobjects/Zuora__CustomerAccount__c/a02UD000003DBdnYAG",
+			  "type" : "Zuora__CustomerAccount__c"
+			}
+	}];
+	
 	console.log('billingAccountsToUpdate:',billingAccountsToUpdate);
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -27,8 +27,6 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 		);
 	}
 
-	const billingAccountsList: BillingAccountRecord[] = parseResponse.data;
-	console.log('billingAccountsList:',billingAccountsList)
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 
 	const { authUrl, clientId, clientSecret } =
@@ -77,22 +75,26 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 	// 	incrementedRecords,
 	// );
 
+
+	const billingAccountsToUpdate: BillingAccountRecord[] = incrementRemovalAttempts(parseResponse.data);
+	console.log('billingAccountsList:',billingAccountsToUpdate)
+
 	const sfUpdateResponse = await updateSfBillingAccounts(
 		sfAuthResponse,
-		billingAccounts,
+		billingAccountsToUpdate,
 	);
 
 	return sfUpdateResponse;
 }
 
-// function incrementRemovalAttempts(
-// 	recordsToIncrement: BillingAccountRecord[],
-// ): BillingAccountRecord[] {
-// 	return recordsToIncrement.map((record) => ({
-// 		...record,
-// 		GDPR_Removal_Attempts__c: record.GDPR_Removal_Attempts__c + 1,
-// 	}));
-// }
+function incrementRemovalAttempts(
+	recordsToIncrement: BillingAccountRecord[],
+): BillingAccountRecord[] {
+	return recordsToIncrement.map((record) => ({
+		...record,
+		GDPR_Removal_Attempts__c: record.GDPR_Removal_Attempts__c + 1,
+	}));
+}
 
 // const DataSchema = z.object({
 //   zuoraBillingAccountId: z.string(),

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -19,19 +19,8 @@ export const handler: Handler<BillingAccountRecord[], SalesforceUpdateResponseAr
 			`Error parsing data from input: ${JSON.stringify(parseResponse.error.format())}`,
 		);
 	}
-	//const billingAccountsToUpdate: BillingAccountRecord[] = parseResponse.data;
+	const billingAccountsToUpdate: BillingAccountRecord[] = parseResponse.data;
 
-	const billingAccountsToUpdate: BillingAccountRecord[] = [{
-			"Id" : "a02UD000003DBdnYAG",
-			"Zuora__External_Id__c":"",
-			"GDPR_Removal_Attempts__c" : 1,
-			"attributes" : {
-			  "url": "/services/data/v54.0/sobjects/Zuora__CustomerAccount__c/a02UD000003DBdnYAG",
-			  "type" : "Zuora__CustomerAccount__c"
-			}
-	}];
-	
-	console.log('billingAccountsToUpdate:',billingAccountsToUpdate);
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 
 	const { authUrl, clientId, clientSecret } =

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -21,7 +21,7 @@ export const handler: Handler = async (event: Event) => {
 		);
 	}
 
-	const sfBillingAccountIds = parseResponse.data.billingAccountProcessingAttempts.map(record => record.sfBillingAccountId);
+	const sfBillingAccountIds = parseResponse.data.map(record => record.sfBillingAccountId);
 	console.log('sfBillingAccountIds:',sfBillingAccountIds)
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -82,12 +82,10 @@ function incrementRemovalAttempts(
 }
 
 const DataSchema = z.object({
-	zuoraBillingAccountId: z.string(),
-	sfBillingAccountId: z.string(),
-	success: z.boolean()
+  zuoraBillingAccountId: z.string(),
+  sfBillingAccountId: z.string(),
+  success: z.boolean()
 });
 
-const EventSchema = z.object({
-	billingAccountProcessingAttempts: z.array(DataSchema)
-});
+const EventSchema = z.array(DataSchema);
 export type Event = z.infer<typeof EventSchema>;

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -1,10 +1,8 @@
 import { stageFromEnvironment } from '@modules/stage';
 import type { Handler } from 'aws-lambda';
-import { z } from 'zod';
 import { BillingAccountRecordSchema, doSfAuth, updateSfBillingAccounts } from './salesforceHttp';
 import type {
 	BillingAccountRecord,
-	SalesforceUpdateRecord,
 	SfApiUserAuth,
 	SfConnectedAppAuth,
 } from './salesforceHttp';
@@ -22,7 +20,7 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 		);
 	}
 
-	const billingAccountsList = parseResponse.data;
+	const billingAccountsList: BillingAccountRecord = parseResponse.data;
 	// const sfBillingAccountIds = parseResponse.data.map(record => record.sfBillingAccountId);
 	console.log('billingAccountsList:',billingAccountsList)
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());
@@ -48,7 +46,7 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 	const sfAuthResponse = await doSfAuth(sfApiUserAuth, sfConnectedAppAuth);
 
 	//mocked records to update will come from input event. Need to create state machine before we will know the exact format of the object.
-	const mockedRecordsToUpdate: BillingAccountRecord[] = billingAccountsList;
+	// const mockedRecordsToUpdate: BillingAccountRecord[] = billingAccountsList;
 	
 	// [
 	// 	{
@@ -67,23 +65,28 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 	// 	},
 	// ];
 
-	const incrementedRecords = incrementRemovalAttempts(mockedRecordsToUpdate);
+	// const incrementedRecords = incrementRemovalAttempts(billingAccountsList);
+	// const sfUpdateResponse = await updateSfBillingAccounts(
+	// 	sfAuthResponse,
+	// 	incrementedRecords,
+	// );
+
 	const sfUpdateResponse = await updateSfBillingAccounts(
 		sfAuthResponse,
-		incrementedRecords,
+		billingAccounts,
 	);
 
 	return sfUpdateResponse;
 }
 
-function incrementRemovalAttempts(
-	recordsToIncrement: BillingAccountRecord[],
-): BillingAccountRecord[] {
-	return recordsToIncrement.map((record) => ({
-		...record,
-		GDPR_Removal_Attempts__c: record.GDPR_Removal_Attempts__c + 1,
-	}));
-}
+// function incrementRemovalAttempts(
+// 	recordsToIncrement: BillingAccountRecord[],
+// ): BillingAccountRecord[] {
+// 	return recordsToIncrement.map((record) => ({
+// 		...record,
+// 		GDPR_Removal_Attempts__c: record.GDPR_Removal_Attempts__c + 1,
+// 	}));
+// }
 
 // const DataSchema = z.object({
 //   zuoraBillingAccountId: z.string(),

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -20,7 +20,7 @@ export const handler: Handler<BillingAccountRecord[], SalesforceUpdateResponseAr
 		);
 	}
 	const billingAccountsToUpdate: BillingAccountRecord[] = parseResponse.data;
-
+	console.log('billingAccountsToUpdate:',billingAccountsToUpdate);
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 
 	const { authUrl, clientId, clientSecret } =

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -10,7 +10,6 @@ import type {
 import { getSalesforceSecretNames, getSecretValue } from './secrets';
 import type { ApiUserSecret, ConnectedAppSecret } from './secrets';
 
-// export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) => {
 export const handler: Handler<BillingAccountRecord[], SalesforceUpdateResponseArray> = async (billingAccounts) => {
 
 	const parseResponse = BillingAccountRecordsSchema.safeParse(billingAccounts);

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -3,13 +3,15 @@ import type { Handler } from 'aws-lambda';
 import { BillingAccountRecordsSchema, doSfAuth, updateSfBillingAccounts } from './salesforceHttp';
 import type {
 	BillingAccountRecord,
+	SalesforceUpdateResponseArray,
 	SfApiUserAuth,
 	SfConnectedAppAuth,
 } from './salesforceHttp';
 import { getSalesforceSecretNames, getSecretValue } from './secrets';
 import type { ApiUserSecret, ConnectedAppSecret } from './secrets';
 
-export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) => {
+// export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) => {
+export const handler: Handler<BillingAccountRecord[], SalesforceUpdateResponseArray> = async (billingAccounts) => {
 
 	const parseResponse = BillingAccountRecordsSchema.safeParse(billingAccounts);
 
@@ -18,6 +20,7 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 			`Error parsing data from input: ${JSON.stringify(parseResponse.error.format())}`,
 		);
 	}
+	const billingAccountsToUpdate: BillingAccountRecord[] = parseResponse.data;
 
 	const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 
@@ -40,7 +43,6 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 	};
 
 	const sfAuthResponse = await doSfAuth(sfApiUserAuth, sfConnectedAppAuth);
-	const billingAccountsToUpdate: BillingAccountRecord[] = incrementRemovalAttempts(parseResponse.data);
 
 	const sfUpdateResponse = await updateSfBillingAccounts(
 		sfAuthResponse,
@@ -49,34 +51,3 @@ export const handler: Handler = async (billingAccounts: BillingAccountRecord[]) 
 
 	return sfUpdateResponse;
 }
-
-function incrementRemovalAttempts(
-	recordsToIncrement: BillingAccountRecord[],
-): BillingAccountRecord[] {
-	return recordsToIncrement.map((record) => ({
-		...record,
-		GDPR_Removal_Attempts__c: record.GDPR_Removal_Attempts__c + 1,
-	}));
-}
-
-// const DataSchema = z.object({
-//   zuoraBillingAccountId: z.string(),
-//   sfBillingAccountId: z.string(),
-//   success: z.boolean()
-// });
-
-// const EventSchema = z.array(DataSchema);
-// export type Event = z.infer<typeof EventSchema>;
-
-// const BillingAccountItemSchema = z.object({
-// 	GDPR_Removal_Attempts__c: z.number(),
-// 	Zuora__External_Id__c: z.string(),
-// 	Id: z.string(),
-//   });
-  
-//   const OriginalRecordSchema = z.object({
-// 	billingAccountItem: BillingAccountItemSchema,
-// 	success: z.boolean(),
-//   });
-//   export const OriginalRecordsSchema = z.array(OriginalRecordSchema);
-//   export type OriginalRecords = z.infer<typeof OriginalRecordsSchema>;

--- a/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateSfBillingAccounts.ts
@@ -1,6 +1,5 @@
 import { stageFromEnvironment } from '@modules/stage';
 import type { Handler } from 'aws-lambda';
-import { z } from 'zod';
 import { BillingAccountRecordsSchema, doSfAuth, updateSfBillingAccounts } from './salesforceHttp';
 import type {
 	BillingAccountRecord,

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -27,7 +27,7 @@ export const handler: Handler = async (event: Event) => {
 		...zuoraBillingAccountUpdateResponse,
 	};
 
-	console.log('returnObj: ', returnObj);
+	console.log('returnObj : ', returnObj);
 	return returnObj;
 };
 

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -11,7 +11,6 @@ export const handler: Handler = async (event: Event) => {
 			`Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`,
 		);
 	}
-	console.log('parseResponse:',parseResponse);
 	const zuoraBillingAccountId = parseResponse.data.item.Zuora__External_Id__c;
 	const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
 		await updateBillingAccountInZuora(zuoraBillingAccountId);

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -20,9 +20,16 @@ export const handler: Handler = async (billingAccount: BillingAccountRecord) => 
 		await updateBillingAccountInZuora(billingAccountItem.Zuora__External_Id__c);
 	console.log('zuoraBillingAccountUpdateResponse:',zuoraBillingAccountUpdateResponse);
 
+	// const returnObj = {
+	// 	billingAccountItem,
+	// 	...zuoraBillingAccountUpdateResponse,
+	// };
+
 	const returnObj = {
-		billingAccountItem,
-		...zuoraBillingAccountUpdateResponse,
+		Id: billingAccountItem.Id,
+		GDPR_Removal_Attempts__c: billingAccountItem.GDPR_Removal_Attempts__c,
+		Zuora__External_Id__c: billingAccountItem.Zuora__External_Id__c,
+		attributes: billingAccountItem.attributes,
 	};
 
 	console.log('returnObj : ', returnObj);
@@ -33,6 +40,10 @@ const DataSchema = z.object({
 	GDPR_Removal_Attempts__c: z.number(),
 	Zuora__External_Id__c: z.string(),
 	Id: z.string(),
+	attributes: z.object({
+		type: z.string(),
+		url: z.string().optional(),
+	}),
 });
 
 const EventSchema = z.object({

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -7,9 +7,7 @@ export const handler: Handler = async (event: Event) => {
 	const parseResponse = EventSchema.safeParse(event);
 
 	if (!parseResponse.success) {
-		const parseError = `Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`;
-		console.error(parseError);
-		throw new Error(parseError);
+		throw new Error(`Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`);
 	}
 
 	const zuoraBillingAccountId = parseResponse.data.Zuora__External_Id__c;

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -12,17 +12,20 @@ export const handler: Handler = async (event: Event) => {
 		);
 	}
 	const zuoraBillingAccountId = parseResponse.data.item.Zuora__External_Id__c;
+	const sfBillingAccountId = parseResponse.data.item.Id;
 	const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
 		await updateBillingAccountInZuora(zuoraBillingAccountId);
 
 	return {
 		zuoraBillingAccountId,
+		sfBillingAccountId,
 		...zuoraBillingAccountUpdateResponse,
 	};
 };
 
 const DataSchema = z.object({
 	Zuora__External_Id__c: z.string(),
+	Id: z.string(),
 });
 
 const EventSchema = z.object({

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -21,11 +21,14 @@ export const handler: Handler = async (event: Event) => {
 		await updateBillingAccountInZuora(zuoraBillingAccountId);
 	console.log('zuoraBillingAccountUpdateResponse:',zuoraBillingAccountUpdateResponse);
 
-	return {
+	const returnObj = {
 		zuoraBillingAccountId,
 		sfBillingAccountId,
 		...zuoraBillingAccountUpdateResponse,
 	};
+
+	console.log('returnObj: ', returnObj);
+	return returnObj;
 };
 
 const DataSchema = z.object({

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -1,10 +1,10 @@
 import type { ZuoraSuccessResponse } from '@modules/zuora/zuoraSchemas';
 import type { Handler } from 'aws-lambda';
 import { z } from 'zod';
-import type { BillingAccountRecord } from './salesforceHttp';
+import type { BillingAccountRecord, BillingAccountRecordWithSuccess } from './salesforceHttp';
 import { updateBillingAccountInZuora } from './zuoraHttp';
 
-export const handler: Handler = async (billingAccount: BillingAccountRecord) => {
+export const handler: Handler<BillingAccountRecord, BillingAccountRecordWithSuccess> = async (billingAccount) => {
 
 	const parseResponse = EventSchema.safeParse(billingAccount);
 	if (!parseResponse.success) {
@@ -17,14 +17,13 @@ export const handler: Handler = async (billingAccount: BillingAccountRecord) => 
 
 	const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
 		await updateBillingAccountInZuora(billingAccountItem.Zuora__External_Id__c);
-	console.log('zuoraBillingAccountUpdateResponse:',zuoraBillingAccountUpdateResponse);
 
-	//todo re-add success value here
 	return {
 		Id: billingAccountItem.Id,
-		GDPR_Removal_Attempts__c: billingAccountItem.GDPR_Removal_Attempts__c,
+		GDPR_Removal_Attempts__c: billingAccountItem.GDPR_Removal_Attempts__c + 1,
 		Zuora__External_Id__c: billingAccountItem.Zuora__External_Id__c,
 		attributes: billingAccountItem.attributes,
+		crmIdRemovedSuccessfully: zuoraBillingAccountUpdateResponse.success
 	};
 };
 

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -11,19 +11,16 @@ export const handler: Handler = async (event: Event) => {
 			`Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`,
 		);
 	}
-	const zuoraBillingAccountId = parseResponse.data.item.Zuora__External_Id__c;
-	console.log('zuoraBillingAccountId:',zuoraBillingAccountId);
 
-	const sfBillingAccountId = parseResponse.data.item.Id;
-	console.log('sfBillingAccountId:',sfBillingAccountId);
+	const billingAccount = parseResponse.data.item;
+	console.log('billingAccount:',billingAccount);
 
 	const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
-		await updateBillingAccountInZuora(zuoraBillingAccountId);
+		await updateBillingAccountInZuora(billingAccount.Zuora__External_Id__c);
 	console.log('zuoraBillingAccountUpdateResponse:',zuoraBillingAccountUpdateResponse);
 
 	const returnObj = {
-		zuoraBillingAccountId,
-		sfBillingAccountId,
+		billingAccount,
 		...zuoraBillingAccountUpdateResponse,
 	};
 
@@ -32,6 +29,7 @@ export const handler: Handler = async (event: Event) => {
 };
 
 const DataSchema = z.object({
+	GDPR_Removal_Attempts__c: z.number(),
 	Zuora__External_Id__c: z.string(),
 	Id: z.string(),
 });

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -7,7 +7,9 @@ export const handler: Handler = async (event: Event) => {
 	const parseResponse = EventSchema.safeParse(event);
 
 	if (!parseResponse.success) {
-		throw new Error(`Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`);
+		throw new Error(
+			`Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`,
+		);
 	}
 
 	const zuoraBillingAccountId = parseResponse.data.Zuora__External_Id__c;

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -5,8 +5,8 @@ import type { BillingAccountRecord } from './salesforceHttp';
 import { updateBillingAccountInZuora } from './zuoraHttp';
 
 export const handler: Handler = async (billingAccount: BillingAccountRecord) => {
+
 	const parseResponse = EventSchema.safeParse(billingAccount);
-	console.log('parseResponse:',parseResponse);
 	if (!parseResponse.success) {
 		throw new Error(
 			`Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`,
@@ -14,26 +14,18 @@ export const handler: Handler = async (billingAccount: BillingAccountRecord) => 
 	}
 
 	const billingAccountItem = parseResponse.data.item;
-	console.log('billingAccountItem:',billingAccountItem);
 
 	const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
 		await updateBillingAccountInZuora(billingAccountItem.Zuora__External_Id__c);
 	console.log('zuoraBillingAccountUpdateResponse:',zuoraBillingAccountUpdateResponse);
 
-	// const returnObj = {
-	// 	billingAccountItem,
-	// 	...zuoraBillingAccountUpdateResponse,
-	// };
-
-	const returnObj = {
+	//todo re-add success value here
+	return {
 		Id: billingAccountItem.Id,
 		GDPR_Removal_Attempts__c: billingAccountItem.GDPR_Removal_Attempts__c,
 		Zuora__External_Id__c: billingAccountItem.Zuora__External_Id__c,
 		attributes: billingAccountItem.attributes,
 	};
-
-	console.log('returnObj : ', returnObj);
-	return returnObj;
 };
 
 const DataSchema = z.object({

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -5,16 +5,21 @@ import { updateBillingAccountInZuora } from './zuoraHttp';
 
 export const handler: Handler = async (event: Event) => {
 	const parseResponse = EventSchema.safeParse(event);
-
+	console.log('parseResponse:',parseResponse);
 	if (!parseResponse.success) {
 		throw new Error(
 			`Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`,
 		);
 	}
 	const zuoraBillingAccountId = parseResponse.data.item.Zuora__External_Id__c;
+	console.log('zuoraBillingAccountId:',zuoraBillingAccountId);
+
 	const sfBillingAccountId = parseResponse.data.item.Id;
+	console.log('sfBillingAccountId:',sfBillingAccountId);
+
 	const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
 		await updateBillingAccountInZuora(zuoraBillingAccountId);
+	console.log('zuoraBillingAccountUpdateResponse:',zuoraBillingAccountUpdateResponse);
 
 	return {
 		zuoraBillingAccountId,

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -11,8 +11,8 @@ export const handler: Handler = async (event: Event) => {
 			`Error parsing billing account id from input: ${JSON.stringify(parseResponse.error.format())}`,
 		);
 	}
-
-	const zuoraBillingAccountId = parseResponse.data.Zuora__External_Id__c;
+	console.log('parseResponse:',parseResponse);
+	const zuoraBillingAccountId = parseResponse.data.item.Zuora__External_Id__c;
 	const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
 		await updateBillingAccountInZuora(zuoraBillingAccountId);
 
@@ -22,7 +22,11 @@ export const handler: Handler = async (event: Event) => {
 	};
 };
 
-const EventSchema = z.object({
+const DataSchema = z.object({
 	Zuora__External_Id__c: z.string(),
+});
+
+const EventSchema = z.object({
+	item: DataSchema,
 });
 export type Event = z.infer<typeof EventSchema>;

--- a/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/updateZuoraBillingAccount.ts
@@ -1,10 +1,11 @@
 import type { ZuoraSuccessResponse } from '@modules/zuora/zuoraSchemas';
 import type { Handler } from 'aws-lambda';
 import { z } from 'zod';
+import type { BillingAccountRecord } from './salesforceHttp';
 import { updateBillingAccountInZuora } from './zuoraHttp';
 
-export const handler: Handler = async (event: Event) => {
-	const parseResponse = EventSchema.safeParse(event);
+export const handler: Handler = async (billingAccount: BillingAccountRecord) => {
+	const parseResponse = EventSchema.safeParse(billingAccount);
 	console.log('parseResponse:',parseResponse);
 	if (!parseResponse.success) {
 		throw new Error(
@@ -12,15 +13,15 @@ export const handler: Handler = async (event: Event) => {
 		);
 	}
 
-	const billingAccount = parseResponse.data.item;
-	console.log('billingAccount:',billingAccount);
+	const billingAccountItem = parseResponse.data.item;
+	console.log('billingAccountItem:',billingAccountItem);
 
 	const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
-		await updateBillingAccountInZuora(billingAccount.Zuora__External_Id__c);
+		await updateBillingAccountInZuora(billingAccountItem.Zuora__External_Id__c);
 	console.log('zuoraBillingAccountUpdateResponse:',zuoraBillingAccountUpdateResponse);
 
 	const returnObj = {
-		billingAccount,
+		billingAccountItem,
 		...zuoraBillingAccountUpdateResponse,
 	};
 


### PR DESCRIPTION
## What does this change?
**Parent Delivery Trello ticket** [Convert Billing Account Remover Lambda from scala to typescript](https://trello.com/c/ne8VPaj0/61-convert-billing-account-remover-lambda-from-scala-to-typescript-l)

Introduce a new State Machine to orchestrate the execution of lambdas created in PRs:

- get billing accounts from salesforce [#2347](https://github.com/guardian/support-service-lambdas/pull/2347)
- update billing account in zuora [#2352](https://github.com/guardian/support-service-lambdas/pull/2352)
- update sf billing accounts [#2357](https://github.com/guardian/support-service-lambdas/pull/2357)

<img width="568" alt="Screenshot 2024-07-10 at 11 59 27" src="https://github.com/guardian/support-service-lambdas/assets/36296660/ba233538-ea85-43f7-a7f6-ff6f63bc67c7">


### State Machine, with example inputs and outputs
<img width="1038" alt="Screenshot 2024-07-10 at 11 33 03" src="https://github.com/guardian/support-service-lambdas/assets/36296660/0d283354-56ed-4bbd-962b-029b577a9cdc">


## How to test
- Create test data in Zuora that will be retrieved by the start query in lambda that queries from Salesforce. Update the test query as needed.
- execute the state machine
- Ensure the crmIds have been removed from the billing accounts in Zuora, and the write backs to Salesforce have been successful (i.e. GDPR_Removal_Attempts__c on billing account records has been incremented by 1). N.B. z360 should then delete the billing accounts in Salesforce a few seconds later, so this can be verified by checking deleted records.