### PR TITLE
Disable deploy comments

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -61,13 +61,14 @@ jobs:
       - run: pnpm --filter cdk package
 
       - name: Upload to Riff-Raff
-        uses: guardian/actions-riff-raff@v4
+        uses: guardian/actions-riff-raff@1275686863875d7b86e0f38e6362644048679500
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           projectName: support-service-lambdas::${{ matrix.subproject }}
           buildNumberOffset: 7000
           configPath: ./handlers/${{ matrix.subproject }}/riff-raff.yaml
+          commentingEnabled: 'false'
           contentDirectories: |
             ${{ matrix.subproject }}-cloudformation:
               - ./cdk/cdk.out/${{ matrix.subproject }}-CODE.template.json

--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -61,7 +61,7 @@ jobs:
       - run: pnpm --filter cdk package
 
       - name: Upload to Riff-Raff
-        uses: guardian/actions-riff-raff@1275686863875d7b86e0f38e6362644048679500
+        uses: guardian/actions-riff-raff@v4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -72,13 +72,14 @@ jobs:
           aws-region: eu-west-1
 
       - name: Upload to Riff-Raff
-        uses: guardian/actions-riff-raff@v4
+        uses: guardian/actions-riff-raff@1275686863875d7b86e0f38e6362644048679500
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           projectName: support-service-lambdas::${{ matrix.subproject }}
           buildNumberOffset: 7000
           configPath: ./handlers/${{ matrix.subproject }}/riff-raff.yaml
+          commentingEnabled: 'false'
           contentDirectories: |
             ${{ matrix.subproject }}-cloudformation:
               - ./cdk/cdk.out

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -72,7 +72,7 @@ jobs:
           aws-region: eu-west-1
 
       - name: Upload to Riff-Raff
-        uses: guardian/actions-riff-raff@1275686863875d7b86e0f38e6362644048679500
+        uses: guardian/actions-riff-raff@v4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR updates the 2 CI workflows which build the various scala and typescript lambdas, to use a new flag available to the riff-raff action which prevents deploy comments being added to the PR. 

The reason for this is that due to the large number of projects in this repo, the deploy comments would get very noisy and it was easy to miss comments from contributors in amongst all the noise.