### PR TITLE
Move Soft opt-in settings into code

### DIFF
--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -61,11 +61,6 @@ Resources:
       Policies:
         - Statement:
             - Effect: Allow
-              Action: s3:GetObject
-              Resource:
-                - !Sub arn:aws:s3:::soft-opt-in-consent-setter/${Stage}/ConsentsByProductMapping.json
-        - Statement:
-            - Effect: Allow
               Action: cloudwatch:PutMetricData
               Resource: "*"
         - Statement:
@@ -113,11 +108,6 @@ Resources:
                 - "dynamodb:PutItem"
               Resource:
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/soft-opt-in-consent-setter-${Stage}-logging
-        - Statement:
-            - Effect: Allow
-              Action: s3:GetObject
-              Resource:
-                - !Sub arn:aws:s3:::soft-opt-in-consent-setter/${Stage}/ConsentsByProductMapping.json
         - Statement:
             - Effect: Allow
               Action: cloudwatch:PutMetricData

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -1,6 +1,7 @@
 package com.gu.soft_opt_in_consent_setter
 
 import com.gu.soft_opt_in_consent_setter.models.{
+  ConsentsMapping,
   EnhancedSub,
   SFAssociatedSubResponse,
   SFSubRecord,
@@ -36,7 +37,7 @@ object Handler extends LazyLogging {
       )
 
       identityConnector = new IdentityConnector(config.identityConfig)
-      consentsCalculator = new ConsentsCalculator(config.consentsMapping)
+      consentsCalculator = new ConsentsCalculator(ConsentsMapping.consentsMapping)
 
       acqSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyToProcessAcquisitionStatus))
       _ <- processAcquiredSubs(acqSubs, identityConnector.sendConsentsReq, sfConnector.updateSubs, consentsCalculator)

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -73,7 +73,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       dynamoConnector <- DynamoConnector()
 
       identityConnector = new IdentityConnector(config.identityConfig)
-      consentsCalculator = new ConsentsCalculator(config.consentsMapping)
+      consentsCalculator = new ConsentsCalculator(ConsentsMapping.consentsMapping)
       mpapiConnector = new MpapiConnector(config.mpapiConfig)
     } yield (sfConnector, identityConnector, consentsCalculator, mpapiConnector, dynamoConnector)
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentMappings.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentMappings.scala
@@ -1,0 +1,100 @@
+package com.gu.soft_opt_in_consent_setter.models
+
+object ConsentMappings {
+  val yourSupportOnboarding = "your_support_onboarding"
+  val similarGuardianProducts = "similar_guardian_products"
+  val supporterNewsletter = "supporter_newsletter"
+  val subscriberPreview = "subscriber_preview"
+  val guardianWeeklyNewsletter = "guardian_weekly_newsletter"
+  val digitalSubscriberPreview = "digital_subscriber_preview"
+
+  val consentsMapping: Map[String, Set[String]] = Map(
+    "Membership" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+    ),
+    "Supporter" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+    ),
+    "Contribution" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+    ),
+    "Recurring Contribution" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+    ),
+    "Contributor" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+    ),
+    "newspaper" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      subscriberPreview,
+      supporterNewsletter,
+    ),
+    "Newspaper - Home Delivery" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      subscriberPreview,
+      supporterNewsletter,
+    ),
+    "Newspaper - Voucher Book" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      subscriberPreview,
+      supporterNewsletter,
+    ),
+    "Newspaper - Digital Voucher" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      subscriberPreview,
+      supporterNewsletter,
+    ),
+    "Guardian Weekly" -> Set(
+      yourSupportOnboarding,
+      guardianWeeklyNewsletter,
+    ),
+    "Digital Pack" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+      digitalSubscriberPreview,
+    ),
+    "Supporter Plus" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+      digitalSubscriberPreview,
+    ),
+    "Tier Three" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+      digitalSubscriberPreview,
+      guardianWeeklyNewsletter,
+    ),
+    "InAppPurchase" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+    ),
+    "Newspaper - National Delivery" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+      supporterNewsletter,
+      subscriberPreview,
+    ),
+    "FeastInAppPurchase" -> Set(
+      yourSupportOnboarding,
+      similarGuardianProducts,
+    ),
+  )
+}

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -1,6 +1,6 @@
 package com.gu.soft_opt_in_consent_setter.models
 
