### PR TITLE
zuora <-> salesforce link remover - enable access to prod secrets for access to salesforce

### DIFF
--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -443,6 +443,38 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                     ],
                   ],
                 },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:PROD/Salesforce/ConnectedApp/BillingAccountRemover-WUdrKa",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:PROD/Salesforce/User/BillingAccountRemoverAPIUser-UJ1SwZ",
+                    ],
+                  ],
+                },
               ],
             },
             {
@@ -695,6 +727,38 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                         "Ref": "AWS::AccountId",
                       },
                       ":secret:DEV/Salesforce/User/integrationapiuser-rvxxrG",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:PROD/Salesforce/ConnectedApp/BillingAccountRemover-WUdrKa",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:PROD/Salesforce/User/BillingAccountRemoverAPIUser-UJ1SwZ",
                     ],
                   ],
                 },
@@ -1716,6 +1780,38 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                     ],
                   ],
                 },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:PROD/Salesforce/ConnectedApp/BillingAccountRemover-WUdrKa",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:PROD/Salesforce/User/BillingAccountRemoverAPIUser-UJ1SwZ",
+                    ],
+                  ],
+                },
               ],
             },
             {
@@ -1968,6 +2064,38 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                         "Ref": "AWS::AccountId",
                       },
                       ":secret:DEV/Salesforce/User/integrationapiuser-rvxxrG",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:PROD/Salesforce/ConnectedApp/BillingAccountRemover-WUdrKa",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:PROD/Salesforce/User/BillingAccountRemoverAPIUser-UJ1SwZ",
                     ],
                   ],
                 },

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -48,6 +48,8 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 						resources: [
 							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:DEV/Salesforce/ConnectedApp/AwsConnectorSandbox-oO8Phf`,
 							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:DEV/Salesforce/User/integrationapiuser-rvxxrG`,
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:PROD/Salesforce/ConnectedApp/BillingAccountRemover-WUdrKa`,
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:PROD/Salesforce/User/BillingAccountRemoverAPIUser-UJ1SwZ`,
 						],
 					}),
 					allowPutMetric,
@@ -100,6 +102,8 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 						resources: [
 							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:DEV/Salesforce/ConnectedApp/AwsConnectorSandbox-oO8Phf`,
 							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:DEV/Salesforce/User/integrationapiuser-rvxxrG`,
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:PROD/Salesforce/ConnectedApp/BillingAccountRemover-WUdrKa`,
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:PROD/Salesforce/User/BillingAccountRemoverAPIUser-UJ1SwZ`,
 						],
 					}),
 					allowPutMetric,

--- a/handlers/zuora-salesforce-link-remover/src/secrets.ts
+++ b/handlers/zuora-salesforce-link-remover/src/secrets.ts
@@ -12,7 +12,7 @@ export function getSalesforceSecretNames(stage: Stage): SecretNames {
 			return {
 				apiUserSecretName: 'PROD/Salesforce/User/BillingAccountRemoverAPIUser',
 				connectedAppSecretName:
-					'PROD/Salesforce/ConnectedApp/AwsConnectorSandbox',
+					'PROD/Salesforce/ConnectedApp/BillingAccountRemover',
 			};
 		default:
 			return {

--- a/handlers/zuora-salesforce-link-remover/test/secrets.test.ts
+++ b/handlers/zuora-salesforce-link-remover/test/secrets.test.ts
@@ -21,7 +21,7 @@ describe('getSalesforceSecretNames', () => {
 		const expected = {
 			apiUserSecretName: 'PROD/Salesforce/User/BillingAccountRemoverAPIUser',
 			connectedAppSecretName:
-				'PROD/Salesforce/ConnectedApp/AwsConnectorSandbox',
+				'PROD/Salesforce/ConnectedApp/BillingAccountRemover',
 		};
 
 		expect(actual).toEqual(expected);

--- a/modules/secrets-manager/test/secrets.test.ts
+++ b/modules/secrets-manager/test/secrets.test.ts
@@ -77,7 +77,7 @@ describe('getSecretNameDependingOnEnvironment', () => {
 		const expected = {
 			apiUserSecretName: 'PROD/Salesforce/User/BillingAccountRemoverAPIUser',
 			connectedAppSecretName:
-				'PROD/Salesforce/ConnectedApp/AwsConnectorSandbox',
+				'PROD/Salesforce/ConnectedApp/BillingAccountRemover',
 		};
 		expect(actual).toEqual(expected);
 	});


### PR DESCRIPTION
## What does this change?
Enable access to prod secrets for salesforce api user and connected app. These credentials will allow the lambdas to authenticate with Salesforce and retrieve the billing accounts for processing.

## How to test
Run in production and verify records are being returned from the start query