### PR TITLE
Get all product currencies in type object

### DIFF
--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -6,7 +6,7 @@ import type {
 	ProductCatalog,
 	ProductCurrency,
 } from '@modules/product-catalog/productCatalog';
-import { isValidProductCurrency } from '@modules/product-catalog/productCatalog';
+import { isProductCurrency } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import type {
 	RatePlan,
@@ -121,7 +121,7 @@ const getCurrency = (
 		'No currency found on the rate plan charge',
 	);
 
-	if (isValidProductCurrency('SupporterPlus', currency)) {
+	if (isProductCurrency('SupporterPlus', currency)) {
 		return currency;
 	}
 	throw new Error(`Unsupported currency ${currency}`);

--- a/modules/product-catalog/package.json
+++ b/modules/product-catalog/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "generateTypes": "ts-node src/generateTypeObjectCommand.ts",
     "updateSnapshots": "jest -u --group=-integration",
+    "build": "tsc",
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
     "check-formatting": "prettier --check **.ts",

--- a/modules/product-catalog/src/generateTypeObject.ts
+++ b/modules/product-catalog/src/generateTypeObject.ts
@@ -1,5 +1,4 @@
 import { arrayToObject, distinct } from '@modules/arrayFunctions';
-import { getIfDefined } from '@modules/nullAndUndefined';
 import type {
 	ZuoraCatalog,
 	ZuoraProductRatePlan,
@@ -27,12 +26,14 @@ const getProductRatePlanCharges = (
 		}),
 	);
 };
-const getCurrenciesForProduct = (productRatePlan: ZuoraProductRatePlan) =>
+const getCurrenciesForProduct = (productRatePlans: ZuoraProductRatePlan[]) =>
 	distinct(
-		productRatePlan.productRatePlanCharges.flatMap((charge) =>
-			charge.pricing.map((price) => price.currency),
-		),
+		productRatePlans
+			.flatMap((prp) => prp.productRatePlanCharges)
+			.flatMap((charge) => charge.pricing)
+			.map((price) => price.currency),
 	);
+
 const getBillingPeriodsForProduct = (
 	productRatePlans: ZuoraProductRatePlan[],
 ) =>
