### PR TITLE
Clarify amount validation message for recurring contributions in new-product-api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
@@ -15,33 +15,33 @@ object AmountLimits {
   def fromMinorToMajor(value: Int) = value / 100
 
   val gbp = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 2, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 4, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 50, max = 2000),
   )
 
   val aud = ContributionLimits(
     monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 200),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 80, max = 2000),
   )
 
   val usd = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 2, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 3, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 30, max = 2000),
   )
 
   val nzd = ContributionLimits(
     monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 200),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 80, max = 2000),
   )
 
   val cad = ContributionLimits(
     monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 5, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 60, max = 2000),
   )
 
   val eur = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 2, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 4, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 50, max = 2000),
   )
 
   def limitsFor(planId: PlanId, currency: Currency): AmountLimits = {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
@@ -11,34 +11,37 @@ case class AmountLimits(min: Int, max: Int)
 
 object AmountLimits {
 
+  def limitsFromMajorToMinorUnits(min: Int, max: Int) = AmountLimits(min * 100, max * 100)
+  def fromMinorToMajor(value: Int) = value / 100
+
   val gbp = ContributionLimits(
-    monthly = AmountLimits(min = 200, max = 16600),
-    annual = AmountLimits(min = 1000, max = 200000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 2, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
   )
 
   val aud = ContributionLimits(
-    monthly = AmountLimits(min = 1000, max = 20000),
-    annual = AmountLimits(min = 1000, max = 200000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 200),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
   )
 
   val usd = ContributionLimits(
-    monthly = AmountLimits(min = 200, max = 16600),
-    annual = AmountLimits(min = 1000, max = 200000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 2, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
   )
 
   val nzd = ContributionLimits(
-    monthly = AmountLimits(min = 1000, max = 20000),
-    annual = AmountLimits(min = 1000, max = 200000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 200),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
   )
 
   val cad = ContributionLimits(
-    monthly = AmountLimits(min = 500, max = 16600),
-    annual = AmountLimits(min = 1000, max = 200000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 5, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
   )
 
   val eur = ContributionLimits(
-    monthly = AmountLimits(min = 200, max = 16600),
-    annual = AmountLimits(min = 1000, max = 200000),
+    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 2, max = 166),
+    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 2000),
   )
 
   def limitsFor(planId: PlanId, currency: Currency): AmountLimits = {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
@@ -11,37 +11,37 @@ case class AmountLimits(min: Int, max: Int)
 
 object AmountLimits {
 
-  def limitsFromMajorToMinorUnits(min: Int, max: Int) = AmountLimits(min * 100, max * 100)
+  def fromMajorUnits(min: Int, max: Int) = AmountLimits(min * 100, max * 100)
   def fromMinorToMajor(value: Int) = value / 100
 
   val gbp = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 4, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 50, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 4, max = 166),
+    annual = AmountLimits.fromMajorUnits(min = 50, max = 2000),
   )
 
   val aud = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 200),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 80, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 10, max = 200),
+    annual = AmountLimits.fromMajorUnits(min = 80, max = 2000),
   )
 
   val usd = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 3, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 30, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 3, max = 166),
+    annual = AmountLimits.fromMajorUnits(min = 30, max = 2000),
   )
 
   val nzd = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 10, max = 200),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 80, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 10, max = 200),
+    annual = AmountLimits.fromMajorUnits(min = 80, max = 2000),
   )
 
   val cad = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 5, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 60, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 5, max = 166),
+    annual = AmountLimits.fromMajorUnits(min = 60, max = 2000),
   )
 
   val eur = ContributionLimits(
-    monthly = AmountLimits.limitsFromMajorToMinorUnits(min = 4, max = 166),
-    annual = AmountLimits.limitsFromMajorToMinorUnits(min = 50, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 4, max = 166),
+    annual = AmountLimits.fromMajorUnits(min = 50, max = 2000),
   )
 
   def limitsFor(planId: PlanId, currency: Currency): AmountLimits = {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
@@ -25,8 +25,8 @@ object ContributionValidations {
       amount <- validatableFields.amountMinorUnits getOrFailWith s"amountMinorUnits is missing"
       _ <- isValidStartDate(validatableFields.startDate)
       limits = limitsFor(planId, currency)
-      _ <- (amount.value <= limits.max) orFailWith s"amount must not be more than $currency ${AmountLimits
+      _ <- (amount.value <= limits.max) orFailWith s"amount for $planId must not be more than $currency ${AmountLimits
           .fromMinorToMajor(limits.max)}"
-      _ <- (amount.value >= limits.min) orFailWith s"amount must be at least $currency ${AmountLimits.fromMinorToMajor(limits.min)}"
+      _ <- (amount.value >= limits.min) orFailWith s"amount for $planId must be at least $currency ${AmountLimits.fromMinorToMajor(limits.min)}"
     } yield (amount)
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
@@ -25,7 +25,8 @@ object ContributionValidations {
       amount <- validatableFields.amountMinorUnits getOrFailWith s"amountMinorUnits is missing"
       _ <- isValidStartDate(validatableFields.startDate)
       limits = limitsFor(planId, currency)
-      _ <- (amount.value <= limits.max) orFailWith s"amount must not be more than ${limits.max}"
-      _ <- (amount.value >= limits.min) orFailWith s"amount must be at least ${limits.min}"
+      _ <- (amount.value <= limits.max) orFailWith s"amount must not be more than $currency ${AmountLimits
+          .fromMinorToMajor(limits.max)}"
+      _ <- (amount.value >= limits.min) orFailWith s"amount must be at least $currency ${AmountLimits.fromMinorToMajor(limits.min)}"
     } yield (amount)
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
@@ -40,7 +40,7 @@ class ContributionValidationsTest extends AnyFlatSpec with Matchers {
       testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(99))),
       MonthlyContribution,
       GBP,
