### PR TITLE
Enforce PNPM with corepack

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -12,7 +12,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-      
+
 jobs:
   gu-cdk-build:
     strategy:
@@ -47,9 +47,8 @@ jobs:
       - name: Run tests and build subproject JAR
         run: sbt "project ${{ matrix.subproject }}" test assembly
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.1.1
+      - run: corepack enable
+        shell: bash
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -49,10 +49,10 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9.1.1
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm --filter cdk package

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -21,9 +21,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.1.1
+      - run: corepack enable
+        shell: bash
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -52,9 +51,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.1.1
+      - run: corepack enable
+        shell: bash
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/README.md
+++ b/README.md
@@ -12,8 +12,22 @@ Please keep all the various README in this project up to date, and improve them!
 There should be one in each project and anywhere else you think it would help.
 
 ## Getting Started - Typescript
-We use [pnpm](https://pnpm.io/) as a package manager so make sure you have it [installed](https://pnpm.io/installation), 
-`brew install pnpm` is a simple way to do this, then run `pnpm install` from the root of the repo to install all dependencies.
+
+Install [Node.js](https://nodejs.org). The Node version is required is encoded in the `.nvmrc` file at the root of the repo.
+We recommend using a Node version manager such as [fnm](https://github.com/Schniz/fnm).
+
+Once Node is installed and you're using the correct version, install the correct package manager (currently [pnpm](https://pnpm.io/))
+with [corepack](https://github.com/nodejs/corepack) (from the root of the repo):
+
+```
+$ corepack enable
+```
+
+Then install dependencies (again, from the root of the repo):
+
+```
+$ pnpm install
+```
 
 Each lambda is a separate [pnpm workspace](https://pnpm.io/workspaces) which allows us to define common settings and
 dependencies for all projects, add dependencies between projects build all projects at once and generally facilitates 

--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
 		"prettier": "^3.3.3",
 		"ts-jest": "^29.2.4",
 		"typescript": "^5.2.2"
-	}
+	},
+	"packageManager": "pnpm@9.1.1"
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Just like with Node, we want developers to be using a consistent package manager/version, to ensure the same experience on our laptops and also in CI. In #2443 a couple of non-pnpm lockfiles were removed. In this PR we start enforcing usage of `pnpm` so this shouldn't happen again. Now if I try to run `yarn` for example I get an error:

`Usage Error: This project is configured to use pnpm`

Also use [corepack](https://github.com/nodejs/corepack) in CI (and specify for local development in the README) to manage package managers.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
