### PR TITLE
Zuora<->salesforce link remover - fix permissions issue

### DIFF
--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -1013,7 +1013,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:PROD/Zuora/SupportServiceLambdas-WeibUa",
+                      ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-Iu3KIT",
                     ],
                   ],
                 },
@@ -2350,7 +2350,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:PROD/Zuora/SupportServiceLambdas-WeibUa",
+                      ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-Iu3KIT",
                     ],
                   ],
                 },

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -75,7 +75,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 						actions: ['secretsmanager:GetSecretValue'],
 						resources: [
 							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:CODE/Zuora-OAuth/SupportServiceLambdas-S8QM4l`,
-							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:PROD/Zuora/SupportServiceLambdas-WeibUa`,
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:PROD/Zuora-OAuth/SupportServiceLambdas-Iu3KIT`,
 						],
 					}),
 					allowPutMetric,

--- a/handlers/zuora-salesforce-link-remover/src/handlers/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/updateZuoraBillingAccount.ts
@@ -27,7 +27,7 @@ export const handler: Handler<BillingAccountRecord, BillingAccountRecordWithSucc
 			crmIdRemovedSuccessfully: zuoraBillingAccountUpdateResponse.success
 		};
 	}catch(error){
-		throw new Error(`Error updating billing accounts in Salesforce: ${JSON.stringify(error)}`);
+		throw new Error(`Error updating billing accounts in Zuora: ${JSON.stringify(error)}`);
 	}
 };
 

--- a/handlers/zuora-salesforce-link-remover/src/secrets.ts
+++ b/handlers/zuora-salesforce-link-remover/src/secrets.ts
@@ -27,7 +27,7 @@ export function getZuoraSecretName(stage: 'CODE' | 'PROD'): string {
 		case 'CODE':
 			return 'CODE/Zuora-OAuth/SupportServiceLambdas';
 		case 'PROD':
-			return 'PROD/Zuora/SupportServiceLambdas';
+			return 'PROD/Zuora-OAuth/SupportServiceLambdas';
 	}
 }
 

--- a/handlers/zuora-salesforce-link-remover/test/secrets.test.ts
+++ b/handlers/zuora-salesforce-link-remover/test/secrets.test.ts
@@ -43,7 +43,7 @@ describe('getZuoraSecretName', () => {
 
 	test('should get PROD Zuora secret name', () => {
 		const actual = getZuoraSecretName('PROD');
-		const expected = 'PROD/Zuora/SupportServiceLambdas';
+		const expected = 'PROD/Zuora-OAuth/SupportServiceLambdas';
 
 		expect(actual).toEqual(expected);
 	});


### PR DESCRIPTION
## What does this change?
Use the correct secret to obtain Zuora credentials
