### PR TITLE
Zuora <-> Salesforce link remover - disengage from test mode

### DIFF
--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -1153,7 +1153,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","InputPath":"$.billingAccountProcessingAttempts","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":10},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","InputPath":"$.billingAccountProcessingAttempts","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2490,7 +2490,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":1},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","InputPath":"$.billingAccountProcessingAttempts","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}}}},"ItemsPath":"$.billingAccountsToProcess","MaxConcurrency":10},"Update Salesforce Billing Accounts":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","InputPath":"$.billingAccountProcessingAttempts","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -308,7 +308,6 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "zuora-salesforce-link-remover",
-            "BillingAccountIds": "",
             "STACK": "membership",
             "STAGE": "CODE",
             "Stage": "CODE",
@@ -1645,7 +1644,6 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "zuora-salesforce-link-remover",
-            "BillingAccountIds": "",
             "STACK": "membership",
             "STAGE": "PROD",
             "Stage": "PROD",

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -37,7 +37,6 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 				runtime: Runtime.NODEJS_20_X,
 				environment: {
 					Stage: this.stage,
-					BillingAccountIds: '',
 				},
 				handler: 'getBillingAccounts.handler',
 				fileName: `${appName}.zip`,

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -143,7 +143,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			this,
 			'Billing Accounts Processor Map',
 			{
-				maxConcurrency: 1,
+				maxConcurrency: 10,
 				itemsPath: JsonPath.stringAt('$.billingAccountsToProcess'),
 				parameters: {
 					item: JsonPath.stringAt('$$.Map.Item.Value'),

--- a/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
@@ -1,4 +1,5 @@
 import { getSecretValue } from '@modules/secrets-manager/src/getSecret';
+import { stageFromEnvironment } from '@modules/stage';
 import { doSfAuth, executeSalesforceQuery } from '../salesforceHttp';
 import type {
 	SalesforceQueryResponse,
@@ -10,18 +11,8 @@ import type { ApiUserSecret, ConnectedAppSecret } from '../secrets';
 
 export async function handler() {
 	try{
-		
-		const stage = process.env.STAGE;
 
-		if (!stage) {
-			throw Error('Stage not defined');
-		}
-
-		if (!isValidStage(stage)) {
-			throw Error('Invalid Stage value');
-		}
-
-		const secretNames = getSalesforceSecretNames(stage);
+		const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 
 		const { authUrl, clientId, clientSecret } =
 			await getSecretValue<ConnectedAppSecret>(
@@ -57,8 +48,4 @@ export async function handler() {
 	}catch(error){
 		throw new Error(`Error fetching billing accounts from Salesforce: ${JSON.stringify(error)}`);
 	}
-}
-
-function isValidStage(value: unknown): value is 'CODE' | 'PROD' {
-	return value === 'CODE' || value === 'PROD';
 }

--- a/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
@@ -12,7 +12,6 @@ export async function handler() {
 	try{
 		
 		const stage = process.env.STAGE;
-		const BillingAccountIds = process.env.BillingAccountIds; //should be in format ('abc', 'def')
 
 		if (!stage) {
 			throw Error('Stage not defined');
@@ -44,16 +43,12 @@ export async function handler() {
 
 		const sfAuthResponse = await doSfAuth(sfApiUserAuth, sfConnectedAppAuth);
 
-		//todo use test query for now, but update to prod query before release
-		//todo generate test data when we get to dev for updating zuora billing accounts
-		// const limit = 200;
-		// const prodQuery = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT $limit`
+		const limit = 200;
+		const query = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT ${limit}`
 
-		const testQuery =
-			`select Id, GDPR_Removal_Attempts__c, Zuora__External_Id__c from Zuora__CustomerAccount__c where Id in ${BillingAccountIds}`;
 		const response: SalesforceQueryResponse = await executeSalesforceQuery(
 			sfAuthResponse,
-			testQuery,
+			query,
 		);
 
 		return {

--- a/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
@@ -35,7 +35,7 @@ export async function handler() {
 		const sfAuthResponse = await doSfAuth(sfApiUserAuth, sfConnectedAppAuth);
 
 		const limit = 200;
-		const query = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT ${limit}`
+		const query = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < 5 ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT ${limit}`
 		console.log('query:',query);
 		const response: SalesforceQueryResponse = await executeSalesforceQuery(
 			sfAuthResponse,

--- a/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
@@ -36,7 +36,7 @@ export async function handler() {
 
 		const limit = 200;
 		const query = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < $maxAttempts ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT ${limit}`
-
+		console.log('query:',query);
 		const response: SalesforceQueryResponse = await executeSalesforceQuery(
 			sfAuthResponse,
 			query,

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -81,33 +81,38 @@ export async function executeSalesforceQuery(
 	sfAuthResponse: SfAuthResponse,
 	query: string,
 ): Promise<SalesforceQueryResponse> {
-	const response = await fetch(
-		`${sfAuthResponse.instance_url}/services/data/${sfApiVersion()}/query?q=${encodeURIComponent(query)}`,
-		{
-			method: 'GET',
-			headers: {
-				Authorization: `Bearer ${sfAuthResponse.access_token}`,
-				'Content-Type': 'application/json',
+	try{
+		const response = await fetch(
+			`${sfAuthResponse.instance_url}/services/data/${sfApiVersion()}/query?q=${encodeURIComponent(query)}`,
+			{
+				method: 'GET',
+				headers: {
+					Authorization: `Bearer ${sfAuthResponse.access_token}`,
+					'Content-Type': 'application/json',
+				},
 			},
-		},
-	);
-	console.log('response:',response);
-	if (!response.ok) {
-		throw new Error(`Failed to execute query: ${response.statusText}`);
-	}
-
-	const sfQueryResponse = (await response.json()) as SalesforceQueryResponse;
-
-	const parseResponse =
-		SalesforceQueryResponseSchema.safeParse(sfQueryResponse);
-
-	if (!parseResponse.success) {
-		throw new Error(
-			`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`,
 		);
-	}
+		console.log('response:',response);
+		if (!response.ok) {
+			throw new Error(`Failed to execute query: ${response.statusText}`);
+		}
 
-	return parseResponse.data;
+		const sfQueryResponse = (await response.json()) as SalesforceQueryResponse;
+
+		const parseResponse =
+			SalesforceQueryResponseSchema.safeParse(sfQueryResponse);
+
+		if (!parseResponse.success) {
+			throw new Error(
+				`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`,
+			);
+		}
+
+		return parseResponse.data;
+	} catch (error) {
+		const errorText = `Error querying Salesforce: ${JSON.stringify(error)}`;
+		throw new Error(errorText);
+	}
 }
 
 const sfApiVersion = (): string => {
@@ -155,18 +160,23 @@ export async function updateSfBillingAccounts(
 	sfAuthResponse: SfAuthResponse,
 	records: BillingAccountRecord[],
 ): Promise<SalesforceUpdateResponse[]> {
-	const url = `${sfAuthResponse.instance_url}/services/data/${sfApiVersion()}/composite/sobjects`;
+	try{
+		const url = `${sfAuthResponse.instance_url}/services/data/${sfApiVersion()}/composite/sobjects`;
 
-	const body = JSON.stringify({
-		allOrNone: false,
-		records,
-	});
-	const sfUpdateResponse = await doCompositeCallout(
-		url,
-		sfAuthResponse.access_token,
-		body,
-	);
-	return sfUpdateResponse;
+		const body = JSON.stringify({
+			allOrNone: false,
+			records,
+		});
+		const sfUpdateResponse = await doCompositeCallout(
+			url,
+			sfAuthResponse.access_token,
+			body,
+		);
+		return sfUpdateResponse;
+	} catch (error) {
+		const errorText = `Error updating billing accounts in Salesforce: ${JSON.stringify(error)}`;
+		throw new Error(errorText);
+	}
 }
 
 export async function doCompositeCallout(
@@ -176,33 +186,38 @@ export async function doCompositeCallout(
 ): Promise<SalesforceUpdateResponse[]> {
 	console.log('doing composite callout...');
 
-	const options = {
-		method: 'PATCH',
-		headers: {
-			Authorization: `Bearer ${token}`,
-			'Content-Type': 'application/json',
-		},
-		body,
-	};
+	try{
+		const options = {
+			method: 'PATCH',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'Content-Type': 'application/json',
+			},
+			body,
+		};
 
-	const response = await fetch(url, options);
-	if (!response.ok) {
-		throw new Error(
-			`Error updating record(s) in Salesforce: ${response.statusText}`,
-		);
+		const response = await fetch(url, options);
+		if (!response.ok) {
+			throw new Error(
+				`Error updating record(s) in Salesforce: ${response.statusText}`,
+			);
+		}
+
+		const sfUpdateResponse = (await response.json()) as SalesforceUpdateResponse;
+		const parseResponse =
+			SalesforceUpdateResponseArraySchema.safeParse(sfUpdateResponse);
+
+		if (!parseResponse.success) {
+			throw new Error(
+				`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`,
+			);
+		}
+
+		return parseResponse.data;
+	} catch (error) {
+		const errorText = `Error executing composite callout to Salesforce: ${JSON.stringify(error)}`;
+		throw new Error(errorText);
 	}
-
-	const sfUpdateResponse = (await response.json()) as SalesforceUpdateResponse;
-	const parseResponse =
-		SalesforceUpdateResponseArraySchema.safeParse(sfUpdateResponse);
-
-	if (!parseResponse.success) {
-		throw new Error(
-			`Error parsing response from Salesforce: ${JSON.stringify(parseResponse.error.format())}`,
-		);
-	}
-
-	return parseResponse.data;
 }
 
 const SalesforceUpdateRecordsSchema = z.object({

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -91,7 +91,7 @@ export async function executeSalesforceQuery(
 			},
 		},
 	);
-
+	console.log('response:',response);
 	if (!response.ok) {
 		throw new Error(`Failed to execute query: ${response.statusText}`);
 	}

--- a/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
+++ b/handlers/zuora-salesforce-link-remover/src/salesforceHttp.ts
@@ -92,7 +92,7 @@ export async function executeSalesforceQuery(
 				},
 			},
 		);
-		console.log('response:',response);
+
 		if (!response.ok) {
 			throw new Error(`Failed to execute query: ${response.statusText}`);
 		}


### PR DESCRIPTION
## What does this change?
We have now verified that the state machine has executed and processed a subset of production records records as expected, so we can now remove the test query and use the production query instead.

I've also:

- updated the code in getBillingAccounts lambda to get the stage value from a shared module
- updated the maximum concurrent invocations of the updateZuoraBillingAccount lambda from 1 at a time to 10 at a time, which will reduce the execution time.