### PR TITLE
Fix gap in prettier checking/formatting

### DIFF
--- a/_templates/new-lambda/api-gateway/package.ejs.t
+++ b/_templates/new-lambda/api-gateway/package.ejs.t
@@ -13,8 +13,8 @@ sh: git add handlers/<%=lambdaName%>/package.json
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr <%=lambdaName%>.zip ./*.js",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.129"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -6,12 +6,12 @@
     "build": "tsc",
     "test": "jest",
     "test-update": "jest -u",
-    "check-formatting": "prettier --check **/*.ts",
+    "check-formatting": "prettier --check **.ts",
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
     "synth": "cdk synth --path-metadata false --version-reporting false",
     "diff": "cdk diff --path-metadata false --version-reporting false",
     "package": "pnpm build && pnpm lint && pnpm check-formatting && pnpm test && pnpm synth",
-    "fix-formatting": "prettier --write **/*.ts"
+    "fix-formatting": "prettier --write **.ts"
   },
   "devDependencies": {
     "@guardian/cdk": "52.3.0",

--- a/handlers/alarms-handler/package.json
+++ b/handlers/alarms-handler/package.json
@@ -7,8 +7,8 @@
 		"build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
 		"lint": "eslint src/**/*.ts",
 		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr alarms-handler.zip ./*.js",
-		"check-formatting": "prettier --check **/*.ts",
-		"fix-formatting": "prettier --write **/*.ts"
+		"check-formatting": "prettier --check **.ts",
+		"fix-formatting": "prettier --write **.ts"
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "^3.556.0",

--- a/handlers/discount-api/package.json
+++ b/handlers/discount-api/package.json
@@ -7,8 +7,8 @@
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr discount-api.zip ./*.js",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "dayjs": "^1.11.12",

--- a/handlers/generate-product-catalog/package.json
+++ b/handlers/generate-product-catalog/package.json
@@ -7,8 +7,8 @@
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr generate-product-catalog.zip ./*.js",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.142",

--- a/handlers/product-switch-api/package.json
+++ b/handlers/product-switch-api/package.json
@@ -7,8 +7,8 @@
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm build && cd target && zip -qr product-switch-api.zip ./*.js",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "dayjs": "^1.11.12",

--- a/handlers/salesforce-disaster-recovery-health-check/package.json
+++ b/handlers/salesforce-disaster-recovery-health-check/package.json
@@ -7,8 +7,8 @@
 		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
 		"lint": "eslint src/**/*.ts",
 		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr salesforce-disaster-recovery-health-check.zip ./*.js",
-		"check-formatting": "prettier --check **/*.ts",
-		"fix-formatting": "prettier --write **/*.ts"
+		"check-formatting": "prettier --check **.ts",
+		"fix-formatting": "prettier --write **.ts"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.142"

--- a/handlers/salesforce-disaster-recovery/package.json
+++ b/handlers/salesforce-disaster-recovery/package.json
@@ -8,8 +8,8 @@
 		"lint": "eslint src/**/*.ts",
 		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr salesforce-disaster-recovery.zip ./*.js",
 		"type-check": "tsc --noEmit",
-		"check-formatting": "prettier --check **/*.ts",
-		"fix-formatting": "prettier --write **/*.ts"
+		"check-formatting": "prettier --check **.ts",
+		"fix-formatting": "prettier --write **.ts"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.142",

--- a/handlers/ticket-tailor-webhook/package.json
+++ b/handlers/ticket-tailor-webhook/package.json
@@ -7,8 +7,8 @@
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr ticket-tailor-webhook.zip ./*.js",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.629.0"

--- a/handlers/update-supporter-plus-amount/package.json
+++ b/handlers/update-supporter-plus-amount/package.json
@@ -7,8 +7,8 @@
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr update-supporter-plus-amount.zip ./*.js",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "dayjs": "^1.11.12",

--- a/handlers/zuora-salesforce-link-remover/package.json
+++ b/handlers/zuora-salesforce-link-remover/package.json
@@ -6,7 +6,7 @@
 		"it-test": "jest --group=integration",
 		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
 		"lint": "eslint src/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm test && pnpm build && cd target; zip -qr zuora-salesforce-link-remover.zip ./*.js",
+		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target; zip -qr zuora-salesforce-link-remover.zip ./*.js",
 		"type-check": "tsc --noEmit",
 		"check-formatting": "prettier --check **/*.ts",
 		"fix-formatting": "prettier --write **/*.ts"

--- a/handlers/zuora-salesforce-link-remover/package.json
+++ b/handlers/zuora-salesforce-link-remover/package.json
@@ -8,8 +8,8 @@
 		"lint": "eslint src/**/*.ts",
 		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target; zip -qr zuora-salesforce-link-remover.zip ./*.js",
 		"type-check": "tsc --noEmit",
-		"check-formatting": "prettier --check **/*.ts",
-		"fix-formatting": "prettier --write **/*.ts"
+		"check-formatting": "prettier --check **.ts",
+		"fix-formatting": "prettier --write **.ts"
 	},
 	"dependencies": {
 		"@aws-sdk/client-secrets-manager": "^3.556.0",

--- a/modules/aws/package.json
+++ b/modules/aws/package.json
@@ -2,8 +2,8 @@
   "name": "aws",
   "version": "1.0.0",
   "scripts": {
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "@aws-sdk/credential-provider-node": "3.451.0"

--- a/modules/email/package.json
+++ b/modules/email/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "3.632.0"

--- a/modules/package.json
+++ b/modules/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   }
 }

--- a/modules/product-catalog/package.json
+++ b/modules/product-catalog/package.json
@@ -6,8 +6,8 @@
     "updateSnapshots": "jest -u --group=-integration",
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/modules/salesforce/package.json
+++ b/modules/salesforce/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "zod": "^3.23.8"

--- a/modules/test-users/package.json
+++ b/modules/test-users/package.json
@@ -8,8 +8,8 @@
     "updateMonthlyContributionAmount": "ts-node ./src/updateMonthlyContributionAmount.ts",
     "cancelSubscription": "ts-node ./src/cancel.ts",
     "deleteAccount": "ts-node ./src/deleteAccount.ts",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "devDependencies": {
     "dayjs": "^1.11.12",

--- a/modules/zuora-catalog/package.json
+++ b/modules/zuora-catalog/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.451.0",

--- a/modules/zuora/package.json
+++ b/modules/zuora/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
-    "check-formatting": "prettier --check **/*.ts",
-    "fix-formatting": "prettier --write **/*.ts"
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.451.0",


### PR DESCRIPTION
## What does this change?

In #2436, some files under handlers/zuora-salesforce-link-remover were reformatted by prettier. I was surprised that these formatting violations hadn't been caught by prettier as part of the build. It turns out there were a couple of issues which caused this, which this PR fixes:

* Add the prettier `check-formatting` command to the zuora-salesforce-link-remover `package` script
* Ensure that the prettier command(s) catch all .ts files under each workspace, no matter how they're nested. This wasn't happening on zuora-salesforce-link-remover previously. I went through various iterations and the only pattern I found which
matched _all_ .ts files nested under the workspace was **.ts. I've made this change for all workspaces, though zuora-salesforce-link-remover is the only one where this has a material impact (due to the way this workspace is organized, there's more nesting here than in other places).
