### PR TITLE
adding new consent for guardian_products_services

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculator.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculator.scala
@@ -1,6 +1,6 @@
 package com.gu.soft_opt_in_consent_setter
 
-import com.gu.soft_opt_in_consent_setter.models.SoftOptInError
+import com.gu.soft_opt_in_consent_setter.models.{ConsentsMapping, SoftOptInError}
 import io.circe.generic.auto._
 import io.circe.syntax.EncoderOps
 
@@ -56,6 +56,7 @@ class ConsentsCalculator(consentsMappings: Map[String, Set[String]]) {
             ),
           )
           .flatMap(cancelledProductConsents => Right(cancelledProductConsents.diff(ownedProductConsents)))
+          .map(removeConsentsNotBeingCancelled)
       })
   }
 
@@ -63,14 +64,10 @@ class ConsentsCalculator(consentsMappings: Map[String, Set[String]]) {
     consents.map(ConsentsObject(_, state)).asJson.toString()
   }
 
-  def removeSimilarGuardianProductFromSet(consents: Set[String]): Set[String] = {
-    // This method was added during https://github.com/guardian/support-service-lambdas/pull/2130
-    // for the sole purpose of removing similar_guardian_products to the set of consents that are
-    // passed sendCancellationConsents. If one day more than one consent needs to be excluded from
-    // being turned off, then the author of the change can adopt the same method, but should
-    // probably rename this function
-
-    consents - "similar_guardian_products"
+  def removeConsentsNotBeingCancelled(consents: Set[String]): Set[String] = {
+    val consentsNotBeingRemoved =
+      Set(ConsentsMapping.similarGuardianProducts, ConsentsMapping.guardianProductsAndServices)
+    consents.removedAll(consentsNotBeingRemoved)
   }
 
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -214,8 +214,7 @@ object Handler extends LazyLogging {
               sub.Product__c,
               associatedActiveNonGiftSubs.map(_.Product__c).toSet,
             )
-            consentWithoutSimilarProducts = consentsCalculator.removeSimilarGuardianProductFromSet(consents)
-            _ <- sendCancellationConsents(sub.Buyer__r.IdentityID__c, consentWithoutSimilarProducts)
+            _ <- sendCancellationConsents(sub.Buyer__r.IdentityID__c, consents)
           } yield ()
 
         logErrors(updateResult)

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -250,8 +250,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
         messageBody.productName,
         productNames.toSet,
       )
-      consentWithoutSimilarProducts = consentsCalculator.removeSimilarGuardianProductFromSet(consents)
-      _ <- sendCancellationConsents(messageBody.identityId, consentWithoutSimilarProducts)
+      _ <- sendCancellationConsents(messageBody.identityId, consents)
     } yield ()
   }
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -3,6 +3,7 @@ package com.gu.soft_opt_in_consent_setter.models
 object ConsentsMapping {
   val yourSupportOnboarding = "your_support_onboarding"
   val similarGuardianProducts = "similar_guardian_products"
+  val guardianProductsAndServices = "guardian_products_services"
   val supporterNewsletter = "supporter_newsletter"
   val subscriberPreview = "subscriber_preview"
   val guardianWeeklyNewsletter = "guardian_weekly_newsletter"
@@ -11,49 +12,58 @@ object ConsentsMapping {
     "Membership" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
     ),
     "Supporter" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
     ),
     "Contribution" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
     ),
     "Recurring Contribution" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
     ),
     "Contributor" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
     ),
     "newspaper" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       subscriberPreview,
       supporterNewsletter,
     ),
     "Newspaper - Home Delivery" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       subscriberPreview,
       supporterNewsletter,
     ),
     "Newspaper - Voucher Book" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       subscriberPreview,
       supporterNewsletter,
     ),
     "Newspaper - Digital Voucher" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       subscriberPreview,
       supporterNewsletter,
     ),
@@ -64,33 +74,39 @@ object ConsentsMapping {
     "Digital Pack" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
     ),
     "Supporter Plus" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
     ),
     "Tier Three" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
       guardianWeeklyNewsletter,
     ),
     "InAppPurchase" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
     ),
     "Newspaper - National Delivery" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
       supporterNewsletter,
       subscriberPreview,
     ),
     "FeastInAppPurchase" -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
