### PR TITLE
don't offer a pause to contribitions with zero amount

### DIFF
--- a/handlers/discount-api/src/eligibilityChecker.ts
+++ b/handlers/discount-api/src/eligibilityChecker.ts
@@ -38,6 +38,18 @@ export class EligibilityChecker {
 			JSON.stringify(nextInvoiceItems),
 		);
 
+		this.logger.log(
+			"making sure there's a payment due - avoid zero contribution amounts",
+		);
+		const nextInvoiceTotal = nextInvoiceItems
+			.map((item) => item.amount)
+			.reduce((a, b) => a + b);
+		this.assertValidState(
+			nextInvoiceTotal > 0,
+			validationRequirements.nextInvoiceGreaterThanZero,
+			JSON.stringify(nextInvoiceItems),
+		);
+
 		this.logger.log('Subscription is generally eligible for the discount');
 	};
 
@@ -108,4 +120,5 @@ export const validationRequirements = {
 	isActive: 'subscription status is active',
 	zeroAccountBalance: 'account balance is zero',
 	atLeastCatalogPrice: 'next invoice must be at least the catalog price',
+	nextInvoiceGreaterThanZero: 'next invoice total must be greater than zero',
 };

--- a/handlers/discount-api/test/eligibilityChecker.test.ts
+++ b/handlers/discount-api/test/eligibilityChecker.test.ts
@@ -22,6 +22,7 @@ import billingPreviewSupporterPlusFullPrice from './fixtures/billing-previews/su
 import subscriptionJson2 from './fixtures/digital-subscriptions/eligibility-checker-test2.json';
 import subscriptionJson3 from './fixtures/digital-subscriptions/eligibility-checker-test3.json';
 import subscriptionJson1 from './fixtures/supporter-plus/free-2-months.json';
+import zeroContributionPreview from './fixtures/billing-previews/zero-contribution.json';
 import subSupporterPlusFullPrice from './fixtures/supporter-plus/full-price.json';
 
 const eligibilityChecker = new EligibilityChecker(new Logger());
@@ -62,6 +63,22 @@ test('Eligibility check fails for a Supporter plus which has already had the off
 		);
 
 	expect(ac2).toThrow(validationRequirements.notAlreadyUsed);
+});
+
+test('Eligibility check fails where the next payment is zero (i.e. a contribution set to 0 amount)', async () => {
+	const sub = zuoraSubscriptionResponseSchema.parse(subscriptionJson1);
+	const billingPreview = loadBillingPreview(zeroContributionPreview);
+
+	const actual = () =>
+		eligibilityChecker.assertGenerallyEligible(
+			sub,
+			0,
+			asLazy(getNextInvoiceItems(billingPreview)),
+		);
+
+	expect(actual).rejects.toThrow(
+		validationRequirements.notAlreadyUsed, //TODO expect fail - change this to nextInvoiceGreaterThanZero,
+	);
 });
 
 test('Eligibility check fails for a S+ subscription which is on a reduced price', async () => {

--- a/handlers/discount-api/test/eligibilityChecker.test.ts
+++ b/handlers/discount-api/test/eligibilityChecker.test.ts
@@ -53,7 +53,9 @@ test('Eligibility check fails for a Supporter plus which has already had the off
 			asLazy(getNextInvoiceItems(billingPreview)),
 		);
 
-	expect(actual).rejects.toThrow(validationRequirements.noNegativePreviewItems);
+	await expect(actual).rejects.toThrow(
+		validationRequirements.noNegativePreviewItems,
+	);
 
 	const ac2 = () =>
 		eligibilityChecker.assertEligibleForFreePeriod(
@@ -76,8 +78,8 @@ test('Eligibility check fails where the next payment is zero (i.e. a contributio
 			asLazy(getNextInvoiceItems(billingPreview)),
 		);
 
-	expect(actual).rejects.toThrow(
-		validationRequirements.notAlreadyUsed, //TODO expect fail - change this to nextInvoiceGreaterThanZero,
+	await expect(actual).rejects.toThrow(
+		validationRequirements.nextInvoiceGreaterThanZero,
 	);
 });
 
@@ -96,7 +98,9 @@ test('Eligibility check fails for a S+ subscription which is on a reduced price'
 			asLazy(getNextInvoiceItems(billingPreview)),
 		);
 
-	expect(actual).rejects.toThrow(validationRequirements.noNegativePreviewItems);
+	await expect(actual).rejects.toThrow(
+		validationRequirements.noNegativePreviewItems,
+	);
 
 	//expect to not throw
 	eligibilityChecker.assertEligibleForFreePeriod(
@@ -175,5 +179,5 @@ test('Eligibility check fails for a subscription which is cancelled', async () =
 			Promise.reject('should not attempt a BP if its cancelled'),
 		);
 
-	expect(ac2).rejects.toThrow(validationRequirements.isActive);
+	await expect(ac2).rejects.toThrow(validationRequirements.isActive);
 });

--- a/handlers/discount-api/test/fixtures/billing-previews/zero-contribution.json
+++ b/handlers/discount-api/test/fixtures/billing-previews/zero-contribution.json
@@ -1,0 +1,51 @@
+{
+  "accountId": "accIdidId123",
+  "invoiceItems": [
+    {
+      "id": "id12345",
+      "subscriptionName": "A-S12313444",
+      "subscriptionId": "subidID1432",
+      "subscriptionNumber": "A-S12313444",
+      "serviceStartDate": "2025-01-01",
+      "serviceEndDate": "2025-01-31",
+      "chargeAmount": 0,
+      "chargeDescription": "",
+      "chargeName": "Monthly Contribution",
+      "chargeNumber": "C-01234344",
+      "chargeId": "chargeididcharID",
+      "productName": "Contributor",
+      "quantity": 1,
+      "taxAmount": 0,
+      "unitOfMeasure": "",
+      "chargeDate": "2024-12-11 10:15:31",
+      "chargeType": "Recurring",
+      "processingType": "Charge",
+      "appliedToItemId": null,
+      "numberOfDeliveries": 0
+    },
+    {
+      "id": "id12345",
+      "subscriptionName": "A-S12313444",
+      "subscriptionId": "subidID1432",
+      "subscriptionNumber": "A-S12313444",
+      "serviceStartDate": "2025-02-01",
+      "serviceEndDate": "2025-02-28",
+      "chargeAmount": 0,
+      "chargeDescription": "",
+      "chargeName": "Monthly Contribution",
+      "chargeNumber": "C-01234344",
+      "chargeId": "chargeididcharID",
+      "productName": "Contributor",
+      "quantity": 1,
+      "taxAmount": 0,
+      "unitOfMeasure": "",
+      "chargeDate": "2024-12-11 10:15:31",
+      "chargeType": "Recurring",
+      "processingType": "Charge",
+      "appliedToItemId": null,
+      "numberOfDeliveries": 0
+    }
+  ],
+  "creditMemoItems": [],
+  "success": true
+}


### PR DESCRIPTION
We noticed that errors were being thrown when a zero-contributor tried to cancel (and thus called the preview-discount endpoint)
This shouldn't have prevented them from cancelling, as manage would handle this, but it caused an error/alarm for us.

This PR changes it so that it notices a zero invoice, and doesn't offer a discount using a normal check.