### PR TITLE
Remove ProductCurrency type

### DIFF
--- a/handlers/product-switch-api/src/catalogInformation.ts
+++ b/handlers/product-switch-api/src/catalogInformation.ts
@@ -1,8 +1,7 @@
 import type { BillingPeriod } from '@modules/billingPeriod';
-import type {
-	ProductCatalog,
-	ProductCurrency,
-} from '@modules/product-catalog/productCatalog';
+import type { Currency } from '@modules/internationalisation/currency';
+import { getIfDefined } from '@modules/nullAndUndefined';
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 
 export type CatalogInformation = {
 	supporterPlus: {
@@ -29,15 +28,18 @@ const getCatalogBillingPeriod = (billingPeriod: BillingPeriod) => {
 export const getCatalogInformation = (
 	productCatalog: ProductCatalog,
 	billingPeriod: BillingPeriod,
-	currency: ProductCurrency<'SupporterPlus'>,
+	currency: Currency,
 ): CatalogInformation => {
 	const catalogBillingPeriod = getCatalogBillingPeriod(billingPeriod);
+	const price = getIfDefined(
+		productCatalog.SupporterPlus.ratePlans[catalogBillingPeriod].pricing[
+			currency
+		],
+		'No Supporter Plus price defined for currency',
+	);
 	return {
 		supporterPlus: {
-			price:
-				productCatalog.SupporterPlus.ratePlans[catalogBillingPeriod].pricing[
-					currency
-				],
+			price,
 			productRatePlanId:
 				productCatalog.SupporterPlus.ratePlans[catalogBillingPeriod].id,
 			subscriptionChargeId:

--- a/handlers/product-switch-api/src/productSwitchEmail.ts
+++ b/handlers/product-switch-api/src/productSwitchEmail.ts
@@ -1,8 +1,8 @@
 import type { BillingPeriod } from '@modules/billingPeriod';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { DataExtensionNames, sendEmail } from '@modules/email/email';
-import type { ProductCurrency } from '@modules/product-catalog/productCatalog';
-import { getCurrencyGlyph } from '@modules/product-catalog/productCatalog';
+import type { Currency } from '@modules/internationalisation/currency';
+import { getCurrencyGlyph } from '@modules/internationalisation/currency';
 import dayjs from 'dayjs';
 import type { SwitchInformation } from './switchInformation';
 
@@ -22,7 +22,7 @@ export const buildEmailMessage = ({
 	emailAddress: string;
 	firstName: string;
 	lastName: string;
-	currency: ProductCurrency<'SupporterPlus'>;
+	currency: Currency;
 	productPrice: number;
 	firstPaymentAmount: number;
 	billingPeriod: BillingPeriod;

--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -1,12 +1,10 @@
 import type { BillingPeriod } from '@modules/billingPeriod';
 import { ValidationError } from '@modules/errors';
+import type { Currency } from '@modules/internationalisation/currency';
+import { isSupportedCurrency } from '@modules/internationalisation/currency';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { prettyPrint } from '@modules/prettyPrint';
-import type {
-	ProductCatalog,
-	ProductCurrency,
-} from '@modules/product-catalog/productCatalog';
-import { isValidProductCurrency } from '@modules/product-catalog/productCatalog';
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import type {
 	RatePlan,
@@ -34,7 +32,7 @@ export type SubscriptionInformation = {
 	previousProductName: string;
 	previousRatePlanName: string;
 	previousAmount: number;
-	currency: ProductCurrency<'SupporterPlus'>;
+	currency: Currency;
 	billingPeriod: BillingPeriod;
 };
 
@@ -113,15 +111,13 @@ export const subscriptionHasAlreadySwitchedToSupporterPlus = (
 	);
 };
 
-const getCurrency = (
-	contributionRatePlan: RatePlan,
-): ProductCurrency<'SupporterPlus'> => {
+const getCurrency = (contributionRatePlan: RatePlan): Currency => {
 	const currency = getIfDefined(
 		contributionRatePlan.ratePlanCharges[0]?.currency,
 		'No currency found on the rate plan charge',
 	);
 
-	if (isValidProductCurrency('SupporterPlus', currency)) {
+	if (isSupportedCurrency(currency)) {
 		return currency;
 	}
 	throw new Error(`Unsupported currency ${currency}`);

--- a/handlers/update-supporter-plus-amount/src/sendEmail.ts
+++ b/handlers/update-supporter-plus-amount/src/sendEmail.ts
@@ -1,9 +1,7 @@
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
-import type {
-	ProductBillingPeriod,
-	ProductCurrency,
-} from '@modules/product-catalog/productCatalog';
+import type { Currency } from '@modules/internationalisation/currency';
+import type { ProductBillingPeriod } from '@modules/product-catalog/productCatalog';
 import type dayjs from 'dayjs';
 
 export type EmailFields = {
@@ -11,7 +9,7 @@ export type EmailFields = {
 	emailAddress: string;
 	firstName: string;
 	lastName: string;
-	currency: ProductCurrency<'SupporterPlus'>;
+	currency: Currency;
 	newAmount: number;
 	billingPeriod: ProductBillingPeriod<'SupporterPlus'>;
 	identityId: string;

--- a/handlers/update-supporter-plus-amount/src/supporterPlusAmountBands.ts
+++ b/handlers/update-supporter-plus-amount/src/supporterPlusAmountBands.ts
@@ -1,10 +1,8 @@
-import type {
-	ProductBillingPeriod,
-	ProductCurrency,
-} from '@modules/product-catalog/productCatalog';
+import type { Currency } from '@modules/internationalisation/currency';
+import type { ProductBillingPeriod } from '@modules/product-catalog/productCatalog';
 
 export const supporterPlusAmountBands: {
-	[K in ProductCurrency<'SupporterPlus'>]: {
+	[C in Currency]: {
 		[K in ProductBillingPeriod<'SupporterPlus'>]: { min: number; max: number };
 	};
 } = {

--- a/modules/internationalisation/src/currency.ts
+++ b/modules/internationalisation/src/currency.ts
@@ -1,0 +1,30 @@
+export const CurrencyValues = [
+	'GBP',
+	'EUR',
+	'AUD',
+	'USD',
+	'CAD',
+	'NZD',
+] as const;
+export type Currency = (typeof CurrencyValues)[number];
+
+export const isSupportedCurrency = (
+	maybeCurrency: string,
+): maybeCurrency is Currency => {
+	return (CurrencyValues as readonly string[]).includes(maybeCurrency);
+};
+
+export const getCurrencyGlyph = (currency: Currency) => {
+	switch (currency) {
+		case 'GBP':
+			return '£';
+		case 'EUR':
+			return '€';
+		case 'AUD':
+		case 'CAD':
+		case 'NZD':
+		case 'USD':
+			return '$';
+	}
+	throw new Error(`Unsupported currency ${currency}`);
+};

--- a/modules/internationalisation/src/currency.ts
+++ b/modules/internationalisation/src/currency.ts
@@ -14,17 +14,14 @@ export const isSupportedCurrency = (
 	return (CurrencyValues as readonly string[]).includes(maybeCurrency);
 };
 
-export const getCurrencyGlyph = (currency: Currency) => {
-	switch (currency) {
-		case 'GBP':
-			return '£';
-		case 'EUR':
-			return '€';
-		case 'AUD':
-		case 'CAD':
-		case 'NZD':
-		case 'USD':
-			return '$';
-	}
-	throw new Error(`Unsupported currency ${currency}`);
+const currencyToGlyphMapping: { [C in Currency]: string } = {
+	GBP: '£',
+	EUR: '€',
+	AUD: '$',
+	USD: '$',
+	CAD: '$',
+	NZD: '$',
 };
+
+export const getCurrencyGlyph = (currency: Currency) =>
+	currencyToGlyphMapping[currency];

--- a/modules/product-catalog/src/generateTypeObject.ts
+++ b/modules/product-catalog/src/generateTypeObject.ts
@@ -1,5 +1,4 @@
 import { arrayToObject, distinct } from '@modules/arrayFunctions';
-import { getIfDefined } from '@modules/nullAndUndefined';
 import type {
 	ZuoraCatalog,
 	ZuoraProductRatePlan,
@@ -27,12 +26,6 @@ const getProductRatePlanCharges = (
 		}),
 	);
 };
-const getCurrenciesForProduct = (productRatePlan: ZuoraProductRatePlan) =>
-	distinct(
-		productRatePlan.productRatePlanCharges.flatMap((charge) =>
-			charge.pricing.map((price) => price.currency),
-		),
-	);
 const getBillingPeriodsForProduct = (
 	productRatePlans: ZuoraProductRatePlan[],
 ) =>
@@ -49,15 +42,8 @@ const getBillingPeriodsForProduct = (
 			) as string[],
 	);
 const getZuoraProduct = (productRatePlans: ZuoraProductRatePlan[]) => {
-	const currencies = getCurrenciesForProduct(
-		getIfDefined(
-			productRatePlans[0],
-			'Undefined productRatePlan in getZuoraProductObjects',
-		),
-	);
 	const billingPeriods = getBillingPeriodsForProduct(productRatePlans);
 	return {
-		currencies,
 		billingPeriods,
 		productRatePlans: arrayToObject(
 			productRatePlans

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -1,3 +1,4 @@
+import type { Currency } from '@modules/internationalisation/currency';
 import { typeObject } from '@modules/product-catalog/typeObject';
 
 type TypeObject = typeof typeObject;
@@ -12,18 +13,6 @@ type ProductRatePlanChargeKey<
 	PRP extends ProductRatePlanKey<P>,
 > = keyof TypeObject[P]['productRatePlans'][PRP];
 
-export type ProductCurrency<P extends ProductKey> =
-	TypeObject[P]['currencies'][number];
-
-export const isProductCurrency = <P extends ProductKey>(
-	product: P,
-	currency: unknown,
-): currency is ProductCurrency<P> => {
-	return (typeObject[product].currencies as readonly unknown[]).includes(
-		currency,
-	);
-};
-
 export type ProductBillingPeriod<P extends ProductKey> =
 	TypeObject[P]['billingPeriods'][number];
 
@@ -36,9 +25,7 @@ export const isProductBillingPeriod = <P extends ProductKey>(
 	);
 };
 
-type ProductPrice<P extends ProductKey> = {
-	[PC in ProductCurrency<P>]: number;
-};
+type ProductPrice = { GBP: number } & Partial<Record<Currency, number>>;
 
 export type ProductRatePlanCharge = {
 	id: string;
@@ -49,7 +36,7 @@ export type ProductRatePlan<
 	PRP extends ProductRatePlanKey<P>,
 > = {
 	id: string;
-	pricing: ProductPrice<P>;
+	pricing: ProductPrice;
 	charges: {
 		[PRPC in ProductRatePlanChargeKey<P, PRP>]: ProductRatePlanCharge;
 	};
@@ -64,28 +51,6 @@ type Product<P extends ProductKey> = {
 
 export type ProductCatalog = {
 	[P in ProductKey]: Product<P>;
-};
-
-export const isValidProductCurrency = <P extends ProductKey>(
-	product: P,
-	maybeCurrency: string,
-): maybeCurrency is ProductCurrency<P> => {
-	return !!typeObject[product].currencies.find((c) => c === maybeCurrency);
-};
-
-export const getCurrencyGlyph = (currency: string) => {
-	switch (currency) {
-		case 'GBP':
-			return '£';
-		case 'EUR':
-			return '€';
-		case 'AUD':
-		case 'CAD':
-		case 'NZD':
-		case 'USD':
-			return '$';
-	}
-	throw new Error(`Unsupported currency ${currency}`);
 };
 
 export class ProductCatalogHelper {

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -1,257 +1,228 @@
 export const typeObject = {
-  "GuardianLight": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "GuardianLight": {}
-      }
-    }
-  },
-  "TierThree": {
-    "billingPeriods": [
-      "Annual",
-      "Month"
-    ],
-    "productRatePlans": {
-      "RestOfWorldAnnualV2": {
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "RestOfWorldMonthlyV2": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {},
-        "NewspaperArchive": {}
-      },
-      "DomesticAnnualV2": {
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "DomesticMonthlyV2": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {},
-        "NewspaperArchive": {}
-      },
-      "RestOfWorldMonthly": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "RestOfWorldAnnual": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "DomesticAnnual": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "DomesticMonthly": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      }
-    }
-  },
-  "DigitalSubscription": {
-    "billingPeriods": [
-      "Quarter",
-      "Month",
-      "Annual"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      },
-      "OneYearGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "NationalDelivery": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Sixday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Saturday": {}
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Everyday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Saturday": {},
-        "Sunday": {}
-      }
-    }
-  },
-  "SupporterPlus": {
-    "billingPeriods": [
-      "Month",
-      "Annual"
-    ],
-    "productRatePlans": {
-      "V1DeprecatedMonthly": {
-        "Subscription": {}
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {}
-      },
-      "Monthly": {
-        "Subscription": {},
-        "Contribution": {}
-      },
-      "Annual": {
-        "Contribution": {},
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyRestOfWorld": {
-    "billingPeriods": [
-      "Month",
-      "Annual",
-      "Quarter"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Monthly": {}
-      },
-      "OneYearGift": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "Quarterly": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyDomestic": {
-    "billingPeriods": [
-      "Annual",
-      "Quarter",
-      "Month"
-    ],
-    "productRatePlans": {
-      "OneYearGift": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "Quarterly": {
-        "Subscription": {}
-      },
-      "Monthly": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "SubscriptionCard": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Thursday": {},
-        "Wednesday": {},
-        "Saturday": {}
-      },
-      "Everyday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Wednesday": {},
-        "Sunday": {}
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Sunday": {
-        "Sunday": {}
-      },
-      "Saturday": {
-        "Saturday": {}
-      }
-    }
-  },
-  "Contribution": {
-    "billingPeriods": [
-      "Annual",
-      "Month"
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Contribution": {}
-      },
-      "Monthly": {
-        "Contribution": {}
-      }
-    }
-  },
-  "HomeDelivery": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Sunday": {},
-        "Wednesday": {},
-        "Friday": {},
-        "Thursday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {}
-      },
-      "Sunday": {
-        "Sunday": {}
-      },
-      "Sixday": {
-        "Wednesday": {},
-        "Friday": {},
-        "Thursday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {}
-      },
-      "Weekend": {
-        "Sunday": {},
-        "Saturday": {}
-      },
-      "Saturday": {
-        "Saturday": {}
-      }
-    }
-  }
+	GuardianLight: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Monthly: {
+				GuardianLight: {},
+			},
+		},
+	},
+	TierThree: {
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			RestOfWorldAnnualV2: {
+				NewspaperArchive: {},
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			RestOfWorldMonthlyV2: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+				NewspaperArchive: {},
+			},
+			DomesticAnnualV2: {
+				NewspaperArchive: {},
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			DomesticMonthlyV2: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+				NewspaperArchive: {},
+			},
+			RestOfWorldMonthly: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			RestOfWorldAnnual: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			DomesticAnnual: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			DomesticMonthly: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+		},
+	},
+	DigitalSubscription: {
+		billingPeriods: ['Quarter', 'Month', 'Annual'],
+		productRatePlans: {
+			Monthly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+			OneYearGift: {
+				Subscription: {},
+			},
+		},
+	},
+	NationalDelivery: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Sixday: {
+				Monday: {},
+				Tuesday: {},
+				Wednesday: {},
+				Thursday: {},
+				Friday: {},
+				Saturday: {},
+			},
+			Weekend: {
+				Saturday: {},
+				Sunday: {},
+			},
+			Everyday: {
+				Monday: {},
+				Tuesday: {},
+				Wednesday: {},
+				Thursday: {},
+				Friday: {},
+				Saturday: {},
+				Sunday: {},
+			},
+		},
+	},
+	SupporterPlus: {
+		billingPeriods: ['Month', 'Annual'],
+		productRatePlans: {
+			V1DeprecatedMonthly: {
+				Subscription: {},
+			},
+			V1DeprecatedAnnual: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+				Contribution: {},
+			},
+			Annual: {
+				Contribution: {},
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyRestOfWorld: {
+		billingPeriods: ['Month', 'Annual', 'Quarter'],
+		productRatePlans: {
+			Monthly: {
+				Monthly: {},
+			},
+			OneYearGift: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			Quarterly: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyDomestic: {
+		billingPeriods: ['Annual', 'Quarter', 'Month'],
+		productRatePlans: {
+			OneYearGift: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			Quarterly: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+		},
+	},
+	SubscriptionCard: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Sixday: {
+				Friday: {},
+				Monday: {},
+				Tuesday: {},
+				Thursday: {},
+				Wednesday: {},
+				Saturday: {},
+			},
+			Everyday: {
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+				Thursday: {},
+				Friday: {},
+				Wednesday: {},
+				Sunday: {},
+			},
+			Weekend: {
+				Saturday: {},
+				Sunday: {},
+			},
+			Sunday: {
+				Sunday: {},
+			},
+			Saturday: {
+				Saturday: {},
+			},
+		},
+	},
+	Contribution: {
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			Annual: {
+				Contribution: {},
+			},
+			Monthly: {
+				Contribution: {},
+			},
+		},
+	},
+	HomeDelivery: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Everyday: {
+				Sunday: {},
+				Wednesday: {},
+				Friday: {},
+				Thursday: {},
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+			},
+			Sunday: {
+				Sunday: {},
+			},
+			Sixday: {
+				Wednesday: {},
+				Friday: {},
+				Thursday: {},
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+			},
+			Weekend: {
+				Sunday: {},
+				Saturday: {},
+			},
+			Saturday: {
+				Saturday: {},
+			},
+		},
+	},
 } as const;

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -1,238 +1,257 @@
 export const typeObject = {
-	GuardianLight: {
-		currencies: ['GBP'],
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Monthly: {
-				GuardianLight: {},
-			},
-		},
-	},
-	TierThree: {
-		currencies: ['GBP', 'USD'],
-		billingPeriods: ['Annual', 'Month'],
-		productRatePlans: {
-			RestOfWorldAnnualV2: {
-				NewspaperArchive: {},
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			RestOfWorldMonthlyV2: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-				NewspaperArchive: {},
-			},
-			DomesticAnnualV2: {
-				NewspaperArchive: {},
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			DomesticMonthlyV2: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-				NewspaperArchive: {},
-			},
-			RestOfWorldMonthly: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			RestOfWorldAnnual: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			DomesticAnnual: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			DomesticMonthly: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-		},
-	},
-	DigitalSubscription: {
-		currencies: ['NZD', 'CAD', 'AUD', 'USD', 'GBP', 'EUR'],
-		billingPeriods: ['Quarter', 'Month', 'Annual'],
-		productRatePlans: {
-			Monthly: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-			ThreeMonthGift: {
-				Subscription: {},
-			},
-			OneYearGift: {
-				Subscription: {},
-			},
-		},
-	},
-	NationalDelivery: {
-		currencies: ['GBP'],
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Sixday: {
-				Monday: {},
-				Tuesday: {},
-				Wednesday: {},
-				Thursday: {},
-				Friday: {},
-				Saturday: {},
-			},
-			Weekend: {
-				Saturday: {},
-				Sunday: {},
-			},
-			Everyday: {
-				Monday: {},
-				Tuesday: {},
-				Wednesday: {},
-				Thursday: {},
-				Friday: {},
-				Saturday: {},
-				Sunday: {},
-			},
-		},
-	},
-	SupporterPlus: {
-		currencies: ['GBP', 'USD', 'AUD', 'EUR', 'NZD', 'CAD'],
-		billingPeriods: ['Month', 'Annual'],
-		productRatePlans: {
-			V1DeprecatedMonthly: {
-				Subscription: {},
-			},
-			V1DeprecatedAnnual: {
-				Subscription: {},
-			},
-			Monthly: {
-				Subscription: {},
-				Contribution: {},
-			},
-			Annual: {
-				Contribution: {},
-				Subscription: {},
-			},
-		},
-	},
-	GuardianWeeklyRestOfWorld: {
-		currencies: ['GBP', 'USD'],
-		billingPeriods: ['Month', 'Annual', 'Quarter'],
-		productRatePlans: {
-			Monthly: {
-				Monthly: {},
-			},
-			OneYearGift: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-			Quarterly: {
-				Subscription: {},
-			},
-			ThreeMonthGift: {
-				Subscription: {},
-			},
-		},
-	},
-	GuardianWeeklyDomestic: {
-		currencies: ['GBP', 'USD', 'NZD', 'EUR', 'CAD', 'AUD'],
-		billingPeriods: ['Annual', 'Quarter', 'Month'],
-		productRatePlans: {
-			OneYearGift: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-			Quarterly: {
-				Subscription: {},
-			},
-			Monthly: {
-				Subscription: {},
-			},
-			ThreeMonthGift: {
-				Subscription: {},
-			},
-		},
-	},
-	SubscriptionCard: {
-		currencies: ['GBP'],
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Sixday: {
-				Friday: {},
-				Monday: {},
-				Tuesday: {},
-				Thursday: {},
-				Wednesday: {},
-				Saturday: {},
-			},
-			Everyday: {
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-				Thursday: {},
-				Friday: {},
-				Wednesday: {},
-				Sunday: {},
-			},
-			Weekend: {
-				Saturday: {},
-				Sunday: {},
-			},
-			Sunday: {
-				Sunday: {},
-			},
-			Saturday: {
-				Saturday: {},
-			},
-		},
-	},
-	Contribution: {
-		currencies: ['GBP', 'USD', 'NZD', 'EUR', 'CAD', 'AUD'],
-		billingPeriods: ['Annual', 'Month'],
-		productRatePlans: {
-			Annual: {
-				Contribution: {},
-			},
-			Monthly: {
-				Contribution: {},
-			},
-		},
-	},
-	HomeDelivery: {
-		currencies: ['GBP'],
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Everyday: {
-				Sunday: {},
-				Wednesday: {},
-				Friday: {},
-				Thursday: {},
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-			},
-			Sunday: {
-				Sunday: {},
-			},
-			Sixday: {
-				Wednesday: {},
-				Friday: {},
-				Thursday: {},
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-			},
-			Weekend: {
-				Sunday: {},
-				Saturday: {},
-			},
-			Saturday: {
-				Saturday: {},
-			},
-		},
-	},
+  "GuardianLight": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "GuardianLight": {}
+      }
+    }
+  },
+  "TierThree": {
+    "billingPeriods": [
+      "Annual",
+      "Month"
+    ],
+    "productRatePlans": {
+      "RestOfWorldAnnualV2": {
+        "NewspaperArchive": {},
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "RestOfWorldMonthlyV2": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {},
+        "NewspaperArchive": {}
+      },
+      "DomesticAnnualV2": {
+        "NewspaperArchive": {},
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "DomesticMonthlyV2": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {},
+        "NewspaperArchive": {}
+      },
+      "RestOfWorldMonthly": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "RestOfWorldAnnual": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "DomesticAnnual": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "DomesticMonthly": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      }
+    }
+  },
+  "DigitalSubscription": {
+    "billingPeriods": [
+      "Quarter",
+      "Month",
+      "Annual"
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      },
+      "ThreeMonthGift": {
+        "Subscription": {}
+      },
+      "OneYearGift": {
+        "Subscription": {}
+      }
+    }
+  },
+  "NationalDelivery": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Sixday": {
+        "Monday": {},
+        "Tuesday": {},
+        "Wednesday": {},
+        "Thursday": {},
+        "Friday": {},
+        "Saturday": {}
+      },
+      "Weekend": {
+        "Saturday": {},
+        "Sunday": {}
+      },
+      "Everyday": {
+        "Monday": {},
+        "Tuesday": {},
+        "Wednesday": {},
+        "Thursday": {},
+        "Friday": {},
+        "Saturday": {},
+        "Sunday": {}
+      }
+    }
+  },
+  "SupporterPlus": {
+    "billingPeriods": [
+      "Month",
+      "Annual"
+    ],
+    "productRatePlans": {
+      "V1DeprecatedMonthly": {
+        "Subscription": {}
+      },
+      "V1DeprecatedAnnual": {
+        "Subscription": {}
+      },
+      "Monthly": {
+        "Subscription": {},
+        "Contribution": {}
+      },
+      "Annual": {
+        "Contribution": {},
+        "Subscription": {}
+      }
+    }
+  },
+  "GuardianWeeklyRestOfWorld": {
+    "billingPeriods": [
+      "Month",
+      "Annual",
+      "Quarter"
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "Monthly": {}
+      },
+      "OneYearGift": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      },
+      "Quarterly": {
+        "Subscription": {}
+      },
+      "ThreeMonthGift": {
+        "Subscription": {}
+      }
+    }
+  },
+  "GuardianWeeklyDomestic": {
+    "billingPeriods": [
+      "Annual",
+      "Quarter",
+      "Month"
+    ],
+    "productRatePlans": {
+      "OneYearGift": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      },
+      "Quarterly": {
+        "Subscription": {}
+      },
+      "Monthly": {
+        "Subscription": {}
+      },
+      "ThreeMonthGift": {
+        "Subscription": {}
+      }
+    }
+  },
+  "SubscriptionCard": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Sixday": {
+        "Friday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Thursday": {},
+        "Wednesday": {},
+        "Saturday": {}
+      },
+      "Everyday": {
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {},
+        "Thursday": {},
+        "Friday": {},
+        "Wednesday": {},
+        "Sunday": {}
+      },
+      "Weekend": {
+        "Saturday": {},
+        "Sunday": {}
+      },
+      "Sunday": {
+        "Sunday": {}
+      },
+      "Saturday": {
+        "Saturday": {}
+      }
+    }
+  },
+  "Contribution": {
+    "billingPeriods": [
+      "Annual",
+      "Month"
+    ],
+    "productRatePlans": {
+      "Annual": {
+        "Contribution": {}
+      },
+      "Monthly": {
+        "Contribution": {}
+      }
+    }
+  },
+  "HomeDelivery": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Everyday": {
+        "Sunday": {},
+        "Wednesday": {},
+        "Friday": {},
+        "Thursday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {}
+      },
+      "Sunday": {
+        "Sunday": {}
+      },
+      "Sixday": {
+        "Wednesday": {},
+        "Friday": {},
+        "Thursday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {}
+      },
+      "Weekend": {
+        "Sunday": {},
+        "Saturday": {}
+      },
+      "Saturday": {
+        "Saturday": {}
+      }
+    }
+  }
 } as const;

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -824,14 +824,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
       "Annual",
       "Month",
     ],
