### PR TITLE
return a billing preview before discount when previewing a discount

### DIFF
--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -6,9 +6,9 @@ import { addDiscount, previewDiscount } from '@modules/zuora/addDiscount';
 import {
 	billingPreviewToSimpleInvoiceItems,
 	getBillingPreview,
-	getOrderedInvoiceTotals,
 	getNextInvoiceItems,
 	getNextNonFreePaymentDate,
+	getOrderedInvoiceTotals,
 } from '@modules/zuora/billingPreview';
 import { zuoraDateFormat } from '@modules/zuora/common';
 import { getAccount } from '@modules/zuora/getAccount';

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -6,6 +6,7 @@ import { addDiscount, previewDiscount } from '@modules/zuora/addDiscount';
 import {
 	billingPreviewToSimpleInvoiceItems,
 	getBillingPreview,
+	getOrderedInvoiceTotals,
 	getNextInvoiceItems,
 	getNextNonFreePaymentDate,
 } from '@modules/zuora/billingPreview';
@@ -38,15 +39,11 @@ export const previewDiscountEndpoint = async (
 		subscriptionNumber,
 	);
 
-	const { discount, dateToApply } = await getDiscountToApply(
-		stage,
-		subscription,
-		account,
-		zuoraClient,
-		today,
-	);
+	const { discount, dateToApply, orderedInvoiceTotals } =
+		await getDiscountToApply(stage, subscription, account, zuoraClient, today);
 
 	console.log('Preview the new price once the discount has been applied');
+	// note that this only returns the next payment - payments are not guaranteed to be identical
 	const previewResponse = await previewDiscount(
 		zuoraClient,
 		subscriptionNumber,
@@ -76,12 +73,20 @@ export const previewDiscountEndpoint = async (
 		dayjs(dateToApply).add(discount.upToPeriods, 'month'),
 	);
 
+	const nonDiscountedPayments = orderedInvoiceTotals
+		.map(({ date, total }) => ({
+			date: zuoraDateFormat(dayjs(date)),
+			amount: total,
+		}))
+		.slice(0, discount.upToPeriods);
+
 	return {
 		discountedPrice,
 		upToPeriods: discount.upToPeriods,
 		upToPeriodsType: discount.upToPeriodsType,
 		firstDiscountedPaymentDate,
 		nextNonDiscountedPaymentDate,
+		nonDiscountedPayments,
 	};
 };
 
@@ -223,10 +228,12 @@ async function getDiscountToApply(
 	const { date: dateToApply, items: nextInvoiceItems } =
 		getNextInvoiceItems(billingPreview);
 
+	const orderedInvoiceTotals = getOrderedInvoiceTotals(billingPreview);
+
 	eligibilityChecker.assertGenerallyEligible(
 		subscription,
 		account.metrics.totalInvoiceBalance,
 		nextInvoiceItems,
 	);
-	return { discount, dateToApply };
+	return { discount, dateToApply, orderedInvoiceTotals };
 }

--- a/handlers/discount-api/src/eligibilityChecker.ts
+++ b/handlers/discount-api/src/eligibilityChecker.ts
@@ -27,7 +27,9 @@ export class EligibilityChecker {
 			`${accountBalance}`,
 		);
 
