### PR TITLE
Routing

### DIFF
--- a/handlers/press-reader-entitlements/src/index.ts
+++ b/handlers/press-reader-entitlements/src/index.ts
@@ -1,4 +1,3 @@
-import { ValidationError } from '@modules/errors';
 import { Lazy } from '@modules/lazy';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { userHasGuardianEmail } from '@modules/product-benefits/userBenefits';
@@ -44,33 +43,18 @@ export const handler: Handler = async (
 async function userEntitlementsHandler(
 	event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> {
-	try {
-		const userId = getIfDefined(
-			event.queryStringParameters?.['userId'],
-			'userId does not exist',
-		);
+	const userId = getIfDefined(
+		event.queryStringParameters?.['userId'],
+		'userId does not exist',
+	);
 
-		const memberDetails = await getMemberDetails(stage, userId);
-		const xmlBody = buildXml(memberDetails);
-		console.log(`Successful response body is ${xmlBody}`);
-		return {
-			body: buildXml(memberDetails),
-			statusCode: 200,
-		};
-	} catch (error) {
-		console.log('Caught exception with message: ', error);
-		if (error instanceof ValidationError) {
-			console.log(`Validation failure: ${error.message}`);
-			return {
-				body: error.message,
-				statusCode: 400,
-			};
-		}
-		return {
-			body: 'Internal server error',
-			statusCode: 500,
-		};
-	}
+	const memberDetails = await getMemberDetails(stage, userId);
+	const xmlBody = buildXml(memberDetails);
+	console.log(`Successful response body is ${xmlBody}`);
+	return {
+		body: buildXml(memberDetails),
+		statusCode: 200,
+	};
 }
 
 export async function getMemberDetails(

--- a/modules/routing/jest.config.js
+++ b/modules/routing/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	runner: 'groups',
+	moduleNameMapper: {
+		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
+		'@modules/(.*)$': '<rootDir>/../../modules/$1',
+	},
+};

--- a/modules/routing/package.json
+++ b/modules/routing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "routing",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "jest --group=-integration"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.129"
+  }
+}

--- a/modules/routing/src/router.ts
+++ b/modules/routing/src/router.ts
@@ -1,20 +1,23 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 
-export const HttpMethods = [
-	'GET',
-	'POST',
-	'PUT',
-	'DELETE',
-	'PATCH',
-	'OPTIONS',
-	'HEAD',
-];
-export type HttpMethod = (typeof HttpMethods)[number];
+export type HttpMethod =
+	| 'GET'
+	| 'POST'
+	| 'PUT'
+	| 'DELETE'
+	| 'PATCH'
+	| 'OPTIONS'
+	| 'HEAD';
 
 type Route = {
 	httpMethod: HttpMethod;
 	path: string;
 	handler: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>;
+};
+
+export const NotFoundResponse = {
+	body: 'Not Found',
+	statusCode: 404,
 };
 
 export class Router {
@@ -30,9 +33,6 @@ export class Router {
 		if (route) {
 			return await route.handler(event);
 		}
-		return {
-			body: 'Not Found',
-			statusCode: 404,
-		};
+		return NotFoundResponse;
 	}
 }

--- a/modules/routing/src/router.ts
+++ b/modules/routing/src/router.ts
@@ -1,0 +1,38 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+
+export const HttpMethods = [
+	'GET',
+	'POST',
+	'PUT',
+	'DELETE',
+	'PATCH',
+	'OPTIONS',
+	'HEAD',
+];
+export type HttpMethod = (typeof HttpMethods)[number];
+
+type Route = {
+	httpMethod: HttpMethod;
+	path: string;
+	handler: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>;
+};
+
+export class Router {
+	constructor(private routes: Route[]) {}
+	async routeRequest(
+		event: APIGatewayProxyEvent,
+	): Promise<APIGatewayProxyResult> {
+		const route = this.routes.find(
+			(route) =>
+				route.path === event.path &&
+				route.httpMethod === event.httpMethod.toUpperCase(),
+		);
+		if (route) {
+			return await route.handler(event);
+		}
+		return {
+			body: 'Not Found',
+			statusCode: 404,
+		};
+	}
+}

