### PR TITLE
fix: add tax amount (not just charge amount) to credit balance

### DIFF
--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -87,7 +87,7 @@ object AutoCancel extends Logging {
             invoice.invoiceItems.filter(_.subscriptionName == subToCancel.value) match {
               case Nil => GenericError(s"Invoice ${invoice.id} isn't for subscription $subToCancel")
               case items =>
-                val amount = items.map(_.chargeAmount).sum
+                val amount = items.map(item => item.chargeAmount + item.taxAmount).sum
                 applyCreditBalance(invoice.id, amount, comment)
             }
         },

--- a/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraGetInvoiceTransactions.scala
+++ b/handlers/zuora-callout-apis/src/main/scala/com/gu/util/zuora/ZuoraGetInvoiceTransactions.scala
@@ -18,6 +18,7 @@ object ZuoraGetInvoiceTransactions extends LazyLogging {
       chargeAmount: Double,
       chargeName: String,
       productName: String,
+      taxAmount: Double,
   )
 
   case class ItemisedInvoice(
@@ -38,7 +39,8 @@ object ZuoraGetInvoiceTransactions extends LazyLogging {
       (JsPath \ "serviceEndDate").read[LocalDate] and
       (JsPath \ "chargeAmount").read[Double] and
       (JsPath \ "chargeName").read[String] and
-      (JsPath \ "productName").read[String]
+      (JsPath \ "productName").read[String] and
+      (JsPath \ "taxAmount").read[Double]
   )(InvoiceItem.apply _)
 
   implicit val itemisedInvoiceReads: Reads[ItemisedInvoice] = (

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/TestData.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/TestData.scala
@@ -15,9 +15,9 @@ object TestData extends Matchers {
   val today = LocalDate.of(2016, 11, 21)
   val accountId = "accountId"
   val invoiceItemA =
-    InvoiceItem("invitem123", "A-S123", today, today.plusMonths(1), 49.21, "Non founder - annual", "Supporter")
-  val invoiceItemB = InvoiceItem("invitem122", "A-S123", today, today.plusMonths(1), 0, "Friends", "Friend")
-  val invoiceItemC = InvoiceItem("invitem121", "A-S123", today, today.plusMonths(1), -4.90, "Percentage", "Discount")
+    InvoiceItem("invitem123", "A-S123", today, today.plusMonths(1), 49.21, "Non founder - annual", "Supporter", 0)
+  val invoiceItemB = InvoiceItem("invitem122", "A-S123", today, today.plusMonths(1), 0, "Friends", "Friend", 0)
+  val invoiceItemC = InvoiceItem("invitem121", "A-S123", today, today.plusMonths(1), -4.90, "Percentage", "Discount", 0)
 
   def itemisedInvoice(balance: Double, invoiceItems: List[InvoiceItem]) =
     ItemisedInvoice("invoice123", today, 49, balance, "Posted", List(invoiceItemA))

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelTest.scala
@@ -154,4 +154,42 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
     )
     AutoCancel.applyCreditBalances(applyCreditBalance)(subToCancel, invoices, "comment")
   }
+
+  it should "apply credit including items tax amount (not just charge amount)" in {
+    val subToCancel = SubscriptionNumber("s1")
+    val applyCreditBalance = mockFunction[String, Double, String, ClientFailableOp[Unit]]
+    applyCreditBalance.expects("invoice1", 26.00, "comment").returning(ClientSuccess(())).once()
+    val invoices = Seq(
+      ItemisedInvoice(
+        id = "invoice1",
+        invoiceDate = LocalDate.of(2022, 1, 1),
+        amount = 26.00,
+        balance = 26.00,
+        status = "Posted",
+        invoiceItems = List(
+          InvoiceItem(
+            id = "item1",
+            subscriptionName = subToCancel.value,
+            serviceStartDate = LocalDate.of(2022, 1, 3),
+            serviceEndDate = LocalDate.of(2022, 2, 2),
+            chargeAmount = 12.34,
+            chargeName = "chg",
+            productName = "prd",
+            taxAmount = 0.66,
+          ),
+          InvoiceItem(
+            id = "item2",
+            subscriptionName = subToCancel.value,
+            serviceStartDate = LocalDate.of(2022, 1, 3),
+            serviceEndDate = LocalDate.of(2022, 2, 2),
+            chargeAmount = 12.34,
+            chargeName = "chg",
+            productName = "prd",
+            taxAmount = 0.66,
+          ),
+        ),
+      ),
+    )
+    AutoCancel.applyCreditBalances(applyCreditBalance)(subToCancel, invoices, "comment")
+  }
 }

