### PR TITLE
Separate supporterProductData.ts into its own module

### DIFF
--- a/handlers/press-reader-entitlements/src/index.ts
+++ b/handlers/press-reader-entitlements/src/index.ts
@@ -3,13 +3,13 @@ import { getIfDefined } from '@modules/nullAndUndefined';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import type {
 	APIGatewayProxyEvent,
 	APIGatewayProxyResult,
 	Handler,
 } from 'aws-lambda';
 import { getClientAccessToken, getIdentityId } from './identity';
-import type { SupporterRatePlanItem } from './supporterProductData';
 import { getLatestSubscription } from './supporterProductData';
 import type { Member } from './xmlBuilder';
 import { buildXml } from './xmlBuilder';

--- a/handlers/press-reader-entitlements/src/supporterProductData.ts
+++ b/handlers/press-reader-entitlements/src/supporterProductData.ts
@@ -1,44 +1,12 @@
-import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
-import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { sortBy } from '@modules/arrayFunctions';
-import { awsConfig } from '@modules/aws/config';
 import type {
 	ProductCatalog,
 	ProductKey,
 } from '@modules/product-catalog/productCatalog';
 import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
-
-const dynamoClient = new DynamoDBClient(awsConfig);
-
-export type SupporterRatePlanItem = {
-	subscriptionName: string; // Unique identifier for the subscription
-	identityId: string; // Unique identifier for user
-	productRatePlanId: string; // Unique identifier for the product in this rate plan
-	productRatePlanName: string; // Name of the product in this rate plan
-	termEndDate: string; // Date that this subscription term ends
-	contractEffectiveDate: string; // Date that this subscription started
-};
-
-export const getSupporterProductData = async (
-	stage: Stage,
-	identityId: string,
-): Promise<SupporterRatePlanItem[] | undefined> => {
-	const tableName = `SupporterProductData-${stage}`;
-	const input = {
-		ExpressionAttributeValues: {
-			':v1': {
-				S: identityId,
-			},
-		},
-		KeyConditionExpression: 'identityId = :v1',
-		TableName: tableName,
-	};
-	console.log(`Querying ${tableName} for identityId ${identityId}`);
-	const data = await dynamoClient.send(new QueryCommand(input));
-	console.log(`Query returned ${JSON.stringify(data)}`);
-	return data.Items?.map((item) => unmarshall(item) as SupporterRatePlanItem);
-};
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
+import { getSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
 
 export async function getLatestSubscription(
 	stage: Stage,

--- a/handlers/press-reader-entitlements/test/pressReaderEntitlements.test.ts
+++ b/handlers/press-reader-entitlements/test/pressReaderEntitlements.test.ts
@@ -1,6 +1,6 @@
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import codeZuoraCatalog from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
-import type { SupporterRatePlanItem } from '../src/supporterProductData';
 import { getLatestValidSubscription } from '../src/supporterProductData';
 import type { Member } from '../src/xmlBuilder';
 import { buildXml } from '../src/xmlBuilder';

--- a/handlers/press-reader-entitlements/test/pressReaderEntitlementsIntegration.test.ts
+++ b/handlers/press-reader-entitlements/test/pressReaderEntitlementsIntegration.test.ts
@@ -6,15 +6,7 @@ import { generateProductCatalog } from '@modules/product-catalog/generateProduct
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import { getMemberDetails } from '../src';
 import { getClientAccessToken, getIdentityId } from '../src/identity';
-import {
-	getLatestSubscription,
-	getSupporterProductData,
-} from '../src/supporterProductData';
-
-test('Dynamo Integration', async () => {
-	const supporterData = await getSupporterProductData('CODE', '110001137');
-	expect(supporterData?.length).toEqual(4);
-});
+import { getLatestSubscription } from '../src/supporterProductData';
 
 test('Entitlements check', async () => {
 	const productCatalog = generateProductCatalog(zuoraCatalogFixture);

--- a/modules/supporter-product-data/jest.config.js
+++ b/modules/supporter-product-data/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	runner: 'groups',
+	moduleNameMapper: {
+		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
+		'@modules/(.*)$': '<rootDir>/../../modules/$1',
+	},
+};

--- a/modules/supporter-product-data/package.json
+++ b/modules/supporter-product-data/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "supporter-product-data",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.679.0",
+    "@aws-sdk/util-dynamodb": "^3.679.0"
+  }
+}

--- a/modules/supporter-product-data/src/supporterProductData.ts
+++ b/modules/supporter-product-data/src/supporterProductData.ts
@@ -1,0 +1,35 @@
+import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+import { awsConfig } from '@modules/aws/config';
+import type { Stage } from '@modules/stage';
+
+const dynamoClient = new DynamoDBClient(awsConfig);
+
+export type SupporterRatePlanItem = {
+	subscriptionName: string; // Unique identifier for the subscription
+	identityId: string; // Unique identifier for user
+	productRatePlanId: string; // Unique identifier for the product in this rate plan
+	productRatePlanName: string; // Name of the product in this rate plan
+	termEndDate: string; // Date that this subscription term ends
+	contractEffectiveDate: string; // Date that this subscription started
+};
+
+export const getSupporterProductData = async (
+	stage: Stage,
+	identityId: string,
+): Promise<SupporterRatePlanItem[] | undefined> => {
+	const tableName = `SupporterProductData-${stage}`;
+	const input = {
+		ExpressionAttributeValues: {
+			':v1': {
+				S: identityId,
+			},
+		},
+		KeyConditionExpression: 'identityId = :v1',
+		TableName: tableName,
+	};
+	console.log(`Querying ${tableName} for identityId ${identityId}`);
+	const data = await dynamoClient.send(new QueryCommand(input));
+	console.log(`Query returned ${JSON.stringify(data)}`);
+	return data.Items?.map((item) => unmarshall(item) as SupporterRatePlanItem);
+};

--- a/modules/supporter-product-data/test/supporterProductDataIntegration.test.ts
+++ b/modules/supporter-product-data/test/supporterProductDataIntegration.test.ts
@@ -1,0 +1,6 @@
+import { getSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
+
+test('Dynamo Integration', async () => {
+	const supporterData = await getSupporterProductData('CODE', '110001137');
+	expect(supporterData?.length).toEqual(4);
+});

--- a/modules/supporter-product-data/tsconfig.json
+++ b/modules/supporter-product-data/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,15 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
 
+  modules/supporter-product-data:
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.679.0
+        version: 3.687.0
+      '@aws-sdk/util-dynamodb':
+        specifier: ^3.679.0
+        version: 3.687.0(@aws-sdk/client-dynamodb@3.687.0)
+
   modules/sync-supporter-product-data:
     devDependencies:
       '@aws-sdk/client-sqs':
@@ -5942,9 +5951,9 @@ snapshots:
       '@aws-sdk/types': 3.686.0
       '@smithy/core': 2.5.4
       '@smithy/node-config-provider': 3.1.11
-      '@smithy/property-provider': 3.1.7
+      '@smithy/property-provider': 3.1.10
       '@smithy/protocol-http': 4.1.7
-      '@smithy/signature-v4': 4.2.0
+      '@smithy/signature-v4': 4.2.3
       '@smithy/smithy-client': 3.4.4
       '@smithy/types': 3.7.1
       '@smithy/util-middleware': 3.0.10
@@ -6326,9 +6335,9 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.687.0(@aws-sdk/client-sso-oidc@3.687.0(@aws-sdk/client-sts@3.687.0))
       '@aws-sdk/credential-provider-web-identity': 3.686.0(@aws-sdk/client-sts@3.687.0)
       '@aws-sdk/types': 3.686.0
-      '@smithy/credential-provider-imds': 3.2.4
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
+      '@smithy/credential-provider-imds': 3.2.7
+      '@smithy/property-provider': 3.1.10
+      '@smithy/shared-ini-file-loader': 3.1.11
       '@smithy/types': 3.7.1
       tslib: 2.6.2
     transitivePeerDependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
       "@modules/product-catalog/*": ["./modules/product-catalog/src/*"],
       "@modules/email/*": ["./modules/email/src/*"],
       "@modules/internationalisation/*": ["./modules/internationalisation/src/*"],
+      "@modules/supporter-product-data/*": ["./modules/supporter-product-data/src/*"],
       "@modules/*": ["./modules/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
#2511 introduced some code to access the supporter-product-data Dynamo table, but it was in the lambda module. This PR moves it out to a stand alone module so that it can be accessed by other lambdas.