### PR TITLE
fix holiday stop alarm

### DIFF
--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -121,7 +121,8 @@ Resources:
             Period: 60
             Unit: Count
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 10
+      Threshold: 1
+      DatapointsToAlarm: 10
       EvaluationPeriods: 240
       TreatMissingData: notBreaching
     DependsOn:


### PR DESCRIPTION
After the last PR I made a silly error so it would have never gone off!

This PR fixes it so the threshold is 1 and the number of data points is 10, as expected.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm

This time I have tested (in PROD, as it's hard to test alarms in CODE as they are not created)
it looks good: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/URGENT+9-5+-+PROD$3A+Failed+to+process+holiday+stops?~(search~'holiday*20stops)