### PR TITLE
add one off suspension email sending endpoint

### DIFF
--- a/handlers/discount-api/src/requestSchema.ts
+++ b/handlers/discount-api/src/requestSchema.ts
@@ -5,3 +5,10 @@ export const applyDiscountSchema = z.object({
 });
 
 export type ApplyDiscountRequestBody = z.infer<typeof applyDiscountSchema>;
+
+export const sendEmailSchema = z.object({
+	identityId: z.string(),
+	emailAddress: z.string(),
+});
+
+export type SendEmailRequestBody = z.infer<typeof sendEmailSchema>;

--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -39,6 +39,7 @@ export const DataExtensionNames = {
 		'digipack-monthly-discount-confirmation-email',
 	supporterPlusAnnualDiscountConfirmationEmail:
 		'supporter-plus-annual-discount-confirmation-email',
+	strikeSuspensionEmail: 'strike-suspension-email',
 } as const;
 
 export type DataExtensionName =


### PR DESCRIPTION
We want to let people register interest to suspend their subscription for a couple of days as a one off.

This new temporary endpoint lets them register interest via manage MMA, then we can collect a list of identity ids later from braze and actually apply the relevant discount manually/via a script.