### PR TITLE
Route discount-api alarms to Value team chat

### DIFF
--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -62,7 +62,7 @@ exports[`The Discount API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":retention-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1030,7 +1030,7 @@ exports[`The Discount API stack matches the snapshot 2`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":retention-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -144,7 +144,7 @@ export class DiscountApi extends GuStack {
 			),
 			evaluationPeriods: 1,
 			threshold: 1,
-			snsTopicName: 'retention-dev',
+			snsTopicName: 'alarms-handler-topic-PROD',
 			actionsEnabled: this.stage === 'PROD',
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -45,6 +45,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'contact-us-api',
 		'delivery-records-api',
 		'delivery-problem-credit-processor',
+		'discount-api',
 		'holiday-stop-api',
 		'holiday-stop-processor',
 		'soft-opt-in-consent-setter',


### PR DESCRIPTION
## What does this change?

Updates the sns topic for discount-api alarms, and routes them to Value chat in the alarms-handler.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