-object ConsentMappings {
+object ConsentsMapping {
   val yourSupportOnboarding = "your_support_onboarding"
   val similarGuardianProducts = "similar_guardian_products"
   val supporterNewsletter = "supporter_newsletter"

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
@@ -1,17 +1,12 @@
 package com.gu.soft_opt_in_consent_setter.models
 
-import com.gu.effects.GetFromS3.fetchString
-import com.gu.effects.S3Location
 import com.gu.salesforce.SFAuthConfig
-import io.circe.parser.decode
-import scala.util.{Failure, Success}
 
 case class SoftOptInConfig(
     sfConfig: SFAuthConfig,
     sfApiVersion: String,
     identityConfig: IdentityConfig,
     mpapiConfig: MpapiConfig,
-    consentsMapping: Map[String, Set[String]],
     stage: String,
 )
 
@@ -29,7 +24,6 @@ object SoftOptInConfig {
       mobilePurchasesAPIUserGetSubscriptionsSecrets <- Secrets.getMobilePurchasesAPIUserGetSubscriptionsSecrets
       sfApiVersion <- sys.env.get("sfApiVersion")
       stage <- sys.env.get("Stage")
-      consentsMapping <- getConsentsByProductMapping(stage)
     } yield SoftOptInConfig(
       SFAuthConfig(
         salesforceConnectedAppSecrets.authUrl,
@@ -48,16 +42,11 @@ object SoftOptInConfig {
         mobilePurchasesAPIUserGetSubscriptionsSecrets.mpapiUrl,
         mobilePurchasesAPIUserGetSubscriptionsSecrets.mpapiToken,
       ),
-      consentsMapping,
       stage,
     )).toRight(
       SoftOptInError(
         "SoftOptInConfig: Could not obtain all config.",
       ),
     )
-  }
-
-  def getConsentsByProductMapping(stage: String): Option[Map[String, Set[String]]] = {
-    Some(ConsentMappings.consentsMapping)
   }
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/softOptInConfig.scala
@@ -58,9 +58,6 @@ object SoftOptInConfig {
   }
 
   def getConsentsByProductMapping(stage: String): Option[Map[String, Set[String]]] = {
-    fetchString(S3Location("soft-opt-in-consent-setter", s"$stage/ConsentsByProductMapping.json")) match {
-      case Success(jsonContent) => decode[Map[String, Set[String]]](jsonContent).toOption
-      case Failure(f) => None
-    }
+    Some(ConsentMappings.consentsMapping)
   }
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -1,14 +1,7 @@
 package com.gu.soft_opt_in_consent_setter
 
 import com.gu.soft_opt_in_consent_setter.models.{ConsentsMapping, SoftOptInError}
-import com.gu.soft_opt_in_consent_setter.testData.ConsentsCalculatorTestData.{
-  contributionMapping,
-  guWeeklyMapping,
-  membershipMapping,
-  newspaperMapping,
-  supporterPlusMapping,
-  testConsentMappings,
-}
+import com.gu.soft_opt_in_consent_setter.testData.ConsentsCalculatorTestData._
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -1,6 +1,10 @@
 import com.gu.soft_opt_in_consent_setter.HandlerIAP._
-import com.gu.soft_opt_in_consent_setter.models.{SFAssociatedSubRecord, SFAssociatedSubResponse, SoftOptInError}
-import com.gu.soft_opt_in_consent_setter.testData.ConsentsCalculatorTestData.testConsentMappings
+import com.gu.soft_opt_in_consent_setter.models.{
+  ConsentsMapping,
+  SFAssociatedSubRecord,
+  SFAssociatedSubResponse,
+  SoftOptInError,
+}
 import com.gu.soft_opt_in_consent_setter.{
   ConsentsCalculator,
   MobileSubscription,
@@ -15,7 +19,7 @@ import org.scalatest.matchers.should.Matchers
 
 class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
-  val calculator = new ConsentsCalculator(testConsentMappings)
+  val calculator = new ConsentsCalculator(ConsentsMapping.consentsMapping)
   val mockSendConsentsReq = mockFunction[String, String, Either[SoftOptInError, Unit]]
   val mockGetMobileSubscriptions = mockFunction[String, Either[SoftOptInError, MobileSubscriptions]]
   val mockSfConnector = mock[SalesforceConnector]
@@ -48,7 +52,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
         true,
         records = Seq(
           SFAssociatedSubRecord(
-            "contributions",
+            "Contributor",
             identityId,
           ),
         ),
@@ -57,8 +61,8 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
-      productName = "supporterPlus",
-      previousProductName = Some("contributions"),
+      productName = "Supporter Plus",
+      previousProductName = Some("Contributor"),
       eventType = Switch,
       subscriptionId = "A-S12345678",
     )
@@ -101,7 +105,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
-      productName = "supporterPlus",
+      productName = "Supporter Plus",
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",
@@ -145,7 +149,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
-      productName = "supporterPlus",
+      productName = "Supporter Plus",
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -195,7 +199,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
-      productName = "supporterPlus",
+      productName = "Supporter Plus",
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -247,7 +251,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
-      productName = "supporterPlus",
+      productName = "Supporter Plus",
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -309,5 +313,3 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     result shouldBe Right(())
   }
 }
-
-

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -8,26 +8,4 @@ object ConsentsCalculatorTestData {
   val newspaperMapping =
     Set("your_support_onboarding", "similar_guardian_products", "subscriber_preview", "supporter_newsletter")
   val guWeeklyMapping = Set("your_support_onboarding", "guardian_weekly_newsletter")
-  val testProductMapping = Set("unique_consent")
-  val testFeastMobileSubscriptionMapping = Set("your_support_onboarding", "similar_guardian_products")
-  val testTierThreeMapping = Set(
-    "your_support_onboarding",
-    "similar_guardian_products",
-    "supporter_newsletter",
-    "digital_subscriber_preview",
-    "guardian_weekly_newsletter",
-  )
-
-  val testConsentMappings = Map(
-    "membership" -> membershipMapping,
-    "contributions" -> contributionMapping,
-    "InAppPurchase" -> contributionMapping,
-    "supporterPlus" -> supporterPlusMapping,
-    "newspaper" -> newspaperMapping,
-    "guardianweekly" -> guWeeklyMapping,
-    "testproduct" -> testProductMapping,
-    "FeastInAppPurchase" -> testFeastMobileSubscriptionMapping,
-    "Tier Three" -> testTierThreeMapping,
-  )
-
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The soft-opt-in-consent-setter lambdas are responsible for setting the correct opt-in values for users when they subscribe to or cancel products.

Previously the mappings between products and consents were stored in a JSON file in S3 and loaded at run time by the lambda, this PR moves that mapping into the project for 3 reasons:
- so that it is version controlled
- so that it is checked by the compiler as opposed to a json file which could be malformed
- to remove a point of failure when the file is loaded from S3