### PR TITLE
Fix new-lambda script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"clean": "rm -rf .parcel-cache && pnpm -r run clean",
 		"test": "pnpm --stream -r run test",
 		"it-test": "pnpm --stream -r run it-test",
-		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && cd ./cdk && yarn lint --fix && yarn test -u && git add ./lib/__snapshots__/*.test.ts.snap",
+		"new-lambda": "pnpm hygen new-lambda api-gateway && pnpm install && pnpm --filter cdk lint --fix && pnpm fix-formatting && pnpm --filter cdk test -- -u && git add ./cdk/lib/__snapshots__/*.test.ts.snap",
 		"prepare": "husky",
 		"fix-formatting": "pnpm -r run fix-formatting",
 		"check-formatting": "pnpm -r run check-formatting"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Since we moved the cdk module to use pnpm, the new-lambda script has been broken as it explicitly uses Yarn. This PR fixes that.