### PR TITLE
User correct stage for SSM parameter

### DIFF
--- a/handlers/press-reader-entitlements/src/identity.ts
+++ b/handlers/press-reader-entitlements/src/identity.ts
@@ -1,5 +1,22 @@
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { awsConfig } from '@modules/aws/config';
+import { getIfDefined } from '@modules/nullAndUndefined';
 import type { Stage } from '@modules/stage';
 import { getIdentityIdSchema } from './schemas';
+
+export const getClientAccessToken = async (stage: Stage) => {
+	const ssmClient = new SSMClient(awsConfig);
+	const params = {
+		Name: `/${stage}/support/press-reader-entitlements/identity-client-access-token`,
+		WithDecryption: true,
+	};
+	const command = new GetParameterCommand(params);
+	const response = await ssmClient.send(command);
+	return getIfDefined(
+		response.Parameter?.Value,
+		"Couldn't retrieve identity client access token from parameter store",
+	);
+};
 
 export async function getIdentityId(
 	clientAccessToken: string,

--- a/handlers/press-reader-entitlements/src/identity.ts
+++ b/handlers/press-reader-entitlements/src/identity.ts
@@ -1,30 +1,15 @@
-import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
-import { awsConfig } from '@modules/aws/config';
-import { Lazy } from '@modules/lazy';
-import { getIfDefined } from '@modules/nullAndUndefined';
 import type { Stage } from '@modules/stage';
 import { getIdentityIdSchema } from './schemas';
 
-const ssmClient = new SSMClient(awsConfig);
-export const lazyClientAccessToken = new Lazy(async () => {
-	const params = {
-		Name: '/CODE/support/press-reader-entitlements/identity-client-access-token',
-		WithDecryption: true,
-	};
-	const command = new GetParameterCommand(params);
-	const response = await ssmClient.send(command);
-	return getIfDefined(
-		response.Parameter?.Value,
-		"Couldn't retrieve identity client access token from parameter store",
-	);
-}, 'clientAccessToken');
-
-export async function getIdentityId(stage: Stage, userId: string) {
+export async function getIdentityId(
+	clientAccessToken: string,
+	stage: Stage,
+	userId: string,
+) {
 	const identityHost =
 		stage === 'CODE'
 			? 'https://idapi.code.dev-theguardian.com'
 			: 'https://idapi.theguardian.com';
-	const clientAccessToken = await lazyClientAccessToken.get();
 
 	const response = await fetch(`${identityHost}/user/braze-uuid/${userId}`, {
 		headers: {

--- a/handlers/press-reader-entitlements/test/pressReaderEntitlementsIntegration.test.ts
+++ b/handlers/press-reader-entitlements/test/pressReaderEntitlementsIntegration.test.ts
@@ -5,7 +5,7 @@
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import { getMemberDetails } from '../src';
-import { getIdentityId, lazyClientAccessToken } from '../src/identity';
+import { getClientAccessToken, getIdentityId } from '../src/identity';
 import {
 	getLatestSubscription,
 	getSupporterProductData,
@@ -26,13 +26,11 @@ test('Entitlements check', async () => {
 	expect(memberDetails).toBeDefined();
 });
 
-test('getIdentityClientAccessToken', async () => {
-	const accessToken = await lazyClientAccessToken.get();
-	expect(accessToken).toBeDefined();
-});
-
 test('getIdentityId', async () => {
+	const accessToken = await getClientAccessToken('CODE');
+	expect(accessToken).toBeDefined();
 	const identityId = await getIdentityId(
+		accessToken,
 		'CODE',
 		'c20da7c7-4f72-44fb-b719-78879bfab70d',
 	);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
#2513 incorrectly hard coded the stage in the SSM parameter name which it uses to load the identity client access token, this PR fixes that.

It has meant moving the code which fetches the token to the top level of the application so that it is aware of the stage at start up.