### PR TITLE
zuora<-> salesforce link remover - block scheduled execution of old scala solution

### DIFF
--- a/handlers/sf-billing-account-remover/cfn.yaml
+++ b/handlers/sf-billing-account-remover/cfn.yaml
@@ -71,7 +71,7 @@ Resources:
           Properties:
             Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule ]
             Description: Runs BillingAccountRemover
-            Enabled: True
+            Enabled: False
       FunctionName:
         !Sub sf-billing-account-remover-${Stage}
       Description: Remove Billing Accounts and related records from Salesforce (via Zuora)


### PR DESCRIPTION
## What does this change?
Stop the scheduled execution of the old scala solution. Once we verify that the new solution is working as expected, we will deprecate this old solution completely.