### PR TITLE
Add retention periods to pii lambda logs

### DIFF
--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -39,6 +39,18 @@ exports[`The Discount API stack matches the snapshot 1`] = `
     },
   },
   "Parameters": {
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555ArtifactHashE09D7C96": {
+      "Description": "Artifact hash for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00": {
+      "Description": "S3 bucket for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D": {
+      "Description": "S3 key for asset version "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -156,6 +168,153 @@ exports[`The Discount API stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
+      "DependsOn": [
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00",
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:PutRetentionPolicy",
+                "logs:DeleteRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "Roles": [
+          {
+            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "S3inlinepolicy3B07399A": {
       "Properties": {
@@ -311,6 +470,29 @@ exports[`The Discount API stack matches the snapshot 1`] = `
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "discountapilambdaLogRetention9F27B9DF": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "discountapilambda972ABED6",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 14,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
     },
     "discountapilambdaServiceRole4CB5B1F4": {
       "Properties": {
@@ -964,43 +1146,6 @@ exports[`The Discount API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "discountapilambdaloggroup1B091C98": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "LogGroupName": {
-          "Fn::Join": [
-            "",
-            [
-              "/aws/lambda/",
-              {
-                "Ref": "discountapilambda972ABED6",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 14,
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
   },
 }
 `;
@@ -1044,6 +1189,18 @@ exports[`The Discount API stack matches the snapshot 2`] = `
     },
   },
   "Parameters": {
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555ArtifactHashE09D7C96": {
+      "Description": "Artifact hash for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00": {
+      "Description": "S3 bucket for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D": {
+      "Description": "S3 key for asset version "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -1161,6 +1318,153 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
+      "DependsOn": [
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00",
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:PutRetentionPolicy",
+                "logs:DeleteRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "Roles": [
+          {
+            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "S3inlinepolicy3B07399A": {
       "Properties": {
@@ -1316,6 +1620,29 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "discountapilambdaLogRetention9F27B9DF": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "discountapilambda972ABED6",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 14,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
     },
     "discountapilambdaServiceRole4CB5B1F4": {
       "Properties": {
@@ -1968,43 +2295,6 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
-    },
-    "discountapilambdaloggroup1B091C98": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "LogGroupName": {
-          "Fn::Join": [
-            "",
-            [
-              "/aws/lambda/",
-              {
-                "Ref": "discountapilambda972ABED6",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 14,
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
     },
   },
 }

--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -169,6 +169,45 @@ exports[`The Discount API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::DomainName",
     },
+    "LambdaRetentionPolicyECD5887F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:DescribeLogGroups",
+                "logs:PutRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:logs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LambdaRetentionPolicyECD5887F",
+        "Roles": [
+          {
+            "Ref": "retentionrole12375474",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
       "DependsOn": [
         "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
@@ -311,6 +350,27 @@ exports[`The Discount API stack matches the snapshot 1`] = `
         "Roles": [
           {
             "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "RetentionS3inlinepolicy268B92D7": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3::*:membership-dist/membership/CODE/discount-api/",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "RetentionS3inlinepolicy268B92D7",
+        "Roles": [
+          {
+            "Ref": "retentionrole12375474",
           },
         ],
       },
@@ -484,7 +544,6 @@ exports[`The Discount API stack matches the snapshot 1`] = `
             ],
           ],
         },
-        "RetentionInDays": 14,
         "ServiceToken": {
           "Fn::GetAtt": [
             "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
@@ -1146,6 +1205,66 @@ exports[`The Discount API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
+    "discountapilambdaloggroupretentionmanager66A6DF3B": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::GetAtt": [
+            "discountapilambdaLogRetention9F27B9DF",
+            "LogGroupName",
+          ],
+        },
+        "LogGroupRegion": {
+          "Ref": "AWS::Region",
+        },
+        "RemovalPolicy": "retain",
+        "RetentionInDays": 14,
+        "SdkRetry": {
+          "maxRetries": 3,
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "retentionrole12375474": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
   },
 }
 `;
@@ -1319,6 +1438,45 @@ exports[`The Discount API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::DomainName",
     },
+    "LambdaRetentionPolicyECD5887F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:DescribeLogGroups",
+                "logs:PutRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:logs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LambdaRetentionPolicyECD5887F",
+        "Roles": [
+          {
+            "Ref": "retentionrole12375474",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
       "DependsOn": [
         "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
@@ -1461,6 +1619,27 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         "Roles": [
           {
             "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "RetentionS3inlinepolicy268B92D7": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3::*:membership-dist/membership/PROD/discount-api/",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "RetentionS3inlinepolicy268B92D7",
+        "Roles": [
+          {
+            "Ref": "retentionrole12375474",
           },
         ],
       },
@@ -1634,7 +1813,6 @@ exports[`The Discount API stack matches the snapshot 2`] = `
             ],
           ],
         },
-        "RetentionInDays": 14,
         "ServiceToken": {
           "Fn::GetAtt": [
             "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
@@ -2295,6 +2473,66 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "discountapilambdaloggroupretentionmanager66A6DF3B": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::GetAtt": [
+            "discountapilambdaLogRetention9F27B9DF",
+            "LogGroupName",
+          ],
+        },
+        "LogGroupRegion": {
+          "Ref": "AWS::Region",
+        },
+        "RemovalPolicy": "retain",
+        "RetentionInDays": 14,
+        "SdkRetry": {
+          "maxRetries": 3,
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "retentionrole12375474": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
   },
 }

--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -39,6 +39,18 @@ exports[`The Discount API stack matches the snapshot 1`] = `
     },
   },
   "Parameters": {
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555ArtifactHashE09D7C96": {
+      "Description": "Artifact hash for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00": {
+      "Description": "S3 bucket for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D": {
+      "Description": "S3 key for asset version "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -156,6 +168,153 @@ exports[`The Discount API stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
+      "DependsOn": [
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00",
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:PutRetentionPolicy",
+                "logs:DeleteRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "Roles": [
+          {
+            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "S3inlinepolicy3B07399A": {
       "Properties": {
@@ -311,6 +470,29 @@ exports[`The Discount API stack matches the snapshot 1`] = `
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "discountapilambdaLogRetention9F27B9DF": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "discountapilambda972ABED6",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 14,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
     },
     "discountapilambdaServiceRole4CB5B1F4": {
       "Properties": {
@@ -1007,6 +1189,18 @@ exports[`The Discount API stack matches the snapshot 2`] = `
     },
   },
   "Parameters": {
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555ArtifactHashE09D7C96": {
+      "Description": "Artifact hash for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00": {
+      "Description": "S3 bucket for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
+    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D": {
+      "Description": "S3 key for asset version "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
+      "Type": "String",
+    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -1124,6 +1318,153 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
+      "DependsOn": [
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00",
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:PutRetentionPolicy",
+                "logs:DeleteRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "Roles": [
+          {
+            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "S3inlinepolicy3B07399A": {
       "Properties": {
@@ -1279,6 +1620,29 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "discountapilambdaLogRetention9F27B9DF": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "discountapilambda972ABED6",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 14,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
     },
     "discountapilambdaServiceRole4CB5B1F4": {
       "Properties": {

--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -39,18 +39,6 @@ exports[`The Discount API stack matches the snapshot 1`] = `
     },
   },
   "Parameters": {
-    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555ArtifactHashE09D7C96": {
-      "Description": "Artifact hash for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
-      "Type": "String",
-    },
-    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00": {
-      "Description": "S3 bucket for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
-      "Type": "String",
-    },
-    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D": {
-      "Description": "S3 key for asset version "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
-      "Type": "String",
-    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -168,153 +156,6 @@ exports[`The Discount API stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
-      "DependsOn": [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00",
-          },
-          "S3Key": {
-            "Fn::Join": [
-              "",
-              [
-                {
-                  "Fn::Select": [
-                    0,
-                    {
-                      "Fn::Split": [
-                        "||",
-                        {
-                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  "Fn::Select": [
-                    1,
-                    {
-                      "Fn::Split": [
-                        "||",
-                        {
-                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": [
-          {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "S3inlinepolicy3B07399A": {
       "Properties": {
@@ -470,29 +311,6 @@ exports[`The Discount API stack matches the snapshot 1`] = `
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "discountapilambdaLogRetention9F27B9DF": {
-      "Properties": {
-        "LogGroupName": {
-          "Fn::Join": [
-            "",
-            [
-              "/aws/lambda/",
-              {
-                "Ref": "discountapilambda972ABED6",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 14,
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::LogRetention",
     },
     "discountapilambdaServiceRole4CB5B1F4": {
       "Properties": {
@@ -1146,6 +964,33 @@ exports[`The Discount API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
+    "discountapilambdaloggroup1B091C98": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/discount-api-CODE",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
   },
 }
 `;
@@ -1189,18 +1034,6 @@ exports[`The Discount API stack matches the snapshot 2`] = `
     },
   },
   "Parameters": {
-    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555ArtifactHashE09D7C96": {
-      "Description": "Artifact hash for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
-      "Type": "String",
-    },
-    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00": {
-      "Description": "S3 bucket for asset "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
-      "Type": "String",
-    },
-    "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D": {
-      "Description": "S3 key for asset version "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555"",
-      "Type": "String",
-    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -1318,153 +1151,6 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
-      "DependsOn": [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3BucketA2053C00",
-          },
-          "S3Key": {
-            "Fn::Join": [
-              "",
-              [
-                {
-                  "Fn::Select": [
-                    0,
-                    {
-                      "Fn::Split": [
-                        "||",
-                        {
-                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  "Fn::Select": [
-                    1,
-                    {
-                      "Fn::Split": [
-                        "||",
-                        {
-                          "Ref": "AssetParameters5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555S3VersionKeyCF717D9D",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": [
-          {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "S3inlinepolicy3B07399A": {
       "Properties": {
@@ -1620,29 +1306,6 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "discountapilambdaLogRetention9F27B9DF": {
-      "Properties": {
-        "LogGroupName": {
-          "Fn::Join": [
-            "",
-            [
-              "/aws/lambda/",
-              {
-                "Ref": "discountapilambda972ABED6",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 14,
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::LogRetention",
     },
     "discountapilambdaServiceRole4CB5B1F4": {
       "Properties": {
@@ -2295,6 +1958,33 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "discountapilambdaloggroup1B091C98": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/discount-api-PROD",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
   },
 }

--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -968,7 +968,15 @@ exports[`The Discount API stack matches the snapshot 1`] = `
       "DeletionPolicy": "Retain",
       "Properties": {
         "LogGroupName": {
-          "Ref": "discountapilambda972ABED6",
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "discountapilambda972ABED6",
+              },
+            ],
+          ],
         },
         "RetentionInDays": 14,
         "Tags": [
@@ -1965,7 +1973,15 @@ exports[`The Discount API stack matches the snapshot 2`] = `
       "DeletionPolicy": "Retain",
       "Properties": {
         "LogGroupName": {
-          "Ref": "discountapilambda972ABED6",
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "discountapilambda972ABED6",
+              },
+            ],
+          ],
         },
         "RetentionInDays": 14,
         "Tags": [

--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -967,7 +967,9 @@ exports[`The Discount API stack matches the snapshot 1`] = `
     "discountapilambdaloggroup1B091C98": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "LogGroupName": "/aws/lambda/discount-api-CODE",
+        "LogGroupName": {
+          "Ref": "discountapilambda972ABED6",
+        },
         "RetentionInDays": 14,
         "Tags": [
           {
@@ -1962,7 +1964,9 @@ exports[`The Discount API stack matches the snapshot 2`] = `
     "discountapilambdaloggroup1B091C98": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "LogGroupName": "/aws/lambda/discount-api-PROD",
+        "LogGroupName": {
+          "Ref": "discountapilambda972ABED6",
+        },
         "RetentionInDays": 14,
         "Tags": [
           {

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -1,19 +1,18 @@
-import { GuApiLambda } from '@guardian/cdk';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuStack } from '@guardian/cdk/lib/constructs/core';
-import type { App } from 'aws-cdk-lib';
-import { Duration, aws_logs as logs } from 'aws-cdk-lib';
-import {
-	ApiKeySourceType,
-	CfnBasePathMapping,
-	CfnDomainName,
-} from 'aws-cdk-lib/aws-apigateway';
-import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
-import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import { LogGroup } from 'aws-cdk-lib/aws-logs';
-import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import {GuApiLambda} from '@guardian/cdk';
+import {GuAlarm} from '@guardian/cdk/lib/constructs/cloudwatch';
+import type {GuStackProps} from '@guardian/cdk/lib/constructs/core';
+import {GuStack} from '@guardian/cdk/lib/constructs/core';
+import type {App} from 'aws-cdk-lib';
+//import { aws_logs as logs, Duration, RemovalPolicy} from 'aws-cdk-lib';
+import { Duration} from 'aws-cdk-lib';
+import {ApiKeySourceType, CfnBasePathMapping, CfnDomainName,} from 'aws-cdk-lib/aws-apigateway';
+import {ComparisonOperator, Metric} from 'aws-cdk-lib/aws-cloudwatch';
+//import {Effect, Grant, IPrincipal, Policy, PolicyStatement, Role, ServicePrincipal} from 'aws-cdk-lib/aws-iam';
+import {Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import {Runtime} from 'aws-cdk-lib/aws-lambda';
+//import {LogGroup, RetentionDays} from 'aws-cdk-lib/aws-logs';
+import { RetentionDays} from 'aws-cdk-lib/aws-logs';
+import {CfnRecordSet} from 'aws-cdk-lib/aws-route53';
 
 export interface DiscountApiProps extends GuStackProps {
 	stack: string;
@@ -50,6 +49,7 @@ export class DiscountApi extends GuStack {
 			monitoringConfiguration: {
 				noMonitoring: true, // There is a threshold alarm defined below
 			},
+			logRetention: RetentionDays.TWO_WEEKS,
 			app: app,
 			api: {
 				id: nameWithStage,
@@ -64,11 +64,6 @@ export class DiscountApi extends GuStack {
 					apiKeyRequired: true,
 				},
 			},
-		});
-
-		new LogGroup(this, `${app}-lambda-log-group`, {
-			logGroupName: `/aws/lambda/${lambda.functionName}`,
-			retention: logs.RetentionDays.TWO_WEEKS,
 		});
 
 		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -1,18 +1,22 @@
-import {GuApiLambda} from '@guardian/cdk';
-import {GuAlarm} from '@guardian/cdk/lib/constructs/cloudwatch';
-import type {GuStackProps} from '@guardian/cdk/lib/constructs/core';
-import {GuStack} from '@guardian/cdk/lib/constructs/core';
-import type {App} from 'aws-cdk-lib';
+import { GuApiLambda } from '@guardian/cdk';
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { App } from 'aws-cdk-lib';
 //import { aws_logs as logs, Duration, RemovalPolicy} from 'aws-cdk-lib';
-import { Duration} from 'aws-cdk-lib';
-import {ApiKeySourceType, CfnBasePathMapping, CfnDomainName,} from 'aws-cdk-lib/aws-apigateway';
-import {ComparisonOperator, Metric} from 'aws-cdk-lib/aws-cloudwatch';
+import { Duration } from 'aws-cdk-lib';
+import {
+	ApiKeySourceType,
+	CfnBasePathMapping,
+	CfnDomainName,
+} from 'aws-cdk-lib/aws-apigateway';
+import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 //import {Effect, Grant, IPrincipal, Policy, PolicyStatement, Role, ServicePrincipal} from 'aws-cdk-lib/aws-iam';
-import {Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import {Runtime} from 'aws-cdk-lib/aws-lambda';
+import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
 //import {LogGroup, RetentionDays} from 'aws-cdk-lib/aws-logs';
-import { RetentionDays} from 'aws-cdk-lib/aws-logs';
-import {CfnRecordSet} from 'aws-cdk-lib/aws-route53';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 
 export interface DiscountApiProps extends GuStackProps {
 	stack: string;

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -3,9 +3,7 @@ import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
-import {aws_logs, Duration} from 'aws-cdk-lib';
-import { aws_logs as logs } from 'aws-cdk-lib';
-import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { Duration, aws_logs as logs} from 'aws-cdk-lib';
 import {
 	ApiKeySourceType,
 	CfnBasePathMapping,
@@ -14,6 +12,7 @@ import {
 import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 
 export interface DiscountApiProps extends GuStackProps {
@@ -67,10 +66,10 @@ export class DiscountApi extends GuStack {
 			},
 		});
 
-		const logGroup = new LogGroup(this, `${app}-lambda-log-group`, {
-		 	logGroupName: `/aws/lambda/discount-api-${this.stage}`,
-		 	retention: logs.RetentionDays.TWO_WEEKS,
-		 });
+		new LogGroup(this, `${app}-lambda-log-group`, {
+			logGroupName: `${lambda.functionName}`,
+			retention: logs.RetentionDays.TWO_WEEKS,
+		});
 
 		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {
 			name: nameWithStage,

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -4,6 +4,7 @@ import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
+import { aws_logs as logs } from 'aws-cdk-lib';
 import {
 	ApiKeySourceType,
 	CfnBasePathMapping,
@@ -64,6 +65,13 @@ export class DiscountApi extends GuStack {
 				},
 			},
 		});
+
+		const logGroup = new logs.LogRetention(this, `${app}-lambda-log-group`, {
+			logGroupName: '/aws/lambda/discount-api-${this.stage}',
+			retention: logs.RetentionDays.TWO_WEEKS,
+			logGroupRegion: 'eu-west-1',
+
+		})
 
 		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {
 			name: nameWithStage,

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -3,7 +3,7 @@ import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
-import { Duration, aws_logs as logs} from 'aws-cdk-lib';
+import { Duration, aws_logs as logs } from 'aws-cdk-lib';
 import {
 	ApiKeySourceType,
 	CfnBasePathMapping,
@@ -12,7 +12,7 @@ import {
 import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 
 export interface DiscountApiProps extends GuStackProps {

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -67,7 +67,7 @@ export class DiscountApi extends GuStack {
 		});
 
 		new LogGroup(this, `${app}-lambda-log-group`, {
-			logGroupName: `${lambda.functionName}`,
+			logGroupName: `/aws/lambda/${lambda.functionName}`,
 			retention: logs.RetentionDays.TWO_WEEKS,
 		});
 

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -51,6 +51,7 @@ export class DiscountApi extends GuStack {
 				noMonitoring: true, // There is a threshold alarm defined below
 			},
 			app: app,
+			logRetention: logs.RetentionDays.TWO_WEEKS,
 			api: {
 				id: nameWithStage,
 				restApiName: nameWithStage,
@@ -65,13 +66,6 @@ export class DiscountApi extends GuStack {
 				},
 			},
 		});
-
-		const logGroup = new logs.LogRetention(this, `${app}-lambda-log-group`, {
-			logGroupName: '/aws/lambda/discount-api-${this.stage}',
-			retention: logs.RetentionDays.TWO_WEEKS,
-			logGroupRegion: 'eu-west-1',
-
-		})
 
 		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {
 			name: nameWithStage,

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -3,8 +3,9 @@ import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import {aws_logs, Duration} from 'aws-cdk-lib';
 import { aws_logs as logs } from 'aws-cdk-lib';
+import { LogGroup } from "aws-cdk-lib/aws-logs";
 import {
 	ApiKeySourceType,
 	CfnBasePathMapping,
@@ -51,7 +52,6 @@ export class DiscountApi extends GuStack {
 				noMonitoring: true, // There is a threshold alarm defined below
 			},
 			app: app,
-			logRetention: logs.RetentionDays.TWO_WEEKS,
 			api: {
 				id: nameWithStage,
 				restApiName: nameWithStage,
@@ -66,6 +66,11 @@ export class DiscountApi extends GuStack {
 				},
 			},
 		});
+
+		const logGroup = new LogGroup(this, `${app}-lambda-log-group`, {
+		 	logGroupName: `/aws/lambda/discount-api-${this.stage}`,
+		 	retention: logs.RetentionDays.TWO_WEEKS,
+		 });
 
 		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {
 			name: nameWithStage,

--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -88,6 +88,11 @@ Resources:
           Value: SAM
       Architectures:
         - arm64
+  LambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: '/aws/lambda/move-product-${Stage}'
+      RetentionInDays: 14
   RefundDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a retention period of 2 weeks to the move-product and discount-api lambdas.
Both these lambdas contain PII and so cannot be moved to external logging services.
This is a competing solution to using the [clouwatch-logs-management repo](https://github.com/guardian/cloudwatch-logs-management/pull/334) to manage retention periods.
The advantage of this approach is that it will not result in log migration resources we are not planning to use being added to the stack.


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
