### PR TITLE
Assign the press-reader-entitlements alarm to Portfolio

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -85,6 +85,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		// support-service-lambdas
 		'generate-product-catalog',
 		'metric-push-api',
+		'press-reader-entitlements',
 	],
 	PLATFORM: [
 		// fulfilment


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The press reader entitlements api is a new api to support the editions app, this PR assigns the alarm from it to Portfolio