### PR TITLE
Add patrons to product catalog

### DIFF
--- a/handlers/press-reader-entitlements/src/supporterProductData.ts
+++ b/handlers/press-reader-entitlements/src/supporterProductData.ts
@@ -71,7 +71,8 @@ export function getLatestValidSubscription(
 		'SubscriptionCard',
 		'SupporterPlus',
 		'TierThree',
-		// ToDo: add Patron, currently not in product catalog
+		'GuardianPatron',
+		'PatronMembership',
 	] as const;
 
 	const productCatalogHelper = new ProductCatalogHelper(productCatalog);

--- a/modules/product-catalog/src/generateProductCatalog.ts
+++ b/modules/product-catalog/src/generateProductCatalog.ts
@@ -8,6 +8,7 @@ import type {
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import { stripeProducts } from '@modules/product-catalog/stripeProducts';
 import {
+	activeProducts,
 	getProductRatePlanChargeKey,
 	getProductRatePlanKey,
 	getZuoraProductKey,
@@ -83,9 +84,13 @@ const getBillingPeriod = (productRatePlan: ZuoraProductRatePlan) => {
 	return billingPeriod;
 };
 
-const getZuoraProduct = (productRatePlans: ZuoraProductRatePlan[]) => {
+const getZuoraProduct = (
+	isActive: boolean,
+	productRatePlans: ZuoraProductRatePlan[],
+) => {
 	return {
 		billingSystem: 'zuora',
+		active: isActive,
 		ratePlans: arrayToObject(
 			productRatePlans
 				.filter((productRatePlan) =>
@@ -121,7 +126,10 @@ export const generateProductCatalog = (
 		supportedProducts.map((product) => {
 			const productName = getZuoraProductKey(product.name);
 			return {
-				[productName]: getZuoraProduct(product.productRatePlans),
+				[productName]: getZuoraProduct(
+					activeProducts.includes(productName),
+					product.productRatePlans,
+				),
 			};
 		}),
 	);

--- a/modules/product-catalog/src/generateProductCatalog.ts
+++ b/modules/product-catalog/src/generateProductCatalog.ts
@@ -6,6 +6,7 @@ import type {
 	ZuoraProductRatePlanCharge,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
+import { stripeProducts } from '@modules/product-catalog/stripeProducts';
 import {
 	getProductRatePlanChargeKey,
 	getProductRatePlanKey,
@@ -84,6 +85,7 @@ const getBillingPeriod = (productRatePlan: ZuoraProductRatePlan) => {
 
 const getZuoraProduct = (productRatePlans: ZuoraProductRatePlan[]) => {
 	return {
+		billingSystem: 'zuora',
 		ratePlans: arrayToObject(
 			productRatePlans
 				.filter((productRatePlan) =>
@@ -123,5 +125,6 @@ export const generateProductCatalog = (
 			};
 		}),
 	);
-	return result as ProductCatalog;
+	const productCatalog = { ...stripeProducts, ...result };
+	return productCatalog as ProductCatalog;
 };

--- a/modules/product-catalog/src/generateTypeObject.ts
+++ b/modules/product-catalog/src/generateTypeObject.ts
@@ -4,6 +4,7 @@ import type {
 	ZuoraProductRatePlan,
 	ZuoraProductRatePlanCharge,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
+import { stripeTypeObject } from '@modules/product-catalog/stripeProducts';
 import {
 	getProductRatePlanChargeKey,
 	getProductRatePlanKey,
@@ -75,5 +76,7 @@ export const generateTypeObject = (catalog: ZuoraCatalog) => {
 		};
 	});
 
-	return arrayToObject(arrayVersion);
+	const zuoraTypeObject = arrayToObject(arrayVersion);
+
+	return { ...zuoraTypeObject, ...stripeTypeObject };
 };

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -45,8 +45,9 @@ export type ProductRatePlan<
 
 type ProductBillingSystem = 'stripe' | 'zuora';
 
-type Product<P extends ProductKey> = {
+export type Product<P extends ProductKey> = {
 	billingSystem: ProductBillingSystem;
+	active: boolean;
 	ratePlans: {
 		[PRP in ProductRatePlanKey<P>]: ProductRatePlan<P, PRP>;
 	};

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -43,7 +43,10 @@ export type ProductRatePlan<
 	billingPeriod?: ProductBillingPeriod<P>;
 };
 
+type ProductBillingSystem = 'stripe' | 'zuora';
+
 type Product<P extends ProductKey> = {
+	billingSystem: ProductBillingSystem;
 	ratePlans: {
 		[PRP in ProductRatePlanKey<P>]: ProductRatePlan<P, PRP>;
 	};
@@ -65,12 +68,20 @@ export class ProductCatalogHelper {
 	) => {
 		return this.catalogData[zuoraProduct].ratePlans[productRatePlan];
 	};
+	getAllProductDetailsForBillingSystem = (
+		billingSystem: ProductBillingSystem,
+	) =>
+		this.getAllProductDetails().filter(
+			(productDetail) => productDetail.billingSystem === billingSystem,
+		);
+
 	getAllProductDetails = () => {
 		const stageMapping = this.catalogData;
 		const zuoraProductKeys = Object.keys(stageMapping) as Array<
 			keyof typeof stageMapping
 		>;
 		return zuoraProductKeys.flatMap((zuoraProduct) => {
+			const billingSystem = stageMapping[zuoraProduct].billingSystem;
 			const productRatePlans = stageMapping[zuoraProduct].ratePlans;
 			const productRatePlanKeys = Object.keys(productRatePlans) as Array<
 				keyof typeof productRatePlans
@@ -79,6 +90,7 @@ export class ProductCatalogHelper {
 				const { id } = this.getProductRatePlan(zuoraProduct, productRatePlan);
 				return {
 					zuoraProduct,
+					billingSystem,
 					productRatePlan,
 					id,
 				};

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -2,7 +2,34 @@ import { z } from 'zod';
 import { typeObject } from '@modules/product-catalog/typeObject';
 
 export const productCatalogSchema = z.object({
+	GuardianPatron: z.object({
+		billingSystem: z.literal('stripe'),
+		active: z.boolean(),
+		ratePlans: z.object({
+			GuardianPatron: z.object({
+				id: z.string(),
+				pricing: z.object({
+					GBP: z.number(),
+					USD: z.number(),
+					NZD: z.number(),
+					EUR: z.number(),
+					AUD: z.number(),
+					CAD: z.number(),
+				}),
+				charges: z.object({
+					Subscription: z.object({
+						id: z.string(),
+					}),
+				}),
+				billingPeriod: z
+					.enum(typeObject.GuardianPatron.billingPeriods)
+					.optional(),
+			}),
+		}),
+	}),
 	GuardianLight: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			Monthly: z.object({
 				id: z.string(),
@@ -16,7 +43,179 @@ export const productCatalogSchema = z.object({
 			}),
 		}),
 	}),
+	SupporterMembership: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
+		ratePlans: z.object({
+			Annual: z.object({
+				id: z.string(),
+				pricing: z.object({
+					CAD: z.number(),
+					AUD: z.number(),
+					EUR: z.number(),
+					GBP: z.number(),
+					USD: z.number(),
+				}),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z
+					.enum(typeObject.SupporterMembership.billingPeriods)
+					.optional(),
+			}),
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					GBP: z.number(),
+					CAD: z.number(),
+					AUD: z.number(),
+					EUR: z.number(),
+					USD: z.number(),
+				}),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z
+					.enum(typeObject.SupporterMembership.billingPeriods)
+					.optional(),
+			}),
+			V2DeprecatedAnnual: z.object({
+				id: z.string(),
+				pricing: z.object({
+					USD: z.number(),
+					GBP: z.number(),
+					CAD: z.number(),
+					EUR: z.number(),
+					AUD: z.number(),
+				}),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z
+					.enum(typeObject.SupporterMembership.billingPeriods)
+					.optional(),
+			}),
+			V1DeprecatedAnnual: z.object({
+				id: z.string(),
+				pricing: z.object({
+					GBP: z.number(),
+				}),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z
+					.enum(typeObject.SupporterMembership.billingPeriods)
+					.optional(),
+			}),
+			V1DeprecatedMonthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					GBP: z.number(),
+				}),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z
+					.enum(typeObject.SupporterMembership.billingPeriods)
+					.optional(),
+			}),
+			V2DeprecatedMonthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					GBP: z.number(),
+					USD: z.number(),
+					AUD: z.number(),
+					EUR: z.number(),
+					CAD: z.number(),
+				}),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z
+					.enum(typeObject.SupporterMembership.billingPeriods)
+					.optional(),
+			}),
+		}),
+	}),
+	PatronMembership: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
+		ratePlans: z.object({
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z.enum(typeObject.PatronMembership.billingPeriods),
+			}),
+			Annual: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z.enum(typeObject.PatronMembership.billingPeriods),
+			}),
+			V1DeprecatedAnnual: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z.enum(typeObject.PatronMembership.billingPeriods),
+			}),
+			V1DeprecatedMonthly: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z.enum(typeObject.PatronMembership.billingPeriods),
+			}),
+		}),
+	}),
+	PartnerMembership: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
+		ratePlans: z.object({
+			V1DeprecatedAnnual: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z.enum(typeObject.PartnerMembership.billingPeriods),
+			}),
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z.enum(typeObject.PartnerMembership.billingPeriods),
+			}),
+			Annual: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z.enum(typeObject.PartnerMembership.billingPeriods),
+			}),
+			V1DeprecatedMonthly: z.object({
+				id: z.string(),
+				pricing: z.object({ GBP: z.number() }),
+				charges: z.object({
+					Subscription: z.object({ id: z.string() }),
+				}),
+				billingPeriod: z.enum(typeObject.PartnerMembership.billingPeriods),
+			}),
+		}),
+	}),
 	DigitalSubscription: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			Annual: z.object({
 				id: z.string(),
@@ -81,6 +280,8 @@ export const productCatalogSchema = z.object({
 		}),
 	}),
 	HomeDelivery: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			Everyday: z.object({
 				id: z.string(),
@@ -143,6 +344,8 @@ export const productCatalogSchema = z.object({
 		}),
 	}),
 	NationalDelivery: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			Everyday: z.object({
 				id: z.string(),
@@ -189,6 +392,8 @@ export const productCatalogSchema = z.object({
 		}),
 	}),
 	SupporterPlus: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			V1DeprecatedMonthly: z.object({
 				id: z.string(),
@@ -263,6 +468,8 @@ export const productCatalogSchema = z.object({
 		}),
 	}),
 	TierThree: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			RestOfWorldMonthly: z.object({
 				id: z.string(),
@@ -399,6 +606,8 @@ export const productCatalogSchema = z.object({
 		}),
 	}),
 	GuardianWeeklyRestOfWorld: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			ThreeMonthGift: z.object({
 				id: z.string(),
@@ -443,6 +652,8 @@ export const productCatalogSchema = z.object({
 		}),
 	}),
 	GuardianWeeklyDomestic: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			ThreeMonthGift: z.object({
 				id: z.string(),
@@ -522,6 +733,8 @@ export const productCatalogSchema = z.object({
 		}),
 	}),
 	SubscriptionCard: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			Everyday: z.object({
 				id: z.string(),
@@ -584,6 +797,8 @@ export const productCatalogSchema = z.object({
 		}),
 	}),
 	Contribution: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
 		ratePlans: z.object({
 			Annual: z.object({
 				id: z.string(),

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -9,7 +9,7 @@ export const productCatalogSchema = z.object({
 				pricing: z.object({
 					GBP: z.number(),
 				}),
-				charges: z.object({ GuardianLight: z.object({ id: z.string() }) }),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.GuardianLight.billingPeriods)
 					.optional(),

--- a/modules/product-catalog/src/stripeProducts.ts
+++ b/modules/product-catalog/src/stripeProducts.ts
@@ -1,0 +1,34 @@
+export const stripeProducts = {
+	GuardianPatron: {
+		billingSystem: 'stripe',
+		ratePlans: {
+			GuardianPatron: {
+				id: 'guardian_patron',
+				pricing: {
+					GBP: 0,
+					USD: 0,
+					NZD: 0,
+					EUR: 0,
+					AUD: 0,
+					CAD: 0,
+				},
+				charges: {
+					GuardianPatron: { id: 'guardian_patron' },
+				},
+				billingPeriod: 'Month',
+			},
+		},
+	},
+};
+
+export const stripeTypeObject = {
+	GuardianPatron: {
+		currencies: ['NZD', 'CAD', 'AUD', 'USD', 'GBP', 'EUR'],
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			GuardianPatron: {
+				GuardianPatron: {},
+			},
+		},
+	},
+};

--- a/modules/product-catalog/src/stripeProducts.ts
+++ b/modules/product-catalog/src/stripeProducts.ts
@@ -1,25 +1,38 @@
-export const stripeProducts = {
-	GuardianPatron: {
-		billingSystem: 'stripe',
-		ratePlans: {
-			GuardianPatron: {
-				id: 'guardian_patron',
-				pricing: {
-					GBP: 0,
-					USD: 0,
-					NZD: 0,
-					EUR: 0,
-					AUD: 0,
-					CAD: 0,
+// This file defines the products we have which only exist in Stripe, this is currently only
+// the Guardian Patron product although this may change in the future. This file is combined
+// with the Zuora products to create a full product catalog.
+import type {
+	Product,
+	ProductKey,
+} from '@modules/product-catalog/productCatalog';
+
+export const stripeProducts: Partial<Record<ProductKey, Product<ProductKey>>> =
+	{
+		GuardianPatron: {
+			billingSystem: 'stripe',
+			active: true,
+			ratePlans: {
+				GuardianPatron: {
+					id: 'guardian_patron',
+					// Pricing on Patrons is complicated and we don't use the product catalog
+					// to manage it so leave this as 0 for now
+					pricing: {
+						GBP: 0,
+						USD: 0,
+						NZD: 0,
+						EUR: 0,
+						AUD: 0,
+						CAD: 0,
+					},
+					// Stripe doesn't have charges in the same way as Zuora
+					charges: {
+						Subscription: { id: 'guardian_patron' },
+					},
+					billingPeriod: 'Month',
 				},
-				charges: {
-					GuardianPatron: { id: 'guardian_patron' },
-				},
-				billingPeriod: 'Month',
 			},
 		},
-	},
-};
+	};
 
 export const stripeTypeObject = {
 	GuardianPatron: {
@@ -27,7 +40,7 @@ export const stripeTypeObject = {
 		billingPeriods: ['Month'],
 		productRatePlans: {
 			GuardianPatron: {
-				GuardianPatron: {},
+				Subscription: {},
 			},
 		},
 	},

--- a/modules/product-catalog/src/stripeProducts.ts
+++ b/modules/product-catalog/src/stripeProducts.ts
@@ -36,7 +36,6 @@ export const stripeProducts: Partial<Record<ProductKey, Product<ProductKey>>> =
 
 export const stripeTypeObject = {
 	GuardianPatron: {
-		currencies: ['NZD', 'CAD', 'AUD', 'USD', 'GBP', 'EUR'],
 		billingPeriods: ['Month'],
 		productRatePlans: {
 			GuardianPatron: {

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -3,7 +3,7 @@ export const typeObject = {
 		billingPeriods: ['Month'],
 		productRatePlans: {
 			Monthly: {
-				GuardianLight: {},
+				Subscription: {},
 			},
 		},
 	},
@@ -88,6 +88,29 @@ export const typeObject = {
 				Friday: {},
 				Saturday: {},
 				Sunday: {},
+			},
+		},
+	},
+	SupporterMembership: {
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			Annual: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+			},
+			V2DeprecatedAnnual: {
+				Subscription: {},
+			},
+			V1DeprecatedAnnual: {
+				Subscription: {},
+			},
+			V1DeprecatedMonthly: {
+				Subscription: {},
+			},
+			V2DeprecatedMonthly: {
+				Subscription: {},
 			},
 		},
 	},
@@ -222,6 +245,49 @@ export const typeObject = {
 			},
 			Saturday: {
 				Saturday: {},
+			},
+		},
+	},
+	PatronMembership: {
+		billingPeriods: ['Month', 'Annual'],
+		productRatePlans: {
+			Monthly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			V1DeprecatedAnnual: {
+				Subscription: {},
+			},
+			V1DeprecatedMonthly: {
+				Subscription: {},
+			},
+		},
+	},
+	PartnerMembership: {
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			V1DeprecatedAnnual: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			V1DeprecatedMonthly: {
+				Subscription: {},
+			},
+		},
+	},
+	GuardianPatron: {
+		currencies: ['NZD', 'CAD', 'AUD', 'USD', 'GBP', 'EUR'],
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			GuardianPatron: {
+				Subscription: {},
 			},
 		},
 	},

--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -129,7 +129,7 @@ const zuoraCatalogToProductRatePlanChargeKey: Record<string, string> = {
 	'Supporter Plus': 'SupporterPlus',
 	'Guardian Weekly': 'GuardianWeekly',
 	'Newspaper Archive': 'NewspaperArchive',
-	'Guardian Light': 'GuardianLight',
+	'Guardian Light': 'Subscription',
 	'Supporter Membership - Annual': 'Subscription',
 	'Supporter Membership - Monthly': 'Subscription',
 	'Partner Membership - Monthly': 'Subscription',

--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -86,6 +86,7 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	'Non Founder Partner - annual': 'Annual',
 	'Partner - annual': 'V1DeprecatedAnnual',
 	'Partner - monthly': 'V1DeprecatedMonthly',
+	'Partner - monthly (Events)': 'V1DeprecatedMonthly',
 	'Non Founder Patron - monthly': 'Monthly',
 	'Non Founder Patron - annual': 'Annual',
 	'Non Founder Patron Membership - Annual': 'Annual',

--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -11,7 +11,23 @@ const zuoraCatalogToProductKey: Record<string, string> = {
 	'Newspaper Delivery': 'HomeDelivery',
 	'Tier Three': 'TierThree',
 	'Guardian Light': 'GuardianLight',
+	Supporter: 'SupporterMembership',
+	Partner: 'PartnerMembership',
+	Patron: 'PatronMembership',
 } as const;
+
+export const activeProducts = [
+	'SupporterPlus',
+	'DigitalSubscription',
+	'TierThree',
+	'GuardianLight',
+	'GuardianWeeklyRestOfWorld',
+	'GuardianWeeklyDomestic',
+	'HomeDelivery',
+	'NationalDelivery',
+	'SubscriptionCard',
+	'Contribution',
+];
 
 const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	'Digital Pack Monthly': 'Monthly',
@@ -60,6 +76,21 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	Weekend: 'Weekend',
 	Sixday: 'Sixday',
 	'Guardian Light Monthly': 'Monthly',
+	'Supporter - monthly': 'V1DeprecatedMonthly',
+	'Supporter - annual': 'V1DeprecatedAnnual',
+	'Non Founder Supporter - monthly': 'V2DeprecatedMonthly',
+	'Non Founder Supporter - annual': 'V2DeprecatedAnnual',
+	'Supporter - annual (2023 Price)': 'Annual',
+	'Supporter - monthly (2023 Price)': 'Monthly',
+	'Non Founder Partner - monthly': 'Monthly',
+	'Non Founder Partner - annual': 'Annual',
+	'Partner - annual': 'V1DeprecatedAnnual',
+	'Partner - monthly': 'V1DeprecatedMonthly',
+	'Non Founder Patron - monthly': 'Monthly',
+	'Non Founder Patron - annual': 'Annual',
+	'Non Founder Patron Membership - Annual': 'Annual',
+	'Patron - annual': 'V1DeprecatedAnnual',
+	'Patron - monthly': 'V1DeprecatedMonthly',
 } as const;
 
 const zuoraCatalogToProductRatePlanChargeKey: Record<string, string> = {
@@ -99,6 +130,14 @@ const zuoraCatalogToProductRatePlanChargeKey: Record<string, string> = {
 	'Guardian Weekly': 'GuardianWeekly',
 	'Newspaper Archive': 'NewspaperArchive',
 	'Guardian Light': 'GuardianLight',
+	'Supporter Membership - Annual': 'Subscription',
+	'Supporter Membership - Monthly': 'Subscription',
+	'Partner Membership - Monthly': 'Subscription',
+	'Partner Membership - Annual': 'Subscription',
+	'Patron Membership - Monthly': 'Subscription',
+	'Patron Membership - Annual': 'Subscription',
+	'Non Founder Patron Membership - Annual': 'Subscription',
+	'Non Founder Patron Membership - Monthly': 'Subscription',
 } as const;
 export const getZuoraProductKey = (product: string): string => {
 	return getIfDefined(

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Generated product catalog matches snapshot 1`] = `
 {
   "Contribution": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -41,6 +42,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "DigitalSubscription": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -111,6 +113,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "GuardianLight": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Monthly": {
         "billingPeriod": "Month",
@@ -126,7 +129,30 @@ exports[`Generated product catalog matches snapshot 1`] = `
       },
     },
   },
+  "GuardianPatron": {
+    "billingSystem": "stripe",
+    "ratePlans": {
+      "GuardianPatron": {
+        "billingPeriod": "Month",
+        "charges": {
+          "GuardianPatron": {
+            "id": "guardian_patron",
+          },
+        },
+        "id": "guardian_patron",
+        "pricing": {
+          "AUD": 0,
+          "CAD": 0,
+          "EUR": 0,
+          "GBP": 0,
+          "NZD": 0,
+          "USD": 0,
+        },
+      },
+    },
+  },
   "GuardianWeeklyDomestic": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -216,6 +242,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "GuardianWeeklyRestOfWorld": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -301,6 +328,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "HomeDelivery": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -401,6 +429,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "NationalDelivery": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -477,6 +506,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "SubscriptionCard": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -577,6 +607,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "SupporterPlus": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -655,6 +686,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "TierThree": {
+    "billingSystem": "zuora",
     "ratePlans": {
       "DomesticAnnual": {
         "billingPeriod": "Annual",
@@ -861,6 +893,24 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "productRatePlans": {
       "Monthly": {
         "GuardianLight": {},
+      },
+    },
+  },
+  "GuardianPatron": {
+    "billingPeriods": [
+      "Month",
+    ],
+    "currencies": [
+      "NZD",
+      "CAD",
+      "AUD",
+      "USD",
+      "GBP",
+      "EUR",
+    ],
+    "productRatePlans": {
+      "GuardianPatron": {
+        "GuardianPatron": {},
       },
     },
   },

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -121,7 +121,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
       "Monthly": {
         "billingPeriod": "Month",
         "charges": {
-          "GuardianLight": {
+          "Subscription": {
             "id": "8a129b7892c35f170192dd3225572b97",
           },
         },
@@ -133,12 +133,13 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "GuardianPatron": {
+    "active": true,
     "billingSystem": "stripe",
     "ratePlans": {
       "GuardianPatron": {
         "billingPeriod": "Month",
         "charges": {
-          "GuardianPatron": {
+          "Subscription": {
             "id": "guardian_patron",
           },
         },
@@ -1104,7 +1105,7 @@ exports[`Generated product catalog types match snapshot 1`] = `
     ],
     "productRatePlans": {
       "Monthly": {
-        "GuardianLight": {},
+        "Subscription": {},
       },
     },
   },
@@ -1122,7 +1123,7 @@ exports[`Generated product catalog types match snapshot 1`] = `
     ],
     "productRatePlans": {
       "GuardianPatron": {
-        "GuardianPatron": {},
+        "Subscription": {},
       },
     },
   },

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -1113,14 +1113,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "billingPeriods": [
       "Month",
     ],
-    "currencies": [
-      "NZD",
-      "CAD",
-      "AUD",
-      "USD",
-      "GBP",
-      "EUR",
-    ],
     "productRatePlans": {
       "GuardianPatron": {
         "Subscription": {},
@@ -1242,9 +1234,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
       "Annual",
       "Month",
     ],
-    "currencies": [
-      "GBP",
-    ],
     "productRatePlans": {
       "Annual": {
         "Subscription": {},
@@ -1264,9 +1253,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "billingPeriods": [
       "Month",
       "Annual",
-    ],
-    "currencies": [
-      "GBP",
     ],
     "productRatePlans": {
       "Annual": {
@@ -1321,13 +1307,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "billingPeriods": [
       "Annual",
       "Month",
-    ],
-    "currencies": [
-      "CAD",
-      "AUD",
-      "EUR",
-      "GBP",
-      "USD",
     ],
     "productRatePlans": {
       "Annual": {

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Generated product catalog matches snapshot 1`] = `
 {
   "Contribution": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
@@ -42,6 +43,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "DigitalSubscription": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
@@ -113,6 +115,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "GuardianLight": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Monthly": {
@@ -152,6 +155,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "GuardianWeeklyDomestic": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
@@ -242,6 +246,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "GuardianWeeklyRestOfWorld": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
@@ -328,6 +333,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "HomeDelivery": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Everyday": {
@@ -429,6 +435,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "NationalDelivery": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Everyday": {
@@ -505,7 +512,116 @@ exports[`Generated product catalog matches snapshot 1`] = `
       },
     },
   },
+  "PartnerMembership": {
+    "active": false,
+    "billingSystem": "zuora",
+    "ratePlans": {
+      "Annual": {
+        "billingPeriod": "Annual",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0f94c54758b014c69f813d939ee",
+          },
+        },
+        "id": "2c92a0f94c54758b014c69f813bd39ec",
+        "pricing": {
+          "GBP": 149,
+        },
+      },
+      "Monthly": {
+        "billingPeriod": "Month",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb4c5481dc014c69f95ff07243",
+          },
+        },
+        "id": "2c92a0fb4c5481dc014c69f95fce7240",
+        "pricing": {
+          "GBP": 15,
+        },
+      },
+      "V1DeprecatedAnnual": {
+        "billingPeriod": "Annual",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb479fbd5d0147d01563184625",
+          },
+        },
+        "id": "2c92a0f9479fb46d0147d0155cb15596",
+        "pricing": {
+          "GBP": 135,
+        },
+      },
+      "V1DeprecatedMonthly": {
+        "billingPeriod": "Month",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb479fbd5d0147d01562c9461a",
+          },
+        },
+        "id": "2c92a0f9479fb46d0147d0155ca15595",
+        "pricing": {
+          "GBP": 15,
+        },
+      },
+    },
+  },
+  "PatronMembership": {
+    "active": false,
+    "billingSystem": "zuora",
+    "ratePlans": {
+      "Annual": {
+        "billingPeriod": "Annual",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0f94c547592014c69fb0e70757a",
+          },
+        },
+        "id": "2c92a0f94c547592014c69fb0c4274fc",
+        "pricing": {
+          "GBP": 599,
+        },
+      },
+      "Monthly": {
+        "billingPeriod": "Month",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb4c5481db014c69fb92b47065",
+          },
+        },
+        "id": "2c92a0fb4c5481db014c69fb9118704b",
+        "pricing": {
+          "GBP": 60,
+        },
+      },
+      "V1DeprecatedAnnual": {
+        "billingPeriod": "Annual",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb479fbd5d0147d015609245da",
+          },
+        },
+        "id": "2c92a0f9479fb46d0147d0155c245581",
+        "pricing": {
+          "GBP": 540,
+        },
+      },
+      "V1DeprecatedMonthly": {
+        "billingPeriod": "Month",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb479fbd5d0147d015602b45d3",
+          },
+        },
+        "id": "2c92a0f9479fb46d0147d0155bf9557a",
+        "pricing": {
+          "GBP": 60,
+        },
+      },
+    },
+  },
   "SubscriptionCard": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Everyday": {
