### PR TITLE
Hygen GuCname changes

### DIFF
--- a/_templates/new-lambda/api-gateway/cdk-bin.ejs.t
+++ b/_templates/new-lambda/api-gateway/cdk-bin.ejs.t
@@ -11,14 +11,10 @@ import { <%= PascalCase %> } from '../lib/<%= lambdaName %>';
 new <%= PascalCase %>(app, '<%= lambdaName %>-CODE', {
     stack: 'support',
     stage: 'CODE',
-    domainName: `<%= lambdaName %>-code.${supportApisDomain}`,
-    hostedZoneId: supportHostedZoneId,
-    certificateId: supportCertificateId,
+    domainName: `<%= lambdaName %>-code.dev-guardianapis.com`,
 });
 new <%= PascalCase %>(app, '<%= lambdaName %>-PROD', {
     stack: 'support',
     stage: 'PROD',
-    domainName: `<%= lambdaName %>.${supportApisDomain}`,
-    hostedZoneId: supportHostedZoneId,
-    certificateId: supportCertificateId,
+    domainName: `<%= lambdaName %>.guardianapis.com`,
 });

--- a/_templates/new-lambda/api-gateway/cdk-lib.ejs.t
+++ b/_templates/new-lambda/api-gateway/cdk-lib.ejs.t
@@ -7,6 +7,7 @@ sh: git add cdk/lib/<%=lambdaName%>.ts
 <% PascalCase = h.changeCase.pascal(lambdaName) %>
 import { GuApiLambda } from '@guardian/cdk';
 import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
@@ -14,18 +15,14 @@ import { Duration } from 'aws-cdk-lib';
 <% if (includeApiKey === 'Y'){ %>
 import { ApiKeySourceType } from 'aws-cdk-lib/aws-apigateway';
 <% } %>
-import { CfnBasePathMapping, CfnDomainName } from 'aws-cdk-lib/aws-apigateway';
 import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 import { nodeVersion } from './node-version';
 
 export interface <%= PascalCase %>Props extends GuStackProps {
 	stack: string;
 	stage: string;
-	certificateId: string;
 	domainName: string;
-	hostedZoneId: string;
 }
 
 export class <%= PascalCase %> extends GuStack {
@@ -124,28 +121,11 @@ export class <%= PascalCase %> extends GuStack {
 			}),
 		});
 
