### PR TITLE
more logging and better searchability for update supporter plus amount lamdba

### DIFF
--- a/handlers/update-supporter-plus-amount/src/index.ts
+++ b/handlers/update-supporter-plus-amount/src/index.ts
@@ -1,7 +1,9 @@
+import { sendEmail } from '@modules/email/email';
 import { ValidationError } from '@modules/errors';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import type { Stage } from '@modules/stage';
+import { Logger } from '@modules/zuora/logger';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type {
 	APIGatewayProxyEvent,
@@ -9,7 +11,7 @@ import type {
 	Handler,
 } from 'aws-lambda';
 import { requestBodySchema } from './schema';
-import { sendThankYouEmail } from './sendEmail';
+import { createThankYouEmail } from './sendEmail';
 import { updateSupporterPlusAmount } from './updateSupporterPlusAmount';
 import { getSubscriptionNumberFromUrl } from './urlParsing';
 
@@ -18,36 +20,49 @@ const stage = process.env.STAGE as Stage;
 export const handler: Handler = async (
 	event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> => {
+	const logger = new Logger();
+	logger.log(`Input is ${JSON.stringify(event)}`);
+	const response = await routeRequest(logger, event);
+	logger.log(`Response is ${JSON.stringify(response)}`);
+	return response;
+};
+
+const routeRequest = async (logger: Logger, event: APIGatewayProxyEvent) => {
 	try {
-		console.log(`Input is ${JSON.stringify(event)}`);
 		const subscriptionNumber = getSubscriptionNumberFromUrl(event.path);
+		logger.mutableAddContext(subscriptionNumber);
 		const eventBody = getIfDefined(event.body, 'No request body provided');
 		const requestBody = requestBodySchema.parse(JSON.parse(eventBody));
 		const identityId = getIfDefined(
 			event.headers['x-identity-id'],
 			'Identity ID not found in request',
 		);
-		const zuoraClient = await ZuoraClient.create(stage);
-		const productCatalog = await getProductCatalogFromApi(stage);
+		const zuoraClient = await ZuoraClient.create(stage, logger);
+		const productCatalog = await getProductCatalogFromApi(
+			stage,
+			logger.log.bind(logger),
+		);
 		const emailFields = await updateSupporterPlusAmount(
+			logger,
 			zuoraClient,
 			productCatalog,
 			identityId,
 			subscriptionNumber,
 			requestBody.newPaymentAmount,
 		);
-		await sendThankYouEmail({
+		await sendEmail(
 			stage,
-			...emailFields,
-		});
+			createThankYouEmail(emailFields),
+			logger.log.bind(logger),
+		);
 		return {
 			body: JSON.stringify({ message: 'Success' }),
 			statusCode: 200,
 		};
 	} catch (error) {
-		console.log('Caught error in index.ts ', error);
+		logger.log('Caught error in index.ts ', error);
 		if (error instanceof ValidationError) {
-			console.log(`Validation failure: ${error.message}`);
+			logger.log(`Validation failure: ${error.message}`);
 			return {
 				body: error.message,
 				statusCode: 400,

--- a/handlers/update-supporter-plus-amount/src/sendEmail.ts
+++ b/handlers/update-supporter-plus-amount/src/sendEmail.ts
@@ -1,10 +1,9 @@
 import type { EmailMessageWithUserId } from '@modules/email/email';
-import { DataExtensionNames, sendEmail } from '@modules/email/email';
+import { DataExtensionNames } from '@modules/email/email';
 import type {
 	ProductBillingPeriod,
 	ProductCurrency,
 } from '@modules/product-catalog/productCatalog';
-import type { Stage } from '@modules/stage';
 import type dayjs from 'dayjs';
 
 export type EmailFields = {
@@ -18,8 +17,7 @@ export type EmailFields = {
 	identityId: string;
 };
 
-export const sendThankYouEmail = async ({
-	stage,
+export const createThankYouEmail = ({
 	nextPaymentDate,
 	emailAddress,
 	firstName,
@@ -28,7 +26,7 @@ export const sendThankYouEmail = async ({
 	newAmount,
 	billingPeriod,
 	identityId,
-}: { stage: Stage } & EmailFields) => {
+}: EmailFields) => {
 	const emailMessage: EmailMessageWithUserId = {
 		To: {
 			Address: emailAddress,
@@ -47,5 +45,5 @@ export const sendThankYouEmail = async ({
 		IdentityUserId: identityId,
 	};
 
-	return await sendEmail(stage, emailMessage);
+	return emailMessage;
 };

--- a/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmountIntegration.test.ts
+++ b/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmountIntegration.test.ts
@@ -2,8 +2,10 @@ import console from 'console';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
-import { sendThankYouEmail } from '../src/sendEmail';
+import { createThankYouEmail } from '../src/sendEmail';
 import { updateSupporterPlusAmount } from '../src/updateSupporterPlusAmount';
+import { Logger } from '@modules/zuora/logger';
+import { sendEmail } from '@modules/email/email';
 
 /**
  * This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
@@ -30,6 +32,7 @@ test('We can carry out an amount change', async () => {
 	const productCatalog = await getProductCatalogFromApi(stage);
 
 	const result = await updateSupporterPlusAmount(
+		new Logger(),
 		zuoraClient,
 		productCatalog,
 		identityId,
@@ -51,17 +54,19 @@ test('We can send a thank you email', async () => {
 	const currency = 'GBP';
 	const billingPeriod = 'Month';
 
-	const result = await sendThankYouEmail({
+	const result = await sendEmail(
 		stage,
-		nextPaymentDate,
-		emailAddress,
-		firstName,
-		lastName,
-		currency,
-		newAmount,
-		billingPeriod,
-		identityId,
-	});
+		createThankYouEmail({
+			nextPaymentDate,
+			emailAddress,
+			firstName,
+			lastName,
+			currency,
+			newAmount,
+			billingPeriod,
+			identityId,
+		}),
+	);
 
 	expect(result.$metadata.httpStatusCode).toEqual(200);
 });

--- a/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmounts.test.ts
+++ b/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmounts.test.ts
@@ -4,6 +4,7 @@ import { zuoraSubscriptionSchema } from '@modules/zuora/zuoraSchemas';
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import { getSupporterPlusData } from '../src/updateSupporterPlusAmount';
 import subscriptionJson from './fixtures/subscription.json';
+import { Logger } from '@modules/zuora/logger';
 
 test('We can get a product rate plan from a subscription', () => {
 	const productCatalog: ProductCatalog =
@@ -11,6 +12,7 @@ test('We can get a product rate plan from a subscription', () => {
 	const subscription = zuoraSubscriptionSchema.parse(subscriptionJson);
 
 	const supporterPlusPlans = getSupporterPlusData(
+		new Logger(),
 		productCatalog,
 		subscription.ratePlans,
 	);

--- a/modules/product-catalog/src/api.ts
+++ b/modules/product-catalog/src/api.ts
@@ -3,8 +3,9 @@ import { productCatalogSchema } from '@modules/product-catalog/productCatalogSch
 
 export const getProductCatalogFromApi = async (
 	stage: string,
+	log: (messsage: string) => void = console.log,
 ): Promise<ProductCatalog> => {
-	console.log('getProductCatalogFromApi');
+	log('getProductCatalogFromApi');
 	const url =
 		stage === 'PROD'
 			? 'https://product-catalog.guardianapis.com/product-catalog.json'
@@ -15,7 +16,7 @@ export const getProductCatalogFromApi = async (
 
 	const json = await response.json();
 	if (response.ok) {
-		console.log(`Response from catalog api was: ${JSON.stringify(json)}`);
+		log(`Response from catalog api was: ${JSON.stringify(json)}`);
 		return productCatalogSchema.parse(json);
 	} else {
 		throw new Error(


### PR DESCRIPTION
We tried to investigate someone who tried to change their S+ amount 4 times and it failed every time as it was trying to back date the amendment to when they switched from annual contribution to supporter plus.  See example at https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fupdate-supporter-plus-amount-PROD/log-events/2024$252F10$252F27$252F$255B$2524LATEST$255Dad4e0a97414b4fdf9ca2e72ca92a8711$3Fstart$3D1730065591579$26refEventId$3D38581751936778500848853083164490340067694877865427861506

We did notice that they are one of the "split" S+ (see https://docs.google.com/document/d/1kDwJ13984jhv4fwkqtHo43upMvYZEZWyfHNSkaYUJbk/edit ) however we don't think that's a particular issue.

We tried going through the log line by line and it was clear that it should have picked the right rate plan and the right charge and date.  We even pasted the data into a unit test and it still seemed to work ok!

As a last resort, this PR adds a load more logging so we can have an idea of where it went wrong.  This also brings in the logger context from this pr https://github.com/guardian/support-service-lambdas/pull/2507 which will only include subscription ID in this lambda (as product is always S+).

Tested in CODE and it seems ok with dummy data via postman.