@@ -606,7 +722,102 @@ exports[`Generated product catalog matches snapshot 1`] = `
       },
     },
   },
+  "SupporterMembership": {
+    "active": false,
+    "billingSystem": "zuora",
+    "ratePlans": {
+      "Annual": {
+        "billingPeriod": "Annual",
+        "charges": {
+          "Subscription": {
+            "id": "8a129ce886834fa90186a20c3f4f0b6c",
+          },
+        },
+        "id": "8a129ce886834fa90186a20c3ee70b6a",
+        "pricing": {
+          "AUD": 160,
+          "CAD": 120,
+          "EUR": 95,
+          "GBP": 75,
+          "USD": 120,
+        },
+      },
+      "Monthly": {
+        "billingPeriod": "Month",
+        "charges": {
+          "Subscription": {
+            "id": "8a12800986832d1d0186a20bf5136471",
+          },
+        },
+        "id": "8a1287c586832d250186a2040b1548fe",
+        "pricing": {
+          "AUD": 14.99,
+          "CAD": 12.99,
+          "EUR": 9.99,
+          "GBP": 7,
+          "USD": 9.99,
+        },
+      },
+      "V1DeprecatedAnnual": {
+        "billingPeriod": "Annual",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb4bb97034014bbbc5626f4ff9",
+          },
+        },
+        "id": "2c92a0fb4bb97034014bbbc562604ff7",
+        "pricing": {
+          "GBP": 50,
+        },
+      },
+      "V1DeprecatedMonthly": {
+        "billingPeriod": "Month",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb4bb97034014bbbc562274ff1",
+          },
+        },
+        "id": "2c92a0fb4bb97034014bbbc562114fef",
+        "pricing": {
+          "GBP": 5,
+        },
+      },
+      "V2DeprecatedAnnual": {
+        "billingPeriod": "Annual",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0fb4c5481db014c69f4a2013bbf",
+          },
+        },
+        "id": "2c92a0fb4c5481db014c69f4a1e03bbd",
+        "pricing": {
+          "AUD": 100,
+          "CAD": 69,
+          "EUR": 49,
+          "GBP": 49,
+          "USD": 69,
+        },
+      },
+      "V2DeprecatedMonthly": {
+        "billingPeriod": "Month",
+        "charges": {
+          "Subscription": {
+            "id": "2c92a0f94c547592014c69f5b1204f80",
+          },
+        },
+        "id": "2c92a0f94c547592014c69f5b0ff4f7e",
+        "pricing": {
+          "AUD": 10,
+          "CAD": 6.99,
+          "EUR": 4.99,
+          "GBP": 5,
+          "USD": 6.99,
+        },
+      },
+    },
+  },
   "SupporterPlus": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "Annual": {
@@ -686,6 +897,7 @@ exports[`Generated product catalog matches snapshot 1`] = `
     },
   },
   "TierThree": {
+    "active": true,
     "billingSystem": "zuora",
     "ratePlans": {
       "DomesticAnnual": {
@@ -1024,6 +1236,52 @@ exports[`Generated product catalog types match snapshot 1`] = `
       },
     },
   },
+  "PartnerMembership": {
+    "billingPeriods": [
+      "Annual",
+      "Month",
+    ],
+    "currencies": [
+      "GBP",
+    ],
+    "productRatePlans": {
+      "Annual": {
+        "Subscription": {},
+      },
+      "Monthly": {
+        "Subscription": {},
+      },
+      "V1DeprecatedAnnual": {
+        "Subscription": {},
+      },
+      "V1DeprecatedMonthly": {
+        "Subscription": {},
+      },
+    },
+  },
+  "PatronMembership": {
+    "billingPeriods": [
+      "Month",
+      "Annual",
+    ],
+    "currencies": [
+      "GBP",
+    ],
+    "productRatePlans": {
+      "Annual": {
+        "Subscription": {},
+      },
+      "Monthly": {
+        "Subscription": {},
+      },
+      "V1DeprecatedAnnual": {
+        "Subscription": {},
+      },
+      "V1DeprecatedMonthly": {
+        "Subscription": {},
+      },
+    },
+  },
   "SubscriptionCard": {
     "billingPeriods": [
       "Month",
@@ -1055,6 +1313,39 @@ exports[`Generated product catalog types match snapshot 1`] = `
       "Weekend": {
         "Saturday": {},
         "Sunday": {},
+      },
+    },
+  },
+  "SupporterMembership": {
+    "billingPeriods": [
+      "Annual",
+      "Month",
+    ],
+    "currencies": [
+      "CAD",
+      "AUD",
+      "EUR",
+      "GBP",
+      "USD",
+    ],
+    "productRatePlans": {
+      "Annual": {
+        "Subscription": {},
+      },
+      "Monthly": {
+        "Subscription": {},
+      },
+      "V1DeprecatedAnnual": {
+        "Subscription": {},
+      },
+      "V1DeprecatedMonthly": {
+        "Subscription": {},
+      },
+      "V2DeprecatedAnnual": {
+        "Subscription": {},
+      },
+      "V2DeprecatedMonthly": {
+        "Subscription": {},
       },
     },
   },

--- a/modules/product-catalog/test/generateProductCatalog.test.ts
+++ b/modules/product-catalog/test/generateProductCatalog.test.ts
@@ -6,6 +6,7 @@ import prod from '../../zuora-catalog/test/fixtures/catalog-prod.json';
 test('Generated product catalog matches snapshot', () => {
 	const prodZuoraCatalog = zuoraCatalogSchema.parse(prod);
 	const prodProductCatalog = generateProductCatalog(prodZuoraCatalog);
+	console.log(JSON.stringify(prodProductCatalog));
 	expect(prodProductCatalog).toMatchSnapshot();
 });
 

--- a/modules/product-catalog/test/productCatalogMapping.test.ts
+++ b/modules/product-catalog/test/productCatalogMapping.test.ts
@@ -70,7 +70,7 @@ test('All zuora products exist in the zuora catalog', () => {
 	zuoraProductExistsInCatalog('PROD');
 });
 
-test('All product rate plan ids are unique', () => {
+test('All Zuora product rate plan ids are unique', () => {
 	const allProducts = codeCatalogHelper
 		.getAllProductDetailsForBillingSystem('zuora')
 		.concat(prodCatalogHelper.getAllProductDetailsForBillingSystem('zuora'));

--- a/modules/product-catalog/test/productCatalogMapping.test.ts
+++ b/modules/product-catalog/test/productCatalogMapping.test.ts
@@ -32,6 +32,7 @@ test('We can find product details from a productRatePlanId', () => {
 	const productRatePlanId = '2c92c0f84bbfec8b014bc655f4852d9d';
 	expect(codeCatalogHelper.findProductDetails(productRatePlanId)).toStrictEqual(
 		{
+			billingSystem: 'zuora',
 			zuoraProduct: 'DigitalSubscription',
 			productRatePlan: 'Monthly',
 			id: productRatePlanId,
@@ -39,26 +40,40 @@ test('We can find product details from a productRatePlanId', () => {
 	);
 });
 
-const productExistsInCatalog = (stage: Stage) => {
+test('We can find product details for a Guardian Patron', () => {
+	const productRatePlanId = 'guardian_patron';
+	expect(codeCatalogHelper.findProductDetails(productRatePlanId)).toStrictEqual(
+		{
+			billingSystem: 'stripe',
+			zuoraProduct: 'GuardianPatron',
+			productRatePlan: 'GuardianPatron',
+			id: productRatePlanId,
+		},
+	);
+});
+
+const zuoraProductExistsInCatalog = (stage: Stage) => {
 	const [zuoraCatalog, productCatalog] =
 		stage === 'CODE'
 			? [new ZuoraCatalogHelper(codeZuoraCatalog), codeCatalogHelper]
 			: [new ZuoraCatalogHelper(prodZuoraCatalog), prodCatalogHelper];
-	const allProductDetails = productCatalog.getAllProductDetails();
+	const allProductDetails =
+		productCatalog.getAllProductDetailsForBillingSystem('zuora');
+
 	allProductDetails.forEach((productDetails) => {
 		expect(zuoraCatalog.getCatalogPlan(productDetails.id)).toBeDefined();
 	});
 };
 
-test('All valid products exist in the catalog', () => {
-	productExistsInCatalog('CODE');
-	productExistsInCatalog('PROD');
+test('All zuora products exist in the zuora catalog', () => {
+	zuoraProductExistsInCatalog('CODE');
+	zuoraProductExistsInCatalog('PROD');
 });
 
 test('All product rate plan ids are unique', () => {
 	const allProducts = codeCatalogHelper
-		.getAllProductDetails()
-		.concat(prodCatalogHelper.getAllProductDetails());
+		.getAllProductDetailsForBillingSystem('zuora')
+		.concat(prodCatalogHelper.getAllProductDetailsForBillingSystem('zuora'));
 	const productRatePlanIds = allProducts
 		.map((product) => {
 			return product.id;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds some products to the product catalog
### The membership products:
- Supporter Membership
- Partner Membership
- Patron Membership
These are no longer sold but we still have active subscriptions to them. To reflect this a new `active` boolean has been added to the product object in the catalog which flags whether a product is still on sale or not.

### Guardian Patrons:
This is a product which does not exist in Zuora, it is billed through Stripe. This is a bit more of a complex change as it means integrating another billing system into the code which generates the product catalog. 
To keep track of which product is billed in which system there is a new flag `billingSystem` on the product object in the product catalog.
