### PR TITLE
fix: revert single-contribution-salesforce-writes lambda to Java 11 as PATCH method not supported

### DIFF
--- a/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
+++ b/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
@@ -164,7 +164,7 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
             "Arn",
           ],
         },
-        "Runtime": "java21",
+        "Runtime": "java11",
         "Tags": [
           {
             "Key": "App",
@@ -681,7 +681,7 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
             "Arn",
           ],
         },
-        "Runtime": "java21",
+        "Runtime": "java11",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/single-contribution-salesforce-writes.ts
+++ b/cdk/lib/single-contribution-salesforce-writes.ts
@@ -71,7 +71,7 @@ export class SingleContributionSalesforceWrites extends GuStack {
 
 		const lambda = new GuLambdaFunction(this, `${APP_NAME}-lambda`, {
 			app: APP_NAME,
-			runtime: Runtime.JAVA_21,
+			runtime: Runtime.JAVA_11,
 			fileName: `${APP_NAME}.jar`,
 			functionName: `${APP_NAME}-${props.stage}`,
 			handler:


### PR DESCRIPTION
## What does this change?

PATCH is (or was) not an official http method, so the built in JRE http client doesn't support it.
https://github.com/openjdk/jdk/blob/b389bb456726184e4691777b1bb02d4b8a8a3f97/src/java.base/share/classes/java/net/HttpURLConnection.java#L363

This reverts the lambda to use Java 11 to get it working again.

Longer term we should move off that http client and onto one of the others e.g. okhttp so that we can update.