### PR TITLE
run prettier on all things to get rid of changes in other lamdas

### DIFF
--- a/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
@@ -1,4 +1,7 @@
-import type { SfApiUserAuth, SfConnectedAppAuth } from '@modules/salesforce/src/auth';
+import type {
+	SfApiUserAuth,
+	SfConnectedAppAuth,
+} from '@modules/salesforce/src/auth';
 import { doSfAuth } from '@modules/salesforce/src/auth';
 import { executeSalesforceQuery } from '@modules/salesforce/src/query';
 import { RecordSchema } from '@modules/salesforce/src/recordSchema';
@@ -9,8 +12,7 @@ import { getSalesforceSecretNames } from '../secrets';
 import type { ApiUserSecret, ConnectedAppSecret } from '../secrets';
 
 export async function handler() {
-	try{
-
+	try {
 		const secretNames = getSalesforceSecretNames(stageFromEnvironment());
 
 		const { authUrl, clientId, clientSecret } =
@@ -34,19 +36,21 @@ export async function handler() {
 		const sfAuthResponse = await doSfAuth(sfApiUserAuth, sfConnectedAppAuth);
 
 		const limit = 200;
-		const query = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < 5 ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT ${limit}`
+		const query = `SELECT Id, Zuora__Account__c, GDPR_Removal_Attempts__c, Zuora__External_Id__c FROM Zuora__CustomerAccount__c WHERE Zuora__External_Id__c != null AND Zuora__Account__r.GDPR_Billing_Accounts_Ready_for_Removal__c = true AND GDPR_Removal_Attempts__c < 5 ORDER BY Zuora__Account__r.GDPR_Date_Successfully_Removed_Related__c desc LIMIT ${limit}`;
 
 		const response = await executeSalesforceQuery(
 			sfAuthResponse,
 			query,
-			BillingAccountRecordSchema
-		  );
+			BillingAccountRecordSchema,
+		);
 
 		return {
 			billingAccountsToProcess: response.records,
 		};
-	}catch(error){
-		throw new Error(`Error fetching billing accounts from Salesforce: ${JSON.stringify(error)}`);
+	} catch (error) {
+		throw new Error(
+			`Error fetching billing accounts from Salesforce: ${JSON.stringify(error)}`,
+		);
 	}
 }
 

--- a/handlers/zuora-salesforce-link-remover/src/handlers/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/updateSfBillingAccounts.ts
@@ -1,7 +1,14 @@
-import type { SfApiUserAuth, SfAuthResponse, SfConnectedAppAuth } from '@modules/salesforce/src/auth';
+import type {
+	SfApiUserAuth,
+	SfAuthResponse,
+	SfConnectedAppAuth,
+} from '@modules/salesforce/src/auth';
 import { doSfAuth } from '@modules/salesforce/src/auth';
 import { sfApiVersion } from '@modules/salesforce/src/config';
-import type { SalesforceUpdateResponse, SalesforceUpdateResponseArray } from '@modules/salesforce/src/updateRecords';
+import type {
+	SalesforceUpdateResponse,
+	SalesforceUpdateResponseArray,
+} from '@modules/salesforce/src/updateRecords';
 import { doCompositeCallout } from '@modules/salesforce/src/updateRecords';
 import { getSecretValue } from '@modules/secrets-manager/src/getSecret';
 import { stageFromEnvironment } from '@modules/stage';
@@ -12,10 +19,14 @@ import type { ApiUserSecret, ConnectedAppSecret } from '../secrets';
 import type { BillingAccountRecord } from './getBillingAccounts';
 import { BillingAccountRecordSchema } from './getBillingAccounts';
 
-export const handler: Handler<BillingAccountRecord[], SalesforceUpdateResponseArray> = async (billingAccounts) => {
-
-	try{
-		const parseResponse = z.array(BillingAccountRecordSchema).safeParse(billingAccounts);
+export const handler: Handler<
+	BillingAccountRecord[],
+	SalesforceUpdateResponseArray
+> = async (billingAccounts) => {
+	try {
+		const parseResponse = z
+			.array(BillingAccountRecordSchema)
+			.safeParse(billingAccounts);
 
 		if (!parseResponse.success) {
 			throw new Error(
@@ -52,10 +63,12 @@ export const handler: Handler<BillingAccountRecord[], SalesforceUpdateResponseAr
 		);
 
 		return sfUpdateResponse;
-	}catch(error){
-		throw new Error(`Error updating billing account in Salesforce: ${JSON.stringify(error)}`);
+	} catch (error) {
+		throw new Error(
+			`Error updating billing account in Salesforce: ${JSON.stringify(error)}`,
+		);
 	}
-}
+};
 
 export async function updateSfBillingAccounts(
 	sfAuthResponse: SfAuthResponse,

--- a/handlers/zuora-salesforce-link-remover/src/handlers/updateZuoraBillingAccount.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/updateZuoraBillingAccount.ts
@@ -2,11 +2,16 @@ import type { ZuoraSuccessResponse } from '@modules/zuora/zuoraSchemas';
 import type { Handler } from 'aws-lambda';
 import { z } from 'zod';
 import { updateBillingAccountInZuora } from '../zuoraHttp';
-import type { BillingAccountRecord, BillingAccountRecordWithSuccess } from './getBillingAccounts';
+import type {
+	BillingAccountRecord,
+	BillingAccountRecordWithSuccess,
+} from './getBillingAccounts';
 
-export const handler: Handler<BillingAccountRecord, BillingAccountRecordWithSuccess> = async (billingAccount) => {
-
-	try{
+export const handler: Handler<
+	BillingAccountRecord,
+	BillingAccountRecordWithSuccess
+> = async (billingAccount) => {
+	try {
 		const parseResponse = EventSchema.safeParse(billingAccount);
 		if (!parseResponse.success) {
 			throw new Error(
@@ -17,17 +22,21 @@ export const handler: Handler<BillingAccountRecord, BillingAccountRecordWithSucc
 		const billingAccountItem = parseResponse.data.item;
 
 		const zuoraBillingAccountUpdateResponse: ZuoraSuccessResponse =
-			await updateBillingAccountInZuora(billingAccountItem.Zuora__External_Id__c);
+			await updateBillingAccountInZuora(
+				billingAccountItem.Zuora__External_Id__c,
+			);
 
 		return {
 			Id: billingAccountItem.Id,
 			GDPR_Removal_Attempts__c: billingAccountItem.GDPR_Removal_Attempts__c + 1,
 			Zuora__External_Id__c: billingAccountItem.Zuora__External_Id__c,
 			attributes: billingAccountItem.attributes,
-			crmIdRemovedSuccessfully: zuoraBillingAccountUpdateResponse.success
+			crmIdRemovedSuccessfully: zuoraBillingAccountUpdateResponse.success,
 		};
-	}catch(error){
-		throw new Error(`Error updating billing accounts in Zuora: ${JSON.stringify(error)}`);
+	} catch (error) {
+		throw new Error(
+			`Error updating billing accounts in Zuora: ${JSON.stringify(error)}`,
+		);
 	}
 };
 


### PR DESCRIPTION
Run prettier on all things to get rid of changes in other lamdas and bring things up to date.

## What does this change?
This change has done nothing but run 
` prettier --check **/*.ts --write`
on the repo and pushed up the changes.

## Why am I doing this?
Whenever I run ` prettier --check **/*.ts --writ` I get a bunch of fixes for lambdas I have not touched.
This change is to make that go away.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