+      guardianProductsAndServices,
     ),
   )
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -102,7 +102,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
     |    "id" : "guardian_weekly_newsletter",
     |    "consented" : true
     |  }
-    |]""".stripMargin)
+    |]""".stripMargin) // be careful this is whitespace sensitive
   }
 
   "buildConsentsBody" should "return a correctly populated JSON array when consents is not empty and state is false" in {
@@ -142,7 +142,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : true
         |  }
-        |]""".stripMargin)
+        |]""".stripMargin) // be careful this is whitespace sensitive
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Recurring Contribution to a Guardian Weekly subscription whilst the user also owns a Newspaper subscription" in {
@@ -156,7 +156,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : true
         |  }
-        |]""".stripMargin)
+        |]""".stripMargin) // be careful this is whitespace sensitive
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription" in {
@@ -186,7 +186,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
                        |    "id" : "supporter_newsletter",
                        |    "consented" : true
                        |  }
-                       |]""".stripMargin.stripLineEnd)
+                       |]""".stripMargin) // be careful this is whitespace sensitive
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Recurring Contribution whilst also owning a Newspaper subscription" in {
@@ -200,7 +200,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : false
         |  }
-        |]""".stripMargin)
+        |]""".stripMargin) // be careful this is whitespace sensitive
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Recurring Contribution" in {
@@ -218,7 +218,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "subscriber_preview",
         |    "consented" : true
         |  }
-        |]""".stripMargin)
+        |]""".stripMargin) // be careful this is whitespace sensitive
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
@@ -236,7 +236,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "subscriber_preview",
         |    "consented" : true
         |  }
-        |]""".stripMargin)
+        |]""".stripMargin) // be careful this is whitespace sensitive
   }
 
   "buildProductSwitchConsents - HandlerIAP" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
@@ -254,7 +254,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "subscriber_preview",
         |    "consented" : true
         |  }
-        |]""".stripMargin)
+        |]""".stripMargin) // be careful this is whitespace sensitive
   }
 
   def removeWhitespace(stringToRemoveWhitespaceFrom: String): String = {

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -42,12 +42,14 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
 
   // getCancellationConsents success cases
   "getCancellationConsents" should "correctly return the mapping when a known product is passed and there are no owned products" in {
-    calculator.getCancellationConsents("Membership", Set()) shouldBe Right(membershipMapping)
+    calculator.getCancellationConsents("Membership", Set()) shouldBe Right(
+      calculator.removeConsentsNotBeingCancelled(membershipMapping),
+    )
   }
 
   "getCancellationConsents" should "correctly return the mapping when a known product is passed and there is an owned product that partially overlaps" in {
     calculator.getCancellationConsents("newspaper", Set("Guardian Weekly")) shouldBe Right(
-      newspaperMapping.diff(guWeeklyMapping),
+      calculator.removeConsentsNotBeingCancelled(newspaperMapping.diff(guWeeklyMapping)),
     )
   }
 
@@ -66,6 +68,12 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
   "getCancellationConsents" should "correctly return the mapping when a known product is passed and there are multiple owned products that completely overlap" in {
     calculator.getCancellationConsents("Guardian Weekly", Set("Membership", "Contributor")) shouldBe Right(
       guWeeklyMapping.diff(membershipMapping ++ contributionMapping),
+    )
+  }
+
+  "getCancellationConsents" should "not cancel guardian_products_services and similar_guardian_products consents" in {
+    calculator.getCancellationConsents("Membership", Set()) shouldBe Right(
+      membershipMapping.removedAll(Set("guardian_products_services", "similar_guardian_products")),
     )
   }
 

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -131,6 +131,10 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "consented" : false
         |  },
         |  {
+        |    "id" : "guardian_products_services",
+        |    "consented" : false
+        |  },
+        |  {
         |    "id" : "supporter_newsletter",
         |    "consented" : false
         |  },
