### PR TITLE
Lower minimum recurring contribution amounts in new-product-api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
@@ -15,33 +15,33 @@ object AmountLimits {
   def fromMinorToMajor(value: Int) = value / 100
 
   val gbp = ContributionLimits(
-    monthly = AmountLimits.fromMajorUnits(min = 4, max = 166),
-    annual = AmountLimits.fromMajorUnits(min = 50, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 2, max = 166),
+    annual = AmountLimits.fromMajorUnits(min = 25, max = 2000),
   )
 
   val aud = ContributionLimits(
-    monthly = AmountLimits.fromMajorUnits(min = 10, max = 200),
-    annual = AmountLimits.fromMajorUnits(min = 80, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 5, max = 200),
+    annual = AmountLimits.fromMajorUnits(min = 40, max = 2000),
   )
 
   val usd = ContributionLimits(
-    monthly = AmountLimits.fromMajorUnits(min = 3, max = 166),
-    annual = AmountLimits.fromMajorUnits(min = 30, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 2, max = 166),
+    annual = AmountLimits.fromMajorUnits(min = 15, max = 2000),
   )
 
   val nzd = ContributionLimits(
-    monthly = AmountLimits.fromMajorUnits(min = 10, max = 200),
-    annual = AmountLimits.fromMajorUnits(min = 80, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 5, max = 200),
+    annual = AmountLimits.fromMajorUnits(min = 40, max = 2000),
   )
 
   val cad = ContributionLimits(
-    monthly = AmountLimits.fromMajorUnits(min = 5, max = 166),
-    annual = AmountLimits.fromMajorUnits(min = 60, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 2, max = 166),
+    annual = AmountLimits.fromMajorUnits(min = 30, max = 2000),
   )
 
   val eur = ContributionLimits(
-    monthly = AmountLimits.fromMajorUnits(min = 4, max = 166),
-    annual = AmountLimits.fromMajorUnits(min = 50, max = 2000),
+    monthly = AmountLimits.fromMajorUnits(min = 2, max = 166),
+    annual = AmountLimits.fromMajorUnits(min = 25, max = 2000),
   )
 
   def limitsFor(planId: PlanId, currency: Currency): AmountLimits = {


### PR DESCRIPTION
## What does this change?
new-product-api is used as the backend for Customer Service Representative (CSR) acquisitions in Salesforce.

In #2450 we adjusted some of the minimum amounts for Recurring Contributions to match the current product proposition for customers online. Subsequent feedback from the contact centre is that they need access to lower thresholds for recurring contributions as a last resort save mechanism for supporters who are at risk of churning.

## How to test
On a Billing Account in Salesforce, click "New Subscription" and setup a new Recurring Contribution. Set the amount above or below the minimum prices defined in handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala to verify the changes.

## How can we measure success?
CSRs can more effectively save supporters from completely churning through offering a low amount recurring contribution.

## Have we considered potential risks?
Have tested in CODE and we will verify in production after deployment.
