### PR TITLE
Press reader error handling

### DIFF
--- a/_templates/new-lambda/api-gateway/cdk-lib.ejs.t
+++ b/_templates/new-lambda/api-gateway/cdk-lib.ejs.t
@@ -77,7 +77,7 @@ export class <%= PascalCase %> extends GuStack {
 	<% if (includeApiKey === 'Y'){ %>
 		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {
 			name: nameWithStage,
-			description: 'REST endpoints for <%= lambdaName %>>',
+			description: 'REST endpoints for <%= lambdaName %>',
 			apiStages: [
 				{
 					stage: lambda.api.deploymentStage,
@@ -97,7 +97,7 @@ export class <%= PascalCase %> extends GuStack {
 
 		// ---- Alarms ---- //
 		const alarmName = (shortDescription: string) =>
-			`<%= h.changeCase.kebabCase(lambdaName).toUpperCase() %>-${this.stage} ${shortDescription}`;
+			`<%= lambdaName %>-${this.stage} ${shortDescription}`;
 
 		const alarmDescription = (description: string) =>
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;

--- a/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
+++ b/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
@@ -70,7 +70,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Impact - Press reader entitlements received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "PRESS-READER-ENTITLEMENTS-CODE API gateway 4XX response",
+        "AlarmName": "press-reader-entitlements-CODE API gateway 4XX response",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -83,7 +83,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
         "Namespace": "AWS/ApiGateway",
         "Period": 300,
         "Statistic": "Sum",
-        "Threshold": 1,
+        "Threshold": 10,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -771,7 +771,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
             "Throttle": {},
           },
         ],
-        "Description": "REST endpoints for press-reader-entitlements>",
+        "Description": "REST endpoints for press-reader-entitlements",
         "Tags": [
           {
             "Key": "App",
@@ -1057,7 +1057,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
         ],
         "AlarmDescription": "Impact - Press reader entitlements received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "PRESS-READER-ENTITLEMENTS-PROD API gateway 4XX response",
+        "AlarmName": "press-reader-entitlements-PROD API gateway 4XX response",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1070,7 +1070,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
         "Namespace": "AWS/ApiGateway",
         "Period": 300,
         "Statistic": "Sum",
-        "Threshold": 1,
+        "Threshold": 10,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -1758,7 +1758,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
             "Throttle": {},
           },
         ],
-        "Description": "REST endpoints for press-reader-entitlements>",
+        "Description": "REST endpoints for press-reader-entitlements",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/press-reader-entitlements.ts
+++ b/cdk/lib/press-reader-entitlements.ts
@@ -79,7 +79,7 @@ export class PressReaderEntitlements extends GuStack {
 
 		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {
 			name: nameWithStage,
-			description: 'REST endpoints for press-reader-entitlements>',
+			description: 'REST endpoints for press-reader-entitlements',
 			apiStages: [
 				{
 					stage: lambda.api.deploymentStage,
@@ -98,7 +98,7 @@ export class PressReaderEntitlements extends GuStack {
 
 		// ---- Alarms ---- //
 		const alarmName = (shortDescription: string) =>
-			`PRESS-READER-ENTITLEMENTS-${this.stage} ${shortDescription}`;
+			`press-reader-entitlements-${this.stage} ${shortDescription}`;
 
 		const alarmDescription = (description: string) =>
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
@@ -110,7 +110,7 @@ export class PressReaderEntitlements extends GuStack {
 				'Press reader entitlements received an invalid request',
 			),
 			evaluationPeriods: 1,
-			threshold: 1,
+			threshold: 10,
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 			actionsEnabled: this.stage === 'PROD',
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,

--- a/handlers/press-reader-entitlements/src/identity.ts
+++ b/handlers/press-reader-entitlements/src/identity.ts
@@ -1,5 +1,6 @@
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { awsConfig } from '@modules/aws/config';
+import { ValidationError } from '@modules/errors';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import type { Stage } from '@modules/stage';
 import { getIdentityIdSchema } from './schemas';
@@ -34,6 +35,11 @@ export async function getIdentityId(
 		},
 		method: 'GET',
 	});
+
+	if (response.status == 404) {
+		throw new ValidationError(`UserId ${userId} does not exist`);
+	}
+
 	const json = await response.json();
 	console.log(`Identity returned ${JSON.stringify(json)}`);
 

--- a/handlers/press-reader-entitlements/src/index.ts
+++ b/handlers/press-reader-entitlements/src/index.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from '@modules/errors';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
@@ -40,7 +41,13 @@ export const handler: Handler = async (
 		};
 	} catch (error) {
 		console.log('Caught exception with message: ', error);
-
+		if (error instanceof ValidationError) {
+			console.log(`Validation failure: ${error.message}`);
+			return {
+				body: error.message,
+				statusCode: 400,
+			};
+		}
 		return {
 			body: 'Internal server error',
 			statusCode: 500,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Currently we are returning a 500 if the press reader API is called with a user id which does not exist. This is a user error rather than an application error so we should return a 400 response.

We are also alarming on every 400 response, which is not necessary. This PR increases the threshold for triggering that alarm.

Finally it tidies up a few formatting issues in one of the hygen templates