### PR TITLE
Update BigQueryConfig version

### DIFF
--- a/lib/google-bigquery/src/main/scala/com/gu/google/BigQueryConfig.scala
+++ b/lib/google-bigquery/src/main/scala/com/gu/google/BigQueryConfig.scala
@@ -7,5 +7,5 @@ case class BigQueryConfig(bigQueryCredentials: JsObject)
 
 object BigQueryConfig {
   implicit val bigQueryConfigReads = Json.reads[BigQueryConfig]
-  implicit val location = ConfigLocation[BigQueryConfig](path = "bigQuery", version = 1)
+  implicit val location = ConfigLocation[BigQueryConfig](path = "bigQuery", version = 2)
 }


### PR DESCRIPTION
## What does this change?
We're about to rotate some credentials used by the [identity-retention](https://github.com/guardian/support-service-lambdas/tree/main/handlers/identity-retention) Lambda. This bumps the version for the config file so that we can keep the old credentials for quick rollback, if needed.