### PR TITLE
Route product-switch-api alarms to the Value team chat

### DIFF
--- a/cdk/lib/__snapshots__/product-switch-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/product-switch-api.test.ts.snap
@@ -1009,7 +1009,7 @@ exports[`The Product switch api stack matches the snapshot 2`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":retention-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1120,7 +1120,7 @@ exports[`The Product switch api stack matches the snapshot 2`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":retention-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },

--- a/cdk/lib/product-switch-api.ts
+++ b/cdk/lib/product-switch-api.ts
@@ -163,6 +163,8 @@ export class ProductSwitchApi extends GuStack {
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
 		if (this.stage === 'PROD') {
+			const snsTopicName = 'alarms-handler-topic-PROD';
+
 			new GuAlarm(this, 'ApiGateway5XXAlarmCDK', {
 				app,
 				alarmName: alarmName('API gateway 5XX response'),
@@ -171,7 +173,7 @@ export class ProductSwitchApi extends GuStack {
 				),
 				evaluationPeriods: 1,
 				threshold: 1,
-				snsTopicName: 'retention-dev',
+				snsTopicName,
 				comparisonOperator:
 					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				metric: new Metric({
@@ -190,7 +192,7 @@ export class ProductSwitchApi extends GuStack {
 				alarmDescription: alarmDescription(
 					'Product switch lambda failed, please check the logs to diagnose the issue.',
 				),
-				snsTopicName: 'retention-dev',
+				snsTopicName,
 				comparisonOperator:
 					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				metric: new Metric({

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -57,6 +57,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'payment-failure-comms',
 		'publishing-alarm-stack-cdk',
 		'salesforce-case-raiser',
+		'product-switch-api',
 	],
 	SRE: ['alarms-handler', 'gchat-test-app'],
 	PP: [


### PR DESCRIPTION
## What does this change?

After this PR is merged, alarms for the `product-switch-api` will be processed by the alarms handler lambda and sent to Value team chat.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
