### PR TITLE
prioritise holiday stop processing more appropriately

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopCreditProcessor.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/HolidayStopCreditProcessor.scala
@@ -38,12 +38,12 @@ object HolidayStopCreditProcessor {
   ): List[ProcessResult[ZuoraHolidayCreditAddResult]] = {
 
     val allProcessableProductTypes = List(
+      NewspaperNationalDelivery,
       NewspaperHomeDelivery,
+      GuardianWeekly,
+      TierThree,
       NewspaperVoucherBook,
       NewspaperDigitalVoucher,
-      GuardianWeekly,
-      NewspaperNationalDelivery,
-      TierThree,
     )
 
     val productTypesToProcess = productTypeAndStopDateOverride match {


### PR DESCRIPTION
We have noticed that when there's a lot of holiday stops, and it's processing a whole weekend, sometimes the stops aren't processed in time for fulfilment, especially national delivery.
National delivery fulfilment is being made later in this PR https://github.com/guardian/national-delivery-fulfilment/pull/47

This PR changes it to do national delivery first in the process, so that it's more likely to complete it.