### PR TITLE
add extra csr auth error

### DIFF
--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -105,7 +105,7 @@ object Handler extends Logging {
     for {
       sfClient <- SalesforceClient.auth(response, config.sfConfig) match {
         case Right(success) => ContinueProcessing(success)
-        case Left(errors) if errors.exists(errors => csrAuthErrors.contains(errors.errorCode)) =>
+        case Left(errors) if errors.exists(error => csrAuthErrors.contains(error.errorCode)) =>
           logger.error(s"SF token was not valid - returning 400 authenticate with SalesForce: $errors")
           ReturnWithResponse(badRequest("salesforce returned auth error"))
         case Left(error) =>

--- a/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
+++ b/handlers/holiday-stop-api/src/test/scala/com/gu/holiday_stops/HandlerTest.scala
@@ -202,7 +202,7 @@ class HandlerTest extends AnyFlatSpec with Matchers {
         response.statusCode should equal("400")
         response.body should equal(
           """{
-          |  "message" : "Bad request: salesforce returned INVALID_OPERATION_WITH_EXPIRED_PASSWORD"
+          |  "message" : "Bad request: salesforce returned auth error"
           |}""".stripMargin,
         )
       }


### PR DESCRIPTION
We have noticed that holiday stop api sometimes fails with a 500 alarm for Invalid session id, as well as the expired password error handled in https://github.com/guardian/support-service-lambdas/pull/2458

This PR adds that error to the list of handled ones, to return a 400 instead of 500 error.

The CSRs know to log out and in if it happens.