### PR TITLE
Pressreader entitlements api

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -36,6 +36,7 @@ jobs:
     strategy:
       matrix:
         subproject:
+          - press-reader-entitlements
           - ticket-tailor-webhook
           - update-supporter-plus-amount
           - product-switch-api

--- a/_templates/new-lambda/api-gateway/cdk-bin.ejs.t
+++ b/_templates/new-lambda/api-gateway/cdk-bin.ejs.t
@@ -11,14 +11,10 @@ import { <%= PascalCase %> } from '../lib/<%= lambdaName %>';
 new <%= PascalCase %>(app, '<%= lambdaName %>-CODE', {
     stack: 'support',
     stage: 'CODE',
-    domainName: `<%= lambdaName %>-code.${supportApisDomain}`,
-    hostedZoneId: supportHostedZoneId,
-    certificateId: supportCertificateId,
+    domainName: `<%= lambdaName %>-code.dev-guardianapis.com`,
 });
 new <%= PascalCase %>(app, '<%= lambdaName %>-PROD', {
     stack: 'support',
     stage: 'PROD',
-    domainName: `<%= lambdaName %>.${supportApisDomain}`,
-    hostedZoneId: supportHostedZoneId,
-    certificateId: supportCertificateId,
+    domainName: `<%= lambdaName %>.guardianapis.com`,
 });

--- a/_templates/new-lambda/api-gateway/cdk-lib.ejs.t
+++ b/_templates/new-lambda/api-gateway/cdk-lib.ejs.t
@@ -7,6 +7,7 @@ sh: git add cdk/lib/<%=lambdaName%>.ts
 <% PascalCase = h.changeCase.pascal(lambdaName) %>
 import { GuApiLambda } from '@guardian/cdk';
 import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
@@ -14,18 +15,14 @@ import { Duration } from 'aws-cdk-lib';
 <% if (includeApiKey === 'Y'){ %>
 import { ApiKeySourceType } from 'aws-cdk-lib/aws-apigateway';
 <% } %>
-import { CfnBasePathMapping, CfnDomainName } from 'aws-cdk-lib/aws-apigateway';
 import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 import { nodeVersion } from './node-version';
 
 export interface <%= PascalCase %>Props extends GuStackProps {
 	stack: string;
 	stage: string;
-	certificateId: string;
 	domainName: string;
-	hostedZoneId: string;
 }
 
 export class <%= PascalCase %> extends GuStack {
@@ -124,28 +121,11 @@ export class <%= PascalCase %> extends GuStack {
 			}),
 		});
 
