### PR TITLE
increase alarm threshold to 10 errors per hour

### DIFF
--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -228,5 +228,5 @@ Resources:
         Namespace: AWS/ApiGateway
         Period: 3600
         Statistic: Sum
-        Threshold: 5
+        Threshold: 10
         TreatMissingData: notBreaching


### PR DESCRIPTION
## What does this change?
Increases the threshold for the `5XX rate from identity-retention-api-PROD has triggered!` alarm from 5 errors per hour to 10 errors per hour.

These errors seem be regularly in clusters at 12 midday (BST). I suspect they are being returned from the API Gateway without actually reaching the Lambda as there's nothing in the logs to indicate an issue (as far as I can see).

The Identity function that calls this endpoint has its [own error monitoring and retries](https://github.com/guardian/identity-data-retention/blob/main/user-deletion-lambda/README.md#troubleshooting), so we might presume that these Identity users are retried later and succeed. I note this threshold hasn't changed since the Lambda was first implemented 6 years ago, despite presumably a steady scaling in the number of records it processes.

This issue is not related to another problem with this Lambda that we need to resolve (where a large backlog is "bouncing" into the queue every three months blocking deletions - [details here](https://trello.com/c/lw4jlcVP/140-identity-retention-add-variation-to-responsevaliduntil-to-avoid-regular-backlog)).