--- a/modules/routing/test/router.test.ts
+++ b/modules/routing/test/router.test.ts
@@ -1,0 +1,81 @@
+import type { HttpMethod } from '@modules/routing/router';
+import { Router } from '@modules/routing/router';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+const successResponse = {
+	body: 'Success',
+	statusCode: 200,
+};
+const notFoundResponse = {
+	body: 'Not Found',
+	statusCode: 404,
+};
+const router = new Router([
+	{
+		httpMethod: 'GET',
+		path: '/benefits/me',
+		handler: () => {
+			return Promise.resolve(successResponse);
+		},
+	},
+]);
+
+describe('Router', () => {
+	test('it should match a route successfully', async () => {
+		expect(
+			await router.routeRequest(buildApiGatewayEvent('/benefits/me', 'GET')),
+		).toEqual(successResponse);
+	});
+	test('it should return a 404 if no route is found', async () => {
+		expect(
+			await router.routeRequest(buildApiGatewayEvent('/not-found', 'GET')),
+		).toEqual(notFoundResponse);
+	});
+});
+
+const buildApiGatewayEvent = (
+	path: string,
+	httpMethod: HttpMethod,
+): APIGatewayProxyEvent => ({
+	body: null,
+	headers: {},
+	multiValueHeaders: {},
+	multiValueQueryStringParameters: null,
+	httpMethod,
+	isBase64Encoded: false,
+	path,
+	pathParameters: null,
+	queryStringParameters: null,
+	stageVariables: null,
+	requestContext: {
+		accountId: '',
+		apiId: '',
+		authorizer: null,
+		httpMethod: 'GET',
+		identity: {
+			accessKey: null,
+			accountId: null,
+			apiKey: null,
+			apiKeyId: null,
+			caller: null,
+			cognitoAuthenticationProvider: null,
+			cognitoAuthenticationType: null,
+			cognitoIdentityId: null,
+			cognitoIdentityPoolId: null,
+			principalOrgId: null,
+			sourceIp: '',
+			user: null,
+			userAgent: null,
+			userArn: null,
+			clientCert: null,
+		},
+		path: '/benefits/me',
+		protocol: '',
+		requestId: '',
+		requestTimeEpoch: 0,
+		resourceId: '',
+		resourcePath: '',
+		stage: '',
+	},
+	resource: '',
+});

--- a/modules/routing/test/router.test.ts
+++ b/modules/routing/test/router.test.ts
@@ -1,15 +1,12 @@
-import type { HttpMethod } from '@modules/routing/router';
-import { Router } from '@modules/routing/router';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
+import type { HttpMethod } from '@modules/routing/router';
+import { NotFoundResponse, Router } from '@modules/routing/router';
 
 const successResponse = {
 	body: 'Success',
 	statusCode: 200,
 };
-const notFoundResponse = {
-	body: 'Not Found',
-	statusCode: 404,
-};
+
 const router = new Router([
 	{
 		httpMethod: 'GET',
@@ -29,7 +26,7 @@ describe('Router', () => {
 	test('it should return a 404 if no route is found', async () => {
 		expect(
 			await router.routeRequest(buildApiGatewayEvent('/not-found', 'GET')),
-		).toEqual(notFoundResponse);
+		).toEqual(NotFoundResponse);
 	});
 });
 

--- a/modules/routing/test/router.test.ts
+++ b/modules/routing/test/router.test.ts
@@ -28,6 +28,11 @@ describe('Router', () => {
 			await router.routeRequest(buildApiGatewayEvent('/not-found', 'GET')),
 		).toEqual(NotFoundResponse);
 	});
+	test('it should check the http method as well as the path', async () => {
+		expect(
+			await router.routeRequest(buildApiGatewayEvent('/benefits/me', 'POST')),
+		).toEqual(NotFoundResponse);
+	});
 });
 
 const buildApiGatewayEvent = (

--- a/modules/routing/tsconfig.json
+++ b/modules/routing/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,12 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
 
+  modules/routing:
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8.10.129
+        version: 8.10.145
+
   modules/salesforce:
     dependencies:
       zod:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
       "@modules/internationalisation/*": ["./modules/internationalisation/src/*"],
       "@modules/supporter-product-data/*": ["./modules/supporter-product-data/src/*"],
       "@modules/identity/*": ["./modules/identity/src/*"],
+      "@modules/routing/*": ["./modules/routing/src/*"],
       "@modules/*": ["./modules/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Creates a very simple module to handle routing of requests from an api gateway event to a handler which will produce a response.

The aim is to standardise the way in which Typescript lambdas do routing in support-service-lambdas and also to make it more testable by separating the routing from the main index file.

In this first iteration requests are only matched on http method and a simple path string. In future path could become a regex to allow for captures to be mapped to parameters.