### PR TITLE
Increasing maxReceived so lambda retries before adding to dlq

### DIFF
--- a/cdk/lib/__snapshots__/ticket-tailor-webhook.test.ts.snap
+++ b/cdk/lib/__snapshots__/ticket-tailor-webhook.test.ts.snap
@@ -676,7 +676,7 @@ exports[`The Ticket tailor webhook stack matches the snapshot 1`] = `
               "Arn",
             ],
           },
-          "maxReceiveCount": 1,
+          "maxReceiveCount": 5,
         },
         "Tags": [
           {
@@ -1455,7 +1455,7 @@ exports[`The Ticket tailor webhook stack matches the snapshot 2`] = `
               "Arn",
             ],
           },
-          "maxReceiveCount": 1,
+          "maxReceiveCount": 5,
         },
         "Tags": [
           {

--- a/cdk/lib/ticket-tailor-webhook.ts
+++ b/cdk/lib/ticket-tailor-webhook.ts
@@ -49,7 +49,7 @@ export class TicketTailorWebhook extends GuStack {
 			queueName,
 			deadLetterQueue: {
 				// The number of times a message can be unsuccessfully dequeued before being moved to the dlq
-				maxReceiveCount: 1,
+				maxReceiveCount: 5,
 				queue: deadLetterQueue,
 			},
 			// This must be >= the lambda timeout


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

Increasing maxReceived as it will allow the lambda to retry before putting the message on the dlq.

Using the recommended setting for now.
https://docs.aws.amazon.com/lambda/latest/operatorguide/sqs-retries.html

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
