### PR TITLE
Update product catalog types & schema for Guardian Light

### DIFF
--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -2,6 +2,20 @@ import { z } from 'zod';
 import { typeObject } from '@modules/product-catalog/typeObject';
 
 export const productCatalogSchema = z.object({
+	GuardianLight: z.object({
+		ratePlans: z.object({
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					GBP: z.number(),
+				}),
+				charges: z.object({ GuardianLight: z.object({ id: z.string() }) }),
+				billingPeriod: z
+					.enum(typeObject.GuardianLight.billingPeriods)
+					.optional(),
+			}),
+		}),
+	}),
 	DigitalSubscription: z.object({
 		ratePlans: z.object({
 			Annual: z.object({

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -1,14 +1,18 @@
 export const typeObject = {
-	TierThree: {
-		currencies: ['USD', 'GBP'],
-		billingPeriods: ['Month', 'Annual'],
+	GuardianLight: {
+		currencies: ['GBP'],
+		billingPeriods: ['Month'],
 		productRatePlans: {
-			DomesticMonthlyV2: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-				NewspaperArchive: {},
+			Monthly: {
+				GuardianLight: {},
 			},
-			DomesticAnnualV2: {
+		},
+	},
+	TierThree: {
+		currencies: ['GBP', 'USD'],
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			RestOfWorldAnnualV2: {
 				NewspaperArchive: {},
 				SupporterPlus: {},
 				GuardianWeekly: {},
@@ -18,10 +22,15 @@ export const typeObject = {
 				GuardianWeekly: {},
 				NewspaperArchive: {},
 			},
-			RestOfWorldAnnualV2: {
+			DomesticAnnualV2: {
 				NewspaperArchive: {},
 				SupporterPlus: {},
 				GuardianWeekly: {},
+			},
+			DomesticMonthlyV2: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+				NewspaperArchive: {},
 			},
 			RestOfWorldMonthly: {
 				SupporterPlus: {},

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -110,6 +110,22 @@ exports[`Generated product catalog matches snapshot 1`] = `
       },
     },
   },
+  "GuardianLight": {
+    "ratePlans": {
+      "Monthly": {
+        "billingPeriod": "Month",
+        "charges": {
+          "GuardianLight": {
+            "id": "8a129b7892c35f170192dd3225572b97",
+          },
+        },
+        "id": "8a12831492c341730192dd1c39207038",
+        "pricing": {
+          "GBP": 2,
+        },
+      },
+    },
+  },
   "GuardianWeeklyDomestic": {
     "ratePlans": {
       "Annual": {
@@ -854,6 +870,19 @@ exports[`Generated product catalog types match snapshot 1`] = `
       },
     },
   },
+  "GuardianLight": {
+    "billingPeriods": [
+      "Month",
+    ],
+    "currencies": [
+      "GBP",
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "GuardianLight": {},
+      },
+    },
+  },
   "GuardianWeeklyDomestic": {
     "billingPeriods": [
       "Annual",
@@ -1051,16 +1080,12 @@ exports[`Generated product catalog types match snapshot 1`] = `
   },
   "TierThree": {
     "billingPeriods": [
-      "Month",
       "Annual",
+      "Month",
     ],
     "currencies": [
       "GBP",
       "USD",
-      "NZD",
-      "EUR",
-      "AUD",
-      "CAD",
     ],
     "productRatePlans": {
       "DomesticAnnual": {

--- a/modules/zuora-catalog/test/catalog.test.ts
+++ b/modules/zuora-catalog/test/catalog.test.ts
@@ -9,7 +9,7 @@ test('catalogSchema', () => {
 	expect(codeCatalog.products.length).toEqual(40);
 
 	const prodCatalog: ZuoraCatalog = zuoraCatalogSchema.parse(prod);
-	expect(prodCatalog.products.length).toEqual(20);
+	expect(prodCatalog.products.length).toEqual(21);
 });
 
 test('getCatalogPriceForCurrency', () => {

--- a/modules/zuora-catalog/test/fixtures/catalog-prod.json
+++ b/modules/zuora-catalog/test/fixtures/catalog-prod.json
@@ -1,6 +1,117 @@
 {
   "products": [
     {
+      "id": "8a128dfb92c341720192dd19626429dc",
+      "sku": "ABC-00000037",
+      "name": "Guardian Light",
+      "description": "",
+      "category": null,
+      "effectiveStartDate": "2024-10-30",
+      "effectiveEndDate": "2099-10-30",
+      "productNumber": "PC-00000021",
+      "allowFeatureChanges": false,
+      "ProductEnabled__c": "True",
+      "Entitlements__c": null,
+      "AcquisitionProfile__c": "Paid",
+      "ProductType__c": "Guardian Light",
+      "ProductLevel__c": null,
+      "Tier__c": null,
+      "productRatePlans": [
+        {
+          "id": "8a12831492c341730192dd1c39207038",
+          "status": "Active",
+          "name": "Guardian Light Monthly",
+          "description": "",
+          "effectiveStartDate": "2024-10-30",
+          "effectiveEndDate": "2099-10-30",
+          "TermType__c": "TERMED",
+          "FrontendId__c": "GuardianLight",
+          "Saving__c": null,
+          "DefaultTerm__c": "12",
+          "RatePlanType__c": "Base",
+          "PromotionCode__c": null,
+          "AnalysisCode__c": null,
+          "externalIdSourceSystem": "",
+          "externallyManagedPlanIds": [],
+          "productRatePlanCharges": [
+            {
+              "id": "8a129b7892c35f170192dd3225572b97",
+              "name": "Guardian Light",
+              "type": "Recurring",
+              "model": "FlatFee",
+              "uom": null,
+              "pricingSummary": [
+                "GBP2"
+              ],
+              "pricing": [
+                {
+                  "currency": "GBP",
+                  "price": 2,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                }
+              ],
+              "defaultQuantity": null,
+              "applyDiscountTo": null,
+              "discountLevel": null,
+              "discountClass": null,
+              "applyToBillingPeriodPartially": false,
+              "productDiscountApplyDetails": [],
+              "endDateCondition": "Subscription_End",
+              "upToPeriods": null,
+              "upToPeriodsType": null,
+              "billingDay": "ChargeTriggerDay",
+              "listPriceBase": "Per_Billing_Period",
+              "specificListPriceBase": null,
+              "billingTiming": "IN_ADVANCE",
+              "ratingGroup": null,
+              "billingPeriod": "Month",
+              "billingPeriodAlignment": "AlignToCharge",
+              "specificBillingPeriod": null,
+              "smoothingModel": null,
+              "numberOfPeriods": null,
+              "overageCalculationOption": null,
+              "overageUnusedUnitsCreditOption": null,
+              "unusedIncludedUnitPrice": null,
+              "usageRecordRatingOption": null,
+              "priceChangeOption": null,
+              "priceIncreasePercentage": null,
+              "useTenantDefaultForPriceChange": true,
+              "taxable": true,
+              "taxCode": "Guardian Light",
+              "taxMode": "TaxInclusive",
+              "prorationOption": null,
+              "ProductCode__c": null,
+              "ProductType__c": "Guardian Light",
+              "triggerEvent": "CustomerAcceptance",
+              "description": "",
+              "revRecCode": null,
+              "revRecTriggerCondition": null,
+              "revenueRecognitionRuleName": "Recognize daily over time",
+              "useDiscountSpecificAccountingCode": null,
+              "financeInformation": {
+                "deferredRevenueAccountingCode": "Deferred Revenue - Guardian Light",
+                "deferredRevenueAccountingCodeType": "DeferredRevenue",
+                "recognizedRevenueAccountingCode": "Guardian Light",
+                "recognizedRevenueAccountingCodeType": "SalesRevenue",
+                "accountsReceivableAccountingCode": "Accounts Receivable",
+                "accountsReceivableAccountingCodeType": "AccountsReceivable"
+              },
+              "deliverySchedule": null,
+              "reflectDiscountInNetAmount": false,
+              "isStackedDiscount": false,
+              "productRatePlanChargeNumber": "PRPC-00000326"
+            }
+          ],
+          "productRatePlanNumber": "PRP-00000201"
+        }
+      ],
+      "productFeatures": []
+    },
+    {
       "id": "2c92a0ff5345f9200153559c6d2a3385",
       "sku": "ABC-00000012",
       "name": "Discounts",
@@ -8086,14 +8197,277 @@
       "Tier__c": null,
       "productRatePlans": [
         {
-          "id": "8a128dfb91f04b9a0191fa315d091c51",
+          "id": "8a129c2591f06a5d0191fa2edb383026",
           "status": "Active",
-          "name": "Supporter Plus, Guardian Weekly Domestic & Archive - Monthly",
+          "name": "Supporter Plus, Guardian Weekly ROW & Archive - Annual",
           "description": "",
           "effectiveStartDate": "2024-01-01",
           "effectiveEndDate": "2099-06-10",
           "TermType__c": null,
-          "FrontendId__c": "TierThreeMonthlyDomestic",
+          "FrontendId__c": "TierThreeAnnualROWV2",
+          "Saving__c": null,
+          "DefaultTerm__c": "12",
+          "RatePlanType__c": "Base",
+          "PromotionCode__c": null,
+          "AnalysisCode__c": "A104",
+          "externalIdSourceSystem": "",
+          "externallyManagedPlanIds": [],
+          "productRatePlanCharges": [
+            {
+              "id": "8a12831491f04b9f0191fa9a1f084ec0",
+              "name": "Newspaper Archive",
+              "type": "Recurring",
+              "model": "FlatFee",
+              "uom": null,
+              "pricingSummary": [
+                "GBP2",
+                "USD2"
+              ],
+              "pricing": [
+                {
+                  "currency": "GBP",
+                  "price": 2,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "USD",
+                  "price": 2,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                }
+              ],
+              "defaultQuantity": null,
+              "applyDiscountTo": null,
+              "discountLevel": null,
+              "discountClass": null,
+              "applyToBillingPeriodPartially": false,
+              "productDiscountApplyDetails": [],
+              "endDateCondition": "Subscription_End",
+              "upToPeriods": null,
+              "upToPeriodsType": null,
+              "billingDay": "ChargeTriggerDay",
+              "listPriceBase": "Per_Billing_Period",
+              "specificListPriceBase": null,
+              "billingTiming": "IN_ADVANCE",
+              "ratingGroup": null,
+              "billingPeriod": "Annual",
+              "billingPeriodAlignment": "AlignToCharge",
+              "specificBillingPeriod": null,
+              "smoothingModel": null,
+              "numberOfPeriods": null,
+              "overageCalculationOption": null,
+              "overageUnusedUnitsCreditOption": null,
+              "unusedIncludedUnitPrice": null,
+              "usageRecordRatingOption": null,
+              "priceChangeOption": null,
+              "priceIncreasePercentage": null,
+              "useTenantDefaultForPriceChange": true,
+              "taxable": true,
+              "taxCode": "Tier Three - Newspaper Archive",
+              "taxMode": "TaxInclusive",
+              "prorationOption": null,
+              "ProductCode__c": "P1016",
+              "ProductType__c": "Newspaper Archive",
+              "triggerEvent": "CustomerAcceptance",
+              "description": "",
+              "revRecCode": null,
+              "revRecTriggerCondition": null,
+              "revenueRecognitionRuleName": "Recognize daily over time",
+              "useDiscountSpecificAccountingCode": null,
+              "financeInformation": {
+                "deferredRevenueAccountingCode": "Deferred Revenue Tier Three - Newspaper Archive",
+                "deferredRevenueAccountingCodeType": "DeferredRevenue",
+                "recognizedRevenueAccountingCode": "Tier Three - Newspaper Archive",
+                "recognizedRevenueAccountingCodeType": "SalesRevenue",
+                "accountsReceivableAccountingCode": "Accounts Receivable",
+                "accountsReceivableAccountingCodeType": "AccountsReceivable"
+              },
+              "deliverySchedule": null,
+              "reflectDiscountInNetAmount": false,
+              "isStackedDiscount": false,
+              "productRatePlanChargeNumber": "PRPC-00000325"
+            },
+            {
+              "id": "8a129c2591f06a5d0191fa2edb803028",
+              "name": "Supporter Plus",
+              "type": "Recurring",
+              "model": "FlatFee",
+              "uom": null,
+              "pricingSummary": [
+                "GBP120",
+                "USD150"
+              ],
+              "pricing": [
+                {
+                  "currency": "GBP",
+                  "price": 120,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "USD",
+                  "price": 150,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                }
+              ],
+              "defaultQuantity": null,
+              "applyDiscountTo": null,
+              "discountLevel": null,
+              "discountClass": null,
+              "applyToBillingPeriodPartially": false,
+              "productDiscountApplyDetails": [],
+              "endDateCondition": "Subscription_End",
+              "upToPeriods": null,
+              "upToPeriodsType": null,
+              "billingDay": "ChargeTriggerDay",
+              "listPriceBase": "Per_Billing_Period",
+              "specificListPriceBase": null,
+              "billingTiming": "IN_ADVANCE",
+              "ratingGroup": null,
+              "billingPeriod": "Annual",
+              "billingPeriodAlignment": "AlignToCharge",
+              "specificBillingPeriod": null,
+              "smoothingModel": null,
+              "numberOfPeriods": null,
+              "overageCalculationOption": null,
+              "overageUnusedUnitsCreditOption": null,
+              "unusedIncludedUnitPrice": null,
+              "usageRecordRatingOption": null,
+              "priceChangeOption": "NoChange",
+              "priceIncreasePercentage": null,
+              "useTenantDefaultForPriceChange": false,
+              "taxable": true,
+              "taxCode": "Tier Three - Supporter Plus",
+              "taxMode": "TaxInclusive",
+              "prorationOption": null,
+              "ProductCode__c": "P1016",
+              "ProductType__c": "Supporter Plus",
+              "triggerEvent": "CustomerAcceptance",
+              "description": "",
+              "revRecCode": null,
+              "revRecTriggerCondition": null,
+              "revenueRecognitionRuleName": "Recognize daily over time",
+              "useDiscountSpecificAccountingCode": null,
+              "financeInformation": {
+                "deferredRevenueAccountingCode": "Deferred Revenue Tier Three - Supporter Plus",
+                "deferredRevenueAccountingCodeType": "DeferredRevenue",
+                "recognizedRevenueAccountingCode": "Tier Three - Supporter Plus",
+                "recognizedRevenueAccountingCodeType": "SalesRevenue",
+                "accountsReceivableAccountingCode": "Accounts Receivable",
+                "accountsReceivableAccountingCodeType": "AccountsReceivable"
+              },
+              "deliverySchedule": null,
+              "reflectDiscountInNetAmount": false,
+              "isStackedDiscount": false,
+              "productRatePlanChargeNumber": null
+            },
+            {
+              "id": "8a129c2591f06a5d0191fa2edbc63030",
+              "name": "Guardian Weekly",
+              "type": "Recurring",
+              "model": "FlatFee",
+              "uom": null,
+              "pricingSummary": [
+                "GBP297.6",
+                "USD396"
+              ],
+              "pricing": [
+                {
+                  "currency": "GBP",
+                  "price": 297.6,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "USD",
+                  "price": 396,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                }
+              ],
+              "defaultQuantity": null,
+              "applyDiscountTo": null,
+              "discountLevel": null,
+              "discountClass": null,
+              "applyToBillingPeriodPartially": false,
+              "productDiscountApplyDetails": [],
+              "endDateCondition": "Subscription_End",
+              "upToPeriods": null,
+              "upToPeriodsType": null,
+              "billingDay": "ChargeTriggerDay",
+              "listPriceBase": "Per_Billing_Period",
+              "specificListPriceBase": null,
+              "billingTiming": "IN_ADVANCE",
+              "ratingGroup": null,
+              "billingPeriod": "Annual",
+              "billingPeriodAlignment": "AlignToCharge",
+              "specificBillingPeriod": null,
+              "smoothingModel": null,
+              "numberOfPeriods": null,
+              "overageCalculationOption": null,
+              "overageUnusedUnitsCreditOption": null,
+              "unusedIncludedUnitPrice": null,
+              "usageRecordRatingOption": null,
+              "priceChangeOption": "NoChange",
+              "priceIncreasePercentage": null,
+              "useTenantDefaultForPriceChange": false,
+              "taxable": true,
+              "taxCode": "Tier Three - Guardian Weekly",
+              "taxMode": "TaxInclusive",
+              "prorationOption": null,
+              "ProductCode__c": "P1016",
+              "ProductType__c": "Guardian Weekly",
+              "triggerEvent": "CustomerAcceptance",
+              "description": "",
+              "revRecCode": null,
+              "revRecTriggerCondition": null,
+              "revenueRecognitionRuleName": "Recognize daily over time",
+              "useDiscountSpecificAccountingCode": null,
+              "financeInformation": {
+                "deferredRevenueAccountingCode": "Deferred Revenue Tier Three - Guardian Weekly",
+                "deferredRevenueAccountingCodeType": "DeferredRevenue",
+                "recognizedRevenueAccountingCode": "Tier Three - Guardian Weekly",
+                "recognizedRevenueAccountingCodeType": "SalesRevenue",
+                "accountsReceivableAccountingCode": "Accounts Receivable",
+                "accountsReceivableAccountingCodeType": "AccountsReceivable"
+              },
+              "deliverySchedule": null,
+              "reflectDiscountInNetAmount": false,
+              "isStackedDiscount": false,
+              "productRatePlanChargeNumber": null
+            }
+          ],
+          "productRatePlanNumber": null
+        },
+        {
+          "id": "8a12891291f04b9d0191fa2ffbe10975",
+          "status": "Active",
+          "name": "Supporter Plus, Guardian Weekly ROW & Archive - Monthly",
+          "description": "",
+          "effectiveStartDate": "2024-01-01",
+          "effectiveEndDate": "2099-06-10",
+          "TermType__c": null,
+          "FrontendId__c": "TierThreeMonthlyROWV2",
           "Saving__c": null,
           "DefaultTerm__c": "12",
           "RatePlanType__c": "Base",
@@ -8103,18 +8477,14 @@
           "externallyManagedPlanIds": [],
           "productRatePlanCharges": [
             {
-              "id": "8a128dfb91f04b9a0191fa315d251c53",
+              "id": "8a12891291f04b9d0191fa2ffc140977",
               "name": "Supporter Plus",
               "type": "Recurring",
               "model": "FlatFee",
               "uom": null,
               "pricingSummary": [
                 "GBP12",
-                "USD15",
-                "NZD20",
-                "EUR12",
-                "AUD20",
-                "CAD15"
+                "USD15"
               ],
               "pricing": [
                 {
@@ -8128,42 +8498,6 @@
                 },
                 {
                   "currency": "USD",
-                  "price": 15,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "NZD",
-                  "price": 20,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "EUR",
-                  "price": 12,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "AUD",
-                  "price": 20,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "CAD",
                   "price": 15,
                   "tiers": null,
                   "includedUnits": null,
@@ -8224,23 +8558,19 @@
               "productRatePlanChargeNumber": null
             },
             {
-              "id": "8a128dfb91f04b9a0191fa315d5b1c5b",
+              "id": "8a12891291f04b9d0191fa2ffc46097f",
               "name": "Guardian Weekly",
               "type": "Recurring",
               "model": "FlatFee",
               "uom": null,
               "pricingSummary": [
-                "GBP15",
-                "USD30",
-                "NZD50",
-                "EUR26.5",
-                "AUD40",
-                "CAD33"
+                "GBP24.8",
+                "USD33"
               ],
               "pricing": [
                 {
                   "currency": "GBP",
-                  "price": 15,
+                  "price": 24.8,
                   "tiers": null,
                   "includedUnits": null,
                   "overagePrice": null,
@@ -8249,42 +8579,6 @@
                 },
                 {
                   "currency": "USD",
-                  "price": 30,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "NZD",
-                  "price": 50,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "EUR",
-                  "price": 26.5,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "AUD",
-                  "price": 40,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "CAD",
                   "price": 33,
                   "tiers": null,
                   "includedUnits": null,
@@ -8345,18 +8639,14 @@
               "productRatePlanChargeNumber": null
             },
             {
-              "id": "8a129c2591f06a5d0191fa945c9177cf",
+              "id": "8a129b7891f06a5a0191fa9888db07de",
               "name": "Newspaper Archive",
               "type": "Recurring",
               "model": "FlatFee",
               "uom": null,
               "pricingSummary": [
                 "GBP2",
-                "USD2",
-                "NZD2",
-                "EUR2",
-                "AUD2",
-                "CAD2"
+                "USD2"
               ],
               "pricing": [
                 {
@@ -8370,42 +8660,6 @@
                 },
                 {
                   "currency": "USD",
-                  "price": 2,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "NZD",
-                  "price": 2,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "EUR",
-                  "price": 2,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "AUD",
-                  "price": 2,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "CAD",
                   "price": 2,
                   "tiers": null,
                   "includedUnits": null,
@@ -8463,7 +8717,7 @@
               "deliverySchedule": null,
               "reflectDiscountInNetAmount": false,
               "isStackedDiscount": false,
-              "productRatePlanChargeNumber": "PRPC-00000322"
+              "productRatePlanChargeNumber": "PRPC-00000324"
             }
           ],
           "productRatePlanNumber": null
@@ -8476,7 +8730,7 @@
           "effectiveStartDate": "2024-01-01",
           "effectiveEndDate": "2099-06-10",
           "TermType__c": null,
-          "FrontendId__c": "TierThreeAnnualDomestic",
+          "FrontendId__c": "TierThreeAnnualDomesticV2",
           "Saving__c": null,
           "DefaultTerm__c": "12",
           "RatePlanType__c": "Base",
@@ -8852,14 +9106,14 @@
           "productRatePlanNumber": null
         },
         {
-          "id": "8a12891291f04b9d0191fa2ffbe10975",
+          "id": "8a128dfb91f04b9a0191fa315d091c51",
           "status": "Active",
-          "name": "Supporter Plus, Guardian Weekly ROW & Archive - Monthly",
+          "name": "Supporter Plus, Guardian Weekly Domestic & Archive - Monthly",
           "description": "",
           "effectiveStartDate": "2024-01-01",
           "effectiveEndDate": "2099-06-10",
           "TermType__c": null,
-          "FrontendId__c": "TierThreeMonthlyROW",
+          "FrontendId__c": "TierThreeMonthlyDomesticV2",
           "Saving__c": null,
           "DefaultTerm__c": "12",
           "RatePlanType__c": "Base",
@@ -8869,14 +9123,18 @@
           "externallyManagedPlanIds": [],
           "productRatePlanCharges": [
             {
-              "id": "8a12891291f04b9d0191fa2ffc140977",
+              "id": "8a128dfb91f04b9a0191fa315d251c53",
               "name": "Supporter Plus",
               "type": "Recurring",
               "model": "FlatFee",
               "uom": null,
               "pricingSummary": [
                 "GBP12",
-                "USD15"
+                "USD15",
+                "NZD20",
+                "EUR12",
+                "AUD20",
+                "CAD15"
               ],
               "pricing": [
                 {
@@ -8890,6 +9148,42 @@
                 },
                 {
                   "currency": "USD",
+                  "price": 15,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "NZD",
+                  "price": 20,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "EUR",
+                  "price": 12,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "AUD",
+                  "price": 20,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "CAD",
                   "price": 15,
                   "tiers": null,
                   "includedUnits": null,
@@ -8950,19 +9244,23 @@
               "productRatePlanChargeNumber": null
             },
             {
-              "id": "8a12891291f04b9d0191fa2ffc46097f",
+              "id": "8a128dfb91f04b9a0191fa315d5b1c5b",
               "name": "Guardian Weekly",
               "type": "Recurring",
               "model": "FlatFee",
               "uom": null,
               "pricingSummary": [
-                "GBP24.8",
-                "USD33"
+                "GBP15",
+                "USD30",
+                "NZD50",
+                "EUR26.5",
+                "AUD40",
+                "CAD33"
               ],
               "pricing": [
                 {
                   "currency": "GBP",
-                  "price": 24.8,
+                  "price": 15,
                   "tiers": null,
                   "includedUnits": null,
                   "overagePrice": null,
@@ -8971,6 +9269,42 @@
                 },
                 {
                   "currency": "USD",
+                  "price": 30,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "NZD",
+                  "price": 50,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "EUR",
+                  "price": 26.5,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "AUD",
+                  "price": 40,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "CAD",
                   "price": 33,
                   "tiers": null,
                   "includedUnits": null,
@@ -9031,14 +9365,18 @@
               "productRatePlanChargeNumber": null
             },
             {
-              "id": "8a129b7891f06a5a0191fa9888db07de",
+              "id": "8a129c2591f06a5d0191fa945c9177cf",
               "name": "Newspaper Archive",
               "type": "Recurring",
               "model": "FlatFee",
               "uom": null,
               "pricingSummary": [
                 "GBP2",
-                "USD2"
+                "USD2",
+                "NZD2",
+                "EUR2",
+                "AUD2",
+                "CAD2"
               ],
               "pricing": [
                 {
@@ -9052,6 +9390,42 @@
                 },
                 {
                   "currency": "USD",
+                  "price": 2,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "NZD",
+                  "price": 2,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "EUR",
+                  "price": 2,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "AUD",
+                  "price": 2,
+                  "tiers": null,
+                  "includedUnits": null,
+                  "overagePrice": null,
+                  "discountPercentage": null,
+                  "discountAmount": null
+                },
+                {
+                  "currency": "CAD",
                   "price": 2,
                   "tiers": null,
                   "includedUnits": null,
@@ -9109,270 +9483,7 @@
               "deliverySchedule": null,
               "reflectDiscountInNetAmount": false,
               "isStackedDiscount": false,
-              "productRatePlanChargeNumber": "PRPC-00000324"
-            }
-          ],
-          "productRatePlanNumber": null
-        },
-        {
-          "id": "8a129c2591f06a5d0191fa2edb383026",
-          "status": "Active",
-          "name": "Supporter Plus, Guardian Weekly ROW & Archive - Annual",
-          "description": "",
-          "effectiveStartDate": "2024-01-01",
-          "effectiveEndDate": "2099-06-10",
-          "TermType__c": null,
-          "FrontendId__c": "TierThreeAnnualROW",
-          "Saving__c": null,
-          "DefaultTerm__c": "12",
-          "RatePlanType__c": "Base",
-          "PromotionCode__c": null,
-          "AnalysisCode__c": "A104",
-          "externalIdSourceSystem": "",
-          "externallyManagedPlanIds": [],
-          "productRatePlanCharges": [
-            {
-              "id": "8a12831491f04b9f0191fa9a1f084ec0",
-              "name": "Newspaper Archive",
-              "type": "Recurring",
-              "model": "FlatFee",
-              "uom": null,
-              "pricingSummary": [
-                "GBP2",
-                "USD2"
-              ],
-              "pricing": [
-                {
-                  "currency": "GBP",
-                  "price": 2,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "USD",
-                  "price": 2,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                }
-              ],
-              "defaultQuantity": null,
-              "applyDiscountTo": null,
-              "discountLevel": null,
-              "discountClass": null,
-              "applyToBillingPeriodPartially": false,
-              "productDiscountApplyDetails": [],
-              "endDateCondition": "Subscription_End",
-              "upToPeriods": null,
-              "upToPeriodsType": null,
-              "billingDay": "ChargeTriggerDay",
-              "listPriceBase": "Per_Billing_Period",
-              "specificListPriceBase": null,
-              "billingTiming": "IN_ADVANCE",
-              "ratingGroup": null,
-              "billingPeriod": "Annual",
-              "billingPeriodAlignment": "AlignToCharge",
-              "specificBillingPeriod": null,
-              "smoothingModel": null,
-              "numberOfPeriods": null,
-              "overageCalculationOption": null,
-              "overageUnusedUnitsCreditOption": null,
-              "unusedIncludedUnitPrice": null,
-              "usageRecordRatingOption": null,
-              "priceChangeOption": null,
-              "priceIncreasePercentage": null,
-              "useTenantDefaultForPriceChange": true,
-              "taxable": true,
-              "taxCode": "Tier Three - Newspaper Archive",
-              "taxMode": "TaxInclusive",
-              "prorationOption": null,
-              "ProductCode__c": "P1016",
-              "ProductType__c": "Newspaper Archive",
-              "triggerEvent": "CustomerAcceptance",
-              "description": "",
-              "revRecCode": null,
-              "revRecTriggerCondition": null,
-              "revenueRecognitionRuleName": "Recognize daily over time",
-              "useDiscountSpecificAccountingCode": null,
-              "financeInformation": {
-                "deferredRevenueAccountingCode": "Deferred Revenue Tier Three - Newspaper Archive",
-                "deferredRevenueAccountingCodeType": "DeferredRevenue",
-                "recognizedRevenueAccountingCode": "Tier Three - Newspaper Archive",
-                "recognizedRevenueAccountingCodeType": "SalesRevenue",
-                "accountsReceivableAccountingCode": "Accounts Receivable",
-                "accountsReceivableAccountingCodeType": "AccountsReceivable"
-              },
-              "deliverySchedule": null,
-              "reflectDiscountInNetAmount": false,
-              "isStackedDiscount": false,
-              "productRatePlanChargeNumber": "PRPC-00000325"
-            },
-            {
-              "id": "8a129c2591f06a5d0191fa2edb803028",
-              "name": "Supporter Plus",
-              "type": "Recurring",
-              "model": "FlatFee",
-              "uom": null,
-              "pricingSummary": [
-                "GBP120",
-                "USD150"
-              ],
-              "pricing": [
-                {
-                  "currency": "GBP",
-                  "price": 120,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "USD",
-                  "price": 150,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                }
-              ],
-              "defaultQuantity": null,
-              "applyDiscountTo": null,
-              "discountLevel": null,
-              "discountClass": null,
-              "applyToBillingPeriodPartially": false,
-              "productDiscountApplyDetails": [],
-              "endDateCondition": "Subscription_End",
-              "upToPeriods": null,
-              "upToPeriodsType": null,
-              "billingDay": "ChargeTriggerDay",
-              "listPriceBase": "Per_Billing_Period",
-              "specificListPriceBase": null,
-              "billingTiming": "IN_ADVANCE",
-              "ratingGroup": null,
-              "billingPeriod": "Annual",
-              "billingPeriodAlignment": "AlignToCharge",
-              "specificBillingPeriod": null,
-              "smoothingModel": null,
-              "numberOfPeriods": null,
-              "overageCalculationOption": null,
-              "overageUnusedUnitsCreditOption": null,
-              "unusedIncludedUnitPrice": null,
-              "usageRecordRatingOption": null,
-              "priceChangeOption": "NoChange",
-              "priceIncreasePercentage": null,
-              "useTenantDefaultForPriceChange": false,
-              "taxable": true,
-              "taxCode": "Tier Three - Supporter Plus",
-              "taxMode": "TaxInclusive",
-              "prorationOption": null,
-              "ProductCode__c": "P1016",
-              "ProductType__c": "Supporter Plus",
-              "triggerEvent": "CustomerAcceptance",
-              "description": "",
-              "revRecCode": null,
-              "revRecTriggerCondition": null,
-              "revenueRecognitionRuleName": "Recognize daily over time",
-              "useDiscountSpecificAccountingCode": null,
-              "financeInformation": {
-                "deferredRevenueAccountingCode": "Deferred Revenue Tier Three - Supporter Plus",
-                "deferredRevenueAccountingCodeType": "DeferredRevenue",
-                "recognizedRevenueAccountingCode": "Tier Three - Supporter Plus",
-                "recognizedRevenueAccountingCodeType": "SalesRevenue",
-                "accountsReceivableAccountingCode": "Accounts Receivable",
-                "accountsReceivableAccountingCodeType": "AccountsReceivable"
-              },
-              "deliverySchedule": null,
-              "reflectDiscountInNetAmount": false,
-              "isStackedDiscount": false,
-              "productRatePlanChargeNumber": null
-            },
-            {
-              "id": "8a129c2591f06a5d0191fa2edbc63030",
-              "name": "Guardian Weekly",
-              "type": "Recurring",
-              "model": "FlatFee",
-              "uom": null,
-              "pricingSummary": [
-                "GBP297.6",
-                "USD396"
-              ],
-              "pricing": [
-                {
-                  "currency": "GBP",
-                  "price": 297.6,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                },
-                {
-                  "currency": "USD",
-                  "price": 396,
-                  "tiers": null,
-                  "includedUnits": null,
-                  "overagePrice": null,
-                  "discountPercentage": null,
-                  "discountAmount": null
-                }
-              ],
-              "defaultQuantity": null,
-              "applyDiscountTo": null,
-              "discountLevel": null,
-              "discountClass": null,
-              "applyToBillingPeriodPartially": false,
-              "productDiscountApplyDetails": [],
-              "endDateCondition": "Subscription_End",
-              "upToPeriods": null,
-              "upToPeriodsType": null,
-              "billingDay": "ChargeTriggerDay",
-              "listPriceBase": "Per_Billing_Period",
-              "specificListPriceBase": null,
-              "billingTiming": "IN_ADVANCE",
-              "ratingGroup": null,
-              "billingPeriod": "Annual",
-              "billingPeriodAlignment": "AlignToCharge",
-              "specificBillingPeriod": null,
-              "smoothingModel": null,
-              "numberOfPeriods": null,
-              "overageCalculationOption": null,
-              "overageUnusedUnitsCreditOption": null,
-              "unusedIncludedUnitPrice": null,
-              "usageRecordRatingOption": null,
-              "priceChangeOption": "NoChange",
-              "priceIncreasePercentage": null,
-              "useTenantDefaultForPriceChange": false,
-              "taxable": true,
-              "taxCode": "Tier Three - Guardian Weekly",
-              "taxMode": "TaxInclusive",
-              "prorationOption": null,
-              "ProductCode__c": "P1016",
-              "ProductType__c": "Guardian Weekly",
-              "triggerEvent": "CustomerAcceptance",
-              "description": "",
-              "revRecCode": null,
-              "revRecTriggerCondition": null,
-              "revenueRecognitionRuleName": "Recognize daily over time",
-              "useDiscountSpecificAccountingCode": null,
-              "financeInformation": {
-                "deferredRevenueAccountingCode": "Deferred Revenue Tier Three - Guardian Weekly",
-                "deferredRevenueAccountingCodeType": "DeferredRevenue",
-                "recognizedRevenueAccountingCode": "Tier Three - Guardian Weekly",
-                "recognizedRevenueAccountingCodeType": "SalesRevenue",
-                "accountsReceivableAccountingCode": "Accounts Receivable",
-                "accountsReceivableAccountingCodeType": "AccountsReceivable"
-              },
-              "deliverySchedule": null,
-              "reflectDiscountInNetAmount": false,
-              "isStackedDiscount": false,
-              "productRatePlanChargeNumber": null
+              "productRatePlanChargeNumber": "PRPC-00000322"
             }
           ],
           "productRatePlanNumber": null


### PR DESCRIPTION
## What does this change?

Update the product catalog types and schema to include the new Guardian Light product, which has now been created in Zuora and is visible in the product catalog API.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
