### PR TITLE
feat: always process all suspensions and throw error at the end if there are failures

### DIFF
--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Failure.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Failure.scala
@@ -11,3 +11,7 @@ case class SalesforceFetchFailure(reason: String) extends Failure
 case class SalesforceWriteFailure(reason: String) extends Failure
 
 case class DigitalVoucherSuspendFailure(reason: String) extends Failure
+
+case class CompositeFailure(failures: List[Failure]) extends Failure {
+  def reason: String = failures.toString
+}

--- a/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Handler.scala
+++ b/handlers/digital-voucher-suspension-processor/src/main/scala/com/gu/digitalvouchersuspensionprocessor/Handler.scala
@@ -12,6 +12,7 @@ import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext
+import scala.collection.immutable
 
 object Handler extends LazyLogging {
 
@@ -28,15 +29,24 @@ object Handler extends LazyLogging {
       config <- EitherT.fromEither[IO](Config.get()).leftWiden[Failure]
       salesforce <- SalesforceClient(sttpBackend, config.salesforce)
         .leftMap(e => SalesforceFetchFailure(s"Failed to create Salesforce client: $e"))
+        .leftWiden[Failure]
       imovo <- ImovoClient(sttpBackend, config.imovo)
         .leftMap(e => DigitalVoucherSuspendFailure(s"Failed to create Imovo client: $e"))
-      suspensions <- fetchSuspensionsToBeProcessed(salesforce).leftWiden[Failure]
-      _ <- suspensions
-        .map(sendSuspensionToDigitalVoucherApi(salesforce, imovo, LocalDateTime.now))
-        .toList
-        .sequence
-        .map(_ => ())
-    } yield ()
+        .leftWiden[Failure]
+      suspensions <- fetchSuspensionsToBeProcessed(salesforce)
+        .leftWiden[Failure]
+      suspensionResults <- EitherT.rightT[IO, Failure](
+        suspensions
+          .map(sendSuspensionToDigitalVoucherApi(salesforce, imovo, LocalDateTime.now))
+          .toList
+          .traverse(_.value),
+      ): EitherT[IO, Failure, List[Either[Failure, Unit]]]
+      failures = suspensionResults.collect { case Left(failure) => failure }
+      aaa = EitherT.rightT[IO, Failure](())
+    } yield () /*failures match {
+      case Nil => aaa
+      case failures => EitherT.leftT[IO, Unit](CompositeFailure(failures))
+    }*/
 
     AsyncHttpClientCatsBackend[IO]()
       .flatMap { sttpBackend =>
@@ -46,7 +56,12 @@ object Handler extends LazyLogging {
       .valueOr { e =>
         logger.error(s"Processing failed: $e")
         throw new RuntimeException(e.toString)
-      }
+      } match {
+      case Nil => () // all the suspensions worked
+      case failures =>
+        logger.error(s"Processing failed: $e")
+        throw new RuntimeException(failures.toString)
+    }
   }
 
   def fetchSuspensionsToBeProcessed[F[_]: Sync](


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/Nmfkwoxo/324-%F0%9F%9A%A8-alarm-urgent-9-5-prod-failed-to-suspend-digital-voucher-subscriptions-has-triggered)

At the moment, if there are 50 suspensions to process and the first fails, an error is thrown straight away.

This update allows to always process all suspensions and only throw the error at the end if there are failures.

Big thanks to @johnduffell for pairing on this!

## How to test

We have tested this on PROD (CODE is broken) and it worked nicely.