### PR TITLE
Holiday stop processor: Log the product name along with count of credit requests

### DIFF
--- a/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
+++ b/handlers/holiday-stop-processor/src/main/scala/com/gu/holidaystopprocessor/Salesforce.scala
@@ -33,7 +33,9 @@ object Salesforce extends LazyLogging {
     }.toDisjunction match {
       case Left(failure) => Left(SalesforceApiFailure(failure.toString))
       case Right(details) =>
-        logger.info(s"There are ${details.length} credit requests from Salesforce to process")
+        logger.info(
+          s"There are ${details.length} credit requests from Salesforce to process for '${productVariant.name}'",
+        )
         if (details.length > batchSize) logger.warn(s"Only processing $batchSize of ${details.length} requests")
         Right(details.take(batchSize))
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Logs the product name along with the count of credit requests for that product. We recently had to investigate an issue and it would have been helpful to have this information all on one line.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I deployed to CODE.

Before:

<img width="872" alt="Screenshot 2024-08-02 at 11 22 22" src="https://github.com/user-attachments/assets/98681107-d238-4fce-9131-bf46d27dc81c">

After:

<img width="957" alt="Screenshot 2024-08-02 at 11 22 28" src="https://github.com/user-attachments/assets/fb4cc184-f371-4f4d-b453-010b9f306cbf">

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
