### PR TITLE
Use zod to validate response from identity-api for checking if account already exists

### DIFF
--- a/handlers/ticket-tailor-webhook/package.json
+++ b/handlers/ticket-tailor-webhook/package.json
@@ -11,7 +11,8 @@
     "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.629.0"
+    "@aws-sdk/client-secrets-manager": "^3.629.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.143",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.629.0
         version: 3.632.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.143


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds zod schema validation to check that the IDAPI response for the Get User Type request contains the expected `userType: string` field and both logs a message and throws an error if the field is missing from this response.

## How to test

- [x] unit tests run correctly.
- [x] Tested on CODE that an order from an existing identity user does not create a guest account.
- [x] Tested on CODE that an order from a new user will result in a request to IDAPI to create a guest account.

## How can we measure success?

If we get a bad response from IDAPI for the Get User Type request, we will now detect and handle it properly.

## Have we considered potential risks?

Minimal functional change. This change reduces existing risks.
