### PR TITLE
Move invoicing-api to Platform

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -30,7 +30,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'digital-voucher-api',
 		'dotcom-components',
 		'fulfilment-date-calculator',
-		'invoicing-api',
 		...sharedMobilePurchasesApps,
 		'new-product-api',
 		'price-migration-engine-state-machine',
@@ -88,11 +87,17 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'canonical-config',
 	],
 	PLATFORM: [
+		// fulfilment
 		'failed-national-delivery-processor',
 		'fulfilment-lambdas',
 		'national-delivery-fulfilment',
+
+		// salesforce
 		'salesforce-disaster-recovery',
 		'salesforce-disaster-recovery-health-check',
+
+		// zuora
+		'invoicing-api',
 		'zuora-oracle-fusion',
 	],
 };


### PR DESCRIPTION
## What does this change?
Moves the invoicing-api alarms to the Platform team.

This repo was designed as a set of small, reusable functions that interact with Zuora. It's only used in a few limited places, notably by manage-frontend to [get invoices to display in MMA](https://github.com/guardian/manage-frontend/blob/1edf632dccddf5c0e7082119e7ee8d873d89896a/server/routes/api.ts#L304), [get a specific pdf for a user in MMA](https://github.com/guardian/manage-frontend/blob/1edf632dccddf5c0e7082119e7ee8d873d89896a/server/routes/api.ts#L304) and [for Supporter Plus cancellation refunds](https://github.com/guardian/support-service-lambdas/blob/main/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala).
