### PR TITLE
Refactor: Move deprecated state machine definition to definitionProperties

### DIFF
--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -18,6 +18,7 @@ import { Topic } from 'aws-cdk-lib/aws-sns';
 import {
 	Choice,
 	Condition,
+	DefinitionBody,
 	JsonPath,
 	Map,
 	Pass,
@@ -177,15 +178,17 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			)
 			.otherwise(new Pass(this, 'No Billing Accounts to process'));
 
-		const definition = getSalesforceBillingAccountsFromLambdaTask.next(
-			billingAccountsExistChoice,
+		const definitionBody = DefinitionBody.fromChainable(
+			getSalesforceBillingAccountsFromLambdaTask.next(
+				billingAccountsExistChoice,
+			),
 		);
 
 		const stateMachine = new StateMachine(
 			this,
 			`zuora-salesforce-link-remover-state-machine-${this.stage}`,
 			{
-				definition,
+				definitionBody: definitionBody,
 			},
 		);
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Statemachine.definition has been deprecated and replaced with definitionBody. 
This change updates the zuora-salesforce-link-remover state-machine, which is still using 'definition' to use definitionBody instead. 

It is used almost exactly the same way.
`
const definition =  getSalesforceBillingAccountsFromLambdaTask.next(billingAccountsExistChoice,);
`
becomes:
`
const definitionBody = StateMachine.definitionBody.fromChainable(getSalesforceBillingAccountsFromLambdaTask
			.next(billingAccountsExistChoice)
  );
`
This work is to help position the repo to start using latest version of cdk. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

No functional change and no change to the generated Cloudformation template.
Testing can be limited to deploying to CODE and confirming Cloudformation resources are as expected.
Confirmed no change to cloudformation template.
Confirmed deploy to CODE successful.
Confirmed zero drift in cloudformation stack after deploy.
Confirmed resources all look as expected.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

This will remove deprecation warnings and be one less barrier to upgrading cdk and other dependencies.

## Have we considered potential risks?

The change populates the same parts of the State Machine in the same way. Confirming the Cloudformation template is unchanged means that this code change will not introduce any new risk.

