### PR TITLE
Disable zuora-salesforce-link-remover schedule

### DIFF
--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -131,7 +131,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
     "ScheduleStateMachineRule91756851": {
       "Properties": {
         "ScheduleExpression": "cron(0 0 1 1 ? *)",
-        "State": "ENABLED",
+        "State": "DISABLED",
         "Targets": [
           {
             "Arn": {
@@ -1546,7 +1546,7 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
     "ScheduleStateMachineRule91756851": {
       "Properties": {
         "ScheduleExpression": "cron(0 * * * ? *)",
-        "State": "ENABLED",
+        "State": "DISABLED",
         "Targets": [
           {
             "Arn": {

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -180,6 +180,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 		new Rule(this, 'ScheduleStateMachineRule', {
 			schedule: Schedule.cron(executionFrequency),
 			targets: [new SfnStateMachine(stateMachine)],
+			enabled: false,
 		});
 
 		const topic = Topic.fromTopicArn(


### PR DESCRIPTION
This is currently failing regularly and noisily. We'll investigate next week.
It's ok for it to not run for a few days