### PR TITLE
Handle discounts in refund lambda

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
@@ -1,33 +1,16 @@
 package com.gu.productmove.refund
 
-import com.amazonaws.services.lambda.runtime.RequestHandler
-import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import com.gu.productmove.{AwsCredentialsLive, AwsS3, AwsS3Live, GuStageLive, SQSLive, SttpClientLive}
+import com.gu.productmove.*
 import com.gu.productmove.GuStageLive.Stage
-import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, OutputBody, Success, TransactionError}
-import zio.{Clock, RIO, Task, ZIO}
+import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.TransactionError
 import com.gu.productmove.invoicingapi.InvoicingApiRefund
-import com.gu.productmove.zuora.InvoiceItemWithTaxDetails
+import com.gu.productmove.zuora.*
 import com.gu.productmove.zuora.model.SubscriptionName
-import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGetLive}
-import com.gu.productmove.zuora.{
-  CreditBalanceAdjustment,
-  GetAccountLive,
-  GetInvoice,
-  GetRefundInvoiceDetails,
-  GetSubscriptionLive,
-  InvoiceItemAdjustment,
-  RefundInvoiceDetails,
-  SubscribeLive,
-  ZuoraCancel,
-  ZuoraCancelLive,
-  ZuoraSetCancellationReason,
-}
-import sttp.capabilities.zio.ZioStreams
 import sttp.client3.SttpBackend
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
+import zio.{Task, ZIO}
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
 
 case class RefundInput(subscriptionName: SubscriptionName)
 
