### PR TITLE
Give Guardian staff access to the PressReader editions app

### DIFF
--- a/handlers/press-reader-entitlements/jest.config.js
+++ b/handlers/press-reader-entitlements/jest.config.js
@@ -8,3 +8,6 @@ module.exports = {
 		'@modules/(.*)$': '<rootDir>/../../modules/$1',
 	},
 };
+process.env = Object.assign(process.env, {
+	Stage: 'CODE',
+});

--- a/handlers/press-reader-entitlements/src/index.ts
+++ b/handlers/press-reader-entitlements/src/index.ts
@@ -4,6 +4,7 @@ import { getIfDefined } from '@modules/nullAndUndefined';
 import { userHasGuardianEmail } from '@modules/product-benefits/userBenefits';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import type { Stage } from '@modules/stage';
+import { stageFromEnvironment } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import type {
 	APIGatewayProxyEvent,
@@ -15,7 +16,7 @@ import { getLatestSubscription } from './supporterProductData';
 import type { Member } from './xmlBuilder';
 import { buildXml } from './xmlBuilder';
 
-const stage = process.env.STAGE as Stage;
+const stage = stageFromEnvironment();
 const lazyProductCatalog = new Lazy(
 	async () => await getProductCatalogFromApi(stage),
 	'Get product catalog',

--- a/handlers/press-reader-entitlements/src/schemas.ts
+++ b/handlers/press-reader-entitlements/src/schemas.ts
@@ -3,19 +3,20 @@ import { z } from 'zod';
 const ok = z.literal('ok');
 const error = z.literal('error');
 
-const successfulGetIdentityIdResponse = z.object({
+const successfulGetUserDetailsResponse = z.object({
 	status: ok,
 	id: z.string(),
+	primaryEmailAddress: z.string(),
 });
 
-const failedGetIdentityIdResponse = z.object({
+const failedGetUserDetailsResponse = z.object({
 	status: error,
 	errors: z.array(z.object({ message: z.string(), description: z.string() })),
 });
 
-export const getIdentityIdSchema = z.discriminatedUnion('status', [
-	successfulGetIdentityIdResponse,
-	failedGetIdentityIdResponse,
+export const getUserDetailsSchema = z.discriminatedUnion('status', [
+	successfulGetUserDetailsResponse,
+	failedGetUserDetailsResponse,
 ]);
 
-export type GetIdentityIdResponse = z.infer<typeof getIdentityIdSchema>;
+export type GetUserDetailsResponse = z.infer<typeof getUserDetailsSchema>;

--- a/handlers/press-reader-entitlements/test/pressReaderEntitlementsIntegration.test.ts
+++ b/handlers/press-reader-entitlements/test/pressReaderEntitlementsIntegration.test.ts
@@ -21,12 +21,12 @@ test('Entitlements check', async () => {
 test('getIdentityId', async () => {
 	const accessToken = await getClientAccessToken('CODE');
 	expect(accessToken).toBeDefined();
-	const identityId = await getUserDetails(
+	const userDetails = await getUserDetails(
 		accessToken,
 		'CODE',
 		'c20da7c7-4f72-44fb-b719-78879bfab70d',
 	);
-	expect(identityId).toBe('200149752');
+	expect(userDetails.identityId).toBe('200149752');
 });
 
 test('getMemberDetails', async () => {
@@ -36,15 +36,15 @@ test('getMemberDetails', async () => {
 			{
 				product: {
 					productID: 'the-guardian',
-					enddate: '2025-09-08',
-					startdate: '2023-09-08',
+					enddate: '2099-01-01',
+					startdate: '1821-05-05',
 				},
 			},
 			{
 				product: {
 					productID: 'the-observer',
-					enddate: '2025-09-08',
-					startdate: '2023-09-08',
+					enddate: '2099-01-01',
+					startdate: '1821-05-05',
 				},
 			},
 		],

--- a/handlers/press-reader-entitlements/test/pressReaderEntitlementsIntegration.test.ts
+++ b/handlers/press-reader-entitlements/test/pressReaderEntitlementsIntegration.test.ts
@@ -5,7 +5,7 @@
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import { getMemberDetails } from '../src';
-import { getClientAccessToken, getIdentityId } from '../src/identity';
+import { getClientAccessToken, getUserDetails } from '../src/identity';
 import { getLatestSubscription } from '../src/supporterProductData';
 
 test('Entitlements check', async () => {
@@ -21,7 +21,7 @@ test('Entitlements check', async () => {
 test('getIdentityId', async () => {
 	const accessToken = await getClientAccessToken('CODE');
 	expect(accessToken).toBeDefined();
-	const identityId = await getIdentityId(
+	const identityId = await getUserDetails(
 		accessToken,
 		'CODE',
 		'c20da7c7-4f72-44fb-b719-78879bfab70d',

--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -34,7 +34,7 @@ export const getUserProducts = async (
 		.filter((product) => product !== undefined);
 };
 
-const userHasGuardianEmail = (email: string): boolean =>
+export const userHasGuardianEmail = (email: string): boolean =>
 	email.endsWith('@theguardian.com') || email.endsWith('@guardian.co.uk');
 
 export const getUserBenefits = async (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR updates the press-reader-entitlements api to grant access to guardian staff using the email address field which is now being returned from identity since [this PR](https://github.com/guardian/identity/pull/2654)