### PR TITLE
Add Sentry search link to metric-push-api alarm

### DIFF
--- a/handlers/metric-push-api/cfn.yaml
+++ b/handlers/metric-push-api/cfn.yaml
@@ -159,7 +159,7 @@ Resources:
             - 'client-side fatal errors are being reported to sentry for support-frontend'
         AlarmDescription: !Join
           - ' '
-          - - 'Impact - some or all browsers are failing to render support client side pages. Log in to Sentry.io to investigate.'
+          - - 'Impact - some or all browsers are failing to render support client side pages. Log in to Sentry to see these errors: https://the-guardian.sentry.io/discover/results/?project=1213654&query=%22Fatal%20error%20rendering%20page%22&queryDataset=error-events&sort=-count&statsPeriod=24h'
             - !FindInMap [ Constants, Alarm, Process ]
             - !FindInMap [StageMap, !Ref Stage, ApiName]
         MetricName: Count


### PR DESCRIPTION
## What does this change?

Add Sentry search link to metric-push-api alarm description. This should make it easier to get to the relevant information in Sentry.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
