### PR TITLE
make the holiday stop alarm not keep repeating

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -99,21 +99,30 @@ Resources:
       AlarmDescription: >
         IMPACT: If this goes unaddressed at least one subscription
         that was supposed to be suspended will be fulfilled.
-        Until we document how to deal with likely problems please alert the SX team.
+        Until we document how to deal with likely problems please alert the Value team.
         For general advice, see
         https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      Metrics:
+        - Id: errors
+          Expression: "FILL(m1,0)"
+          Label: ErrorCount
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Errors
+              Dimensions:
+              - Name: FunctionName
+                Value: !Ref HolidayStopProcessor
+            Stat: Sum
+            Period: 60
+            Unit: Count
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref HolidayStopProcessor
-      EvaluationPeriods: 6
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Period: 900
-      Statistic: Sum
-      Threshold: 1
+      Threshold: 10
+      EvaluationPeriods: 240
       TreatMissingData: notBreaching
     DependsOn:
       - HolidayStopProcessor


### PR DESCRIPTION
We have to complete all holiday stops by the time that fulfilment runs (lunch time)

If it hasn't worked overnight, we want an alarm (just one) by the time we get in to the office, so that we can look into it and rerun if necessary.

The existing alarm flips in and out of alarm state due to quirks in how alarms work in AWS.

This PR fixes it to alarm after around 4 hours and stay in alarm until it consistently passes.

I can't help feeling that the real fix is we should write all the stops to an SQS queue, process them from there, and alarm if the oldest message in the queue is 6 hours old

--

Further background info below and also on [this thread](https://chat.google.com/room/AAAAFNJwTZs/qcCuoSBdIA8/qcCuoSBdIA8?cls=10)

This morning it started going off at 2:57am local time which is almost 2 hours (i.e. 6 actual runs) since it started processing the big batches overnight.
at 3:01 it went back to OK.

the alarm period is actually a rolling 15 minutes, and the processor happens to run every 20 minutes
and it treats missing data as good 
so if it's failing every 20 minutes, then 3 out of 4 datapoints would be error and one would be missing
on the face of it, it sounds like it would never go off

However CW alarm behaviour is to search back for more datapoints before it uses missing ones so It is this lookback that lets it activate (they don't actually document how the lookback windows are calculated, they just say it depends on the period etc of the alarm - see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#:~:text=The%20exact%20number%20of%20data%20points%20it%20attempts%20to%20retrieve%20depends%20on%20the%20length%20of%20the%20alarm%20period%20and%20whether%20it%20is%20based%20on%20a%20metric%20with%20standard%20resolution%20or%20high%20resolution. )

2:40am was the 6th datapoint that failed. Although it timed out at 2:55:20 the timestamp is backdated to when the lambda was kicked off https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html#:~:text=The%20timestamp%20on%20a%20metric%20reflects%20when%20the%20function%20was%20invoked.%20Depending%20on%20the%20duration%20of%20the%20invocation%2C%20this%20can%20be%20several%20minutes%20before%20the%20metric%20is%20emitted.

the alarm then triggered at 2:57am
And it went out of alarm at 3:01 presumably because the first (1:00) data point dropped out of the window.


a technique I've used in the past is to use metric math to "FILL" all the data points to zero if there's no value, then it gets easier to reason about (since no data logically means there are no errors)
this means the "evaluation range" is predictable (I assume the evaluation range here is about 2 hours)