@@ -117,12 +100,14 @@ object RefundSupporterPlus {
     // - one for the charge where the SourceType is "InvoiceDetail" and SourceId is the invoice item id
     // - one for the tax where the SourceType is "Tax" and SourceId is the taxation item id
     // https://www.zuora.com/developer/api-references/older-api/operation/Object_POSTInvoiceItemAdjustment/#!path=SourceType&t=request
-    invoiceItems.filter(_.amountWithTax != 0).flatMap { invoiceItem =>
+    invoiceItems.filter(item => item.amountWithTax != 0).flatMap { invoiceItem =>
       val chargeAdjustment =
         List(
           InvoiceItemAdjustment.PostBody(
             AdjustmentDate = invoiceItem.chargeDateAsDate,
-            Amount = invoiceItem.ChargeAmount.abs,
+            // ChargeAmount will be negative for charges and positive for discounts,
+            // we need to invert this for the adjustments
+            Amount = invoiceItem.ChargeAmount * -1,
             InvoiceId = invoiceItem.InvoiceId,
             SourceId = invoiceItem.Id,
             SourceType = "InvoiceDetail",
@@ -133,7 +118,9 @@ object RefundSupporterPlus {
           List(
             InvoiceItemAdjustment.PostBody(
               AdjustmentDate = invoiceItem.chargeDateAsDate,
-              Amount = taxDetails.amount.abs,
+              // Tax amount will be negative for charges and positive for discounts,
+              // we need to invert this for the adjustments
+              Amount = taxDetails.amount * -1,
               InvoiceId = invoiceItem.InvoiceId,
               SourceId = taxDetails.taxationId,
               SourceType = "Tax",

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
@@ -108,18 +108,17 @@ object RefundSupporterPlus {
     // and discounts as this takes the invoice to values which are not allowed by Zuora. Instead we need to subtract
     // the discount from the charge and create an adjustment for the difference.
     val (charges, discounts) = invoiceItems
-      .filter(_.amountWithTax != 0) // Ignore any items with a zero amount, they will be the contribution charge where the user is just paying the base price
+      .filter(
+        _.amountWithTax != 0,
+      ) // Ignore any items with a zero amount, they will be the contribution charge where the user is just paying the base price
       .partition(_.amountWithTax < 0)
+
     val maybeDiscount = discounts.headOption
-    val discountedCharge = maybeDiscount.flatMap(discount =>
-      charges.find(charge =>
-        charge.ChargeAmount.abs >= discount.ChargeAmount &&
-          charge.taxAmount.abs >= discount.taxAmount,
-      ),
-    )
+    val maybeDiscountedCharge =
+      maybeDiscount.flatMap(discount => charges.find(charge => discount.AppliedToInvoiceItemId.contains(charge.Id)))
 
     val chargesWithDiscounts = charges
-      .map(charge => ChargeWithDiscount(charge, if discountedCharge.contains(charge) then maybeDiscount else None))
+      .map(charge => ChargeWithDiscount(charge, if maybeDiscountedCharge.contains(charge) then maybeDiscount else None))
 
     chargesWithDiscounts.flatMap { chargeWithDiscount =>
       val discountChargeAmount = chargeWithDiscount.discount.map(_.ChargeAmount).getOrElse(BigDecimal(0))

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
@@ -100,7 +100,7 @@ object RefundSupporterPlus {
     // - one for the charge where the SourceType is "InvoiceDetail" and SourceId is the invoice item id
     // - one for the tax where the SourceType is "Tax" and SourceId is the taxation item id
     // https://www.zuora.com/developer/api-references/older-api/operation/Object_POSTInvoiceItemAdjustment/#!path=SourceType&t=request
-    invoiceItems.filter(item => item.amountWithTax != 0).flatMap { invoiceItem =>
+    invoiceItems.filter(_.amountWithTax != 0).flatMap { invoiceItem =>
       val chargeAdjustment =
         List(
           InvoiceItemAdjustment.PostBody(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetRefundInvoiceDetails.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetRefundInvoiceDetails.scala
@@ -1,29 +1,24 @@
 package com.gu.productmove.zuora
 
-import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
-import com.gu.productmove.AwsS3
-import com.gu.productmove.GuStageLive.Stage
-import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError}
 import com.gu.productmove.zuora.model.SubscriptionName
 import com.gu.productmove.zuora.rest.{ZuoraGet, ZuoraRestBody}
-import sttp.capabilities.zio.ZioStreams
-import sttp.capabilities.{Effect, WebSockets}
 import sttp.client3.*
-import sttp.client3.httpclient.zio.HttpClientZioBackend
-import sttp.client3.ziojson.*
-import sttp.model.Uri
 import zio.json.*
-import zio.{IO, RIO, Task, URLayer, ZIO, ZLayer}
+import zio.{RIO, Task, URLayer, ZIO, ZLayer}
 
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, LocalDateTime}
 import scala.collection.immutable.ListMap
-import math.Ordered.orderingToOrdered
+import scala.math.Ordered.orderingToOrdered
 
 object GetRefundInvoiceDetailsLive {
   val layer: URLayer[ZuoraGet, GetRefundInvoiceDetails] =
     ZLayer.fromFunction(GetRefundInvoiceDetailsLive(_))
 }
+
+sealed trait InvoiceItemProcessingType
+case object ChargeProcessingType extends InvoiceItemProcessingType
+case object DiscountProcessingType extends InvoiceItemProcessingType
 
 private class GetRefundInvoiceDetailsLive(zuoraGet: ZuoraGet) extends GetRefundInvoiceDetails {
   private def getInvoiceItemsQuery(subscriptionName: SubscriptionName) =
@@ -64,6 +59,7 @@ private class GetRefundInvoiceDetailsLive(zuoraGet: ZuoraGet) extends GetRefundI
           i.Id,
           i.ChargeDate,
           i.ChargeAmount,
+          i.ProcessingType,
           if (i.TaxAmount != 0) {
             println(s"Tax amount for invoice item $i is ${i.TaxAmount} searching for matching taxation item")
             val item = taxationItems.find(_.InvoiceItemId == i.Id)
@@ -134,6 +130,7 @@ private class GetRefundInvoiceDetailsLive(zuoraGet: ZuoraGet) extends GetRefundI
       Id: String,
       ChargeDate: String,
       ChargeAmount: BigDecimal,
+      ProcessingType: InvoiceItemProcessingType,
       TaxAmount: BigDecimal,
       InvoiceId: String,
   ) {
@@ -145,6 +142,10 @@ private class GetRefundInvoiceDetailsLive(zuoraGet: ZuoraGet) extends GetRefundI
   given JsonEncoder[PostBody] = DeriveJsonEncoder.gen[PostBody]
   given JsonDecoder[TaxationItems] = DeriveJsonDecoder.gen[TaxationItems]
   given JsonDecoder[TaxationItem] = DeriveJsonDecoder.gen[TaxationItem]
+  given JsonDecoder[InvoiceItemProcessingType] = JsonDecoder[Int].map({
+    case 0 => ChargeProcessingType
+    case 1 => DiscountProcessingType
+  })
 }
 
 trait GetRefundInvoiceDetails {
@@ -160,6 +161,7 @@ case class InvoiceItemWithTaxDetails(
     Id: String,
     ChargeDate: String,
     ChargeAmount: BigDecimal,
+    ProcessingType: InvoiceItemProcessingType,
     TaxDetails: Option[TaxDetails],
     InvoiceId: String,
 ) {

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetRefundInvoiceDetails.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetRefundInvoiceDetails.scala
@@ -163,7 +163,8 @@ case class InvoiceItemWithTaxDetails(
     TaxDetails: Option[TaxDetails],
     InvoiceId: String,
 ) {
-  def amountWithTax = ChargeAmount + TaxDetails.map(_.amount).getOrElse(0)
+  def taxAmount = TaxDetails.map(_.amount).getOrElse(BigDecimal(0))
+  def amountWithTax = ChargeAmount + taxAmount
   def chargeDateAsDate = LocalDate.parse(ChargeDate, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 }
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundInvoiceDetailsLiveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundInvoiceDetailsLiveSpec.scala
@@ -63,7 +63,7 @@ object GetRefundInvoiceDetailsLiveSpec extends ZIOSpecDefault {
             )
         } yield {
           assertTrue(
-            result.negativeInvoiceItems.size == 2,
+            result.negativeInvoiceItems.size == 3
           )
         }
       },

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundInvoiceDetailsLiveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundInvoiceDetailsLiveSpec.scala
@@ -46,6 +46,28 @@ object GetRefundInvoiceDetailsLiveSpec extends ZIOSpecDefault {
           )
         }
       },
+      test("finds discount details for a subscription") {
+        for {
+          result <- GetRefundInvoiceDetails
+            .get(SubscriptionName("A-S00631534"))
+            .provide(
+              GetRefundInvoiceDetailsLive.layer,
+              ZLayer.succeed(
+                new MockStackedGetInvoicesZuoraClient(
+                  mutable.Stack(
+                    MockGetInvoicesZuoraClient.responseWithDiscount,
+                    MockGetInvoicesZuoraClient.taxationItemsForDiscount,
+                  ),
+                ),
+              ),
+              ZuoraGetLive.layer,
+            )
+        } yield {
+          assertTrue(
+            result.negativeInvoiceItems.count(_.ProcessingType == ChargeProcessingType) == 2
+          )
+        }
+      },
       test("checkInvoicesEqualBalance function works correctly") {
 
         for {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundInvoiceDetailsLiveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundInvoiceDetailsLiveSpec.scala
@@ -21,7 +21,6 @@ object GetRefundInvoiceDetailsLiveSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("GetInvoiceItemsForSubscriptionLive")(
       test("finds taxation details for a subscription") {
-
         for {
           result <- GetRefundInvoiceDetails
             .get(SubscriptionName("A-S00631534"))
@@ -64,7 +63,7 @@ object GetRefundInvoiceDetailsLiveSpec extends ZIOSpecDefault {
             )
         } yield {
           assertTrue(
-            result.negativeInvoiceItems.count(_.ProcessingType == ChargeProcessingType) == 2
+            result.negativeInvoiceItems.size == 2,
           )
         }
       },

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
@@ -51,7 +51,6 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
               Id = "8ad08dc989d472290189db0888460962",
               ChargeDate = "2023-08-09T17:01:56.000+01:00",
               ChargeAmount = -120,
-              ProcessingType = ChargeProcessingType,
               TaxDetails = None,
               InvoiceId = "8ad08dc989d472290189db08883a0961",
             ),
@@ -59,7 +58,6 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
               Id = "8ad08dc989d472290189db0888460963",
               ChargeDate = "2023-08-09T17:01:56.000+01:00",
               ChargeAmount = 0,
-              ProcessingType = ChargeProcessingType,
               TaxDetails = None,
               InvoiceId = "8ad08dc989d472290189db08883a0961",
             ),
@@ -75,7 +73,6 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
               Id = "8a12843289e577d00189f660966d56bd",
               ChargeDate = "2023-08-15T00:27:52.000+01:00",
               ChargeAmount = 33,
-              ProcessingType = ChargeProcessingType,
               TaxDetails = None,
               InvoiceId = "8a12843289e577d00189f660965f56bc",
             ),
@@ -83,7 +80,6 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
               Id = "8a12843289e577d00189f660966d56be",
               ChargeDate = "2023-08-15T00:27:52.000+01:00",
               ChargeAmount = 15.45,
-              ProcessingType = ChargeProcessingType,
               TaxDetails = None,
               InvoiceId = "8a12843289e577d00189f660965f56bc",
             ),
@@ -100,7 +96,6 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             Id = "8a12867e90766628019084f204fa5335",
             InvoiceId = "8a12867e90766628019084f204f15333",
             ChargeAmount = -9.09,
-            ProcessingType = ChargeProcessingType,
           ),
           InvoiceItemWithTaxDetails(
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
@@ -108,7 +103,6 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             Id = "8a12867e90766628019084f204fa5336",
             InvoiceId = "8a12867e90766628019084f204f15333",
             ChargeAmount = 4.55,
-            ProcessingType = DiscountProcessingType,
           ),
         )
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
@@ -48,18 +48,20 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
         val adjustments = RefundSupporterPlus.buildInvoiceItemAdjustments(
           List(
             InvoiceItemWithTaxDetails(
-              "8ad08dc989d472290189db0888460962",
-              "2023-08-09T17:01:56.000+01:00",
-              -120,
-              None,
-              "8ad08dc989d472290189db08883a0961",
+              Id = "8ad08dc989d472290189db0888460962",
+              ChargeDate = "2023-08-09T17:01:56.000+01:00",
+              ChargeAmount = -120,
+              ProcessingType = ChargeProcessingType,
+              TaxDetails = None,
+              InvoiceId = "8ad08dc989d472290189db08883a0961",
             ),
             InvoiceItemWithTaxDetails(
-              "8ad08dc989d472290189db0888460963",
-              "2023-08-09T17:01:56.000+01:00",
-              0,
-              None,
-              "8ad08dc989d472290189db08883a0961",
+              Id = "8ad08dc989d472290189db0888460963",
+              ChargeDate = "2023-08-09T17:01:56.000+01:00",
+              ChargeAmount = 0,
+              ProcessingType = ChargeProcessingType,
+              TaxDetails = None,
+              InvoiceId = "8ad08dc989d472290189db08883a0961",
             ),
           ),
         )
@@ -70,23 +72,52 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
         val adjustments = RefundSupporterPlus.buildInvoiceItemAdjustments(
           List(
             InvoiceItemWithTaxDetails(
-              "8a12843289e577d00189f660966d56bd",
-              "2023-08-15T00:27:52.000+01:00",
-              33,
-              None,
-              "8a12843289e577d00189f660965f56bc",
+              Id = "8a12843289e577d00189f660966d56bd",
+              ChargeDate = "2023-08-15T00:27:52.000+01:00",
+              ChargeAmount = 33,
+              ProcessingType = ChargeProcessingType,
+              TaxDetails = None,
+              InvoiceId = "8a12843289e577d00189f660965f56bc",
             ),
             InvoiceItemWithTaxDetails(
-              "8a12843289e577d00189f660966d56be",
-              "2023-08-15T00:27:52.000+01:00",
-              15.45,
-              None,
-              "8a12843289e577d00189f660965f56bc",
+              Id = "8a12843289e577d00189f660966d56be",
+              ChargeDate = "2023-08-15T00:27:52.000+01:00",
+              ChargeAmount = 15.45,
+              ProcessingType = ChargeProcessingType,
+              TaxDetails = None,
+              InvoiceId = "8a12843289e577d00189f660965f56bc",
             ),
           ),
         )
         assert(adjustments.length)(equalTo(2)) &&
         assert(adjustments.head.AdjustmentDate.getDayOfMonth)(equalTo(15))
+      },
+      test("buildInvoiceAdjustments function handles discounts correctly") {
+        val invoiceItems = List(
+          InvoiceItemWithTaxDetails(
+            ChargeDate = "2024-07-05T23:09:31.000+01:00",
+            TaxDetails = Some(TaxDetails(-0.91, "8a12867e90766628019084f204fa5338")),
+            Id = "8a12867e90766628019084f204fa5335",
+            InvoiceId = "8a12867e90766628019084f204f15333",
+            ChargeAmount = -9.09,
+            ProcessingType = ChargeProcessingType,
+          ),
+          InvoiceItemWithTaxDetails(
+            ChargeDate = "2024-07-05T23:09:31.000+01:00",
+            TaxDetails = Some(TaxDetails(0.45, "8a12867e90766628019084f204fa5339")),
+            Id = "8a12867e90766628019084f204fa5336",
+            InvoiceId = "8a12867e90766628019084f204f15333",
+            ChargeAmount = 4.55,
+            ProcessingType = DiscountProcessingType,
+          ),
+        )
+
+        val adjustments = RefundSupporterPlus.buildInvoiceItemAdjustments(
+          invoiceItems,
+        )
+        val adjustmentAmount = adjustments.map(item => item.Amount).sum
+        assert(adjustments.length)(equalTo(4)) &&
+        assert(adjustmentAmount)(equalTo(5))
       },
       test("Deserialisation of the invoice adjustment response works") {
         val responseJson =

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
@@ -90,13 +90,15 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
       },
       test("buildInvoiceAdjustments function handles discounts correctly for sub with tax and no contribution") {
         val invoiceItems = List(
+          // Contribution charge
           InvoiceItemWithTaxDetails(
-            "8a12867e90766628019084f204fa5334",
-            "2024-07-05T23:09:31.000+01:00",
-            0,
-            None,
-            "8a12867e90766628019084f204f15333",
+            Id = "8a12867e90766628019084f204fa5334",
+            ChargeDate = "2024-07-05T23:09:31.000+01:00",
+            ChargeAmount = 0,
+            TaxDetails = None,
+            InvoiceId = "8a12867e90766628019084f204f15333",
           ),
+          // Subscription charge
           InvoiceItemWithTaxDetails(
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             TaxDetails = Some(TaxDetails(-0.91, "8a12867e90766628019084f204fa5338")),
@@ -104,8 +106,10 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             InvoiceId = "8a12867e90766628019084f204f15333",
             ChargeAmount = -9.09,
           ),
+          // The discount
           InvoiceItemWithTaxDetails(
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
+            AppliedToInvoiceItemId = Some("8a12867e90766628019084f204fa5335"),
             TaxDetails = Some(TaxDetails(0.45, "8a12867e90766628019084f204fa5339")),
             Id = "8a12867e90766628019084f204fa5336",
             InvoiceId = "8a12867e90766628019084f204f15333",
@@ -122,13 +126,15 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
       },
       test("buildInvoiceAdjustments function handles discounts correctly for sub with tax and contribution") {
         val invoiceItems = List(
+          // Contribution charge
           InvoiceItemWithTaxDetails(
+            Id = "8a12867e90766628019084f204fa5334",
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
-            TaxDetails = Some(TaxDetails(0.45, "8a12867e90766628019084f204fa5339")),
-            Id = "8a12867e90766628019084f204fa5336",
+            ChargeAmount = -10,
+            TaxDetails = None,
             InvoiceId = "8a12867e90766628019084f204f15333",
-            ChargeAmount = 4.55,
           ),
+          // Subscription charge
           InvoiceItemWithTaxDetails(
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             TaxDetails = Some(TaxDetails(-0.91, "8a12867e90766628019084f204fa5338")),
@@ -136,12 +142,14 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             InvoiceId = "8a12867e90766628019084f204f15333",
             ChargeAmount = -9.09,
           ),
+          // The discount
           InvoiceItemWithTaxDetails(
-            "8a12867e90766628019084f204fa5334",
-            "2024-07-05T23:09:31.000+01:00",
-            -10,
-            None,
-            "8a12867e90766628019084f204f15333",
+            ChargeDate = "2024-07-05T23:09:31.000+01:00",
+            AppliedToInvoiceItemId = Some("8a12867e90766628019084f204fa5335"),
+            TaxDetails = Some(TaxDetails(0.45, "8a12867e90766628019084f204fa5339")),
+            Id = "8a12867e90766628019084f204fa5336",
+            InvoiceId = "8a12867e90766628019084f204f15333",
+            ChargeAmount = 4.55,
           ),
         )
 
@@ -154,13 +162,15 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
       },
       test("buildInvoiceAdjustments function handles discounts correctly for sub with no tax and contribution") {
         val invoiceItems = List(
+          // Contribution charge
           InvoiceItemWithTaxDetails(
+            Id = "8a12867e90766628019084f204fa5334",
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
+            ChargeAmount = -10,
             TaxDetails = None,
-            Id = "8a12867e90766628019084f204fa5336",
             InvoiceId = "8a12867e90766628019084f204f15333",
-            ChargeAmount = 5,
           ),
+          // Subscription charge
           InvoiceItemWithTaxDetails(
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             TaxDetails = None,
@@ -168,12 +178,14 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             InvoiceId = "8a12867e90766628019084f204f15333",
             ChargeAmount = -15,
           ),
+          // The discount
           InvoiceItemWithTaxDetails(
-            "8a12867e90766628019084f204fa5334",
-            "2024-07-05T23:09:31.000+01:00",
-            -10,
-            None,
-            "8a12867e90766628019084f204f15333",
+            ChargeDate = "2024-07-05T23:09:31.000+01:00",
+            AppliedToInvoiceItemId = Some("8a12867e90766628019084f204fa5335"),
+            TaxDetails = None,
+            Id = "8a12867e90766628019084f204fa5336",
+            InvoiceId = "8a12867e90766628019084f204f15333",
+            ChargeAmount = 5,
           ),
         )
 
@@ -182,6 +194,7 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
         )
         val adjustmentAmount = adjustments.map(item => item.Amount).sum
         assert(adjustments.length)(equalTo(2)) &&
+        assert(adjustments.find(_.SourceId == "8a12867e90766628019084f204fa5335").get.Amount)(equalTo(10)) &&
         assert(adjustmentAmount)(equalTo(20))
       },
       test("Deserialisation of the invoice adjustment response works") {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoicesZuoraClient.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoicesZuoraClient.scala
@@ -215,6 +215,7 @@ object MockGetInvoicesZuoraClient {
       |    {
       |      "ChargeDate": "2023-08-11T10:03:41.000+01:00",
       |      "TaxAmount": 0,
+      |      "ProcessingType": 0,
       |      "Id": "8ad081c689e27bbb0189e3d654fc04bb",
       |      "InvoiceId": "8ad081c689e27bbb0189e3d654f104ba",
       |      "ChargeAmount": 0
@@ -222,6 +223,7 @@ object MockGetInvoicesZuoraClient {
       |    {
       |      "ChargeDate": "2023-08-11T10:03:41.000+01:00",
       |      "TaxAmount": 0.91,
+      |      "ProcessingType": 0,
       |      "Id": "8ad081c689e27bbb0189e3d654fc04bc",
       |      "InvoiceId": "8ad081c689e27bbb0189e3d654f104ba",
       |      "ChargeAmount": 9.09
@@ -229,6 +231,7 @@ object MockGetInvoicesZuoraClient {
       |    {
       |      "ChargeDate": "2023-08-11T11:04:54.000+01:00",
       |      "TaxAmount": -0.91,
+      |      "ProcessingType": 0,
       |      "Id": "8ad08dc989e27bbe0189e40e611d0abb",
       |      "InvoiceId": "8ad08dc989e27bbe0189e40e61110aba",
       |      "ChargeAmount": -9.09
@@ -236,6 +239,7 @@ object MockGetInvoicesZuoraClient {
       |    {
       |      "ChargeDate": "2023-08-11T11:04:54.000+01:00",
       |      "TaxAmount": 0,
+      |      "ProcessingType": 0,
       |      "Id": "8ad08dc989e27bbe0189e40e611d0abc",
       |      "InvoiceId": "8ad08dc989e27bbe0189e40e61110aba",
       |      "ChargeAmount": 0
@@ -384,6 +388,89 @@ object MockGetInvoicesZuoraClient {
   val taxationItemsForAmountTest =
     """
       |{"size":1,"records":[{"InvoiceItemId":"8ad0880589b2ecb50189b49e46f155c8","Id":"8ad0880589b2ecb50189b49e46df55c6","InvoiceId":"8ad0880589b2ecb50189b49e46e755c7"}],"done":true}
+      |""".stripMargin
+
+  val responseWithDiscount =
+    """
+      |{
+      |    "size": 6,
+      |    "records": [
+      |        {
+      |            "ChargeDate": "2024-07-05T23:09:31.000+01:00",
+      |            "TaxAmount": 0,
+      |            "ProcessingType": 0,
+      |            "Id": "8a12867e90766628019084f204fa5334",
+      |            "InvoiceId": "8a12867e90766628019084f204f15333",
+      |            "ChargeAmount": 0
+      |        },
+      |        {
+      |            "ChargeDate": "2024-07-05T23:09:31.000+01:00",
+      |            "TaxAmount": -0.91,
+      |            "ProcessingType": 0,
+      |            "Id": "8a12867e90766628019084f204fa5335",
+      |            "InvoiceId": "8a12867e90766628019084f204f15333",
+      |            "ChargeAmount": -9.09
+      |        },
+      |        {
+      |            "ChargeDate": "2024-07-05T23:09:31.000+01:00",
+      |            "TaxAmount": 0.45,
+      |            "ProcessingType": 1,
+      |            "Id": "8a12867e90766628019084f204fa5336",
+      |            "InvoiceId": "8a12867e90766628019084f204f15333",
+      |            "ChargeAmount": 4.55
+      |        },
+      |        {
+      |            "ChargeDate": "2024-06-25T16:04:41.000+01:00",
+      |            "TaxAmount": 0.91,
+      |            "ProcessingType": 0,
+      |            "Id": "8a12997890498d8901904fed779d1763",
+      |            "InvoiceId": "8a12997890498d8901904fed778f1762",
+      |            "ChargeAmount": 9.09
+      |        },
+      |        {
+      |            "ChargeDate": "2024-06-25T16:04:41.000+01:00",
+      |            "TaxAmount": -0.45,
+      |            "ProcessingType": 1,
+      |            "Id": "8a12997890498d8901904fed779e1764",
+      |            "InvoiceId": "8a12997890498d8901904fed778f1762",
+      |            "ChargeAmount": -4.55
+      |        },
+      |        {
+      |            "ChargeDate": "2024-06-25T16:04:41.000+01:00",
+      |            "TaxAmount": 0,
+      |            "ProcessingType": 0,
+      |            "Id": "8a12997890498d8901904fed779e1765",
+      |            "InvoiceId": "8a12997890498d8901904fed778f1762",
+      |            "ChargeAmount": 0
+      |        }
+      |    ],
+      |    "done": true
+      |}
+      |""".stripMargin
+
+  val taxationItemsForDiscount =
+    """
+      |{
+      |    "size": 3,
+      |    "records": [
+      |        {
+      |            "InvoiceItemId": "8a12867e90766628019084f204fa5334",
+      |            "Id": "8a12867e90766628019084f204fa5337",
+      |            "InvoiceId": "8a12867e90766628019084f204f15333"
+      |        },
+      |        {
+      |            "InvoiceItemId": "8a12867e90766628019084f204fa5335",
+      |            "Id": "8a12867e90766628019084f204fa5338",
+      |            "InvoiceId": "8a12867e90766628019084f204f15333"
+      |        },
+      |        {
+      |            "InvoiceItemId": "8a12867e90766628019084f204fa5336",
+      |            "Id": "8a12867e90766628019084f204fa5339",
+      |            "InvoiceId": "8a12867e90766628019084f204f15333"
+      |        }
+      |    ],
+      |    "done": true
+      |}
       |""".stripMargin
 }
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoicesZuoraClient.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoicesZuoraClient.scala
@@ -215,7 +215,6 @@ object MockGetInvoicesZuoraClient {
       |    {
       |      "ChargeDate": "2023-08-11T10:03:41.000+01:00",
       |      "TaxAmount": 0,
-      |      "ProcessingType": 0,
       |      "Id": "8ad081c689e27bbb0189e3d654fc04bb",
       |      "InvoiceId": "8ad081c689e27bbb0189e3d654f104ba",
       |      "ChargeAmount": 0
@@ -223,7 +222,6 @@ object MockGetInvoicesZuoraClient {
       |    {
       |      "ChargeDate": "2023-08-11T10:03:41.000+01:00",
       |      "TaxAmount": 0.91,
-      |      "ProcessingType": 0,
       |      "Id": "8ad081c689e27bbb0189e3d654fc04bc",
       |      "InvoiceId": "8ad081c689e27bbb0189e3d654f104ba",
       |      "ChargeAmount": 9.09
@@ -231,7 +229,6 @@ object MockGetInvoicesZuoraClient {
       |    {
       |      "ChargeDate": "2023-08-11T11:04:54.000+01:00",
       |      "TaxAmount": -0.91,
-      |      "ProcessingType": 0,
       |      "Id": "8ad08dc989e27bbe0189e40e611d0abb",
       |      "InvoiceId": "8ad08dc989e27bbe0189e40e61110aba",
       |      "ChargeAmount": -9.09
@@ -239,7 +236,6 @@ object MockGetInvoicesZuoraClient {
       |    {
       |      "ChargeDate": "2023-08-11T11:04:54.000+01:00",
       |      "TaxAmount": 0,
-      |      "ProcessingType": 0,
       |      "Id": "8ad08dc989e27bbe0189e40e611d0abc",
       |      "InvoiceId": "8ad08dc989e27bbe0189e40e61110aba",
       |      "ChargeAmount": 0
@@ -398,7 +394,6 @@ object MockGetInvoicesZuoraClient {
       |        {
       |            "ChargeDate": "2024-07-05T23:09:31.000+01:00",
       |            "TaxAmount": 0,
-      |            "ProcessingType": 0,
       |            "Id": "8a12867e90766628019084f204fa5334",
       |            "InvoiceId": "8a12867e90766628019084f204f15333",
       |            "ChargeAmount": 0
@@ -406,7 +401,6 @@ object MockGetInvoicesZuoraClient {
       |        {
       |            "ChargeDate": "2024-07-05T23:09:31.000+01:00",
       |            "TaxAmount": -0.91,
-      |            "ProcessingType": 0,
       |            "Id": "8a12867e90766628019084f204fa5335",
       |            "InvoiceId": "8a12867e90766628019084f204f15333",
       |            "ChargeAmount": -9.09
@@ -414,7 +408,6 @@ object MockGetInvoicesZuoraClient {
       |        {
       |            "ChargeDate": "2024-07-05T23:09:31.000+01:00",
       |            "TaxAmount": 0.45,
-      |            "ProcessingType": 1,
       |            "Id": "8a12867e90766628019084f204fa5336",
       |            "InvoiceId": "8a12867e90766628019084f204f15333",
       |            "ChargeAmount": 4.55
@@ -422,7 +415,6 @@ object MockGetInvoicesZuoraClient {
       |        {
       |            "ChargeDate": "2024-06-25T16:04:41.000+01:00",
       |            "TaxAmount": 0.91,
-      |            "ProcessingType": 0,
       |            "Id": "8a12997890498d8901904fed779d1763",
       |            "InvoiceId": "8a12997890498d8901904fed778f1762",
       |            "ChargeAmount": 9.09
@@ -430,7 +422,6 @@ object MockGetInvoicesZuoraClient {
       |        {
       |            "ChargeDate": "2024-06-25T16:04:41.000+01:00",
       |            "TaxAmount": -0.45,
-      |            "ProcessingType": 1,
       |            "Id": "8a12997890498d8901904fed779e1764",
       |            "InvoiceId": "8a12997890498d8901904fed778f1762",
       |            "ChargeAmount": -4.55
@@ -438,7 +429,6 @@ object MockGetInvoicesZuoraClient {
       |        {
       |            "ChargeDate": "2024-06-25T16:04:41.000+01:00",
       |            "TaxAmount": 0,
-      |            "ProcessingType": 0,
       |            "Id": "8a12997890498d8901904fed779e1765",
       |            "InvoiceId": "8a12997890498d8901904fed778f1762",
       |            "ChargeAmount": 0

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoicesZuoraClient.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoicesZuoraClient.scala
@@ -396,7 +396,7 @@ object MockGetInvoicesZuoraClient {
       |            "TaxAmount": 0,
       |            "Id": "8a12867e90766628019084f204fa5334",
       |            "InvoiceId": "8a12867e90766628019084f204f15333",
-      |            "ChargeAmount": 0
+      |            "ChargeAmount": -10
       |        },
       |        {
       |            "ChargeDate": "2024-07-05T23:09:31.000+01:00",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The Supporter Plus cancellation refund lambda in the product-move-api doesn't handle discounts correctly because it was written before discounts were supported on S+. 

This PR updates it so that it works correctly, see PR comments for further explanation.