### PR TITLE
Bug Fix: Handle situation where missing return amount because at end of payment period

### DIFF
--- a/handlers/product-switch-api/src/contributionToSupporterPlus.ts
+++ b/handlers/product-switch-api/src/contributionToSupporterPlus.ts
@@ -65,11 +65,11 @@ export const switchToSupporterPlus = async (
 	};
 };
 
-export const handleMissingRefundAmount = (
+export const refundExpected = (
 	catalogInformation: CatalogInformation,
 	subscription: ZuoraSubscription,
 	currentDate: Date,
-): number => {
+): boolean => {
 	const ratePlan = getIfDefined(
 		subscription.ratePlans.find(
 			(ratePlan: RatePlan) =>
@@ -88,11 +88,7 @@ export const handleMissingRefundAmount = (
 		'No matching chargedThroughDate found in Subscription',
 	);
 
-	if (!(currentDate.toDateString() == chargedThroughDate.toDateString())) {
-		throw Error('No contribution refund amount found in the preview response');
-	}
-
-	return 0;
+	return !(currentDate.toDateString() == chargedThroughDate.toDateString());
 };
 
 export const getContributionRefundAmount = (
@@ -105,11 +101,14 @@ export const getContributionRefundAmount = (
 			invoiceItem.productRatePlanChargeId ===
 			catalogInformation.contribution.chargeId,
 	)?.amountWithoutTax;
+	if (
+		contributionRefundAmount == undefined &&
+		refundExpected(catalogInformation, subscription, new Date())
+	) {
+		throw Error('No contribution refund amount found in the preview response');
+	}
 
-	return (
-		contributionRefundAmount ??
-		handleMissingRefundAmount(catalogInformation, subscription, new Date())
-	);
+	return contributionRefundAmount ?? 0;
 };
 
 export const previewResponseFromZuoraResponse = (

--- a/handlers/product-switch-api/src/productSwitchEndpoint.ts
+++ b/handlers/product-switch-api/src/productSwitchEndpoint.ts
@@ -26,7 +26,9 @@ export const contributionToSupporterPlusEndpoint = async (
 	const input = productSwitchRequestSchema.parse(JSON.parse(body));
 	console.log(`Request body is ${prettyPrint(input)}`);
 	console.log('Getting the subscription and account details from Zuora');
+
 	const subscription = await getSubscription(zuoraClient, subscriptionNumber);
+
 	const account = await getAccount(zuoraClient, subscription.accountNumber);
 
 	const switchInformation = getSwitchInformationWithOwnerCheck(
@@ -37,8 +39,9 @@ export const contributionToSupporterPlusEndpoint = async (
 		productCatalog,
 		identityId,
 	);
+
 	const response = input.preview
-		? await preview(zuoraClient, switchInformation)
+		? await preview(zuoraClient, switchInformation, subscription)
 		: await switchToSupporterPlus(zuoraClient, switchInformation);
 
 	return {

--- a/handlers/product-switch-api/src/schemas.ts
+++ b/handlers/product-switch-api/src/schemas.ts
@@ -11,32 +11,40 @@ export type ProductSwitchRequestBody = z.infer<
 	typeof productSwitchRequestSchema
 >;
 
+export const zuoraPreviewResponseInvoiceItemSchema = z.object({
+	serviceStartDate: z.string(),
+	serviceEndDate: z.string(),
+	amountWithoutTax: z.number(),
+	taxAmount: z.number(),
+	chargeName: z.string(),
+	processingType: z.string(),
+	productName: z.string(),
+	productRatePlanChargeId: z.string(),
+	unitPrice: z.number(),
+	subscriptionNumber: z.string(),
+});
+
+export type ZuoraPreviewResponseInvoiceItem = z.infer<
+	typeof zuoraPreviewResponseInvoiceItemSchema
+>;
+
+export const zuoraPreviewResponseInvoiceSchema = z.object({
+	amount: z.number(),
+	amountWithoutTax: z.number(),
+	taxAmount: z.number(),
+	targetDate: z.string(),
+	invoiceItems: z.array(zuoraPreviewResponseInvoiceItemSchema),
+});
+
+export type ZuoraPreviewResponseInvoice = z.infer<
+	typeof zuoraPreviewResponseInvoiceSchema
+>;
+
 export const zuoraPreviewResponseSchema = z.object({
 	success: z.boolean(),
 	previewResult: z.optional(
 		z.object({
-			invoices: z.array(
-				z.object({
-					amount: z.number(),
-					amountWithoutTax: z.number(),
-					taxAmount: z.number(),
-					targetDate: z.string(),
-					invoiceItems: z.array(
-						z.object({
-							serviceStartDate: z.string(),
-							serviceEndDate: z.string(),
-							amountWithoutTax: z.number(),
-							taxAmount: z.number(),
-							chargeName: z.string(),
-							processingType: z.string(),
-							productName: z.string(),
-							productRatePlanChargeId: z.string(),
-							unitPrice: z.number(),
-							subscriptionNumber: z.string(),
-						}),
-					),
-				}),
-			),
+			invoices: z.array(zuoraPreviewResponseInvoiceSchema),
 		}),
 	),
 	reasons: z.optional(z.array(z.object({ message: z.string() }))),

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -14,7 +14,7 @@ import {
 import dayjs from 'dayjs';
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import {
-	handleMissingRefundAmount,
+	refundExpected,
 	previewResponseFromZuoraResponse,
 } from '../src/contributionToSupporterPlus';
 import { buildEmailMessage } from '../src/productSwitchEmail';
@@ -227,11 +227,11 @@ test('handleMissingRefundAmount() called on the charge-through-date for a subscr
 			'Problem with test data: zuoraSubscriptionWithMonthlyContribution should contain a charged-through-date',
 		);
 	}
-	const currentDate = new Date(chargeThroughDate);
+	const currentDate = new Date(chargedThroughDate);
 
-	expect(
-		handleMissingRefundAmount(catalogInformation, subscription, currentDate),
-	).toBe(0);
+	expect(refundExpected(catalogInformation, subscription, currentDate)).toBe(
+		false,
+	);
 });
 
 test('handleMissingRefundAmount() called on a date that is not the charge-through-date for a subscription will throw an error', () => {
@@ -254,12 +254,8 @@ test('handleMissingRefundAmount() called on a date that is not the charge-throug
 	//Current value of charge-through-date is '2024-07-01'
 	const currentDate = new Date('2024-07-02');
 
-	expect(() =>
-		handleMissingRefundAmount(catalogInformation, subscription, currentDate),
-	).toThrow(
-		ReferenceError(
-			'No contribution refund amount found in the preview response',
-		),
+	expect(refundExpected(catalogInformation, subscription, currentDate)).toBe(
+		true,
 	);
 });
 

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -220,11 +220,11 @@ test('handleMissingRefundAmount() called on the charge-through-date for a subscr
 		zuoraSubscriptionWithMonthlyContribution,
 	);
 
-	const chargeThroughDate =
+	const chargedThroughDate =
 		subscription.ratePlans[0]?.ratePlanCharges[0]?.chargedThroughDate;
-	if (!chargeThroughDate) {
+	if (!chargedThroughDate) {
 		throw Error(
-			'Problem with test data: zuoraSubscriptionWithMonthlyContribution should contain a charge-through-date',
+			'Problem with test data: zuoraSubscriptionWithMonthlyContribution should contain a charged-through-date',
 		);
 	}
 	const currentDate = new Date(chargeThroughDate);

--- a/handlers/product-switch-api/test/contributionToSupporterPlusIntegration.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlusIntegration.test.ts
@@ -43,7 +43,7 @@ describe('product-switching behaviour', () => {
 			identityId,
 		);
 
-		const result = await preview(zuoraClient, switchInformation);
+		const result = await preview(zuoraClient, switchInformation, subscription);
 
 		expect(result.supporterPlusPurchaseAmount).toEqual(20);
 	});
@@ -65,7 +65,7 @@ describe('product-switching behaviour', () => {
 			identityId,
 		);
 
-		const result = await preview(zuoraClient, switchInformation);
+		const result = await preview(zuoraClient, switchInformation, subscription);
 
 		const expectedResult = {
 			supporterPlusPurchaseAmount: 120,

--- a/handlers/product-switch-api/test/fixtures/zuora-subscription-with-monthly-contribution.json
+++ b/handlers/product-switch-api/test/fixtures/zuora-subscription-with-monthly-contribution.json
@@ -1,0 +1,45 @@
+{
+  "success": true,
+  "id": "8a1295998f51a921018f5be20c7b2975",
+  "accountNumber": "A02071906",
+  "subscriptionNumber": "A-S02138089",
+  "status": "Active",
+  "contractEffectiveDate": "2024-05-31",
+  "serviceActivationDate": "2024-05-31",
+  "customerAcceptanceDate": "2024-05-31",
+  "subscriptionStartDate": "2024-07-01",
+  "subscriptionEndDate": "2025-07-01",
+  "lastBookingDate": "2024-06-11",
+  "termStartDate": "2024-05-31",
+  "termEndDate": "2025-05-31",
+  "ratePlans": [
+    {
+      "id": "8a1295998f51a921018f5be20c922977",
+      "lastChangeType": "Foo",
+      "productId": "2c92a0fe5aacfabe015ad24bf6e15ff6",
+      "productName": "Contributor",
+      "productRatePlanId": "2c92a0fc5e1dc084015e37f58c200eea",
+      "ratePlanName": "Annual Contribution",
+      "ratePlanCharges": [
+        {
+          "id": "8a1295998f51a921018f5be20cab297c",
+          "productRatePlanChargeId": "2c92a0fc5e1dc084015e37f58c7b0f35",
+          "number": "C-05575926",
+          "name": "Monthly Contribution",
+          "type": "Recurring",
+          "model": "FlatFee",
+          "currency": "EUR",
+          "effectiveStartDate": "2024-05-31",
+          "effectiveEndDate": "2025-05-31",
+          "billingPeriod": "Month",
+          "processedThroughDate": "2024-07-01",
+          "chargedThroughDate": "2024-07-01",
+          "upToPeriodsType": null,
+          "upToPeriods": null,
+          "price": 50,
+          "discountPercentage": null
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
This is a bug fix. Associated trello card is [here](https://trello.com/c/4WpazHGb/463-support-fix-unhandled-case-in-product-switch-api).

## What does this change?

This changes contributionsToSupporterPlus.ts and adds a check to handle the situation where the payment-switch is made on the same day of month as the term-start-date.
In this situation the previous payment term has completed but the payments for the next term have not yet been taken.
Consequently there is no payment to refund.

In this situation, the zuoraPreviewResponse invoice will not have an invoiceItem with the refund amount.
Currently this throws an error. It should instead return 0 as there is nothing to refund.

## The specifics of the change:
If there is no invoice item found for the recurring payments charge id, this change will check the term-start-date against the current date. If they have the same day of month, it will return 0 instead of throwing an error.

This change involved adding the zuoraSubscription as a parameter to the previewResponseFromZuoraResponse method, so that we can extract the term-start-date.

## How to test

- [x] New unit tests created to capture this scenario.
- [x] Unit tests pass.
- [x] Successfully deployed to CODE.

## How can we measure success?

This particular scenario will not throw an error.
Other scenario's where the zuoraPreviewResponse invoice is lacking an invoiceItem with the refund amount will throw an error.

## Have we considered potential risks?

Only risk is that fix is incorrectly applied. Unit tests confirm this is not the case.
