### PR TITLE
Move Data Retention alarms to platform

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -98,6 +98,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'zuora-oracle-fusion',
 
 		//data retention
+		'identity-retention',
 		'zuora-retention', //https://github.com/guardian/zuora-retention
 		'zuora-salesforce-link-remover',
 	],

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -39,7 +39,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'sf-gocardless-sync',
 		'super-mode-calculator',
 		'support-reminders',
-		'zuora-salesforce-link-remover',
 	],
 	VALUE: [
 		'cancellation-sf-cases-api',
@@ -70,9 +69,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		// zuora-finance
 		'zuora-creditor',
 
-		// zuora-retention
-		'zuora-retention',
-
 		// support-frontend
 		'frontend',
 		'it-test-runner',
@@ -100,6 +96,10 @@ const teamToAppMappings: Record<Team, string[]> = {
 		// zuora
 		'invoicing-api',
 		'zuora-oracle-fusion',
+
+		//data retention
+		'zuora-retention', //https://github.com/guardian/zuora-retention
+		'zuora-salesforce-link-remover',
 	],
 };
 

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -212,7 +212,7 @@ Resources:
       Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
         AlarmName:
           !Sub
             - 5XX rate from ${ApiName}


### PR DESCRIPTION
## What does this change?
Moves data retention-related alarms to the Platform team, as per updated [SR Ownership list](https://docs.google.com/spreadsheets/d/1bb8WB-6ZFRdUwERHMOVIolN8WU8zJMcsyi-WJuwp07Q/edit?gid=0#gid=0)

I added a comment to clarify that zuora-retention is related to [this](https://github.com/guardian/zuora-retention), not [this](https://github.com/guardian/support-service-lambdas/tree/main/handlers/zuora-retention).