### PR TITLE
Route update-supporter-plus amount-alarm to the Value team

### DIFF
--- a/cdk/lib/__snapshots__/update-supporter-plus-amount.test.ts.snap
+++ b/cdk/lib/__snapshots__/update-supporter-plus-amount.test.ts.snap
@@ -1008,7 +1008,7 @@ exports[`The Update supporter plus amount stack matches the snapshot 2`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":retention-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },

--- a/cdk/lib/update-supporter-plus-amount.ts
+++ b/cdk/lib/update-supporter-plus-amount.ts
@@ -104,7 +104,7 @@ export class UpdateSupporterPlusAmount extends GuStack {
 				),
 				evaluationPeriods: 1,
 				threshold: 1,
-				snsTopicName: 'retention-dev',
+				snsTopicName: 'alarms-handler-topic-PROD',
 				comparisonOperator:
 					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				metric: new Metric({

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -58,7 +58,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'publishing-alarm-stack-cdk',
 		'salesforce-case-raiser',
 		'product-switch-api',
-		'update-supporter-plus-amounts',
+		'update-supporter-plus-amount',
 	],
 	SRE: ['alarms-handler', 'gchat-test-app'],
 	PP: [

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -58,6 +58,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'publishing-alarm-stack-cdk',
 		'salesforce-case-raiser',
 		'product-switch-api',
+		'update-supporter-plus-amounts',
 	],
 	SRE: ['alarms-handler', 'gchat-test-app'],
 	PP: [


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR changes the destination of the update-supporter-plus-amount alarm to the Value team chat.
Merge after #2394