### PR TITLE
stop running cdk tests and linting on every push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-pnpm --filter cdk lint && pnpm --filter cdk test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,13 @@
+# Fetch the latest changes from the remote without merging
+git fetch origin
+
+# Get the name of the current branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Check if there are changes in the 'cdk' folder between the local branch and its remote
+if git diff --exit-code --quiet origin/$CURRENT_BRANCH -- cdk/; then
+  echo "No changes detected in the 'cdk' folder. Skipping lint and test."
+else
+  echo "Changes detected in the 'cdk' folder. Running lint and test..."
+  pnpm --filter cdk lint && pnpm --filter cdk test
+fi


### PR DESCRIPTION
I was working on another project recently and noticed the pushes were really quick.  I noticed they take around 20s on this project even with trivial changes.  After looking into why they are so slow, it seems like we are running CDK linting and tests on every push.

This PR changes it so it only runs when you change cdk/* so otherwise push finishes before I even click away (1-2 seconds).

Script courtesy of @AndreaDiotallevi via AI!

Original PR adding the check is here https://github.com/guardian/support-service-lambdas/pull/2199