-		// ---- DNS ---- //
-		const certificateArn = `arn:aws:acm:eu-west-1:${this.account}:certificate/${props.certificateId}`;
-		const cfnDomainName = new CfnDomainName(this, 'DomainName', {
+		new GuCname(this, `NS1 DNS entry for ${props.domainName}`, {
+			app: app,
 			domainName: props.domainName,
-			regionalCertificateArn: certificateArn,
-			endpointConfiguration: {
-				types: ['REGIONAL'],
-			},
-		});
-
-		new CfnBasePathMapping(this, 'BasePathMapping', {
-			domainName: cfnDomainName.ref,
-			restApiId: lambda.api.restApiId,
-			stage: lambda.api.deploymentStage.stageName,
-		});
-
-		new CfnRecordSet(this, 'DNSRecord', {
-			name: props.domainName,
-			type: 'CNAME',
-			hostedZoneId: props.hostedZoneId,
-			ttl: '120',
-			resourceRecords: [cfnDomainName.attrRegionalDomainName],
+			ttl: Duration.hours(1),
+			resourceRecord: 'guardian.map.fastly.net',
 		});
 
 		const s3InlinePolicy: Policy = new Policy(this, 'S3 inline policy', {

--- a/_templates/new-lambda/api-gateway/cdk-test.ejs.t
+++ b/_templates/new-lambda/api-gateway/cdk-test.ejs.t
@@ -7,11 +7,6 @@ sh: git add cdk/lib/<%=lambdaName%>.test.ts
 <% PascalCase = h.changeCase.pascal(lambdaName) %>
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import {
-	supportApisDomain,
-	supportCertificateId,
-	supportHostedZoneId,
-} from '../bin/cdk';
 import { <%= PascalCase %> } from './<%= lambdaName %>';
 
 describe('The <%= h.changeCase.sentenceCase(lambdaName) %> stack', () => {
@@ -20,16 +15,12 @@ describe('The <%= h.changeCase.sentenceCase(lambdaName) %> stack', () => {
 		const codeStack = new <%= PascalCase %>(app, '<%= lambdaName %>-CODE', {
 			stack: 'membership',
 			stage: 'CODE',
-			domainName: `<%= lambdaName %>.code.${supportApisDomain}`,
-			hostedZoneId: supportHostedZoneId,
-			certificateId: supportCertificateId,
+			domainName: `<%= lambdaName %>.code.dev-guardianapis.com`,
 		});
 		const prodStack = new <%= PascalCase %>(app, '<%= lambdaName %>-PROD', {
 			stack: 'membership',
 			stage: 'PROD',
-			domainName: `<%= lambdaName %>.${supportApisDomain}`,
-			hostedZoneId: supportHostedZoneId,
-			certificateId: supportCertificateId,
+			domainName: `<%= lambdaName %>.guardianapis.com`,
 		});
 
 		expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();

--- a/_templates/new-lambda/api-gateway/index.ejs.t
+++ b/_templates/new-lambda/api-gateway/index.ejs.t
@@ -19,5 +19,3 @@ export const handler: Handler = async (
 		statusCode: 200,
 	});
 };
-
-

--- a/_templates/new-lambda/api-gateway/integration-test.ejs.t
+++ b/_templates/new-lambda/api-gateway/integration-test.ejs.t
@@ -5,12 +5,13 @@ to: handlers/<%=lambdaName%>/test/firstIntegration.test.ts
 sh: git add handlers/<%=lambdaName%>/test/firstIntegration.test.ts
 ---
 /**
-* This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
-* command and will not be run during continuous integration.
-* This makes it useful for testing things that require credentials which are available locally but not on the CI server.
-*
-* @group integration
-*/
-test("my app", () => {
-    expect(1 + 1).toEqual(2);
+ * This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
+ * command and will not be run during continuous integration.
+ * This makes it useful for testing things that require credentials which are available locally but not on the CI server.
+ *
+ * @group integration
+ */
+test('my app', () => {
+	expect(1 + 1).toEqual(2);
 });
+

--- a/_templates/new-lambda/api-gateway/test.ejs.t
+++ b/_templates/new-lambda/api-gateway/test.ejs.t
@@ -5,9 +5,9 @@ to: handlers/<%=lambdaName%>/test/firstTest.test.ts
 sh: git add handlers/<%=lambdaName%>/test/firstTest.test.ts
 ---
 /**
-* This is a unit test, it can be run by the `pnpm test` command, and will be run by the CI/CD pipeline
-*
-*/
-test("my app", () => {
-    expect(1 + 1).toEqual(2);
+ * This is a unit test, it can be run by the `pnpm test` command, and will be run by the CI/CD pipeline
+ *
+ */
+test('my app', () => {
+	expect(1 + 1).toEqual(2);
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -7,6 +7,7 @@ import { DiscountApi } from '../lib/discount-api';
 import { GenerateProductCatalog } from '../lib/generate-product-catalog';
 import type { NewProductApiProps } from '../lib/new-product-api';
 import { NewProductApi } from '../lib/new-product-api';
+import { PressReaderEntitlements } from '../lib/press-reader-entitlements';
 import { ProductSwitchApi } from '../lib/product-switch-api';
 import { SalesforceDisasterRecovery } from '../lib/salesforce-disaster-recovery';
 import { SalesforceDisasterRecoveryHealthCheck } from '../lib/salesforce-disaster-recovery-health-check';
@@ -244,4 +245,14 @@ new TicketTailorWebhook(app, 'ticket-tailor-webhook-CODE', {
 new TicketTailorWebhook(app, 'ticket-tailor-webhook-PROD', {
 	stack: 'support',
 	stage: 'PROD',
+});
+new PressReaderEntitlements(app, 'press-reader-entitlements-CODE', {
+	stack: 'support',
+	stage: 'CODE',
+	domainName: `press-reader-entitlements-code.dev-guardianapis.com`,
+});
+new PressReaderEntitlements(app, 'press-reader-entitlements-PROD', {
+	stack: 'support',
+	stage: 'PROD',
+	domainName: `press-reader-entitlements.guardianapis.com`,
 });

--- a/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
+++ b/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
@@ -1,0 +1,1817 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Press reader entitlements stack matches the snapshot 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuApiLambda",
+      "GuApiGateway5xxPercentageAlarm",
+      "GuAlarm",
+      "GuCname",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "pressreaderentitlementslambdapressreaderentitlementsCODEEndpoint27926FF8": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentStageCODECC968CC0",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiGateway4XXAlarmCDKC83EACCA": {
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Impact - Press reader entitlements received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "AlarmName": "PRESS-READER-ENTITLEMENTS-CODE API gateway 4XX response",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": "press-reader-entitlements-CODE",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGatewayHigh5xxPercentageAlarmPressreaderentitlements39081247": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "press-reader-entitlements exceeded 5% error rate",
+        "AlarmName": "High 5XX error percentage from press-reader-entitlements (ApiGateway) in CODE",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for press-reader-entitlements",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "press-reader-entitlements-CODE",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "press-reader-entitlements-CODE",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NS1DNSentryforpressreaderentitlementscodedevguardianapiscom": {
+      "Properties": {
+        "Name": "press-reader-entitlements.code.dev-guardianapis.com",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          "guardian.map.fastly.net",
+        ],
+        "Stage": "CODE",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "S3inlinepolicy3B07399A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3::*:membership-dist/membership/CODE/press-reader-entitlements/",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "S3inlinepolicy3B07399A",
+        "Roles": [
+          {
+            "Ref": "pressreaderentitlementslambdaServiceRole94C17F23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "pressreaderentitlementslambda849A2923": {
+      "DependsOn": [
+        "pressreaderentitlementslambdaServiceRoleDefaultPolicyE75EB370",
+        "pressreaderentitlementslambdaServiceRole94C17F23",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/CODE/press-reader-entitlements/press-reader-entitlements.zip",
+        },
+        "Description": "An API Gateway triggered lambda generated in the support-service-lambdas repo",
+        "Environment": {
+          "Variables": {
+            "APP": "press-reader-entitlements",
+            "App": "press-reader-entitlements",
+            "STACK": "membership",
+            "STAGE": "CODE",
+            "Stack": "membership",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "press-reader-entitlements-CODE",
+        "Handler": "index.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambdaServiceRole94C17F23",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "pressreaderentitlementslambdaServiceRole94C17F23": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "pressreaderentitlementslambdaServiceRoleDefaultPolicyE75EB370": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/CODE/press-reader-entitlements/press-reader-entitlements.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/membership/press-reader-entitlements",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/membership/press-reader-entitlements/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "pressreaderentitlementslambdaServiceRoleDefaultPolicyE75EB370",
+        "Roles": [
+          {
+            "Ref": "pressreaderentitlementslambdaServiceRole94C17F23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320": {
+      "Properties": {
+        "ApiKeySourceType": "HEADER",
+        "Description": "API Gateway created by CDK",
+        "Name": "press-reader-entitlements-CODE",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEANYApiPermissionTestpressreaderentitlementsCODEpressreaderentitlementslambdapressreaderentitlementsCODE7D056EE0ANY74606790": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambda849A2923",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEANYApiPermissionpressreaderentitlementsCODEpressreaderentitlementslambdapressreaderentitlementsCODE7D056EE0ANYCBFBAA0B": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambda849A2923",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+              },
+              "/",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentStageCODECC968CC0",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEANYBCD0DFF3": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderentitlementslambda849A2923",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEAccount58595882": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambdapressreaderentitlementsCODECloudWatchRoleCD886C4B",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODECloudWatchRoleCD886C4B": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentAF63E253dcc78fbadae79b72e926c362765ad40f": {
+      "DependsOn": [
+        "pressreaderentitlementslambdapressreaderentitlementsCODEproxyANY94DA2830",
+        "pressreaderentitlementslambdapressreaderentitlementsCODEproxyC7B8C5A6",
+        "pressreaderentitlementslambdapressreaderentitlementsCODEANYBCD0DFF3",
+      ],
+      "Properties": {
+        "Description": "API Gateway created by CDK",
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentStageCODECC968CC0": {
+      "DependsOn": [
+        "pressreaderentitlementslambdapressreaderentitlementsCODEAccount58595882",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentAF63E253dcc78fbadae79b72e926c362765ad40f",
+        },
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+        },
+        "StageName": "CODE",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEUsagePlan67DAEFF0": {
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+            },
+            "Stage": {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentStageCODECC968CC0",
+            },
+            "Throttle": {},
+          },
+        ],
+        "Description": "REST endpoints for press-reader-entitlements>",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "UsagePlanName": "press-reader-entitlements-CODE",
+      },
+      "Type": "AWS::ApiGateway::UsagePlan",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEUsagePlanUsagePlanKeyResourcepressreaderentitlementsCODEpressreaderentitlementslambdapressreaderentitlementsCODEpressreaderentitlementskeyCODECB615F12622657CE": {
+      "Properties": {
+        "KeyId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEpressreaderentitlementskeyCODE9FF4AE4F",
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEUsagePlan67DAEFF0",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEpressreaderentitlementskeyCODE9FF4AE4F": {
+      "Properties": {
+        "Enabled": true,
+        "Name": "press-reader-entitlements-key-CODE",
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+            },
+            "StageName": {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentStageCODECC968CC0",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::ApiKey",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEproxyANY94DA2830": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderentitlementslambda849A2923",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEproxyC7B8C5A6",
+        },
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEproxyANYApiPermissionTestpressreaderentitlementsCODEpressreaderentitlementslambdapressreaderentitlementsCODE7D056EE0ANYproxyB8CECD42": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambda849A2923",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEproxyANYApiPermissionpressreaderentitlementsCODEpressreaderentitlementslambdapressreaderentitlementsCODE7D056EE0ANYproxyDB078E55": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambda849A2923",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+              },
+              "/",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentStageCODECC968CC0",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsCODEproxyC7B8C5A6": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+  },
+}
+`;
+
+exports[`The Press reader entitlements stack matches the snapshot 2`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuApiLambda",
+      "GuApiGateway5xxPercentageAlarm",
+      "GuAlarm",
+      "GuCname",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "pressreaderentitlementslambdapressreaderentitlementsPRODEndpointC96D7D91": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentStagePROD6E99A268",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiGateway4XXAlarmCDKC83EACCA": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Impact - Press reader entitlements received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "AlarmName": "PRESS-READER-ENTITLEMENTS-PROD API gateway 4XX response",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": "press-reader-entitlements-PROD",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGatewayHigh5xxPercentageAlarmPressreaderentitlements39081247": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "press-reader-entitlements exceeded 5% error rate",
+        "AlarmName": "High 5XX error percentage from press-reader-entitlements (ApiGateway) in PROD",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for press-reader-entitlements",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "press-reader-entitlements-PROD",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "press-reader-entitlements-PROD",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NS1DNSentryforpressreaderentitlementsguardianapiscom": {
+      "Properties": {
+        "Name": "press-reader-entitlements.guardianapis.com",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          "guardian.map.fastly.net",
+        ],
+        "Stage": "PROD",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "S3inlinepolicy3B07399A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3::*:membership-dist/membership/PROD/press-reader-entitlements/",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "S3inlinepolicy3B07399A",
+        "Roles": [
+          {
+            "Ref": "pressreaderentitlementslambdaServiceRole94C17F23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "pressreaderentitlementslambda849A2923": {
+      "DependsOn": [
+        "pressreaderentitlementslambdaServiceRoleDefaultPolicyE75EB370",
+        "pressreaderentitlementslambdaServiceRole94C17F23",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/PROD/press-reader-entitlements/press-reader-entitlements.zip",
+        },
+        "Description": "An API Gateway triggered lambda generated in the support-service-lambdas repo",
+        "Environment": {
+          "Variables": {
+            "APP": "press-reader-entitlements",
+            "App": "press-reader-entitlements",
+            "STACK": "membership",
+            "STAGE": "PROD",
+            "Stack": "membership",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "press-reader-entitlements-PROD",
+        "Handler": "index.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambdaServiceRole94C17F23",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "pressreaderentitlementslambdaServiceRole94C17F23": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "pressreaderentitlementslambdaServiceRoleDefaultPolicyE75EB370": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/PROD/press-reader-entitlements/press-reader-entitlements.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/membership/press-reader-entitlements",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/membership/press-reader-entitlements/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "pressreaderentitlementslambdaServiceRoleDefaultPolicyE75EB370",
+        "Roles": [
+          {
+            "Ref": "pressreaderentitlementslambdaServiceRole94C17F23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODANYA19F1CF4": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderentitlementslambda849A2923",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODANYApiPermissionTestpressreaderentitlementsPRODpressreaderentitlementslambdapressreaderentitlementsPROD471B412CANY7D865E46": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambda849A2923",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODANYApiPermissionpressreaderentitlementsPRODpressreaderentitlementslambdapressreaderentitlementsPROD471B412CANY87E6A018": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambda849A2923",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+              },
+              "/",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentStagePROD6E99A268",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODAccount54D83A30": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambdapressreaderentitlementsPRODCloudWatchRoleB26A4812",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODCloudWatchRoleB26A4812": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA": {
+      "Properties": {
+        "ApiKeySourceType": "HEADER",
+        "Description": "API Gateway created by CDK",
+        "Name": "press-reader-entitlements-PROD",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentD4B7367101f9305c35ee5681d8ac6f33855b3e0f": {
+      "DependsOn": [
+        "pressreaderentitlementslambdapressreaderentitlementsPRODproxyANY3A6E2187",
+        "pressreaderentitlementslambdapressreaderentitlementsPRODproxyA619485E",
+        "pressreaderentitlementslambdapressreaderentitlementsPRODANYA19F1CF4",
+      ],
+      "Properties": {
+        "Description": "API Gateway created by CDK",
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentStagePROD6E99A268": {
+      "DependsOn": [
+        "pressreaderentitlementslambdapressreaderentitlementsPRODAccount54D83A30",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentD4B7367101f9305c35ee5681d8ac6f33855b3e0f",
+        },
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+        },
+        "StageName": "PROD",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODUsagePlan38E9853E": {
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+            },
+            "Stage": {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentStagePROD6E99A268",
+            },
+            "Throttle": {},
+          },
+        ],
+        "Description": "REST endpoints for press-reader-entitlements>",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "UsagePlanName": "press-reader-entitlements-PROD",
+      },
+      "Type": "AWS::ApiGateway::UsagePlan",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODUsagePlanUsagePlanKeyResourcepressreaderentitlementsPRODpressreaderentitlementslambdapressreaderentitlementsPRODpressreaderentitlementskeyPRODCE66A9513BA32151": {
+      "Properties": {
+        "KeyId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODpressreaderentitlementskeyPROD67D1169B",
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODUsagePlan38E9853E",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODpressreaderentitlementskeyPROD67D1169B": {
+      "Properties": {
+        "Enabled": true,
+        "Name": "press-reader-entitlements-key-PROD",
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+            },
+            "StageName": {
+              "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentStagePROD6E99A268",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::ApiKey",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODproxyA619485E": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODproxyANY3A6E2187": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderentitlementslambda849A2923",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODproxyA619485E",
+        },
+        "RestApiId": {
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODproxyANYApiPermissionTestpressreaderentitlementsPRODpressreaderentitlementslambdapressreaderentitlementsPROD471B412CANYproxy24006336": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambda849A2923",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderentitlementslambdapressreaderentitlementsPRODproxyANYApiPermissionpressreaderentitlementsPRODpressreaderentitlementslambdapressreaderentitlementsPROD471B412CANYproxyF59FA99A": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderentitlementslambda849A2923",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
+              },
+              "/",
+              {
+                "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentStagePROD6E99A268",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+}
+`;

--- a/cdk/lib/press-reader-entitlements.test.ts
+++ b/cdk/lib/press-reader-entitlements.test.ts
@@ -1,0 +1,30 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { PressReaderEntitlements } from './press-reader-entitlements';
+
+describe('The Press reader entitlements stack', () => {
+	it('matches the snapshot', () => {
+		const app = new App();
+		const codeStack = new PressReaderEntitlements(
+			app,
+			'press-reader-entitlements-CODE',
+			{
+				stack: 'membership',
+				stage: 'CODE',
+				domainName: `press-reader-entitlements.code.dev-guardianapis.com`,
+			},
+		);
+		const prodStack = new PressReaderEntitlements(
+			app,
+			'press-reader-entitlements-PROD',
+			{
+				stack: 'membership',
+				stage: 'PROD',
+				domainName: `press-reader-entitlements.guardianapis.com`,
+			},
+		);
+
+		expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
+		expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();
+	});
+});

--- a/cdk/lib/press-reader-entitlements.ts
+++ b/cdk/lib/press-reader-entitlements.ts
@@ -1,0 +1,134 @@
+import { GuApiLambda } from '@guardian/cdk';
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import type { App } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
+import { ApiKeySourceType } from 'aws-cdk-lib/aws-apigateway';
+import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
+import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { nodeVersion } from './node-version';
+
+export interface PressReaderEntitlementsProps extends GuStackProps {
+	stack: string;
+	stage: string;
+	domainName: string;
+}
+
+export class PressReaderEntitlements extends GuStack {
+	constructor(scope: App, id: string, props: PressReaderEntitlementsProps) {
+		super(scope, id, props);
+
+		const app = 'press-reader-entitlements';
+		const nameWithStage = `${app}-${this.stage}`;
+
+		const commonEnvironmentVariables = {
+			App: app,
+			Stack: this.stack,
+			Stage: this.stage,
+		};
+
+		// ---- API-triggered lambda functions ---- //
+		const lambda = new GuApiLambda(this, `${app}-lambda`, {
+			description:
+				'An API Gateway triggered lambda generated in the support-service-lambdas repo',
+			functionName: nameWithStage,
+			fileName: `${app}.zip`,
+			handler: 'index.handler',
+			runtime: nodeVersion,
+			memorySize: 1024,
+			timeout: Duration.seconds(300),
+			environment: commonEnvironmentVariables,
+			// Create an alarm
+			monitoringConfiguration: {
+				http5xxAlarm: { tolerated5xxPercentage: 5 },
+				snsTopicName: `alarms-handler-topic-${this.stage}`,
+			},
+			app: app,
+			api: {
+				id: nameWithStage,
+				restApiName: nameWithStage,
+				description: 'API Gateway created by CDK',
+				proxy: true,
+				deployOptions: {
+					stageName: this.stage,
+				},
+
+				apiKeySourceType: ApiKeySourceType.HEADER,
+				defaultMethodOptions: {
+					apiKeyRequired: true,
+				},
+			},
+		});
+
+		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {
+			name: nameWithStage,
+			description: 'REST endpoints for press-reader-entitlements>',
+			apiStages: [
+				{
+					stage: lambda.api.deploymentStage,
+					api: lambda.api,
+				},
+			],
+		});
+
+		// create api key
+		const apiKey = lambda.api.addApiKey(`${app}-key-${this.stage}`, {
+			apiKeyName: `${app}-key-${this.stage}`,
+		});
+
+		// associate api key to plan
+		usagePlan.addApiKey(apiKey);
+
+		// ---- Alarms ---- //
+		const alarmName = (shortDescription: string) =>
+			`PRESS-READER-ENTITLEMENTS-${this.stage} ${shortDescription}`;
+
+		const alarmDescription = (description: string) =>
+			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
+
+		new GuAlarm(this, 'ApiGateway4XXAlarmCDK', {
+			app,
+			alarmName: alarmName('API gateway 4XX response'),
+			alarmDescription: alarmDescription(
+				'Press reader entitlements received an invalid request',
+			),
+			evaluationPeriods: 1,
+			threshold: 1,
+			snsTopicName: `alarms-handler-topic-${this.stage}`,
+			actionsEnabled: this.stage === 'PROD',
+			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			metric: new Metric({
+				metricName: '4XXError',
+				namespace: 'AWS/ApiGateway',
+				statistic: 'Sum',
+				period: Duration.seconds(300),
+				dimensionsMap: {
+					ApiName: nameWithStage,
+				},
+			}),
+		});
+
+		new GuCname(this, `NS1 DNS entry for ${props.domainName}`, {
+			app: app,
+			domainName: props.domainName,
+			ttl: Duration.hours(1),
+			resourceRecord: 'guardian.map.fastly.net',
+		});
+
+		const s3InlinePolicy: Policy = new Policy(this, 'S3 inline policy', {
+			statements: [
+				new PolicyStatement({
+					effect: Effect.ALLOW,
+					actions: ['s3:GetObject'],
+					resources: [
+						`arn:aws:s3::*:membership-dist/${this.stack}/${this.stage}/${app}/`,
+					],
+				}),
+			],
+		});
+
+		lambda.role?.attachInlinePolicy(s3InlinePolicy);
+	}
+}

--- a/handlers/press-reader-entitlements/jest.config.js
+++ b/handlers/press-reader-entitlements/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	runner: 'groups',
+	moduleNameMapper: {
+		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
+		'@modules/(.*)$': '<rootDir>/../../modules/$1',
+	},
+};

--- a/handlers/press-reader-entitlements/package.json
+++ b/handlers/press-reader-entitlements/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "press-reader-entitlements",
+  "scripts": {
+    "test": "jest --group=-integration",
+    "it-test": "jest --group=integration",
+    "type-check": "tsc --noEmit",
+    "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
+    "lint": "eslint src/**/*.ts",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr press-reader-entitlements.zip ./*.js",
+    "check-formatting": "prettier --check **.ts",
+    "fix-formatting": "prettier --write **.ts"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.129"
+  }
+}

--- a/handlers/press-reader-entitlements/riff-raff.yaml
+++ b/handlers/press-reader-entitlements/riff-raff.yaml
@@ -1,0 +1,25 @@
+stacks:
+- support
+regions:
+- eu-west-1
+allowedStages:
+  - CODE
+  - PROD
+deployments:
+  press-reader-entitlements-cloudformation:
+    type: cloud-formation
+    app: press-reader-entitlements
+    parameters:
+      templateStagePaths:
+        CODE: press-reader-entitlements-CODE.template.json
+        PROD: press-reader-entitlements-PROD.template.json
+
+  press-reader-entitlements:
+    type: aws-lambda
+    parameters:
+      fileName: press-reader-entitlements.zip
+      bucketSsmLookup: true
+      prefixStack: false
+      functionNames:
+      - press-reader-entitlements-
+    dependencies: [press-reader-entitlements-cloudformation]

--- a/handlers/press-reader-entitlements/src/index.ts
+++ b/handlers/press-reader-entitlements/src/index.ts
@@ -1,0 +1,15 @@
+import type {
+	APIGatewayProxyEvent,
+	APIGatewayProxyResult,
+	Handler,
+} from 'aws-lambda';
+
+export const handler: Handler = async (
+	event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> => {
+	console.log(`Input is ${JSON.stringify(event)}`);
+	return await Promise.resolve({
+		body: 'Hello World',
+		statusCode: 200,
+	});
+};

--- a/handlers/press-reader-entitlements/test/firstIntegration.test.ts
+++ b/handlers/press-reader-entitlements/test/firstIntegration.test.ts
@@ -1,0 +1,10 @@
+/**
+ * This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
+ * command and will not be run during continuous integration.
+ * This makes it useful for testing things that require credentials which are available locally but not on the CI server.
+ *
+ * @group integration
+ */
+test('my app', () => {
+	expect(1 + 1).toEqual(2);
+});

--- a/handlers/press-reader-entitlements/test/firstTest.test.ts
+++ b/handlers/press-reader-entitlements/test/firstTest.test.ts
@@ -1,0 +1,7 @@
+/**
+ * This is a unit test, it can be run by the `pnpm test` command, and will be run by the CI/CD pipeline
+ *
+ */
+test('my app', () => {
+	expect(1 + 1).toEqual(2);
+});

--- a/handlers/press-reader-entitlements/tsconfig.json
+++ b/handlers/press-reader-entitlements/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json",
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"clean": "rm -rf .parcel-cache && pnpm -r run clean",
 		"test": "pnpm --stream -r run test",
 		"it-test": "pnpm --stream -r run it-test",
-		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && cd ./cdk && yarn lint --fix && yarn test -u && git add ./lib/__snapshots__/*.test.ts.snap",
+		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && pnpm --filter cdk lint --fix && pnpm --filter cdk test -- -u && git add ./cdk/lib/__snapshots__/*.test.ts.snap",
 		"prepare": "husky",
 		"fix-formatting": "pnpm -r run fix-formatting",
 		"check-formatting": "pnpm -r run check-formatting"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"clean": "rm -rf .parcel-cache && pnpm -r run clean",
 		"test": "pnpm --stream -r run test",
 		"it-test": "pnpm --stream -r run it-test",
-		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && pnpm --filter cdk lint --fix && pnpm --filter cdk test -- -u && git add ./cdk/lib/__snapshots__/*.test.ts.snap",
+		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && pnpm --filter cdk lint --fix && pnpm fix-formatting && pnpm --filter cdk test -- -u && git add ./cdk/lib/__snapshots__/*.test.ts.snap",
 		"prepare": "husky",
 		"fix-formatting": "pnpm -r run fix-formatting",
 		"check-formatting": "pnpm -r run check-formatting"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,12 @@ importers:
         specifier: ^8.10.142
         version: 8.10.142
 
+  handlers/press-reader-entitlements:
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8.10.129
+        version: 8.10.143
+
   handlers/product-switch-api:
     dependencies:
       '@aws-sdk/client-sqs':


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