-		// ---- DNS ---- //
-		const certificateArn = `arn:aws:acm:eu-west-1:${this.account}:certificate/${props.certificateId}`;
-		const cfnDomainName = new CfnDomainName(this, 'DomainName', {
+		new GuCname(this, `NS1 DNS entry for ${props.domainName}`, {
+			app: app,
 			domainName: props.domainName,
-			regionalCertificateArn: certificateArn,
-			endpointConfiguration: {
-				types: ['REGIONAL'],
-			},
-		});
-
-		new CfnBasePathMapping(this, 'BasePathMapping', {
-			domainName: cfnDomainName.ref,
-			restApiId: lambda.api.restApiId,
-			stage: lambda.api.deploymentStage.stageName,
-		});
-
-		new CfnRecordSet(this, 'DNSRecord', {
-			name: props.domainName,
-			type: 'CNAME',
-			hostedZoneId: props.hostedZoneId,
-			ttl: '120',
-			resourceRecords: [cfnDomainName.attrRegionalDomainName],
+			ttl: Duration.hours(1),
+			resourceRecord: 'guardian.map.fastly.net',
 		});
 
 		const s3InlinePolicy: Policy = new Policy(this, 'S3 inline policy', {

--- a/_templates/new-lambda/api-gateway/cdk-test.ejs.t
+++ b/_templates/new-lambda/api-gateway/cdk-test.ejs.t
@@ -7,11 +7,6 @@ sh: git add cdk/lib/<%=lambdaName%>.test.ts
 <% PascalCase = h.changeCase.pascal(lambdaName) %>
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import {
-	supportApisDomain,
-	supportCertificateId,
-	supportHostedZoneId,
-} from '../bin/cdk';
 import { <%= PascalCase %> } from './<%= lambdaName %>';
 
 describe('The <%= h.changeCase.sentenceCase(lambdaName) %> stack', () => {
@@ -20,16 +15,12 @@ describe('The <%= h.changeCase.sentenceCase(lambdaName) %> stack', () => {
 		const codeStack = new <%= PascalCase %>(app, '<%= lambdaName %>-CODE', {
 			stack: 'membership',
 			stage: 'CODE',
-			domainName: `<%= lambdaName %>.code.${supportApisDomain}`,
-			hostedZoneId: supportHostedZoneId,
-			certificateId: supportCertificateId,
+			domainName: `<%= lambdaName %>.code.dev-guardianapis.com`,
 		});
 		const prodStack = new <%= PascalCase %>(app, '<%= lambdaName %>-PROD', {
 			stack: 'membership',
 			stage: 'PROD',
-			domainName: `<%= lambdaName %>.${supportApisDomain}`,
-			hostedZoneId: supportHostedZoneId,
-			certificateId: supportCertificateId,
+			domainName: `<%= lambdaName %>.guardianapis.com`,
 		});
 
 		expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();

--- a/_templates/new-lambda/api-gateway/index.ejs.t
+++ b/_templates/new-lambda/api-gateway/index.ejs.t
@@ -19,5 +19,3 @@ export const handler: Handler = async (
 		statusCode: 200,
 	});
 };
-
-

--- a/_templates/new-lambda/api-gateway/integration-test.ejs.t
+++ b/_templates/new-lambda/api-gateway/integration-test.ejs.t
@@ -5,12 +5,13 @@ to: handlers/<%=lambdaName%>/test/firstIntegration.test.ts
 sh: git add handlers/<%=lambdaName%>/test/firstIntegration.test.ts
 ---
 /**
-* This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
-* command and will not be run during continuous integration.
-* This makes it useful for testing things that require credentials which are available locally but not on the CI server.
-*
-* @group integration
-*/
-test("my app", () => {
-    expect(1 + 1).toEqual(2);
+ * This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
+ * command and will not be run during continuous integration.
+ * This makes it useful for testing things that require credentials which are available locally but not on the CI server.
+ *
+ * @group integration
+ */
+test('my app', () => {
+	expect(1 + 1).toEqual(2);
 });
+

--- a/_templates/new-lambda/api-gateway/test.ejs.t
+++ b/_templates/new-lambda/api-gateway/test.ejs.t
@@ -5,9 +5,9 @@ to: handlers/<%=lambdaName%>/test/firstTest.test.ts
 sh: git add handlers/<%=lambdaName%>/test/firstTest.test.ts
 ---
 /**
-* This is a unit test, it can be run by the `pnpm test` command, and will be run by the CI/CD pipeline
-*
-*/
-test("my app", () => {
-    expect(1 + 1).toEqual(2);
+ * This is a unit test, it can be run by the `pnpm test` command, and will be run by the CI/CD pipeline
+ *
+ */
+test('my app', () => {
+	expect(1 + 1).toEqual(2);
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"clean": "rm -rf .parcel-cache && pnpm -r run clean",
 		"test": "pnpm --stream -r run test",
 		"it-test": "pnpm --stream -r run it-test",
-		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && cd ./cdk && yarn lint --fix && yarn test -u && git add ./lib/__snapshots__/*.test.ts.snap",
+		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && pnpm --filter cdk lint --fix && pnpm --filter cdk test -- -u && git add ./cdk/lib/__snapshots__/*.test.ts.snap",
 		"prepare": "husky",
 		"fix-formatting": "pnpm -r run fix-formatting",
 		"check-formatting": "pnpm -r run check-formatting"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"clean": "rm -rf .parcel-cache && pnpm -r run clean",
 		"test": "pnpm --stream -r run test",
 		"it-test": "pnpm --stream -r run it-test",
-		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && pnpm --filter cdk lint --fix && pnpm --filter cdk test -- -u && git add ./cdk/lib/__snapshots__/*.test.ts.snap",
+		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && pnpm --filter cdk lint --fix && pnpm fix-formatting && pnpm --filter cdk test -- -u && git add ./cdk/lib/__snapshots__/*.test.ts.snap",
 		"prepare": "husky",
 		"fix-formatting": "pnpm -r run fix-formatting",
 		"check-formatting": "pnpm -r run check-formatting"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Since we moved the cdk module to use pnpm rather than yarn, the new-lambda script has been broken. 
This PR fixes that and also updates the cdk generated by the templates to use the [`GuCname` construct](https://guardian.github.io/cdk/classes/constructs_dns.GuCname.html) for DNS as [recommended here](https://github.com/guardian/recommendations/blob/main/domain-names.md)