-    "currencies": [
-      "GBP",
-      "USD",
-      "NZD",
-      "EUR",
-      "CAD",
-      "AUD",
-    ],
     "productRatePlans": {
       "Annual": {
         "Contribution": {},
@@ -846,14 +838,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
       "Quarter",
       "Month",
       "Annual",
-    ],
-    "currencies": [
-      "NZD",
-      "CAD",
-      "AUD",
-      "USD",
-      "GBP",
-      "EUR",
     ],
     "productRatePlans": {
       "Annual": {
@@ -874,9 +858,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "billingPeriods": [
       "Month",
     ],
-    "currencies": [
-      "GBP",
-    ],
     "productRatePlans": {
       "Monthly": {
         "GuardianLight": {},
@@ -888,14 +869,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
       "Annual",
       "Quarter",
       "Month",
-    ],
-    "currencies": [
-      "GBP",
-      "USD",
-      "NZD",
-      "EUR",
-      "CAD",
-      "AUD",
     ],
     "productRatePlans": {
       "Annual": {
@@ -921,10 +894,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
       "Annual",
       "Quarter",
     ],
-    "currencies": [
-      "GBP",
-      "USD",
-    ],
     "productRatePlans": {
       "Annual": {
         "Subscription": {},
@@ -946,9 +915,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
   "HomeDelivery": {
     "billingPeriods": [
       "Month",
-    ],
-    "currencies": [
-      "GBP",
     ],
     "productRatePlans": {
       "Everyday": {
@@ -984,9 +950,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "billingPeriods": [
       "Month",
     ],
-    "currencies": [
-      "GBP",
-    ],
     "productRatePlans": {
       "Everyday": {
         "Friday": {},
@@ -1014,9 +977,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
   "SubscriptionCard": {
     "billingPeriods": [
       "Month",
-    ],
-    "currencies": [
-      "GBP",
     ],
     "productRatePlans": {
       "Everyday": {
@@ -1053,14 +1013,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
       "Month",
       "Annual",
     ],
-    "currencies": [
-      "GBP",
-      "USD",
-      "AUD",
-      "EUR",
-      "NZD",
-      "CAD",
-    ],
     "productRatePlans": {
       "Annual": {
         "Contribution": {},
@@ -1082,10 +1034,6 @@ exports[`Generated product catalog types match snapshot 1`] = `
     "billingPeriods": [
       "Annual",
       "Month",
-    ],
-    "currencies": [
-      "GBP",
-      "USD",
     ],
     "productRatePlans": {
       "DomesticAnnual": {

--- a/modules/product-catalog/tsconfig.json
+++ b/modules/product-catalog/tsconfig.json
@@ -11,6 +11,7 @@
       "@modules/zuora/*": ["../zuora/src/*"],
       "@modules/zuora-catalog/*": ["../zuora-catalog/src/*"],
       "@modules/product-catalog/*": ["../product-catalog/src/*"],
+      "@modules/internationalisation/*": ["../internationalisation/src/*"],
       "@modules/*": ["../*"]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
       "@modules/zuora-catalog/*": ["./modules/zuora-catalog/src/*"],
       "@modules/product-catalog/*": ["./modules/product-catalog/src/*"],
       "@modules/email/*": ["./modules/email/src/*"],
+      "@modules/internationalisation/*": ["./modules/internationalisation/src/*"],
       "@modules/*": ["./modules/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Previously we had a type in the product-catalog Typescript module called `ProductCurrency<P>` which allowed us to check whether a given currency was valid for a particular product. 

However this was not actually accurate because there are some products where different rate plans allow different currencies, for instance T3. 

To make this accurate would mean making the type into `ProductRatePlanCurrency<P, PRP>` where PRP is the product rate plan type. This starts to become quite unwieldy and in fact wasn't possible to derive from the type object which we use to derive all the other types. 

Given that the check was only used in two places, I have decided to remove the product element of the currency, and just have a list of supported currencies instead.


------------------------------

## For future reference
The issue with deriving the product rate plan currency from a type object is this:
``` typescript
export const typeObject = {
	GuardianLight: {
		billingPeriods: ['Month'],
		productRatePlans: {
			Monthly: {
				currencies: { GBP: {} },
			},
		},
	},
} as const;

type TypeObject = typeof typeObject;

export type ProductKey = keyof TypeObject;

export type ProductRatePlanKey<P extends ProductKey> =
	keyof TypeObject[P]['productRatePlans']; // At the first level we are able to get the productRatePlans keys

export type ProductCurrency<
	P extends ProductKey,
	PRP extends ProductRatePlanKey<P>,
> = keyof TypeObject[P]['productRatePlans'][PRP]['currencies']; // At the next level down we cannot get the currencies keys 
// - error TS2536: Type '"currencies"' cannot be used to index type '{ readonly GuardianLight: { readonly billingPeriods: readonly ["Month"]; readonly productRatePlans: { readonly Monthly: { readonly currencies: { readonly GBP: {}; }; }; }; }; }[P]["productRatePlans"][PRP]'.
```

### Update - managed to resolve this issue with the following changes:
I've still decided to go ahead with this PR though as there were a couple of other type issues that were non-trivial to fix

``` Typescript
export const typeObject = {
	GuardianLight: {
		billingPeriods: ['Month'],
		productRatePlans: {
			Monthly: {
				currencies: { GBP: {}, USD: {} },
			},
		},
	},
} as const;

type TypeObject = typeof typeObject;

export type ProductKey = keyof TypeObject;

export type ProductRatePlanKey<P extends ProductKey> =
	keyof TypeObject[P]['productRatePlans'];

export type ProductRatePlanCurrency<
	P extends ProductKey,
	PRP extends ProductRatePlanKey<P>,
> = keyof (TypeObject[P]['productRatePlans'][PRP] & {
	currencies: Record<string, unknown>;
})['currencies'];

export const currency: ProductRatePlanCurrency<'GuardianLight', 'Monthly'> =
	'USD';
```