### PR TITLE
infra: block public access for general purpose S3 buckets

### DIFF
--- a/handlers/fulfilment-date-calculator/cfn.yaml
+++ b/handlers/fulfilment-date-calculator/cfn.yaml
@@ -26,6 +26,11 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !FindInMap [StageMap, !Ref Stage, bucketName]
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -24,6 +24,11 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !FindInMap [StageMap, !Ref Stage, localbucketName]
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/axAyxmPb/344-aws-fsbp-high-vulnerabilities-s3-general-purpose-buckets-should-block-public-access)

S3 general purpose buckets should block public access.

## Why are you making this change?

This is part of new obligations for fixing AWS vulnerabilities.

See [document](https://docs.google.com/document/d/1Q_ts5mbRvASCGo3UfsPHwUVvSXc3f2fkK2Fwp6N9Pxc/edit?tab=t.0#heading=h.64oh0k2bzslf) for more details.

## How to test

Before:
<img width="515" alt="Screenshot 2024-11-04 at 14 38 43" src="https://github.com/user-attachments/assets/f773e566-b352-43c7-a2df-b562d6eeacc5">

After deploying the branch to CODE:
<img width="544" alt="Screenshot 2024-11-04 at 14 41 34" src="https://github.com/user-attachments/assets/db04ec03-b564-4080-acb0-5cee154ff239">
