### PR TITLE
Move zuora canonical config alarm to Portfolio

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -72,6 +72,9 @@ const teamToAppMappings: Record<Team, string[]> = {
 		// zuora-finance
 		'zuora-creditor',
 
+		// zuora-config
+		'canonical-config',
+
 		// support-frontend
 		'frontend',
 		'it-test-runner',
@@ -113,9 +116,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'identity-retention',
 		'zuora-retention', //https://github.com/guardian/zuora-retention
 		'zuora-salesforce-link-remover',
-
-		// finance
-		'canonical-config',
 	],
 };
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
There is an alarm which triggers if the canonical config stored in the [zuora-config repository](https://github.com/guardian/zuora-config/tree/c45905003a7462ad90916b574bfe7a7844608e7a/finance/canonical-config/src/canonicalConfig/PROD) does not match the current product catalog in Zuora PROD.

This alarm has previously gone to the Platform team, but we have decided that it would be better to go to Portfolio as that is the team primarily responsible for product catalog changes.