### PR TITLE
Move Fulfilment Date Calculator alarms to Platform

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -29,7 +29,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'contributions-ticker-calculator',
 		'digital-voucher-api',
 		'dotcom-components',
-		'fulfilment-date-calculator',
 		...sharedMobilePurchasesApps,
 		'new-product-api',
 		'price-migration-engine-state-machine',
@@ -85,6 +84,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'failed-national-delivery-processor',
 		'fulfilment-lambdas',
 		'national-delivery-fulfilment',
+		'fulfilment-date-calculator',
 
 		// salesforce
 		'salesforce-disaster-recovery',


### PR DESCRIPTION
## What does this change?
Moves the alarms for the fulfilment-data-calculator lambda to the Platform team as per [the updated ownership sheet](https://docs.google.com/spreadsheets/d/1bb8WB-6ZFRdUwERHMOVIolN8WU8zJMcsyi-WJuwp07Q/edit?gid=0#gid=0).