### PR TITLE
Move digital-voucher alarms to platform

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -28,7 +28,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'component-event-stream',
 		'contributions-store-queue',
 		'contributions-ticker-calculator',
-		'digital-voucher-api',
 		'dotcom-components',
 		...sharedMobilePurchasesApps,
 		'new-product-api',
@@ -79,7 +78,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'payment-api',
 
 		// support-service-lambdas
-		'digital-voucher-suspension-processor',
 		'metric-push-api',
 	],
 	PLATFORM: [
@@ -88,6 +86,10 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'fulfilment-lambdas',
 		'national-delivery-fulfilment',
 		'fulfilment-date-calculator',
+
+		// digital vouchers (subscription cards)
+		'digital-voucher-api',
+		'digital-voucher-suspension-processor',
 
 		// salesforce
 		'salesforce-disaster-recovery',


### PR DESCRIPTION
## What does this change?
Moves the digital-voucher-api alarms (related to subscription cards) to Platform as per [ownership sheet](https://docs.google.com/spreadsheets/d/1bb8WB-6ZFRdUwERHMOVIolN8WU8zJMcsyi-WJuwp07Q/edit?gid=0#gid=0)