--- a/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelTest.scala
+++ b/handlers/zuora-callout-apis/src/test/scala/com/gu/autoCancel/AutoCancelTest.scala
@@ -32,6 +32,7 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
             chargeAmount = 12.34,
             chargeName = "chg",
             productName = "prd",
+            taxAmount = 0,
           ),
         ),
       ),
@@ -50,6 +51,7 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
             chargeAmount = 11.34,
             chargeName = "chg",
             productName = "prd",
+            taxAmount = 0,
           ),
         ),
       ),
@@ -77,6 +79,7 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
             chargeAmount = 6.87,
             chargeName = "chg",
             productName = "prd",
+            taxAmount = 0,
           ),
           InvoiceItem(
             id = "item2",
@@ -86,6 +89,7 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
             chargeAmount = 5.47,
             chargeName = "chg",
             productName = "prd",
+            taxAmount = 0,
           ),
         ),
       ),
@@ -113,6 +117,7 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
             chargeAmount = 6.87,
             chargeName = "chg",
             productName = "prd",
+            taxAmount = 0,
           ),
           InvoiceItem(
             id = "item3",
@@ -122,6 +127,7 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
             chargeAmount = 5.45,
             chargeName = "chg",
             productName = "prd",
+            taxAmount = 0,
           ),
           InvoiceItem(
             id = "item4",
@@ -131,6 +137,7 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
             chargeAmount = -1.23,
             chargeName = "discount",
             productName = "discount",
+            taxAmount = 0,
           ),
           InvoiceItem(
             id = "item2",
@@ -140,6 +147,7 @@ class AutoCancelTest extends AnyFlatSpec with Matchers with MockFactory {
             chargeAmount = 5.47,
             chargeName = "chg",
             productName = "prd",
+            taxAmount = 0,
           ),
         ),
       ),


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/fNtuEDS4/301-unbalanced-invoices-autocancel-tax-bug)

This fixes the following bug: when Digital Plus/Supporter Plus subscriptions get auto cancelled, the credit balance decrease that should zero the positive invoice doesn’t account for tax - leaving a small positive balance on the unpaid invoice after cancellation.

Example: https://www.zuora.com/platform/apps/com_zuora/invoice/8a1284c0917efcaf019182776ed76aed
<img width="1660" alt="Screenshot 2024-10-07 at 17 00 31" src="https://github.com/user-attachments/assets/f75dc08e-17d9-48be-9ac8-2fbb6ff0fcb0">

## How to test

1. Find an active subscription in Zuora CODE for Supporter Plus
2. Find an invoice that has been paid more than a month ago
3. Find the transaction for that invoice and refund it
4. In Postman call the Api Gateway endpoint for CODE auto cancellations

API Gateway: https://eu-west-1.console.aws.amazon.com/apigateway/main/apis/aefy0066u0/stages?api=aefy0066u0&region=eu-west-1

URL: https://aefy0066u0.execute-api.eu-west-1.amazonaws.com/CODE/auto-cancel?apiToken=xxx

API token: https://eu-west-1.console.aws.amazon.com/s3/object/gu-reader-revenue-private?region=eu-west-1&bucketType=general&prefix=membership/support-service-lambdas/CODE/trustedApi-CODE.v1.json

Body:
```
{
    "accountId": "8ad08e018442728701845227ca306aba",
    "autoPay": "true",
    "creditCardExpirationMonth": "02",
    "creditCardExpirationYear": "27",
    "creditCardType": "Visa",
    "currency": "AUD",
    "email": "support.e2e+EfS-pjPYxqU01jxa9VI9h@thegulocal.com",
    "firstName": "Test",
    "invoiceId": "8ad097da9085a84001908b915f7a6ed7",
    "lastName": "test",
    "paymentMethodType": "test",
    "sfContactId": "003UD00000HuoDFYAZ"
}
```

5. Verify that the invoice final balance is zero

## How can we measure success?

New Supporter Plus auto cancellations should not leave unbalanced invoices.