### PR TITLE
fix: move metrics-push-api alarms to alarms-handler

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -82,6 +82,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 
 		// support-service-lambdas
 		'digital-voucher-suspension-processor',
+		'metric-push-api',
 
 		// other
 		'canonical-config',

--- a/handlers/metric-push-api/cfn.yaml
+++ b/handlers/metric-push-api/cfn.yaml
@@ -125,7 +125,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
         AlarmName: !Join
         - ' '
         - - !FindInMap [ Constants, Alarm, Urgent ]
@@ -151,7 +151,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
         AlarmName: !Join
           - ' '
           - - !FindInMap [ Constants, Alarm, Urgent ]


### PR DESCRIPTION
Alerts `alarms-handler` from `metric-push-api` and assigns those to Portfolio