### PR TITLE
Add metrics for validation errors 

### DIFF
--- a/cdk/lib/__snapshots__/ticket-tailor-webhook.test.ts.snap
+++ b/cdk/lib/__snapshots__/ticket-tailor-webhook.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The Ticket tailor webhook stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
+      "GuPutCloudwatchMetricsPolicy",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -106,6 +107,27 @@ exports[`The Ticket tailor webhook stack matches the snapshot 1`] = `
         "Roles": [
           {
             "Ref": "ApiGatewayToSqsRole590217A3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuPutCloudwatchMetricsPolicyC5BCE402": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuPutCloudwatchMetricsPolicyC5BCE402",
+        "Roles": [
+          {
+            "Ref": "tickettailorwebhooklambdaServiceRole8D9E481D",
           },
         ],
       },
@@ -713,6 +735,7 @@ exports[`The Ticket tailor webhook stack matches the snapshot 2`] = `
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
       "GuApiGateway5xxPercentageAlarm",
+      "GuPutCloudwatchMetricsPolicy",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -885,6 +908,27 @@ exports[`The Ticket tailor webhook stack matches the snapshot 2`] = `
         "Roles": [
           {
             "Ref": "ApiGatewayToSqsRole590217A3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuPutCloudwatchMetricsPolicyC5BCE402": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuPutCloudwatchMetricsPolicyC5BCE402",
+        "Roles": [
+          {
+            "Ref": "tickettailorwebhooklambdaServiceRole8D9E481D",
           },
         ],
       },

--- a/cdk/lib/ticket-tailor-webhook.ts
+++ b/cdk/lib/ticket-tailor-webhook.ts
@@ -1,6 +1,7 @@
 import { GuApiGatewayWithLambdaByPath } from '@guardian/cdk';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuPutCloudwatchMetricsPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda/lambda';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
@@ -161,7 +162,10 @@ export class TicketTailorWebhook extends GuStack {
 			},
 		);
 
+		const cloudwatchPutMetricPolicy = new GuPutCloudwatchMetricsPolicy(this);
+
 		lambda.role?.attachInlinePolicy(s3InlinePolicy);
 		lambda.role?.attachInlinePolicy(secretManagerAccessPolicy);
+		lambda.role?.attachInlinePolicy(cloudwatchPutMetricPolicy);
 	}
 }

--- a/handlers/ticket-tailor-webhook/package.json
+++ b/handlers/ticket-tailor-webhook/package.json
@@ -11,6 +11,7 @@
     "fix-formatting": "prettier --write **.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.556.0",
     "@aws-sdk/client-secrets-manager": "^3.629.0",
     "zod": "^3.23.8"
   },

--- a/handlers/ticket-tailor-webhook/src/cloudwatch.ts
+++ b/handlers/ticket-tailor-webhook/src/cloudwatch.ts
@@ -7,10 +7,9 @@ import {
 	CloudWatchClient,
 	PutMetricDataCommand,
 } from '@aws-sdk/client-cloudwatch';
+import { stageFromEnvironment } from '@modules/stage';
 
 export async function putMetric(metricName: string): Promise<void> {
-	console.log('putting metric... metricName:', metricName);
-
 	const cloudwatch = new CloudWatchClient({
 		region: process.env.AWS_REGION ?? 'eu-west-1',
 	});
@@ -22,7 +21,7 @@ export async function putMetric(metricName: string): Promise<void> {
 		},
 		{
 			Name: 'Stage',
-			Value: process.env.STAGE,
+			Value: stageFromEnvironment(),
 		},
 	];
 

--- a/handlers/ticket-tailor-webhook/src/cloudwatch.ts
+++ b/handlers/ticket-tailor-webhook/src/cloudwatch.ts
@@ -7,9 +7,24 @@ import {
 	CloudWatchClient,
 	PutMetricDataCommand,
 } from '@aws-sdk/client-cloudwatch';
-import { stageFromEnvironment } from '@modules/stage';
+
+export type Stage = 'CODE' | 'DEV' | 'PROD';
+
+const getStage = (): Stage | undefined => {
+	const stage = process.env.Stage;
+	if (stage === undefined) {
+		throw new Error('Stage is not defined as an environment variable');
+	}
+	return stage as Stage;
+};
 
 export async function putMetric(metricName: string): Promise<void> {
+	const stage = getStage();
+	if (stage == 'DEV') {
+		console.log('No metrics sent as running local test');
+		return;
+	}
+
 	const cloudwatch = new CloudWatchClient({
 		region: process.env.AWS_REGION ?? 'eu-west-1',
 	});
@@ -21,7 +36,7 @@ export async function putMetric(metricName: string): Promise<void> {
 		},
 		{
 			Name: 'Stage',
-			Value: stageFromEnvironment(),
+			Value: stage,
 		},
 	];
 

--- a/handlers/ticket-tailor-webhook/src/cloudwatch.ts
+++ b/handlers/ticket-tailor-webhook/src/cloudwatch.ts
@@ -1,0 +1,32 @@
+import { CloudWatchClient, Dimension, PutMetricDataCommand, PutMetricDataCommandInput } from '@aws-sdk/client-cloudwatch';
+import { stageFromEnvironment, Stage } from '@modules/stage';
+import * as process from "process";
+
+export async function putMetric(metricName: string): Promise<void> {
+    console.log('putting metric... metricName:',metricName);
+
+    const stage: Stage = stageFromEnvironment();
+    const cloudwatch = new CloudWatchClient({ region: process.env.AWSREGION });
+
+    const dimensions: Dimension[] = [{
+        Name:"Stage",
+        Value:process.env.STAGE
+    }];
+
+    const params: PutMetricDataCommandInput = {
+        Namespace: `ticket-tailor-webhook-${stage}`,
+        MetricData: [
+            {
+                MetricName: metricName,
+                Value: 1,
+                Unit: 'Count',
+                Dimensions: dimensions
+            },
+        ],
+
+    };
+
+    const command = new PutMetricDataCommand(params);
+
+    await cloudwatch.send(command);
+}

--- a/handlers/ticket-tailor-webhook/src/cloudwatch.ts
+++ b/handlers/ticket-tailor-webhook/src/cloudwatch.ts
@@ -1,32 +1,43 @@
-import { CloudWatchClient, Dimension, PutMetricDataCommand, PutMetricDataCommandInput } from '@aws-sdk/client-cloudwatch';
-import { stageFromEnvironment, Stage } from '@modules/stage';
-import * as process from "process";
+import * as process from 'process';
+import type {
+	Dimension,
+	PutMetricDataCommandInput,
+} from '@aws-sdk/client-cloudwatch';
+import {
+	CloudWatchClient,
+	PutMetricDataCommand,
+} from '@aws-sdk/client-cloudwatch';
+import type { Stage } from '@modules/stage';
+import { stageFromEnvironment } from '@modules/stage';
 
 export async function putMetric(metricName: string): Promise<void> {
-    console.log('putting metric... metricName:',metricName);
+	console.log('putting metric... metricName:', metricName);
 
-    const stage: Stage = stageFromEnvironment();
-    const cloudwatch = new CloudWatchClient({ region: process.env.AWSREGION });
+	const stage: Stage = stageFromEnvironment();
+	const cloudwatch = new CloudWatchClient({
+		region: process.env.AWS_REGION ?? 'eu-west-1',
+	});
 
-    const dimensions: Dimension[] = [{
-        Name:"Stage",
-        Value:process.env.STAGE
-    }];
+	const dimensions: Dimension[] = [
+		{
+			Name: 'Stage',
+			Value: process.env.STAGE,
+		},
+	];
 
-    const params: PutMetricDataCommandInput = {
-        Namespace: `ticket-tailor-webhook-${stage}`,
-        MetricData: [
-            {
-                MetricName: metricName,
-                Value: 1,
-                Unit: 'Count',
-                Dimensions: dimensions
-            },
-        ],
+	const params: PutMetricDataCommandInput = {
+		Namespace: `ticket-tailor-webhook-${stage}`,
+		MetricData: [
+			{
+				MetricName: metricName,
+				Value: 1,
+				Unit: 'Count',
+				Dimensions: dimensions,
+			},
+		],
+	};
 
-    };
+	const command = new PutMetricDataCommand(params);
 
-    const command = new PutMetricDataCommand(params);
-
-    await cloudwatch.send(command);
+	await cloudwatch.send(command);
 }

--- a/handlers/ticket-tailor-webhook/src/cloudwatch.ts
+++ b/handlers/ticket-tailor-webhook/src/cloudwatch.ts
@@ -7,18 +7,19 @@ import {
 	CloudWatchClient,
 	PutMetricDataCommand,
 } from '@aws-sdk/client-cloudwatch';
-import type { Stage } from '@modules/stage';
-import { stageFromEnvironment } from '@modules/stage';
 
 export async function putMetric(metricName: string): Promise<void> {
 	console.log('putting metric... metricName:', metricName);
 
-	const stage: Stage = stageFromEnvironment();
 	const cloudwatch = new CloudWatchClient({
 		region: process.env.AWS_REGION ?? 'eu-west-1',
 	});
 
 	const dimensions: Dimension[] = [
+		{
+			Name: 'App',
+			Value: process.env.App,
+		},
 		{
 			Name: 'Stage',
 			Value: process.env.STAGE,
@@ -26,7 +27,7 @@ export async function putMetric(metricName: string): Promise<void> {
 	];
 
 	const params: PutMetricDataCommandInput = {
-		Namespace: `ticket-tailor-webhook-${stage}`,
+		Namespace: `support-service-lambdas`,
 		MetricData: [
 			{
 				MetricName: metricName,

--- a/handlers/ticket-tailor-webhook/src/index.ts
+++ b/handlers/ticket-tailor-webhook/src/index.ts
@@ -40,7 +40,6 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 			if (validRequest) {
 				await processValidSqsRecord(sqsRecord);
 			} else {
-				await putMetric('ticket-tailor-webhook-validation-failure');
 				console.error('Request failed validation. Processing terminated.');
 				return;
 			}

--- a/handlers/ticket-tailor-webhook/src/index.ts
+++ b/handlers/ticket-tailor-webhook/src/index.ts
@@ -1,7 +1,7 @@
 import type { SQSEvent, SQSRecord } from 'aws-lambda';
+import { putMetric } from './cloudwatch';
 import { createGuestAccount, fetchUserType } from './idapiService';
 import { validateRequest } from './validateRequest';
-import {putMetric} from "./cloudwatch";
 
 /*
 The payload of a webhook request contains an order object:
@@ -41,6 +41,7 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 				await processValidSqsRecord(sqsRecord);
 			} else {
 				console.error('Request failed validation. Processing terminated.');
+				await putMetric('ticket-tailor-webhook-validation-failure');
 				return;
 			}
 		},

--- a/handlers/ticket-tailor-webhook/src/index.ts
+++ b/handlers/ticket-tailor-webhook/src/index.ts
@@ -1,6 +1,7 @@
 import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import { createGuestAccount, fetchUserType } from './idapiService';
 import { validateRequest } from './validateRequest';
+import {putMetric} from "./cloudwatch";
 
 /*
 The payload of a webhook request contains an order object:
@@ -39,6 +40,7 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 			if (validRequest) {
 				await processValidSqsRecord(sqsRecord);
 			} else {
+				await putMetric('ticket-tailor-webhook-validation-failure');
 				console.error('Request failed validation. Processing terminated.');
 				return;
 			}

--- a/handlers/ticket-tailor-webhook/src/validateRequest.ts
+++ b/handlers/ticket-tailor-webhook/src/validateRequest.ts
@@ -8,7 +8,7 @@ export type HmacKey = {
 	secret: string;
 };
 
-const validationFalureMetricName = 'ticket-tailor-webhook-validation-failure'
+const validationFailureMetricName = 'ticket-tailor-webhook-validation-failure'
 
 export const getTimestampAndSignature = (
 	record: SQSRecord,
@@ -17,7 +17,7 @@ export const getTimestampAndSignature = (
 		record.messageAttributes['tickettailor-webhook-signature']?.stringValue;
 
 	if (!(typeof signatureWithTs === 'string')) {
-		await putMetric('ticket-tailor-webhook-validation-failure');
+		await putMetric(validationFailureMetricName);
 		console.error(
 			'No valid value found for MessgeAttritbute: tickettailor-webhook-signature on incoming request.',
 		);
@@ -28,7 +28,7 @@ export const getTimestampAndSignature = (
 	const signature = signatureWithTs.split(',')[1]?.split('v1=')[1];
 
 	if (!(timestamp && signature) || isNaN(Number(timestamp))) {
-		await putMetric('ticket-tailor-webhook-validation-failure');
+		await putMetric(validationFailureMetricName);
 		console.error(
 			`Invalid formatting of MessageAttribute 'tickettailor-webhook-signature': ${signatureWithTs}. Missing or incorrectly formatted timestamp or signature.`,
 		);
@@ -106,6 +106,6 @@ export const validateRequest = async (record: SQSRecord): Promise<boolean> => {
 			`Webhook Signature timestamp ${timestamp} is older than ${maxValidTimeWindowSeconds} seconds. Webhook will not be processed.`,
 		);
 	}
-
+	await putMetric(validationFailureMetricName);
 	return withinTimeWindow && signatureMatches;
 };

--- a/handlers/ticket-tailor-webhook/src/validateRequest.ts
+++ b/handlers/ticket-tailor-webhook/src/validateRequest.ts
@@ -61,7 +61,21 @@ export const hasMatchingSignature = (
 	const hash = createHmac('sha256', validationSecret.secret)
 		.update(timestamp.concat(record.body))
 		.digest('hex');
-	return timingSafeEqual(Buffer.from(hash), Buffer.from(signature));
+
+	try {
+		console.log('Comparing generated hash and signature from request');
+		return timingSafeEqual(Buffer.from(hash), Buffer.from(signature));
+	} catch (e) {
+		if (e instanceof Error) {
+			console.error(
+				`Hash and signature comparison failed with the following error message: ${e.message}`,
+			);
+		} else {
+			console.error(`Hash and signature comparison failed for Unknown reason.`);
+		}
+
+		return false;
+	}
 };
 
 export const maxValidTimeWindowSeconds = 300;

--- a/handlers/ticket-tailor-webhook/test/index.test.ts
+++ b/handlers/ticket-tailor-webhook/test/index.test.ts
@@ -23,7 +23,7 @@ const validEpochSeconds =
 	Number(validSQSRecordTimestamp) + maxValidTimeWindowSeconds;
 
 beforeEach(() => {
-	process.env.Stage = 'CODE';
+	process.env.Stage = 'DEV';
 	fetchMock.restore();
 });
 

--- a/handlers/ticket-tailor-webhook/test/validateRequest.test.ts
+++ b/handlers/ticket-tailor-webhook/test/validateRequest.test.ts
@@ -37,8 +37,8 @@ const invalidSignature =
 	'a3dbd8cfb0f04a0a9b0dd9d2547f1dd1a51e60d528a4edaee3bc02085517bd51';
 
 //Tests for getTimestampAndSignature()
-test('getTimestampAndSignature() called on an SQSRecord returns the correct values', () => {
-	const timestampAndSignature = getTimestampAndSignature(validSQSRecord);
+test('getTimestampAndSignature() called on an SQSRecord returns the correct values', async () => {
+	const timestampAndSignature = await getTimestampAndSignature(validSQSRecord);
 	if (!timestampAndSignature) {
 		throw new Error('Test Data missing timestamp and signature');
 	}

--- a/handlers/ticket-tailor-webhook/test/validateRequest.test.ts
+++ b/handlers/ticket-tailor-webhook/test/validateRequest.test.ts
@@ -37,8 +37,8 @@ const invalidSignature =
 	'a3dbd8cfb0f04a0a9b0dd9d2547f1dd1a51e60d528a4edaee3bc02085517bd51';
 
 //Tests for getTimestampAndSignature()
-test('getTimestampAndSignature() called on an SQSRecord returns the correct values', async () => {
-	const timestampAndSignature = await getTimestampAndSignature(validSQSRecord);
+test('getTimestampAndSignature() called on an SQSRecord returns the correct values', () => {
+	const timestampAndSignature = getTimestampAndSignature(validSQSRecord);
 	if (!timestampAndSignature) {
 		throw new Error('Test Data missing timestamp and signature');
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
 
   handlers/ticket-tailor-webhook:
     dependencies:
+      '@aws-sdk/client-cloudwatch':
+        specifier: ^3.556.0
+        version: 3.556.0
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.629.0
         version: 3.632.0
@@ -5853,7 +5856,7 @@ snapshots:
       '@aws-sdk/credential-provider-env': 3.577.0
       '@aws-sdk/credential-provider-process': 3.577.0
       '@aws-sdk/credential-provider-sso': 3.577.0(@aws-sdk/client-sso-oidc@3.632.0(@aws-sdk/client-sts@3.577.0))
-      '@aws-sdk/credential-provider-web-identity': 3.577.0(@aws-sdk/client-sts@3.577.0(@aws-sdk/client-sso-oidc@3.577.0))
+      '@aws-sdk/credential-provider-web-identity': 3.577.0(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/credential-provider-imds': 3.0.0
       '@smithy/property-provider': 3.0.0
@@ -5995,7 +5998,7 @@ snapshots:
       '@aws-sdk/credential-provider-ini': 3.577.0(@aws-sdk/client-sso-oidc@3.632.0(@aws-sdk/client-sts@3.577.0))(@aws-sdk/client-sts@3.577.0(@aws-sdk/client-sso-oidc@3.577.0))
       '@aws-sdk/credential-provider-process': 3.577.0
       '@aws-sdk/credential-provider-sso': 3.577.0(@aws-sdk/client-sso-oidc@3.632.0(@aws-sdk/client-sts@3.577.0))
-      '@aws-sdk/credential-provider-web-identity': 3.577.0(@aws-sdk/client-sts@3.577.0(@aws-sdk/client-sso-oidc@3.577.0))
+      '@aws-sdk/credential-provider-web-identity': 3.577.0(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/credential-provider-imds': 3.0.0
       '@smithy/property-provider': 3.0.0
@@ -6240,7 +6243,7 @@ snapshots:
       '@aws-sdk/credential-provider-node': 3.577.0(@aws-sdk/client-sso-oidc@3.632.0(@aws-sdk/client-sts@3.577.0))(@aws-sdk/client-sts@3.577.0(@aws-sdk/client-sso-oidc@3.577.0))
       '@aws-sdk/credential-provider-process': 3.577.0
       '@aws-sdk/credential-provider-sso': 3.577.0(@aws-sdk/client-sso-oidc@3.632.0(@aws-sdk/client-sts@3.577.0))
-      '@aws-sdk/credential-provider-web-identity': 3.577.0(@aws-sdk/client-sts@3.577.0(@aws-sdk/client-sso-oidc@3.577.0))
+      '@aws-sdk/credential-provider-web-identity': 3.577.0(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/credential-provider-imds': 3.0.0
       '@smithy/property-provider': 3.0.0


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Validation failures will now generate a metric named 'ticket-tailor-webhook-validation-failure'.
This allows us to track and set up alerts for ticket-tailor-webhook requests that fail validation.

Currently validation failures log an error message but do not throw an error. 
This is because we wish to avoid generating retry attempts that we know will fail anyway.
Adding a metric to track these scenarios will allow us to set up alerts to trigger on validation failures without forcing a retry attempt.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- [x] Unit tests all pass.
- [x] Deployed to CODE and tested with invalid request to confirm metric is generated.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

We are able to track and alert on validation errors.
