### PR TITLE
send digipack cancellation save email

### DIFF
--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -139,19 +139,17 @@ export const applyDiscountEndpoint = async (
 		billingPreviewToSimpleInvoiceItems(billingPreviewAfter),
 	);
 
-	const emailPayload = discount.emailIdentifier
-		? generateCancellationDiscountConfirmationEmail(
-				{
-					firstDiscountedPaymentDate: dayjs(dateToApply),
-					nextNonDiscountedPaymentDate: dayjs(nextPaymentDate),
-					emailAddress: account.billToContact.workEmail,
-					firstName: account.billToContact.firstName,
-					lastName: account.billToContact.lastName,
-					identityId: account.basicInfo.identityId,
-				},
-				discount.emailIdentifier,
-			)
-		: undefined;
+	const emailPayload = generateCancellationDiscountConfirmationEmail(
+		{
+			firstDiscountedPaymentDate: dayjs(dateToApply),
+			nextNonDiscountedPaymentDate: dayjs(nextPaymentDate),
+			emailAddress: account.billToContact.workEmail,
+			firstName: account.billToContact.firstName,
+			lastName: account.billToContact.lastName,
+			identityId: account.basicInfo.identityId,
+		},
+		discount.emailIdentifier,
+	);
 
 	return {
 		emailPayload,

--- a/handlers/discount-api/src/index.ts
+++ b/handlers/discount-api/src/index.ts
@@ -45,9 +45,7 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 					subscriptionNumber,
 					dayjs(),
 				);
-				if (emailPayload) {
-					await sendEmail(stage, emailPayload);
-				}
+				await sendEmail(stage, emailPayload);
 				return {
 					body: stringify<ApplyDiscountResponseBody>(response),
 					statusCode: 200,

--- a/handlers/discount-api/src/productToDiscountMapping.ts
+++ b/handlers/discount-api/src/productToDiscountMapping.ts
@@ -44,7 +44,7 @@ export type Discount = {
 	name: string;
 	upToPeriods: number;
 	upToPeriodsType: string;
-	emailIdentifier?: DataExtensionName;
+	emailIdentifier: DataExtensionName;
 	eligibilityCheckForRatePlan?: EligibilityCheck;
 };
 
@@ -106,7 +106,8 @@ const Discounts: (stage: Stage) => { [K in string]: Discount } = (
 			name: 'Cancellation Save Discount - 25% off for 3 months',
 			upToPeriods: 3,
 			upToPeriodsType: 'Months',
-			emailIdentifier: undefined,
+			emailIdentifier:
+				DataExtensionNames.digipackMonthlyDiscountConfirmationEmail,
 			eligibilityCheckForRatePlan: 'AtCatalogPrice',
 		},
 		cancellation25pc12mo: {
@@ -117,7 +118,8 @@ const Discounts: (stage: Stage) => { [K in string]: Discount } = (
 			name: 'Cancellation Save Discount - 25% off for 12 months',
 			upToPeriods: 12,
 			upToPeriodsType: 'Months',
-			emailIdentifier: undefined,
+			emailIdentifier:
+				DataExtensionNames.digipackAnnualDiscountConfirmationEmail,
 			eligibilityCheckForRatePlan: 'AtCatalogPrice',
 		},
 		cancellationFree2MoSP: getCancellationFree2Mo(

--- a/handlers/discount-api/test/getDiscountFromSubscription.test.ts
+++ b/handlers/discount-api/test/getDiscountFromSubscription.test.ts
@@ -5,6 +5,7 @@ import {
 	getDiscountFromSubscription,
 } from '../src/productToDiscountMapping';
 import json from './fixtures/digital-subscriptions/get-discount-test.json';
+import { DataExtensionNames } from '@modules/email/email';
 
 test('getDiscountFromSubscription should return an annual discount for an annual sub', () => {
 	const sub = zuoraSubscriptionSchema.parse(json);
@@ -13,7 +14,7 @@ test('getDiscountFromSubscription should return an annual discount for an annual
 		name: 'Cancellation Save Discount - 25% off for 12 months',
 		upToPeriods: 12,
 		upToPeriodsType: 'Months',
-		emailIdentifier: undefined,
+		emailIdentifier: DataExtensionNames.digipackAnnualDiscountConfirmationEmail,
 		eligibilityCheckForRatePlan: 'AtCatalogPrice',
 	};
 	const { discount, discountableProductRatePlanId } =

--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -33,6 +33,10 @@ export const DataExtensionNames = {
 	updateSupporterPlusAmount: 'payment-amount-changed-email',
 	cancellationDiscountConfirmation: 'cancellation-discount-confirmation-email',
 	contributionPauseConfirmationEmail: 'contribution-pause-confirmation-email',
+	digipackAnnualDiscountConfirmationEmail:
+		'digipack-annual-discount-confirmation-email',
+	digipackMonthlyDiscountConfirmationEmail:
+		'digipack-monthly-discount-confirmation-email',
 } as const;
 
 export type DataExtensionName =


### PR DESCRIPTION
following from adding the email in braze and in https://github.com/guardian/membership-workflow/pull/544
This PR makes us actually send the Digi sub cancellation confirmation email.
This was missed when the logic was first added.
https://trello.com/c/0hukFF2C/351-add-confirmation-email-for-digisub-cancellation-saves-offer