@@ -162,23 +166,27 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
       Set("newspaper"),
       calculator,
     ) shouldBe Right("""[
-        |  {
-        |    "id" : "guardian_weekly_newsletter",
-        |    "consented" : false
-        |  },
-        |  {
-        |    "id" : "similar_guardian_products",
-        |    "consented" : true
-        |  },
-        |  {
-        |    "id" : "subscriber_preview",
-        |    "consented" : true
-        |  },
-        |  {
-        |    "id" : "supporter_newsletter",
-        |    "consented" : true
-        |  }
-        |]""".stripMargin)
+                       |  {
+                       |    "id" : "similar_guardian_products",
+                       |    "consented" : true
+                       |  },
+                       |  {
+                       |    "id" : "guardian_products_services",
+                       |    "consented" : true
+                       |  },
+                       |  {
+                       |    "id" : "subscriber_preview",
+                       |    "consented" : true
+                       |  },
+                       |  {
+                       |    "id" : "guardian_weekly_newsletter",
+                       |    "consented" : false
+                       |  },
+                       |  {
+                       |    "id" : "supporter_newsletter",
+                       |    "consented" : true
+                       |  }
+                       |]""".stripMargin.stripLineEnd)
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Recurring Contribution whilst also owning a Newspaper subscription" in {

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -102,7 +102,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
     |    "id" : "guardian_weekly_newsletter",
     |    "consented" : true
     |  }
-    |]""".stripMargin) // be careful this is whitespace sensitive
+    |]""".stripMargin)
   }
 
   "buildConsentsBody" should "return a correctly populated JSON array when consents is not empty and state is false" in {
@@ -120,12 +120,14 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Recurring Contribution to Guardian Weekly subscription" in {
-    Handler.buildProductSwitchConsents(
-      "Contributor",
-      "Guardian Weekly",
-      Set("Guardian Weekly"),
-      calculator,
-    ) shouldBe Right("""[
+    Handler
+      .buildProductSwitchConsents(
+        "Contributor",
+        "Guardian Weekly",
+        Set("Guardian Weekly"),
+        calculator,
+      )
+      .map(removeWhitespace) shouldBe Right(removeWhitespace("""[
         |  {
         |    "id" : "similar_guardian_products",
         |    "consented" : false
@@ -142,30 +144,34 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : true
         |  }
-        |]""".stripMargin) // be careful this is whitespace sensitive
+        |]""".stripMargin))
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Recurring Contribution to a Guardian Weekly subscription whilst the user also owns a Newspaper subscription" in {
-    Handler.buildProductSwitchConsents(
-      "Contributor",
-      "Guardian Weekly",
-      Set("Guardian Weekly", "newspaper"),
-      calculator,
-    ) shouldBe Right("""[
+    Handler
+      .buildProductSwitchConsents(
+        "Contributor",
+        "Guardian Weekly",
+        Set("Guardian Weekly", "newspaper"),
+        calculator,
+      )
+      .map(removeWhitespace) shouldBe Right(removeWhitespace("""[
         |  {
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : true
         |  }
-        |]""".stripMargin) // be careful this is whitespace sensitive
+        |]""".stripMargin)) // be careful this is whitespace sensitive
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription" in {
-    Handler.buildProductSwitchConsents(
-      "Guardian Weekly",
-      "newspaper",
-      Set("newspaper"),
-      calculator,
-    ) shouldBe Right("""[
+    Handler
+      .buildProductSwitchConsents(
+        "Guardian Weekly",
+        "newspaper",
+        Set("newspaper"),
+        calculator,
+      )
+      .map(removeWhitespace) shouldBe Right(removeWhitespace("""[
                        |  {
                        |    "id" : "similar_guardian_products",
                        |    "consented" : true
@@ -186,30 +192,34 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
                        |    "id" : "supporter_newsletter",
                        |    "consented" : true
                        |  }
-                       |]""".stripMargin) // be careful this is whitespace sensitive
+                       |]""".stripMargin))
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Recurring Contribution whilst also owning a Newspaper subscription" in {
-    Handler.buildProductSwitchConsents(
-      "Guardian Weekly",
-      "Contributor",
-      Set("newspaper", "Contributor"),
-      calculator,
-    ) shouldBe Right("""[
+    Handler
+      .buildProductSwitchConsents(
+        "Guardian Weekly",
+        "Contributor",
+        Set("newspaper", "Contributor"),
+        calculator,
+      )
+      .map(removeWhitespace) shouldBe Right(removeWhitespace("""[
         |  {
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : false
         |  }
-        |]""".stripMargin) // be careful this is whitespace sensitive
+        |]""".stripMargin))
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Recurring Contribution" in {
-    Handler.buildProductSwitchConsents(
-      "Guardian Weekly",
-      "newspaper",
-      Set("newspaper", "Contributor"),
-      calculator,
-    ) shouldBe Right("""[
+    Handler
+      .buildProductSwitchConsents(
+        "Guardian Weekly",
+        "newspaper",
+        Set("newspaper", "Contributor"),
+        calculator,
+      )
+      .map(removeWhitespace) shouldBe Right(removeWhitespace("""[
         |  {
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : false
@@ -218,16 +228,18 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "subscriber_preview",
         |    "consented" : true
         |  }
-        |]""".stripMargin) // be careful this is whitespace sensitive
+        |]""".stripMargin)) // be careful this is whitespace sensitive
   }
 
   "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
-    Handler.buildProductSwitchConsents(
-      "Guardian Weekly",
-      "newspaper",
-      Set("newspaper", "InAppPurchase"),
-      calculator,
-    ) shouldBe Right("""[
+    Handler
+      .buildProductSwitchConsents(
+        "Guardian Weekly",
+        "newspaper",
+        Set("newspaper", "InAppPurchase"),
+        calculator,
+      )
+      .map(removeWhitespace) shouldBe Right(removeWhitespace("""[
         |  {
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : false
@@ -236,16 +248,18 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "subscriber_preview",
         |    "consented" : true
         |  }
-        |]""".stripMargin) // be careful this is whitespace sensitive
+        |]""".stripMargin))
   }
 
   "buildProductSwitchConsents - HandlerIAP" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
-    HandlerIAP.buildProductSwitchConsents(
-      "Guardian Weekly",
-      "newspaper",
-      Set("newspaper", "InAppPurchase"),
-      calculator,
-    ) shouldBe Right("""[
+    HandlerIAP
+      .buildProductSwitchConsents(
+        "Guardian Weekly",
+        "newspaper",
+        Set("newspaper", "InAppPurchase"),
+        calculator,
+      )
+      .map(removeWhitespace) shouldBe Right(removeWhitespace("""[
         |  {
         |    "id" : "guardian_weekly_newsletter",
         |    "consented" : false
@@ -254,7 +268,7 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "id" : "subscriber_preview",
         |    "consented" : true
         |  }
-        |]""".stripMargin) // be careful this is whitespace sensitive
+        |]""".stripMargin))
   }
 
   def removeWhitespace(stringToRemoveWhitespaceFrom: String): String = {

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -88,6 +88,10 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
           |    "consented" : true
           |  },
           |  {
+          |    "id" : "guardian_products_services",
+          |    "consented" : true
+          |  },
+          |  {
           |    "id" : "supporter_newsletter",
           |    "consented" : true
           |  }
@@ -163,6 +167,10 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
         """[
           |  {
           |    "id" : "your_support_onboarding",
+          |    "consented" : false
+          |  },
+          |  {
+          |    "id" : "guardian_products_services",
           |    "consented" : false
           |  },
           |  {
@@ -253,6 +261,10 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
         "someIdentityId",
         """[
           |  {
+          |    "id" : "guardian_weekly_newsletter",
+          |    "consented" : true
+          |  },
+          |  {
           |    "id" : "your_support_onboarding",
           |    "consented" : true
           |  },
@@ -261,11 +273,11 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
           |    "consented" : true
           |  },
           |  {
-          |    "id" : "supporter_newsletter",
+          |    "id" : "guardian_products_services",
           |    "consented" : true
           |  },
           |  {
-          |    "id" : "guardian_weekly_newsletter",
+          |    "id" : "supporter_newsletter",
           |    "consented" : true
           |  }
           |]""".stripMargin,

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -170,10 +170,6 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
           |    "consented" : false
           |  },
           |  {
-          |    "id" : "guardian_products_services",
-          |    "consented" : false
-          |  },
-          |  {
           |    "id" : "supporter_newsletter",
           |    "consented" : false
           |  }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -77,7 +77,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
   test(testName = "processAcquiredSub should handle acquisition event correctly") {
     mockSendConsentsReq
       .expects(
-        "someIdentityId",
+        "someIdentityId", // be careful this is whitespace sensitive
         """[
           |  {
           |    "id" : "your_support_onboarding",
@@ -163,7 +163,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     mockSendConsentsReq
       .expects(
-        "someIdentityId",
+        "someIdentityId", // be careful this is whitespace sensitive
         """[
           |  {
           |    "id" : "your_support_onboarding",
@@ -219,7 +219,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
 
     mockSendConsentsReq
       .expects(
-        "someIdentityId",
+        "someIdentityId", // be careful this is whitespace sensitive
         """[
           |  {
           |    "id" : "supporter_newsletter",
@@ -258,7 +258,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
   test(testName = "processAcquiredSub should handle a Tier Three acquisition event correctly") {
     mockSendConsentsReq
       .expects(
-        "someIdentityId",
+        "someIdentityId", // be careful this is whitespace sensitive
         """[
           |  {
           |    "id" : "guardian_weekly_newsletter",

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -1,11 +1,19 @@
 package com.gu.soft_opt_in_consent_setter.testData
 
 object ConsentsCalculatorTestData {
-  val membershipMapping = Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter")
-  val contributionMapping = Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter")
+  val membershipMapping =
+    Set("your_support_onboarding", "similar_guardian_products", "guardian_products_services", "supporter_newsletter")
+  val contributionMapping =
+    Set("your_support_onboarding", "similar_guardian_products", "guardian_products_services", "supporter_newsletter")
   val supporterPlusMapping =
-    Set("your_support_onboarding", "similar_guardian_products", "supporter_newsletter")
+    Set("your_support_onboarding", "similar_guardian_products", "guardian_products_services", "supporter_newsletter")
   val newspaperMapping =
-    Set("your_support_onboarding", "similar_guardian_products", "subscriber_preview", "supporter_newsletter")
+    Set(
+      "your_support_onboarding",
+      "similar_guardian_products",
+      "guardian_products_services",
+      "subscriber_preview",
+      "supporter_newsletter",
+    )
   val guWeeklyMapping = Set("your_support_onboarding", "guardian_weekly_newsletter")
 }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/testData/ConsentsCalculatorTestData.scala
@@ -1,19 +1,11 @@
 package com.gu.soft_opt_in_consent_setter.testData
 
+import com.gu.soft_opt_in_consent_setter.models.ConsentsMapping
+
 object ConsentsCalculatorTestData {
-  val membershipMapping =
-    Set("your_support_onboarding", "similar_guardian_products", "guardian_products_services", "supporter_newsletter")
-  val contributionMapping =
-    Set("your_support_onboarding", "similar_guardian_products", "guardian_products_services", "supporter_newsletter")
-  val supporterPlusMapping =
-    Set("your_support_onboarding", "similar_guardian_products", "guardian_products_services", "supporter_newsletter")
-  val newspaperMapping =
-    Set(
-      "your_support_onboarding",
-      "similar_guardian_products",
-      "guardian_products_services",
-      "subscriber_preview",
-      "supporter_newsletter",
-    )
-  val guWeeklyMapping = Set("your_support_onboarding", "guardian_weekly_newsletter")
+  val membershipMapping: Set[String] = ConsentsMapping.consentsMapping("Membership")
+  val contributionMapping: Set[String] = ConsentsMapping.consentsMapping("Contribution")
+  val supporterPlusMapping: Set[String] = ConsentsMapping.consentsMapping("Supporter Plus")
+  val newspaperMapping: Set[String] = ConsentsMapping.consentsMapping("newspaper")
+  val guWeeklyMapping: Set[String] = ConsentsMapping.consentsMapping("Guardian Weekly")
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?


We are creating a new marketing permission called Guardian Products and Services to differentiate from Similar Guardian Products.

We’re currently using ‘Similar Guardian Products’ (SGP) for both the ‘negotiation of sale’ soft opt-in (account registrations), and the ‘sale’ soft opt-in (supporters). This means that there is no way to tell at source which type of marketing emails these readers should be receiving—acquisition or upsell.
see the 1 pager for more info
https://docs.google.com/document/d/1H4SitgsfONXFhu2mqzcdnXUHmYD75P_tf59c-lY2meo

We have a solution approved by Data Privacy: the creation of a new reader marketing permission called ‘Guardian Products and Services’ (GPS).

This change is adding the new consent setting `guardian_products_services` to the soft-opt in service.

~There is a corresponding change on the consent-autolapse lambda here:~
~https://github.com/guardian/consent-autolapse/pull/20~
update: we don't want to autolapse the consents

**Blocked** until corresponding changes in MMA made