@@ -49,12 +50,7 @@ const getBillingPeriodsForProduct = (
 			) as string[],
 	);
 const getZuoraProduct = (productRatePlans: ZuoraProductRatePlan[]) => {
-	const currencies = getCurrenciesForProduct(
-		getIfDefined(
-			productRatePlans[0],
-			'Undefined productRatePlan in getZuoraProductObjects',
-		),
-	);
+	const currencies = getCurrenciesForProduct(productRatePlans);
 	const billingPeriods = getBillingPeriodsForProduct(productRatePlans);
 	return {
 		currencies,

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -12,8 +12,10 @@ type ProductRatePlanChargeKey<
 	PRP extends ProductRatePlanKey<P>,
 > = keyof TypeObject[P]['productRatePlans'][PRP];
 
-export type ProductCurrency<P extends ProductKey> =
-	TypeObject[P]['currencies'][number];
+export type ProductCurrency<
+	P extends ProductKey,
+	PRP extends ProductRatePlanKey<P>,
+> = TypeObject[P]['currencies'][number];
 
 export const isProductCurrency = <P extends ProductKey>(
 	product: P,

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -66,13 +66,6 @@ export type ProductCatalog = {
 	[P in ProductKey]: Product<P>;
 };
 
-export const isValidProductCurrency = <P extends ProductKey>(
-	product: P,
-	maybeCurrency: string,
-): maybeCurrency is ProductCurrency<P> => {
-	return !!typeObject[product].currencies.find((c) => c === maybeCurrency);
-};
-
 export const getCurrencyGlyph = (currency: string) => {
 	switch (currency) {
 		case 'GBP':

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -1,14 +1,24 @@
 import { z } from 'zod';
 import { typeObject } from '@modules/product-catalog/typeObject';
 
+const pricingGBPOnly = z.object({
+	GBP: z.number(),
+});
+const pricingAllCurrencies = z.object({
+	GBP: z.number(),
+	USD: z.number().optional(),
+	NZD: z.number().optional(),
+	EUR: z.number().optional(),
+	CAD: z.number().optional(),
+	AUD: z.number().optional(),
+});
+
 export const productCatalogSchema = z.object({
 	GuardianLight: z.object({
 		ratePlans: z.object({
 			Monthly: z.object({
 				id: z.string(),
-				pricing: z.object({
-					GBP: z.number(),
-				}),
+				pricing: pricingGBPOnly,
 				charges: z.object({ GuardianLight: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.GuardianLight.billingPeriods)
@@ -20,14 +30,7 @@ export const productCatalogSchema = z.object({
 		ratePlans: z.object({
 			Annual: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.DigitalSubscription.billingPeriods)
@@ -35,14 +38,7 @@ export const productCatalogSchema = z.object({
 			}),
 			ThreeMonthGift: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.DigitalSubscription.billingPeriods)
@@ -50,14 +46,7 @@ export const productCatalogSchema = z.object({
 			}),
 			OneYearGift: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.DigitalSubscription.billingPeriods)
@@ -65,14 +54,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Monthly: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.DigitalSubscription.billingPeriods)
@@ -84,7 +66,7 @@ export const productCatalogSchema = z.object({
 		ratePlans: z.object({
 			Everyday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Saturday: z.object({ id: z.string() }),
 					Monday: z.object({ id: z.string() }),
@@ -100,7 +82,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Sixday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Friday: z.object({ id: z.string() }),
 					Thursday: z.object({ id: z.string() }),
@@ -115,7 +97,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Weekend: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Saturday: z.object({ id: z.string() }),
 					Sunday: z.object({ id: z.string() }),
@@ -126,7 +108,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Saturday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({ Saturday: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.HomeDelivery.billingPeriods)
@@ -134,7 +116,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Sunday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({ Sunday: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.HomeDelivery.billingPeriods)
@@ -146,7 +128,7 @@ export const productCatalogSchema = z.object({
 		ratePlans: z.object({
 			Everyday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Monday: z.object({ id: z.string() }),
 					Tuesday: z.object({ id: z.string() }),
@@ -162,7 +144,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Weekend: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Saturday: z.object({ id: z.string() }),
 					Sunday: z.object({ id: z.string() }),
@@ -173,7 +155,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Sixday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Thursday: z.object({ id: z.string() }),
 					Monday: z.object({ id: z.string() }),
@@ -446,14 +428,7 @@ export const productCatalogSchema = z.object({
 		ratePlans: z.object({
 			ThreeMonthGift: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
@@ -461,14 +436,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Quarterly: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
@@ -476,14 +444,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Annual: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
@@ -491,14 +452,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Monthly: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.GuardianWeeklyDomestic.billingPeriods)
@@ -525,7 +479,7 @@ export const productCatalogSchema = z.object({
 		ratePlans: z.object({
 			Everyday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Monday: z.object({ id: z.string() }),
 					Friday: z.object({ id: z.string() }),
@@ -541,7 +495,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Weekend: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Saturday: z.object({ id: z.string() }),
 					Sunday: z.object({ id: z.string() }),
@@ -552,7 +506,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Sixday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({
 					Thursday: z.object({ id: z.string() }),
 					Friday: z.object({ id: z.string() }),
@@ -567,7 +521,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Sunday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({ Sunday: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.SubscriptionCard.billingPeriods)
@@ -575,7 +529,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Saturday: z.object({
 				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
+				pricing: pricingGBPOnly,
 				charges: z.object({ Saturday: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.SubscriptionCard.billingPeriods)
@@ -587,14 +541,7 @@ export const productCatalogSchema = z.object({
 		ratePlans: z.object({
 			Annual: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Contribution: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.Contribution.billingPeriods)
@@ -602,14 +549,7 @@ export const productCatalogSchema = z.object({
 			}),
 			Monthly: z.object({
 				id: z.string(),
-				pricing: z.object({
-					USD: z.number(),
-					NZD: z.number(),
-					EUR: z.number(),
-					GBP: z.number(),
-					CAD: z.number(),
-					AUD: z.number(),
-				}),
+				pricing: pricingAllCurrencies,
 				charges: z.object({ Contribution: z.object({ id: z.string() }) }),
 				billingPeriod: z
 					.enum(typeObject.Contribution.billingPeriods)

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -9,7 +9,7 @@ export const typeObject = {
 		},
 	},
 	TierThree: {
-		currencies: ['GBP', 'USD'],
+		currencies: ['GBP', 'USD', 'CAD', 'NZD', 'EUR', 'AUD'],
 		billingPeriods: ['Annual', 'Month'],
 		productRatePlans: {
 			RestOfWorldAnnualV2: {
@@ -116,7 +116,7 @@ export const typeObject = {
 		},
 	},
 	GuardianWeeklyRestOfWorld: {
-		currencies: ['GBP', 'USD'],
+		currencies: ['GBP', 'USD', 'NZD', 'EUR', 'CAD', 'AUD'],
 		billingPeriods: ['Month', 'Annual', 'Quarter'],
 		productRatePlans: {
 			Monthly: {

--- a/modules/product-catalog/src/typeObjectTest.ts
+++ b/modules/product-catalog/src/typeObjectTest.ts
@@ -1,0 +1,36 @@
+export const typeObject = {
+	GuardianLight: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Monthly: {
+				currencies: { GBP: {} },
+				charges: {
+					GuardianLight: {},
+				},
+			},
+		},
+	},
+} as const;
+
+type TypeObject = typeof typeObject;
+
+export type ProductKey = keyof TypeObject;
+
+export type ProductRatePlanKey<P extends ProductKey> =
+	keyof TypeObject[P]['productRatePlans'];
+
+export type ProductRatePlanChargeKey<
+	P extends ProductKey,
+	PRP extends ProductRatePlanKey<P>,
+> = keyof TypeObject[P]['productRatePlans'][PRP]['charges'];
+
+export type ProductCurrency<
+	P extends ProductKey,
+	PRP extends ProductRatePlanKey<P>,
+> = keyof TypeObject[P]['productRatePlans'][PRP]['currencies'];
+
+const blah: ProductRatePlanChargeKey<'GuardianLight', 'Monthly'> = 'currencies';
+// export type ProductCurrency<
+// 	P extends ProductKey,
+// 	PRP extends ProductRatePlanKey<P>,
+// > = keyof NonNullable<TypeObject[P]['productRatePlans'][PRP]['currencies']>;

--- a/modules/product-catalog/src/typeObjectTest.ts
+++ b/modules/product-catalog/src/typeObjectTest.ts
@@ -3,10 +3,7 @@ export const typeObject = {
 		billingPeriods: ['Month'],
 		productRatePlans: {
 			Monthly: {
-				currencies: { GBP: {} },
-				charges: {
-					GuardianLight: {},
-				},
+				currencies: { GBP: {}, USD: {} },
 			},
 		},
 	},
@@ -19,18 +16,12 @@ export type ProductKey = keyof TypeObject;
 export type ProductRatePlanKey<P extends ProductKey> =
 	keyof TypeObject[P]['productRatePlans'];
 
-export type ProductRatePlanChargeKey<
+export type ProductRatePlanCurrency<
 	P extends ProductKey,
 	PRP extends ProductRatePlanKey<P>,
-> = keyof TypeObject[P]['productRatePlans'][PRP]['charges'];
+> = keyof (TypeObject[P]['productRatePlans'][PRP] & {
+	currencies: Record<string, unknown>;
+})['currencies'];
 
-export type ProductCurrency<
-	P extends ProductKey,
-	PRP extends ProductRatePlanKey<P>,
-> = keyof TypeObject[P]['productRatePlans'][PRP]['currencies'];
-
-const blah: ProductRatePlanChargeKey<'GuardianLight', 'Monthly'> = 'currencies';
-// export type ProductCurrency<
-// 	P extends ProductKey,
-// 	PRP extends ProductRatePlanKey<P>,
-// > = keyof NonNullable<TypeObject[P]['productRatePlans'][PRP]['currencies']>;
+export const currency: ProductRatePlanCurrency<'GuardianLight', 'Monthly'> =
+	'USD';

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -924,6 +924,10 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "currencies": [
       "GBP",
       "USD",
+      "NZD",
+      "EUR",
+      "CAD",
+      "AUD",
     ],
     "productRatePlans": {
       "Annual": {
@@ -1086,6 +1090,10 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "currencies": [
       "GBP",
       "USD",
+      "CAD",
+      "NZD",
+      "EUR",
+      "AUD",
     ],
     "productRatePlans": {
       "DomesticAnnual": {


### PR DESCRIPTION
The product-catalog module has a type object which allows us to generate a `ProductCurrency<P extends Product>` type, which in turn lets us validate that a given currency is valid for a particular product.

Previously the code which generates this type was only checking the currencies which were supported on the first product rate plan of any product, on the assumption that they would be the same for all rate plans, however this assumption was incorrect - for some products supported currencies can vary between rate plans.

This PR updates the `product.currencies` to contain all currencies supported by a product across all rate plans.