### PR TITLE
lazy billing preview to avoid previewing cancelled subscriptions

### DIFF
--- a/handlers/discount-api/src/eligibilityChecker.ts
+++ b/handlers/discount-api/src/eligibilityChecker.ts
@@ -6,14 +6,15 @@ import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
 import type { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
+import type { Lazy } from './lazy';
 
 export class EligibilityChecker {
 	constructor(private subscriptionNumber: string) {}
 
-	assertGenerallyEligible = (
+	assertGenerallyEligible = async (
 		subscription: ZuoraSubscription,
 		accountBalance: number,
-		nextInvoiceItems: SimpleInvoiceItem[],
+		lazyNextInvoiceItems: Lazy<SimpleInvoiceItem[]>,
 	) => {
 		console.log('Checking basic eligibility for the subscription');
 		this.assertValidState(
@@ -30,6 +31,7 @@ export class EligibilityChecker {
 		console.log(
 			'ensuring there are no refunds/discounts expected on the affected invoices',
 		);
+		const nextInvoiceItems = await lazyNextInvoiceItems.get();
 		this.assertValidState(
 			nextInvoiceItems.every((item) => item.amount >= 0),
 			validationRequirements.noNegativePreviewItems,

--- a/handlers/discount-api/src/lazy.ts
+++ b/handlers/discount-api/src/lazy.ts
@@ -1,0 +1,18 @@
+export class Lazy<T> {
+	private val: Promise<T> | undefined;
+	constructor(
+		private getValue: () => Promise<T>,
+		private message: string,
+	) {}
+
+	public get(): Promise<T> {
+		if (this.val === undefined) {
+			console.log('initialising lazy value <' + this.message + '>');
+		}
+		return this.val ?? (this.val = this.getValue());
+	}
+
+	public map<B>(f: (t: T) => B): Lazy<B> {
+		return new Lazy(() => this.getValue().then(f), this.message);
+	}
+}

--- a/handlers/discount-api/test/eligibilityChecker.test.ts
+++ b/handlers/discount-api/test/eligibilityChecker.test.ts
@@ -18,10 +18,12 @@ import subscriptionJson1 from './fixtures/supporter-plus/free-2-months.json';
 import {
 	billingPreviewToSimpleInvoiceItems,
 	getNextInvoiceItems,
+	SimpleInvoiceItem,
 } from '@modules/zuora/billingPreview';
 import { getDiscountFromSubscription } from '../src/productToDiscountMapping';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
+import { Lazy } from '../src/lazy';
 
 const eligibilityChecker = new EligibilityChecker('A-S001');
 const catalogProd = new ZuoraCatalogHelper(
@@ -30,6 +32,10 @@ const catalogProd = new ZuoraCatalogHelper(
 
 function loadBillingPreview(data: any) {
 	return billingPreviewToSimpleInvoiceItems(billingPreviewSchema.parse(data));
+}
+
+function pure<T>(value: T): Lazy<T> {
+	return new Lazy<T>(() => Promise.resolve(value), 'test lazy');
 }
 
 test('Eligibility check fails for a Supporter plus which has already had the offer', async () => {
@@ -44,10 +50,10 @@ test('Eligibility check fails for a Supporter plus which has already had the off
 		eligibilityChecker.assertGenerallyEligible(
 			sub,
 			0,
-			getNextInvoiceItems(billingPreview).items,
+			pure(getNextInvoiceItems(billingPreview).items),
 		);
 
-	expect(actual).toThrow(validationRequirements.noNegativePreviewItems);
+	expect(actual).rejects.toThrow(validationRequirements.noNegativePreviewItems);
 
 	const ac2 = () =>
 		eligibilityChecker.assertEligibleForFreePeriod(
@@ -71,10 +77,10 @@ test('Eligibility check fails for a S+ subscription which is on a reduced price'
 		eligibilityChecker.assertGenerallyEligible(
 			sub,
 			0,
-			getNextInvoiceItems(billingPreview).items,
+			pure(getNextInvoiceItems(billingPreview).items),
 		);
 
-	expect(actual).toThrow(validationRequirements.noNegativePreviewItems);
+	expect(actual).rejects.toThrow(validationRequirements.noNegativePreviewItems);
 
 	//expect to not throw
 	eligibilityChecker.assertEligibleForFreePeriod(
@@ -104,10 +110,10 @@ test('Eligibility check works for a price risen subscription', async () => {
 	const billingPreview = loadBillingPreview(billingPreviewJson2);
 	const discount = getDiscountFromSubscription('PROD', sub);
 
-	eligibilityChecker.assertGenerallyEligible(
+	await eligibilityChecker.assertGenerallyEligible(
 		sub,
 		0,
-		getNextInvoiceItems(billingPreview).items,
+		pure(getNextInvoiceItems(billingPreview).items),
 	);
 
 	// shouldn't throw
@@ -129,10 +135,10 @@ test('Eligibility check works for supporter plus with 2 rate plans', async () =>
 		.add(2, 'months')
 		.add(1, 'days');
 
-	eligibilityChecker.assertGenerallyEligible(
+	await eligibilityChecker.assertGenerallyEligible(
 		sub,
 		0,
-		getNextInvoiceItems(billingPreview).items,
+		pure(getNextInvoiceItems(billingPreview).items),
 	);
 
 	//shouldn't throw
@@ -141,4 +147,22 @@ test('Eligibility check works for supporter plus with 2 rate plans', async () =>
 		sub,
 		after2Months,
 	);
+});
+
+test('Eligibility check fails for a subscription which is cancelled', async () => {
+	const sub = zuoraSubscriptionSchema.parse(subSupporterPlusFullPrice);
+	sub.status = 'Cancelled';
+	expect(subSupporterPlusFullPrice.status).toEqual('Active');
+
+	const ac2 = () =>
+		eligibilityChecker.assertGenerallyEligible(
+			sub,
+			0,
+			new Lazy<SimpleInvoiceItem[]>(
+				() => Promise.reject('should not attempt a BP if its cancelled'),
+				'fail promise',
+			),
+		);
+
+	expect(ac2).rejects.toThrow(validationRequirements.isActive);
 });

--- a/handlers/discount-api/test/lazy.test.ts
+++ b/handlers/discount-api/test/lazy.test.ts
@@ -1,0 +1,27 @@
+import { Lazy } from '../src/lazy';
+
+test('it should only call the function when its used', async () => {
+	let log = 0;
+	const sut = new Lazy<string>(() => {
+		log++;
+		return Promise.resolve('hi');
+	}, 'testing');
+	expect(log).toEqual(0);
+	expect(sut.get()).resolves.toEqual('hi');
+	expect(log).toEqual(1);
+	expect(sut.get()).resolves.toEqual('hi');
+	expect(log).toEqual(1);
+});
+
+test('it should handle failed promises', async () => {
+	let log = 0;
+	const sut = new Lazy<string>(() => {
+		log++;
+		return Promise.reject('boom');
+	}, 'testing');
+	expect(log).toEqual(0);
+	expect(sut.get()).rejects.toEqual('boom');
+	expect(log).toEqual(1);
+	expect(sut.get()).rejects.toEqual('boom');
+	expect(log).toEqual(1);
+});


### PR DESCRIPTION
This PR replaces https://github.com/guardian/support-service-lambdas/pull/2485

There was an issue where we are getting a billing preview before checking if a subscription is cancelled.  Since there is no billing preview possible for a cancelled subscription, this was wasteful and caused an error.

In the above PR I split up the basic validation, but after review by the team it was decided to keep the logic together and make the billing preview called lazily.
