### PR TITLE
don't get a billing preview for cancelled subscriptions

### DIFF
--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -196,6 +196,11 @@ async function getDiscountToApply(
 		subscription.subscriptionNumber,
 	);
 
+	eligibilityChecker.assertBasicEligibility(
+		subscription,
+		account.metrics.totalInvoiceBalance,
+	);
+
 	console.log('get billing preview for the subscription');
 	const billingPreview = billingPreviewToSimpleInvoiceItems(
 		await getBillingPreview(
@@ -235,10 +240,7 @@ async function getDiscountToApply(
 
 	const orderedInvoiceTotals = getOrderedInvoiceTotals(billingPreview);
 
-	eligibilityChecker.assertGenerallyEligible(
-		subscription,
-		account.metrics.totalInvoiceBalance,
-		nextInvoiceItems,
-	);
+	eligibilityChecker.assertInvoicesEligible(nextInvoiceItems);
+
 	return { discount, dateToApply, orderedInvoiceTotals };
 }

--- a/handlers/discount-api/src/eligibilityChecker.ts
+++ b/handlers/discount-api/src/eligibilityChecker.ts
@@ -10,10 +10,9 @@ import dayjs from 'dayjs';
 export class EligibilityChecker {
 	constructor(private subscriptionNumber: string) {}
 
-	assertGenerallyEligible = (
+	assertBasicEligibility = (
 		subscription: ZuoraSubscription,
 		accountBalance: number,
-		nextInvoiceItems: SimpleInvoiceItem[],
 	) => {
 		console.log('Checking basic eligibility for the subscription');
 		this.assertValidState(
@@ -28,6 +27,12 @@ export class EligibilityChecker {
 		);
 
 		console.log(
+			'Subscription and account are generally eligible for the discount',
+		);
+	};
+
+	assertInvoicesEligible = (nextInvoiceItems: SimpleInvoiceItem[]) => {
+		console.log(
 			'ensuring there are no refunds/discounts expected on the affected invoices',
 		);
 		this.assertValidState(
@@ -36,7 +41,7 @@ export class EligibilityChecker {
 			JSON.stringify(nextInvoiceItems),
 		);
 
-		console.log('Subscription is generally eligible for the discount');
+		console.log('next invoice is eligible for the discount');
 	};
 
 	assertNextPaymentIsAtCatalogPrice = (

--- a/handlers/discount-api/test/eligibilityChecker.test.ts
+++ b/handlers/discount-api/test/eligibilityChecker.test.ts
@@ -40,10 +40,10 @@ test('Eligibility check fails for a Supporter plus which has already had the off
 		.add(2, 'months')
 		.add(1, 'days');
 
+	eligibilityChecker.assertBasicEligibility(sub, 0);
+
 	const actual = () =>
-		eligibilityChecker.assertGenerallyEligible(
-			sub,
-			0,
+		eligibilityChecker.assertInvoicesEligible(
 			getNextInvoiceItems(billingPreview).items,
 		);
 
@@ -67,10 +67,10 @@ test('Eligibility check fails for a S+ subscription which is on a reduced price'
 		.add(2, 'months')
 		.add(1, 'days');
 
+	eligibilityChecker.assertBasicEligibility(sub, 0);
+
 	const actual = () =>
-		eligibilityChecker.assertGenerallyEligible(
-			sub,
-			0,
+		eligibilityChecker.assertInvoicesEligible(
 			getNextInvoiceItems(billingPreview).items,
 		);
 
@@ -104,9 +104,9 @@ test('Eligibility check works for a price risen subscription', async () => {
 	const billingPreview = loadBillingPreview(billingPreviewJson2);
 	const discount = getDiscountFromSubscription('PROD', sub);
 
-	eligibilityChecker.assertGenerallyEligible(
-		sub,
-		0,
+	eligibilityChecker.assertBasicEligibility(sub, 0);
+
+	eligibilityChecker.assertInvoicesEligible(
 		getNextInvoiceItems(billingPreview).items,
 	);
 
@@ -129,9 +129,9 @@ test('Eligibility check works for supporter plus with 2 rate plans', async () =>
 		.add(2, 'months')
 		.add(1, 'days');
 
-	eligibilityChecker.assertGenerallyEligible(
-		sub,
-		0,
+	eligibilityChecker.assertBasicEligibility(sub, 0);
+
+	eligibilityChecker.assertInvoicesEligible(
 		getNextInvoiceItems(billingPreview).items,
 	);
 


### PR DESCRIPTION
This PR makes sure that the cancelled status is checked before we attempt to get a billing preview

This bug was introduced when the code was refactored to detect an existing discount based on the billing preview.

It was causing a lot of 500 errors `no invoice items in preview`

https://trello.com/c/i4CmGdkT/542-discount-api-mitigation-for-cancelled-subs