### PR TITLE
Removed digitalSubscriberPreview consent as it's not needed

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -78,7 +78,6 @@ object ConsentsMapping {
       yourSupportOnboarding,
       similarGuardianProducts,
       supporterNewsletter,
-      digitalSubscriberPreview,
       guardianWeeklyNewsletter,
     ),
     "InAppPurchase" -> Set(

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -6,7 +6,6 @@ object ConsentsMapping {
   val supporterNewsletter = "supporter_newsletter"
   val subscriberPreview = "subscriber_preview"
   val guardianWeeklyNewsletter = "guardian_weekly_newsletter"
-  val digitalSubscriberPreview = "digital_subscriber_preview"
 
   val consentsMapping: Map[String, Set[String]] = Map(
     "Membership" -> Set(
@@ -66,13 +65,11 @@ object ConsentsMapping {
       yourSupportOnboarding,
       similarGuardianProducts,
       supporterNewsletter,
-      digitalSubscriberPreview,
     ),
     "Supporter Plus" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
       supporterNewsletter,
-      digitalSubscriberPreview,
     ),
     "Tier Three" -> Set(
       yourSupportOnboarding,

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -38,10 +38,6 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       .expects(
         identityId,
         """[
-          |  {
-          |    "id" : "digital_subscriber_preview",
-          |    "consented" : true
-          |  }
           |]""".stripMargin,
       )
       .returning(Right(()))
@@ -94,10 +90,6 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
           |  {
           |    "id" : "supporter_newsletter",
           |    "consented" : true
-          |  },
-          |  {
-          |    "id" : "digital_subscriber_preview",
-          |    "consented" : true
           |  }
           |]""".stripMargin,
       )
@@ -131,13 +123,9 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
       .expects(
         "someIdentityId",
         """[
-          |  {
-          |    "id" : "digital_subscriber_preview",
-          |    "consented" : false
-          |  }
           |]""".stripMargin,
       )
-      .returning(Right(()))
+      .never
     mockGetMobileSubscriptions.expects("someIdentityId").returning(Right(mobileSubscriptions))
     mockSfConnector.getActiveSubs _ expects Seq("someIdentityId") returning Right(
       SFAssociatedSubResponse(
@@ -179,10 +167,6 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
           |  },
           |  {
           |    "id" : "supporter_newsletter",
-          |    "consented" : false
-          |  },
-          |  {
-          |    "id" : "digital_subscriber_preview",
           |    "consented" : false
           |  }
           |]""".stripMargin,
@@ -231,10 +215,6 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
         """[
           |  {
           |    "id" : "supporter_newsletter",
-          |    "consented" : false
-          |  },
-          |  {
-          |    "id" : "digital_subscriber_preview",
           |    "consented" : false
           |  }
           |]""".stripMargin,

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -273,14 +273,6 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
         "someIdentityId",
         """[
           |  {
-          |    "id" : "digital_subscriber_preview",
-          |    "consented" : true
-          |  },
-          |  {
-          |    "id" : "guardian_weekly_newsletter",
-          |    "consented" : true
-          |  },
-          |  {
           |    "id" : "your_support_onboarding",
           |    "consented" : true
           |  },
@@ -290,6 +282,10 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
           |  },
           |  {
           |    "id" : "supporter_newsletter",
+          |    "consented" : true
+          |  },
+          |  {
+          |    "id" : "guardian_weekly_newsletter",
           |    "consented" : true
           |  }
           |]""".stripMargin,

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -4,7 +4,7 @@ object ConsentsCalculatorTestData {
   val membershipMapping = Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter")
   val contributionMapping = Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter")
   val supporterPlusMapping =
-    Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter", "digital_subscriber_preview")
+    Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter")
   val newspaperMapping =
     Set("your_support_onboarding", "similar_guardian_products", "subscriber_preview", "supporter_newsletter")
   val guWeeklyMapping = Set("your_support_onboarding", "guardian_weekly_newsletter")


### PR DESCRIPTION
## What does this change?

This removes the `digitalSubscriberPreview` consent from the soft opt-in consent setter for all subscriptions as it's not used by MRR anymore.