### PR TITLE
Ensure that 4xx response bubble up correctly from identity

### DIFF
--- a/handlers/user-benefits/src/index.ts
+++ b/handlers/user-benefits/src/index.ts
@@ -1,8 +1,4 @@
 import { ValidationError } from '@modules/errors';
-import type {
-	AuthenticatedApiGatewayEvent,
-	FailedAuthenticationResponse,
-} from '@modules/identity/apiGateway';
 import { IdentityApiGatewayAuthenticator } from '@modules/identity/apiGateway';
 import type { IdentityUserDetails } from '@modules/identity/identity';
 import { Lazy } from '@modules/lazy';
@@ -55,13 +51,11 @@ export const handler: Handler = async (
 		};
 	}
 	try {
-		const maybeAuthenticatedEvent:
-			| AuthenticatedApiGatewayEvent
-			| FailedAuthenticationResponse =
+		const maybeAuthenticatedEvent =
 			await identityAuthenticator.authenticate(event);
 
-		if (maybeAuthenticatedEvent.type === 'FailedAuthenticationResponse') {
-			return maybeAuthenticatedEvent;
+		if (maybeAuthenticatedEvent.type === 'failure') {
+			return maybeAuthenticatedEvent.response;
 		}
 
 		const userBenefitsResponse = await getUserBenefitsResponse(

--- a/modules/identity/test/identity.test.ts
+++ b/modules/identity/test/identity.test.ts
@@ -81,46 +81,45 @@ test('we throw an error if the token is expired', async () => {
 const authenticator = new IdentityApiGatewayAuthenticator('CODE', []);
 
 test('ApiGateway event with a valid token returns an authenticated result', async () => {
-	const response = await authenticator.authenticate(
+	const result = await authenticator.authenticate(
 		buildProxyEvent(validAuthHeader),
 	);
-	console.log(response);
-	expect(response.type).toBe('AuthenticatedApiGatewayEvent');
-	if (response.type !== 'AuthenticatedApiGatewayEvent') {
+	expect(result.type).toBe('success');
+	if (result.type !== 'success') {
 		throw new Error('Expected response to be an AuthenticatedApiGatewayEvent');
 	}
-	expect(response.userDetails.identityId.length).toBeGreaterThan(0);
+	expect(result.userDetails.identityId.length).toBeGreaterThan(0);
 });
 
 test('ApiGateway event with expired token returns a 401 response', async () => {
-	const response = await authenticator.authenticate(
+	const result = await authenticator.authenticate(
 		buildProxyEvent(expiredAuthHeader),
 	);
-	expect(response.type).toBe('FailedAuthenticationResponse');
-	if (response.type !== 'FailedAuthenticationResponse') {
-		throw new Error('Expected response to be a FailedAuthenticationResponse');
+	expect(result.type).toBe('failure');
+	if (result.type !== 'failure') {
+		throw new Error('Expected response to be a failure');
 	}
-	expect(response.statusCode).toBe(401);
+	expect(result.response.statusCode).toBe(401);
 });
 
 test('ApiGateway event with an invalid token returns a 401 response', async () => {
-	const response = await authenticator.authenticate(
+	const result = await authenticator.authenticate(
 		buildProxyEvent('Bearer invalid-token'),
 	);
-	expect(response.type).toBe('FailedAuthenticationResponse');
-	if (response.type !== 'FailedAuthenticationResponse') {
-		throw new Error('Expected response to be a FailedAuthenticationResponse');
+	expect(result.type).toBe('failure');
+	if (result.type !== 'failure') {
+		throw new Error('Expected response to be a failure');
 	}
-	expect(response.statusCode).toBe(401);
+	expect(result.response.statusCode).toBe(401);
 });
 
 test('ApiGateway event with an missing token returns a 401 response', async () => {
-	const response = await authenticator.authenticate(buildProxyEvent(undefined));
-	expect(response.type).toBe('FailedAuthenticationResponse');
-	if (response.type !== 'FailedAuthenticationResponse') {
-		throw new Error('Expected response to be a FailedAuthenticationResponse');
+	const result = await authenticator.authenticate(buildProxyEvent(undefined));
+	expect(result.type).toBe('failure');
+	if (result.type !== 'failure') {
+		throw new Error('Expected response to be a failure');
 	}
-	expect(response.statusCode).toBe(401);
+	expect(result.response.statusCode).toBe(401);
 });
 
 test('ApiGateway event with a valid token with incorrect scopes returns a 403 response', async () => {
@@ -128,12 +127,12 @@ test('ApiGateway event with a valid token with incorrect scopes returns a 403 re
 		'CODE',
 		['non-existent.scope'],
 	);
-	const response = await authenticatorWithNonExistantScope.authenticate(
+	const result = await authenticatorWithNonExistantScope.authenticate(
 		buildProxyEvent(validAuthHeader),
 	);
-	expect(response.type).toBe('FailedAuthenticationResponse');
-	if (response.type !== 'FailedAuthenticationResponse') {
-		throw new Error('Expected response to be a FailedAuthenticationResponse');
+	expect(result.type).toBe('failure');
+	if (result.type !== 'failure') {
+		throw new Error('Expected response to be a failure');
 	}
-	expect(response.statusCode).toBe(403);
+	expect(result.response.statusCode).toBe(403);
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Previously API gateway wasn't happy with the `type` property which was added to the response resulting in a 502 to the client. This only existed so that internally we could tell what kind of response we'd got back. Now the response for a failed auth request is nested, so the type doesn't appear in the response we give back to API gateway.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run the integration tests
- [x] Check in CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