-    ) shouldBe Failed("amount must be at least GBP 1")
+    ) shouldBe Failed("amount for MonthlyContribution must be at least GBP 1")
   }
 
   it should "return error if amount is too large" in {
@@ -48,7 +48,7 @@ class ContributionValidationsTest extends AnyFlatSpec with Matchers {
       testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(201))),
       MonthlyContribution,
       GBP,
-    ) shouldBe Failed("amount must not be more than GBP 2")
+    ) shouldBe Failed("amount for MonthlyContribution must not be more than GBP 2")
   }
   it should "return success if amount is within valid range" in {
     wiredValidator(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
@@ -23,7 +23,7 @@ class ContributionValidationsTest extends AnyFlatSpec with Matchers {
   def amountLimitsFor(planId: PlanId, currency: Currency) = {
     planId shouldBe MonthlyContribution
     currency shouldBe GBP
-    AmountLimits(min = 100, max = 200)
+    AmountLimits.limitsFromMajorToMinorUnits(min = 1, max = 2)
   }
 
   def isValidStartDate(d: LocalDate): ValidationResult[Unit] =
@@ -40,7 +40,7 @@ class ContributionValidationsTest extends AnyFlatSpec with Matchers {
       testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(99))),
       MonthlyContribution,
       GBP,
-    ) shouldBe Failed("amount must be at least 100")
+    ) shouldBe Failed("amount must be at least GBP 1")
   }
 
   it should "return error if amount is too large" in {
@@ -48,7 +48,7 @@ class ContributionValidationsTest extends AnyFlatSpec with Matchers {
       testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(201))),
       MonthlyContribution,
       GBP,
-    ) shouldBe Failed("amount must not be more than 200")
+    ) shouldBe Failed("amount must not be more than GBP 2")
   }
   it should "return success if amount is within valid range" in {
     wiredValidator(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
@@ -23,7 +23,7 @@ class ContributionValidationsTest extends AnyFlatSpec with Matchers {
   def amountLimitsFor(planId: PlanId, currency: Currency) = {
     planId shouldBe MonthlyContribution
     currency shouldBe GBP
-    AmountLimits.limitsFromMajorToMinorUnits(min = 1, max = 2)
+    AmountLimits.fromMajorUnits(min = 1, max = 2)
   }
 
   def isValidStartDate(d: LocalDate): ValidationResult[Unit] =


### PR DESCRIPTION
## What does this change?
Within new-product-api, brings the amount validation of Recurring Contributions into line with the newer Supporter Plus product.

This is in response to a bug report, where a user was confused why the error they got advised them that a recurring contribution must be at least AU$1000. The error message was based on minor units, and this updates it to use major units along with stating the currency.

Also updates some of the minimum amounts to match the current product pricing grid from MRR. 

Before:
<img width="1181" alt="Screenshot 2024-08-29 at 15 42 25" src="https://github.com/user-attachments/assets/d8470b8a-5a8e-49eb-8a15-3f7df4fabbbd">

After:
<img width="864" alt="Screenshot 2024-08-29 at 16 58 31" src="https://github.com/user-attachments/assets/8ffd1e43-8576-40bf-941d-b0f2973e95d8">

I've also updated the way the min/max amounts are stored to be more in line with Supporter Plus (I do think it's clearer).

## How to test
On a Billing Account in Salesforce, click "New Subscription" and setup a new Recurring Contribution. Set the amount above or below the minimum prices defined in handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala

## How can we measure success?
CSRs are less likely to be confused by this error message.

## Have we considered potential risks?
Have tested in CODE and we verify in production after deployment.