### PR TITLE
Add some variation to the responseValidUntil date returned by the identity-retention lambda

### DIFF
--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
@@ -1,6 +1,7 @@
 package com.gu.identityRetention
 
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import play.api.libs.json.{Json, Writes}
 

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
@@ -34,12 +34,13 @@ object IdentityRetentionResponseModels {
       val responseValidUntil =
         if (effectiveDeletionDate isBefore today)
           today.plusMonths(3)
-        else
+        else {
           val proportionOfMaxLifetimes = today.until(effectiveDeletionDate, ChronoUnit.DAYS) / (365 * 7)
           List(
             effectiveDeletionDate, 
             today.plusDays(60 + (proportionOfMaxLifetimes * 60)) //adds some variation so that the validUntil date is between 60 and 120 days (or longer, if the deletion date is over 7 years in the future)
           ).min
+        }
       SuccessResponse(ongoingRelationship, relationshipEndDate, effectiveDeletionDate, responseValidUntil)
     }
   }

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
@@ -19,7 +19,7 @@ object IdentityRetentionResponseModels {
     implicit val successResponseWrites = Json.writes[SuccessResponse]
 
     /** effectiveDeletionDate is 7 years after relationshipEndDate the response is valid until the effectiveDeletionDate
-      * or in three months time, whichever is sooner.
+      * or in about 3 months time, whichever is sooner.
       * @param ongoingRelationship
       * @param relationshipEndDate
       * @return
@@ -34,7 +34,11 @@ object IdentityRetentionResponseModels {
         if (effectiveDeletionDate isBefore today)
           today.plusMonths(3)
         else
-          List(effectiveDeletionDate, today.plusMonths(3)).min
+          val proportionOfMaxLifetimes = today.until(effectiveDeletionDate, ChronoUnit.DAYS) / (365 * 7)
+          List(
+            effectiveDeletionDate, 
+            today.plusDays(60 + (proportionOfMaxLifetimes * 60)) //adds some variation so that the validUntil date is between 60 and 120 days (or longer, if the deletion date is over 7 years in the future)
+          ).min
       SuccessResponse(ongoingRelationship, relationshipEndDate, effectiveDeletionDate, responseValidUntil)
     }
   }

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
@@ -35,10 +35,10 @@ object IdentityRetentionResponseModels {
         if (effectiveDeletionDate isBefore today)
           today.plusMonths(3)
         else {
-          val proportionOfMaxLifetimes = today.until(effectiveDeletionDate, ChronoUnit.DAYS) / (365 * 7)
+          val proportionOfMaxLifetimes = today.until(effectiveDeletionDate, ChronoUnit.DAYS) / (365.25 * 7)
           List(
             effectiveDeletionDate, 
-            today.plusDays(60 + (proportionOfMaxLifetimes * 60)) //adds some variation so that the validUntil date is between 60 and 120 days (or longer, if the deletion date is over 7 years in the future)
+            today.plusDays(60 + (proportionOfMaxLifetimes * 60).toInt) //adds some variation so that the validUntil date is between 60 and 120 days (or longer, if the deletion date is over 7 years in the future)
           ).min
         }
       SuccessResponse(ongoingRelationship, relationshipEndDate, effectiveDeletionDate, responseValidUntil)

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
@@ -35,7 +35,8 @@ object IdentityRetentionResponseModels {
         if (effectiveDeletionDate isBefore today)
           today.plusMonths(3)
         else {
-          val proportionOfMaxLifetimes = today.until(effectiveDeletionDate, ChronoUnit.DAYS) / (365.25 * 7)
+          val maxLifeInDays: Double = 365.25 * 7
+          val proportionOfMaxLifetimes = today.until(effectiveDeletionDate, ChronoUnit.DAYS).toDouble / maxLifeInDays
           List(
             effectiveDeletionDate, 
             today.plusDays(60 + (proportionOfMaxLifetimes * 60).toInt) //adds some variation so that the validUntil date is between 60 and 120 days (or longer, if the deletion date is over 7 years in the future)

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionApiResponsesTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionApiResponsesTest.scala
@@ -42,7 +42,7 @@ class IdentityRetentionApiResponsesTest extends AnyFlatSpec with Matchers {
 
     "cancelledRelationship" should "calculate the deletion date 7 years after cancellation date and vary the valid until date" in {
     IdentityRetentionApiResponses.lapsedRelationship(
-      latestLapsedDate = LocalDate.of(2024, 1, 1),
+      latestLapsedDate = LocalDate.of(2024, 9, 1),
       today,
     ) shouldEqual ApiResponse(
       "200",

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionApiResponsesTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionApiResponsesTest.scala
@@ -20,7 +20,7 @@ class IdentityRetentionApiResponsesTest extends AnyFlatSpec with Matchers {
          |  "ongoingRelationship" : true,
          |  "relationshipEndDate" : "2024-01-01",
          |  "effectiveDeletionDate" : "2031-01-01",
-         |  "responseValidUntil" : "2023-08-31"
+         |  "responseValidUntil" : "2023-10-03"
          |}""".stripMargin,
     )
   }
@@ -35,7 +35,22 @@ class IdentityRetentionApiResponsesTest extends AnyFlatSpec with Matchers {
         |  "ongoingRelationship" : false,
         |  "relationshipEndDate" : "2024-01-01",
         |  "effectiveDeletionDate" : "2031-01-01",
-        |  "responseValidUntil" : "2023-08-31"
+        |  "responseValidUntil" : "2023-10-03"
+        |}""".stripMargin,
+    )
+  }
+
+    "cancelledRelationship" should "calculate the deletion date 7 years after cancellation date and vary the valid until date" in {
+    IdentityRetentionApiResponses.lapsedRelationship(
+      latestLapsedDate = LocalDate.of(2024, 1, 1),
+      today,
+    ) shouldEqual ApiResponse(
+      "200",
+      """{
+        |  "ongoingRelationship" : false,
+        |  "relationshipEndDate" : "2024-09-01",
+        |  "effectiveDeletionDate" : "2031-09-01",
+        |  "responseValidUntil" : "2023-10-08"
         |}""".stripMargin,
     )
   }

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/RelationshipForHoldingsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/RelationshipForHoldingsTest.scala
@@ -44,7 +44,7 @@ class RelationshipForHoldingsTest extends AnyFlatSpec with Matchers {
                |  "ongoingRelationship" : true,
                |  "relationshipEndDate" : "2024-02-01",
                |  "effectiveDeletionDate" : "2031-02-01",
-               |  "responseValidUntil" : "2023-08-31"
+               |  "responseValidUntil" : "2023-10-03"
                |}""".stripMargin,
     )
   }
@@ -68,7 +68,7 @@ class RelationshipForHoldingsTest extends AnyFlatSpec with Matchers {
                |  "ongoingRelationship" : false,
                |  "relationshipEndDate" : "2024-03-01",
                |  "effectiveDeletionDate" : "2031-03-01",
-               |  "responseValidUntil" : "2023-08-31"
+               |  "responseValidUntil" : "2023-10-04"
                |}""".stripMargin,
     )
   }


### PR DESCRIPTION
## What does this change?

#### Background
A key rotation [issue](https://mail.google.com/chat/u/0/#chat/space/AAAAIddGn5w/VlhvlPnNQZM/VlhvlPnNQZM) in March 2024 meant that a large number of accounts were not deleted as planned.  Once the issue was fixed, there was a special run done to catch up all the missed accounts.  The accounts are checked every 3 months from the last check, meaning that the re-check date for the caught up ones fell on the same day as each other in late June.

The Identity team have [recently observed](https://mail.google.com/chat/u/0/#chat/space/AAAAIddGn5w/twb0ZzTaY9g/Fu6889OyCnA) that their Identity account retention lambda did not delete any accounts for several days, raising their alarms. In the linked conversation, it was determined that this was likely due to the large number of lapsed relationship accounts that were impacted by the issue in late-March 2024 are now hitting their three month “check again” responseValidUntil date - as Identity's lambda can only process 7k or so accounts per day, it was not able to clear the backlog quickly enough and this led to it not deleting any accounts for several days.

Although we have scaled up to process them all, these have again got a date in 3 months time, and this will recur for up to 7 years if we do nothing.

####  Changes
We introduce some arbitrary variation in the responseValidUntil date, which should allow the backlog of lapsed relationship accounts to be somewhat spread out rather than appearing all within a few days. This should help avoid the backlog breaching the 7k per day limit (which is also being increased by allowing the Identity lambda to complete more runs each day).

## How to test
Updated IdentityRetentionApiResponsesTest to demonstrate the varied dates.

## How can we measure success?
The next predicted spike in requests (late December?) this logic should kick in and help disperse future requests.

## Have we considered potential risks?
We should give the Identity team a heads up that we're making this change, and ask them to let us know if there's any odd behaviour observed from their side.