### PR TITLE
Improved logging & a test for T3

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -90,7 +90,7 @@ object Handler extends LazyLogging {
             consents <- consentsCalculator.getSoftOptInsByProduct(sub.Product__c)
             consentsBody = consentsCalculator.buildConsentsBody(consents, state = true)
             _ = logger.info(
-              s"Sending consents request for sub with name ${sub.Name} and Identity id for ${sub.Buyer__r.IdentityID__c} with body $consentsBody",
+              s"Sending consents request - sub ${sub.Name}, Identity id ${sub.Buyer__r.IdentityID__c}, product ${sub.Product__c} with body $consentsBody",
             )
             _ <- sendConsentsReq(sub.Buyer__r.IdentityID__c, consentsBody)
           } yield ()

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -89,6 +89,9 @@ object Handler extends LazyLogging {
           for {
             consents <- consentsCalculator.getSoftOptInsByProduct(sub.Product__c)
             consentsBody = consentsCalculator.buildConsentsBody(consents, state = true)
+            _ = logger.info(
+              s"Sending consents request for sub with name ${sub.Name} and Identity id for ${sub.Buyer__r.IdentityID__c} with body $consentsBody",
+            )
             _ <- sendConsentsReq(sub.Buyer__r.IdentityID__c, consentsBody)
           } yield ()
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
@@ -1,12 +1,15 @@
 package com.gu.soft_opt_in_consent_setter
 
 import com.gu.soft_opt_in_consent_setter.models.{IdentityConfig, SoftOptInError}
+import com.typesafe.scalalogging.LazyLogging
 import scalaj.http.{Http, HttpResponse}
+
 import scala.util.Try
 
-class IdentityConnector(config: IdentityConfig) {
+class IdentityConnector(config: IdentityConfig) extends LazyLogging {
 
   def sendConsentsReq(identityId: String, body: String): Either[SoftOptInError, Unit] = {
+    logger.info(s"Sending consents request to Identity for $identityId with body $body")
     handleConsentsResp(
       sendReq(url = s"${config.identityUrl}/users/$identityId/consents", body),
       errorDesc = s"Identity request failed while processing $identityId with body $body",

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
@@ -9,7 +9,6 @@ import scala.util.Try
 class IdentityConnector(config: IdentityConfig) extends LazyLogging {
 
   def sendConsentsReq(identityId: String, body: String): Either[SoftOptInError, Unit] = {
-    logger.info(s"Sending consents request to Identity for $identityId with body $body")
     handleConsentsResp(
       sendReq(url = s"${config.identityUrl}/users/$identityId/consents", body),
       errorDesc = s"Identity request failed while processing $identityId with body $body",

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
@@ -1,9 +1,7 @@
 package com.gu.soft_opt_in_consent_setter
 
 import com.gu.soft_opt_in_consent_setter.models.{IdentityConfig, SoftOptInError}
-import com.typesafe.scalalogging.LazyLogging
 import scalaj.http.{Http, HttpResponse}
-
 import scala.util.Try
 
 class IdentityConnector(config: IdentityConfig) {

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
@@ -6,7 +6,7 @@ import scalaj.http.{Http, HttpResponse}
 
 import scala.util.Try
 
-class IdentityConnector(config: IdentityConfig) extends LazyLogging {
+class IdentityConnector(config: IdentityConfig) {
 
   def sendConsentsReq(identityId: String, body: String): Either[SoftOptInError, Unit] = {
     handleConsentsResp(

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -263,4 +263,51 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     result shouldBe Right(())
   }
+  test(testName = "processAcquiredSub should handle a Tier Three acquisition event correctly") {
+    mockSendConsentsReq
+      .expects(
+        "someIdentityId",
+        """[
+          |  {
+          |    "id" : "digital_subscriber_preview",
+          |    "consented" : true
+          |  },
+          |  {
+          |    "id" : "guardian_weekly_newsletter",
+          |    "consented" : true
+          |  },
+          |  {
+          |    "id" : "your_support_onboarding",
+          |    "consented" : true
+          |  },
+          |  {
+          |    "id" : "similar_guardian_products",
+          |    "consented" : true
+          |  },
+          |  {
+          |    "id" : "supporter_newsletter",
+          |    "consented" : true
+          |  }
+          |]""".stripMargin,
+      )
+      .returning(Right(()))
+
+    val testMessageBody = MessageBody(
+      identityId = "someIdentityId",
+      productName = "Tier Three",
+      previousProductName = None,
+      eventType = Acquisition,
+      subscriptionId = "A-S12345678",
+    )
+
+    val result = processAcquiredSub(
+      testMessageBody,
+      mockSendConsentsReq,
+      calculator,
+    )
+
+    result shouldBe Right(())
+  }
 }
+
+

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -10,6 +10,13 @@ object ConsentsCalculatorTestData {
   val guWeeklyMapping = Set("your_support_onboarding", "guardian_weekly_newsletter")
   val testProductMapping = Set("unique_consent")
   val testFeastMobileSubscriptionMapping = Set("your_support_onboarding", "similar_guardian_products")
+  val testTierThreeMapping = Set(
+    "your_support_onboarding",
+    "similar_guardian_products",
+    "supporter_newsletter",
+    "digital_subscriber_preview",
+    "guardian_weekly_newsletter",
+  )
 
   val testConsentMappings = Map(
     "membership" -> membershipMapping,
@@ -20,6 +27,7 @@ object ConsentsCalculatorTestData {
     "guardianweekly" -> guWeeklyMapping,
     "testproduct" -> testProductMapping,
     "FeastInAppPurchase" -> testFeastMobileSubscriptionMapping,
+    "Tier Three" -> testTierThreeMapping,
   )
 
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR justs adds some additional logging to the soft-opt-in-consent-setter lambda as currently it is very minimal. It also adds a test for the new Tier Three product although I'm not sure there's a massive amount of value to it as it doesn't use the actual json file where consents are defined (this is in S3).

I think it would an improvement to move the definition of consents from this json file into this repo where it can be properly tested and version controlled, but that will be a separate PR.