-		console.log('Working out the date to apply the discount');
+		console.log(
+			'ensuring there are no refunds/discounts expected on the affected invoices',
+		);
 		this.assertValidState(
 			nextInvoiceItems.every((item) => item.amount >= 0),
 			validationRequirements.noNegativePreviewItems,

--- a/handlers/discount-api/src/responseSchema.ts
+++ b/handlers/discount-api/src/responseSchema.ts
@@ -6,6 +6,9 @@ export const previewDiscountSchema = z.object({
 	upToPeriodsType: z.string(),
 	firstDiscountedPaymentDate: z.string(),
 	nextNonDiscountedPaymentDate: z.string(),
+	nonDiscountedPayments: z.array(
+		z.object({ amount: z.number(), date: z.string() }),
+	),
 });
 
 export type EligibilityCheckResponseBody = z.infer<

--- a/handlers/discount-api/test/getOrderedInvoiceTotals.test.ts
+++ b/handlers/discount-api/test/getOrderedInvoiceTotals.test.ts
@@ -1,0 +1,51 @@
+import { getOrderedInvoiceTotals } from '@modules/zuora/billingPreview';
+
+test('getOrderedInvoiceTotals doesnt affect if theyre already in order', () => {
+	const items = [
+		{ date: new Date('2020-01-01'), amount: 0 },
+		{ date: new Date('2020-02-01'), amount: 10 },
+		{ date: new Date('2020-03-01'), amount: 10 },
+	];
+
+	const actual = getOrderedInvoiceTotals(items);
+
+	expect(actual).toEqual([
+		{ date: new Date('2020-01-01'), total: 0 },
+		{ date: new Date('2020-02-01'), total: 10 },
+		{ date: new Date('2020-03-01'), total: 10 },
+	]);
+});
+
+test('getOrderedInvoiceTotals reorders them if theyre NOT in order', () => {
+	const items = [
+		{ date: new Date('2020-02-01'), amount: 10 },
+		{ date: new Date('2020-01-01'), amount: 0 },
+		{ date: new Date('2020-03-01'), amount: 10 },
+	];
+
+	const actual = getOrderedInvoiceTotals(items);
+
+	expect(actual).toEqual([
+		{ date: new Date('2020-01-01'), total: 0 },
+		{ date: new Date('2020-02-01'), total: 10 },
+		{ date: new Date('2020-03-01'), total: 10 },
+	]);
+});
+
+test('getOrderedInvoiceTotals adds them up and reorders them', () => {
+	const items = [
+		{ date: new Date('2020-01-01'), amount: 1 },
+		{ date: new Date('2020-02-01'), amount: 10 },
+		{ date: new Date('2020-03-01'), amount: 100 },
+		{ date: new Date('2020-02-01'), amount: 20 },
+		{ date: new Date('2020-01-01'), amount: 2 },
+	];
+
+	const actual = getOrderedInvoiceTotals(items);
+
+	expect(actual).toEqual([
+		{ date: new Date('2020-01-01'), total: 3 },
+		{ date: new Date('2020-02-01'), total: 30 },
+		{ date: new Date('2020-03-01'), total: 100 },
+	]);
+});

--- a/handlers/discount-api/test/previewDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/previewDiscountIntegration.test.ts
@@ -93,6 +93,11 @@ test('Subscriptions on the new price are eligible', async () => {
 		upToPeriodsType: 'Months',
 		firstDiscountedPaymentDate: zuoraDateFormat(paymentDate),
 		nextNonDiscountedPaymentDate: zuoraDateFormat(paymentDate.add(3, 'months')),
+		nonDiscountedPayments: [
+			{ date: zuoraDateFormat(paymentDate), amount: 14.99 },
+			{ date: zuoraDateFormat(paymentDate.add(1, 'months')), amount: 14.99 },
+			{ date: zuoraDateFormat(paymentDate.add(2, 'months')), amount: 14.99 },
+		],
 	};
 	expect(eligibilityCheckResult).toEqual(expected);
 
@@ -129,6 +134,10 @@ test('Supporter Plus subscriptions are eligible', async () => {
 		upToPeriodsType: 'Months',
 		firstDiscountedPaymentDate: zuoraDateFormat(paymentDate),
 		nextNonDiscountedPaymentDate: zuoraDateFormat(paymentDate.add(2, 'months')),
+		nonDiscountedPayments: [
+			{ date: zuoraDateFormat(paymentDate), amount: 12 },
+			{ date: zuoraDateFormat(paymentDate.add(1, 'months')), amount: 12 },
+		],
 	};
 	expect(eligibilityCheckResult).toEqual(expected);
 

--- a/modules/zuora/src/billingPreview.ts
+++ b/modules/zuora/src/billingPreview.ts
@@ -49,6 +49,14 @@ export function getNextNonFreePaymentDate(
 	return firstNonFree.date;
 }
 
+export function getOrderedInvoiceTotals(
+	invoiceItems: Array<SimpleInvoiceItem>,
+) {
+	return getOrderedInvoiceItemGroups(invoiceItems).map((invoiceGroup) =>
+		convertItemsToTotal(invoiceGroup),
+	);
+}
+
 function getOrderedInvoiceItemGroups(invoiceItems: Array<SimpleInvoiceItem>) {
 	if (invoiceItems[0] === undefined) {
 		throw new Error('no invoice items in preview');


### PR DESCRIPTION
as per https://trello.com/c/yd1qCiC6/425-return-billing-preview-dates-and-amounts-before-discount-from-discount-api-endpoint

We want to display the two missed payments if someone has a price rise during their proposed discount/suspension.

This PR makes the discount preview endpoint return the "before" amounts for all the payments affected by the discount.