### PR TITLE
Zuora salesforce link remover enable production testing

### DIFF
--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -308,6 +308,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "zuora-salesforce-link-remover",
+            "BillingAccountIds": "",
             "STACK": "membership",
             "STAGE": "CODE",
             "Stage": "CODE",
@@ -1580,6 +1581,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "zuora-salesforce-link-remover",
+            "BillingAccountIds": "",
             "STACK": "membership",
             "STAGE": "PROD",
             "Stage": "PROD",

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -37,7 +37,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 				runtime: Runtime.NODEJS_20_X,
 				environment: {
 					Stage: this.stage,
-					BillingAccountIds:''
+					BillingAccountIds: '',
 				},
 				handler: 'getBillingAccounts.handler',
 				fileName: `${appName}.zip`,

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -37,6 +37,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 				runtime: Runtime.NODEJS_20_X,
 				environment: {
 					Stage: this.stage,
+					BillingAccountIds:''
 				},
 				handler: 'getBillingAccounts.handler',
 				fileName: `${appName}.zip`,

--- a/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
@@ -12,6 +12,7 @@ export async function handler() {
 	try{
 		
 		const stage = process.env.STAGE;
+		const BillingAccountIds = process.env.BillingAccountIds; //should be in format ('abc', 'def')
 
 		if (!stage) {
 			throw Error('Stage not defined');
@@ -49,7 +50,7 @@ export async function handler() {
 		// const prodQuery = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit`
 
 		const testQuery =
-			"select Id, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where name like 'unlink account.testing%'  and GDPR_Removal_Attempts__c = 0 order by createddate asc LIMIT 2";
+			`select Id, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Id in ${BillingAccountIds}`;
 		const response: SalesforceQueryResponse = await executeSalesforceQuery(
 			sfAuthResponse,
 			testQuery,


### PR DESCRIPTION
## What does this change?
Add an environment variable so that targeted testing can take place in production. The environment variable will hold billing account Ids that should be picked up by the start query.

The testing will target just a few billing accounts to begin with, by using their ids in the query to grab them from Salesforce:

```select Id, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Id in ('abc','def')```

Here the contents of the environment variable would be ('abc','def')

Once we verify that the billing accounts are being processed as expected, we'll remove the environment variable and revert the query to the production query:

```SELECT Id, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < 5 ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT 200```


## How to test

In CODE
- Update the environment variable so that it contains billing account Ids to be processed
- execute the state machine
- verify the crmIds are removed from the billing accounts in Zuora and the GDPR_removal_attempts__c field on the records in Salesforce is incremented by 1
