### PR TITLE
Add some tests for the user benefits handler

### DIFF
--- a/handlers/user-benefits/jest.config.js
+++ b/handlers/user-benefits/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	runner: 'groups',
+	moduleNameMapper: {
+		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
+		'@modules/(.*)$': '<rootDir>/../../modules/$1',
+	},
+};

--- a/handlers/user-benefits/package.json
+++ b/handlers/user-benefits/package.json
@@ -1,10 +1,11 @@
 {
   "name": "user-benefits",
   "scripts": {
+    "test": "jest --group=-integration",
     "type-check": "tsc --noEmit",
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm build && cd target && zip -qr user-benefits.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr user-benefits.zip ./*.js",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   },

--- a/handlers/user-benefits/test/index.test.ts
+++ b/handlers/user-benefits/test/index.test.ts
@@ -1,0 +1,60 @@
+import type { UserBenefitsResponse } from '@modules/product-benefits/schemas';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { handler } from '../src/index';
+
+jest.mock('@modules/identity/apiGateway', () => ({
+	buildAuthenticate: () => (event: APIGatewayProxyEvent) => {
+		if (event.headers.Authorization === 'Bearer good-token') {
+			return {
+				type: 'AuthenticatedApiGatewayEvent',
+				userDetails: {
+					identityId: 'good-identity-id',
+					email: 'email@example.com',
+				},
+			};
+		} else {
+			return {
+				type: 'FailedAuthenticationResponse',
+				statusCode: 401,
+			};
+		}
+	},
+}));
+jest.mock('@modules/product-catalog/api', () => ({
+	getProductCatalogFromApi: () => ({}),
+}));
+jest.mock('@modules/product-benefits/userBenefits', () => ({
+	getUserBenefits: () => ['adFree'],
+}));
+
+describe('handler', () => {
+	it('returns a 404 for an unrecognized path or HTTP method', async () => {
+		const requestEvent = {
+			path: '/bad/path',
+			httpMethod: 'GET',
+			headers: {},
+		} as unknown as APIGatewayProxyEvent;
+
+		const response = await handler(requestEvent);
+
+		expect(response.statusCode).toEqual(404);
+	});
+
+	describe('/benefits/me', () => {
+		it('returns a 200 with user benefits', async () => {
+			const requestEvent = {
+				path: '/benefits/me',
+				httpMethod: 'GET',
+				headers: {
+					Authorization: 'Bearer good-token',
+				},
+			} as unknown as APIGatewayProxyEvent;
+
+			const response = await handler(requestEvent);
+
+			expect(response.statusCode).toEqual(200);
+			const parsedBody = JSON.parse(response.body) as UserBenefitsResponse;
+			expect(parsedBody.benefits).toEqual(['adFree']);
+		});
+	});
+});

--- a/modules/identity/src/apiGateway.ts
+++ b/modules/identity/src/apiGateway.ts
@@ -98,3 +98,15 @@ export class IdentityApiGatewayAuthenticator {
 		}
 	}
 }
+
+export const buildAuthenticate = (
+	stage: Stage,
+	requiredScopes: string[],
+): ((event: APIGatewayProxyEvent) => Promise<AuthenticationResult>) => {
+	const authenticator = new IdentityApiGatewayAuthenticator(
+		stage,
+		requiredScopes,
+	);
+
+	return (event: APIGatewayProxyEvent) => authenticator.authenticate(event);
+};

--- a/modules/identity/src/apiGateway.ts
+++ b/modules/identity/src/apiGateway.ts
@@ -103,10 +103,18 @@ export const buildAuthenticate = (
 	stage: Stage,
 	requiredScopes: string[],
 ): ((event: APIGatewayProxyEvent) => Promise<AuthenticationResult>) => {
+	// We only build one of these instances, the function returned below closes
+	// over the instance and uses it each time it is invoked.
 	const authenticator = new IdentityApiGatewayAuthenticator(
 		stage,
 		requiredScopes,
 	);
+	console.log(
+		`Created an IdentityApiGatewayAuthenticator instance. Stage: ${stage}. Scopes: ${requiredScopes.join(', ')}.`,
+	);
 
-	return (event: APIGatewayProxyEvent) => authenticator.authenticate(event);
+	const authenticate = (event: APIGatewayProxyEvent) =>
+		authenticator.authenticate(event);
+
+	return authenticate;
 };


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

I'm planning on making some changes to the user benefits handler, including to the routing, so add some tests. This involved a little bit of setup to make jest work in this workspace.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

```
$ pnpm --filter user-benefits test
```

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
