### PR TITLE
feat: move single-contribution-salesforce-writes alarm to Platform team

### DIFF
--- a/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
+++ b/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
@@ -97,13 +97,7 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "singlecontributionsalesforcewritestopicD1E1FC97",
-                    "TopicName",
-                  ],
-                },
+                ":alarms-handler-topic-CODE",
               ],
             ],
           },
@@ -519,40 +513,6 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
-    "singlecontributionsalesforcewritestopicD1E1FC97": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "TopicName": "single-contribution-salesforce-writes-topic-CODE",
-      },
-      "Type": "AWS::SNS::Topic",
-    },
-    "singlecontributionsalesforcewritestopicsupporterrevenueengineguardiancouk88BB94BA": {
-      "Properties": {
-        "Endpoint": "supporter.revenue.engine@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "singlecontributionsalesforcewritestopicD1E1FC97",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
   },
 }
 `;
@@ -654,13 +614,7 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "singlecontributionsalesforcewritestopicD1E1FC97",
-                    "TopicName",
-                  ],
-                },
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1075,40 +1029,6 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
-    },
-    "singlecontributionsalesforcewritestopicD1E1FC97": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "membership",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "TopicName": "single-contribution-salesforce-writes-topic-PROD",
-      },
-      "Type": "AWS::SNS::Topic",
-    },
-    "singlecontributionsalesforcewritestopicsupporterrevenueengineguardiancouk88BB94BA": {
-      "Properties": {
-        "Endpoint": "supporter.revenue.engine@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "singlecontributionsalesforcewritestopicD1E1FC97",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
     },
   },
 }

--- a/cdk/lib/single-contribution-salesforce-writes.ts
+++ b/cdk/lib/single-contribution-salesforce-writes.ts
@@ -9,8 +9,6 @@ import { SqsQueue } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
-import { Topic } from 'aws-cdk-lib/aws-sns';
-import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 export const APP_NAME = 'single-contribution-salesforce-writes';
@@ -92,17 +90,9 @@ export class SingleContributionSalesforceWrites extends GuStack {
 
 		lambda.addToRolePolicy(getSecretValuePolicyStatement);
 
-		const snsTopic = new Topic(this, `${APP_NAME}-topic`, {
-			topicName: `${APP_NAME}-topic-${props.stage}`,
-		});
-
-		snsTopic.addSubscription(
-			new EmailSubscription('supporter.revenue.engine@guardian.co.uk'),
-		);
-
 		new GuAlarm(this, `${APP_NAME}-alarm`, {
 			app: APP_NAME,
-			snsTopicName: snsTopic.topicName,
+			snsTopicName: `alarms-handler-topic-${this.stage}`,
 			alarmName: `${this.stage}: Failed to sync single contribution to Salesforce`,
 			alarmDescription: `Impact: A Single Contribution record has not been added to Salesforce. Fix: check logs for lambda ${lambda.functionName} and redrive from dead letter queue or, if Salesforce is preventing record creation due to a data quality issue, fix and add record manually to Salesforce`,
 			metric: deadLetterQueue

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -92,6 +92,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		// salesforce
 		'salesforce-disaster-recovery',
 		'salesforce-disaster-recovery-health-check',
+		'single-contribution-salesforce-writes',
 
 		// zuora
 		'invoicing-api',


### PR DESCRIPTION
## What does this change?

- Move `single-contribution-salesforce-writes` ownership to Platform

## How can we measure success?

The next single-contribution-salesforce-writes alarm goes to the Platform chat.
