### PR TITLE
Identify Guardian users in user-benefits code

### DIFF
--- a/handlers/user-benefits/src/index.ts
+++ b/handlers/user-benefits/src/index.ts
@@ -4,6 +4,7 @@ import type {
 	FailedAuthenticationResponse,
 } from '@modules/identity/apiGateway';
 import { IdentityApiGatewayAuthenticator } from '@modules/identity/apiGateway';
+import type { IdentityUserDetails } from '@modules/identity/identity';
 import { Lazy } from '@modules/lazy';
 import type { UserBenefitsResponse } from '@modules/product-benefits/schemas';
 import { getUserBenefits } from '@modules/product-benefits/userBenefits';
@@ -27,16 +28,16 @@ const productCatalog = new Lazy(
 const getUserBenefitsResponse = async (
 	stage: Stage,
 	productCatalogHelper: ProductCatalogHelper,
-	identityId: string,
+	userDetails: IdentityUserDetails,
 ): Promise<UserBenefitsResponse> => {
 	const benefits = await getUserBenefits(
 		stage,
 		productCatalogHelper,
-		identityId,
+		userDetails,
 	);
-	console.log(`Benefits for user ${identityId} are: `, benefits);
+	console.log(`Benefits for user ${userDetails.identityId} are: `, benefits);
 	const trials = getTrialInformation(benefits);
-	console.log(`Trials for user ${identityId} are: `, trials);
+	console.log(`Trials for user ${userDetails.identityId} are: `, trials);
 	return {
 		benefits,
 		trials,
@@ -66,7 +67,7 @@ export const handler: Handler = async (
 		const userBenefitsResponse = await getUserBenefitsResponse(
 			stage,
 			new ProductCatalogHelper(await productCatalog.get()),
-			maybeAuthenticatedEvent.identityId,
+			maybeAuthenticatedEvent.userDetails,
 		);
 		return {
 			body: JSON.stringify(userBenefitsResponse),

--- a/modules/identity/package.json
+++ b/modules/identity/package.json
@@ -6,7 +6,8 @@
     "build": "tsc --noEmit"
   },
   "dependencies": {
-    "@okta/jwt-verifier": "^4.0.1"
+    "@okta/jwt-verifier": "^4.0.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.145"

--- a/modules/identity/src/apiGateway.ts
+++ b/modules/identity/src/apiGateway.ts
@@ -1,6 +1,7 @@
 import { ValidationError } from '@modules/errors';
 import type { Stage } from '@modules/stage';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import type { IdentityUserDetails } from '@modules/identity/identity';
 import {
 	ExpiredTokenError,
 	InvalidScopesError,
@@ -10,7 +11,7 @@ import {
 
 export type AuthenticatedApiGatewayEvent = APIGatewayProxyEvent & {
 	type: 'AuthenticatedApiGatewayEvent';
-	identityId: string;
+	userDetails: IdentityUserDetails;
 };
 
 export type FailedAuthenticationResponse = APIGatewayProxyResult & {
@@ -36,14 +37,14 @@ export class IdentityApiGatewayAuthenticator {
 			};
 		}
 		try {
-			const identityId = await this.tokenHelper.getIdentityId(authHeader);
+			const userDetails = await this.tokenHelper.getIdentityId(authHeader);
 			console.log(
-				`Successfully authenticated user with identityId: ${identityId}`,
+				`Successfully authenticated user with identityId: ${userDetails.identityId}`,
 			);
 			return {
 				type: 'AuthenticatedApiGatewayEvent',
 				...event,
-				identityId,
+				userDetails,
 			};
 		} catch (error) {
 			console.log('Caught exception with message: ', error);

--- a/modules/identity/test/identity.test.ts
+++ b/modules/identity/test/identity.test.ts
@@ -52,15 +52,17 @@ test('we can decode an access token without the Bearer prefix', async () => {
 });
 
 test('we can return an identity id', async () => {
-	const identityId =
+	const userDetails =
 		await identityHelperWithNoRequiredScopes.getIdentityId(validAuthHeader);
-	expect(identityId.length).toBeGreaterThan(0);
+	expect(userDetails.identityId.length).toBeGreaterThan(0);
+	expect(userDetails.email.length).toBeGreaterThan(0);
 });
 
 test('we can return an identity id with required scopes', async () => {
 	const identityHelper = new OktaTokenHelper('CODE', ['profile']);
-	const identityId = await identityHelper.getIdentityId(validAuthHeader);
-	expect(identityId.length).toBeGreaterThan(0);
+	const userDetails = await identityHelper.getIdentityId(validAuthHeader);
+	expect(userDetails.identityId.length).toBeGreaterThan(0);
+	expect(userDetails.email.length).toBeGreaterThan(0);
 });
 
 test('we throw an error if the token does not have the required scopes', async () => {
@@ -87,7 +89,7 @@ test('ApiGateway event with a valid token returns an authenticated result', asyn
 	if (response.type !== 'AuthenticatedApiGatewayEvent') {
 		throw new Error('Expected response to be an AuthenticatedApiGatewayEvent');
 	}
-	expect(response.identityId.length).toBeGreaterThan(0);
+	expect(response.userDetails.identityId.length).toBeGreaterThan(0);
 });
 
 test('ApiGateway event with expired token returns a 401 response', async () => {

--- a/modules/product-benefits/src/productBenefit.ts
+++ b/modules/product-benefits/src/productBenefit.ts
@@ -1,5 +1,9 @@
 import type { ProductKey } from '@modules/product-catalog/productCatalog';
 import type { ProductBenefit } from './schemas';
+import { productBenefitListSchema } from './schemas';
+
+export const allProductBenefits: ProductBenefit[] =
+	productBenefitListSchema.options;
 
 export const supporterPlusBenefits: ProductBenefit[] = [
 	'adFree',

--- a/modules/product-benefits/src/schemas.ts
+++ b/modules/product-benefits/src/schemas.ts
@@ -1,18 +1,21 @@
 import { z } from 'zod';
 
-const productBenefitSchema = z.union([
-	z.literal('feastApp'),
-	z.literal('adFree'),
-	z.literal('newspaperArchive'),
-	z.literal('newspaperEdition'),
-	z.literal('guardianWeeklyEdition'),
-	z.literal('liveApp'),
-	z.literal('fewerSupportAsks'),
-	z.literal('rejectTracking'),
-	z.literal('liveEvents'), // Do we need this?
+const productBenefitSchema = z.enum([
+	'feastApp',
+	'adFree',
+	'newspaperArchive',
+	'newspaperEdition',
+	'guardianWeeklyEdition',
+	'liveApp',
+	'fewerSupportAsks',
+	'rejectTracking',
+	'liveEvents',
 ]);
 
 export type ProductBenefit = z.infer<typeof productBenefitSchema>;
+
+export const allProductBenefits: ProductBenefit[] =
+	productBenefitSchema.options;
 
 const trialSchema = z.object({
 	iosSubscriptionGroup: z.string(),

--- a/modules/product-benefits/src/schemas.ts
+++ b/modules/product-benefits/src/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const productBenefitSchema = z.enum([
+export const productBenefitListSchema = z.enum([
 	'feastApp',
 	'adFree',
 	'newspaperArchive',
@@ -12,21 +12,18 @@ const productBenefitSchema = z.enum([
 	'liveEvents',
 ]);
 
-export type ProductBenefit = z.infer<typeof productBenefitSchema>;
-
-export const allProductBenefits: ProductBenefit[] =
-	productBenefitSchema.options;
+export type ProductBenefit = z.infer<typeof productBenefitListSchema>;
 
 const trialSchema = z.object({
 	iosSubscriptionGroup: z.string(),
 	androidOfferTag: z.string(),
 });
 export type Trial = z.infer<typeof trialSchema>;
-const trialInformationSchema = z.record(productBenefitSchema, trialSchema);
+const trialInformationSchema = z.record(productBenefitListSchema, trialSchema);
 export type TrialInformation = z.infer<typeof trialInformationSchema>;
 
 export const userBenefitsSchema = z.object({
-	benefits: z.array(productBenefitSchema),
+	benefits: z.array(productBenefitListSchema),
 	trials: trialInformationSchema,
 });
 

--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -6,9 +6,11 @@ import type {
 } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import { getSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
-import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
+import {
+	allProductBenefits,
+	productBenefitMapping,
+} from '@modules/product-benefits/productBenefit';
 import type { ProductBenefit } from '@modules/product-benefits/schemas';
-import { allProductBenefits } from '@modules/product-benefits/schemas';
 
 export const getUserProducts = async (
 	stage: Stage,

--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -1,11 +1,15 @@
 import { distinct } from '@modules/arrayFunctions';
+import type { IdentityUserDetails } from '@modules/identity/identity';
 import type {
 	ProductCatalogHelper,
 	ProductKey,
 } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import { getSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
-import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
+import {
+	productBenefitMapping,
+	tierThreeBenefits,
+} from '@modules/product-benefits/productBenefit';
 import type { ProductBenefit } from '@modules/product-benefits/schemas';
 
 export const getUserProducts = async (
@@ -30,15 +34,21 @@ export const getUserProducts = async (
 		.filter((product) => product !== undefined);
 };
 
+const userWorksForTheGuardian = (email: string): boolean =>
+	email.endsWith('@theguardian.com') || email.endsWith('@guardian.co.uk');
+
 export const getUserBenefits = async (
 	stage: Stage,
 	productCatalogHelper: ProductCatalogHelper,
-	identityId: string,
+	userDetails: IdentityUserDetails,
 ): Promise<ProductBenefit[]> => {
+	if (userWorksForTheGuardian(userDetails.email)) {
+		return tierThreeBenefits;
+	}
 	const userProducts = await getUserProducts(
 		stage,
 		productCatalogHelper,
-		identityId,
+		userDetails.identityId,
 	);
 	return getUserBenefitsFromUserProducts(userProducts);
 };

--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -6,11 +6,9 @@ import type {
 } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import { getSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
-import {
-	productBenefitMapping,
-	tierThreeBenefits,
-} from '@modules/product-benefits/productBenefit';
+import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
 import type { ProductBenefit } from '@modules/product-benefits/schemas';
+import { allProductBenefits } from '@modules/product-benefits/schemas';
 
 export const getUserProducts = async (
 	stage: Stage,
@@ -34,7 +32,7 @@ export const getUserProducts = async (
 		.filter((product) => product !== undefined);
 };
 
-const userWorksForTheGuardian = (email: string): boolean =>
+const userHasGuardianEmail = (email: string): boolean =>
 	email.endsWith('@theguardian.com') || email.endsWith('@guardian.co.uk');
 
 export const getUserBenefits = async (
@@ -42,8 +40,8 @@ export const getUserBenefits = async (
 	productCatalogHelper: ProductCatalogHelper,
 	userDetails: IdentityUserDetails,
 ): Promise<ProductBenefit[]> => {
-	if (userWorksForTheGuardian(userDetails.email)) {
-		return tierThreeBenefits;
+	if (userHasGuardianEmail(userDetails.email)) {
+		return allProductBenefits;
 	}
 	const userProducts = await getUserProducts(
 		stage,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 3.699.0
       '@aws-sdk/credential-providers':
         specifier: 3.665.0
-        version: 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))
+        version: 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -266,6 +266,9 @@ importers:
       '@okta/jwt-verifier':
         specifier: ^4.0.1
         version: 4.0.1
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.145
@@ -4838,7 +4841,7 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.699.0(@aws-sdk/client-sts@3.665.0)
+      '@aws-sdk/client-sso-oidc': 3.699.0(@aws-sdk/client-sts@3.699.0)
       '@aws-sdk/client-sts': 3.699.0
       '@aws-sdk/core': 3.696.0
       '@aws-sdk/credential-provider-node': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.699.0)
@@ -5465,7 +5468,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/client-sts': 3.665.0
       '@aws-sdk/core': 3.696.0
-      '@aws-sdk/credential-provider-node': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)
+      '@aws-sdk/credential-provider-node': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/middleware-host-header': 3.696.0
       '@aws-sdk/middleware-logger': 3.696.0
       '@aws-sdk/middleware-recursion-detection': 3.696.0
@@ -6190,13 +6193,13 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)':
+  '@aws-sdk/credential-provider-ini@3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.665.0
       '@aws-sdk/credential-provider-env': 3.664.0
       '@aws-sdk/credential-provider-http': 3.664.0
       '@aws-sdk/credential-provider-process': 3.664.0
-      '@aws-sdk/credential-provider-sso': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))
+      '@aws-sdk/credential-provider-sso': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))
       '@aws-sdk/credential-provider-web-identity': 3.664.0(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/types': 3.664.0
       '@smithy/credential-provider-imds': 3.2.7
@@ -6265,14 +6268,14 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)':
+  '@aws-sdk/credential-provider-ini@3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.665.0
       '@aws-sdk/core': 3.696.0
       '@aws-sdk/credential-provider-env': 3.696.0
       '@aws-sdk/credential-provider-http': 3.696.0
       '@aws-sdk/credential-provider-process': 3.696.0
-      '@aws-sdk/credential-provider-sso': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))
+      '@aws-sdk/credential-provider-sso': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))
       '@aws-sdk/credential-provider-web-identity': 3.696.0(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/types': 3.696.0
       '@smithy/credential-provider-imds': 3.2.7
@@ -6312,23 +6315,23 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.665.0(@aws-sdk/client-sso-oidc@3.665.0(@aws-sdk/client-sts@3.665.0))
       '@aws-sdk/credential-provider-web-identity': 3.664.0(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/types': 3.664.0
-      '@smithy/credential-provider-imds': 3.2.7
-      '@smithy/property-provider': 3.1.10
-      '@smithy/shared-ini-file-loader': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/credential-provider-imds': 3.2.4
+      '@smithy/property-provider': 3.1.7
+      '@smithy/shared-ini-file-loader': 3.1.8
+      '@smithy/types': 3.5.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@aws-sdk/client-sts'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)':
+  '@aws-sdk/credential-provider-node@3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.664.0
       '@aws-sdk/credential-provider-http': 3.664.0
-      '@aws-sdk/credential-provider-ini': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)
+      '@aws-sdk/credential-provider-ini': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/credential-provider-process': 3.664.0
-      '@aws-sdk/credential-provider-sso': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))
+      '@aws-sdk/credential-provider-sso': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))
       '@aws-sdk/credential-provider-web-identity': 3.664.0(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/types': 3.664.0
       '@smithy/credential-provider-imds': 3.2.4
@@ -6398,13 +6401,13 @@ snapshots:
       - '@aws-sdk/client-sts'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)':
+  '@aws-sdk/credential-provider-node@3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.696.0
       '@aws-sdk/credential-provider-http': 3.696.0
-      '@aws-sdk/credential-provider-ini': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)
+      '@aws-sdk/credential-provider-ini': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/credential-provider-process': 3.696.0
-      '@aws-sdk/credential-provider-sso': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))
+      '@aws-sdk/credential-provider-sso': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))
       '@aws-sdk/credential-provider-web-identity': 3.696.0(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/types': 3.696.0
       '@smithy/credential-provider-imds': 3.2.7
@@ -6493,10 +6496,10 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-sso@3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))':
+  '@aws-sdk/credential-provider-sso@3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))':
     dependencies:
       '@aws-sdk/client-sso': 3.665.0
-      '@aws-sdk/token-providers': 3.664.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))
+      '@aws-sdk/token-providers': 3.664.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))
       '@aws-sdk/types': 3.664.0
       '@smithy/property-provider': 3.1.10
       '@smithy/shared-ini-file-loader': 3.1.11
@@ -6540,6 +6543,20 @@ snapshots:
       '@aws-sdk/core': 3.693.0
       '@aws-sdk/token-providers': 3.693.0(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.693.0))
       '@aws-sdk/types': 3.692.0
+      '@smithy/property-provider': 3.1.10
+      '@smithy/shared-ini-file-loader': 3.1.11
+      '@smithy/types': 3.7.1
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+
+  '@aws-sdk/credential-provider-sso@3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))':
+    dependencies:
+      '@aws-sdk/client-sso': 3.696.0
+      '@aws-sdk/core': 3.696.0
+      '@aws-sdk/token-providers': 3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))
+      '@aws-sdk/types': 3.696.0
       '@smithy/property-provider': 3.1.10
       '@smithy/shared-ini-file-loader': 3.1.11
       '@smithy/types': 3.7.1
@@ -6615,7 +6632,7 @@ snapshots:
       '@smithy/types': 3.7.1
       tslib: 2.6.2
 
-  '@aws-sdk/credential-providers@3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))':
+  '@aws-sdk/credential-providers@3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))':
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.665.0
       '@aws-sdk/client-sso': 3.665.0
@@ -6623,10 +6640,10 @@ snapshots:
       '@aws-sdk/credential-provider-cognito-identity': 3.665.0
       '@aws-sdk/credential-provider-env': 3.664.0
       '@aws-sdk/credential-provider-http': 3.664.0
-      '@aws-sdk/credential-provider-ini': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)
-      '@aws-sdk/credential-provider-node': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(@aws-sdk/client-sts@3.665.0)
+      '@aws-sdk/credential-provider-ini': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)
+      '@aws-sdk/credential-provider-node': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/credential-provider-process': 3.664.0
-      '@aws-sdk/credential-provider-sso': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))
+      '@aws-sdk/credential-provider-sso': 3.665.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))
       '@aws-sdk/credential-provider-web-identity': 3.664.0(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/types': 3.664.0
       '@smithy/credential-provider-imds': 3.2.4
@@ -6931,7 +6948,7 @@ snapshots:
       '@smithy/types': 3.7.1
       tslib: 2.6.2
 
-  '@aws-sdk/token-providers@3.664.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))':
+  '@aws-sdk/token-providers@3.664.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))':
     dependencies:
       '@aws-sdk/client-sso-oidc': 3.699.0(@aws-sdk/client-sts@3.665.0)
       '@aws-sdk/types': 3.664.0
@@ -6962,6 +6979,15 @@ snapshots:
     dependencies:
       '@aws-sdk/client-sso-oidc': 3.693.0(@aws-sdk/client-sts@3.693.0)
       '@aws-sdk/types': 3.692.0
+      '@smithy/property-provider': 3.1.10
+      '@smithy/shared-ini-file-loader': 3.1.11
+      '@smithy/types': 3.7.1
+      tslib: 2.6.2
+
+  '@aws-sdk/token-providers@3.699.0(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.665.0))':
+    dependencies:
+      '@aws-sdk/client-sso-oidc': 3.699.0(@aws-sdk/client-sts@3.665.0)
+      '@aws-sdk/types': 3.696.0
       '@smithy/property-provider': 3.1.10
       '@smithy/shared-ini-file-loader': 3.1.11
       '@smithy/types': 3.7.1
@@ -7610,7 +7636,7 @@ snapshots:
       '@typescript-eslint/parser': 8.1.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.29.1)(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       tslib: 2.6.2
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -7623,7 +7649,7 @@ snapshots:
       eslint: 8.57.1
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -9795,7 +9821,7 @@ snapshots:
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-core-module: 2.15.1
@@ -9850,7 +9876,7 @@ snapshots:
       eslint: 8.57.1
       ignore: 5.3.2
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Updates the user-benefits module and API to be aware of users with a Guardian email address and to grant them all digital benefits.

To do this we need to extract the email address from the Okta JWT when we verify the users sign in status. This is stored in the `sub` claim.