### PR TITLE
Fix user benefits CODE URL in the README

### DIFF
--- a/handlers/user-benefits/README.md
+++ b/handlers/user-benefits/README.md
@@ -1,8 +1,10 @@
 # User benefits API
+
 This API is an API Gateway triggered lambda to return information about the digital benefits or entitlements that a user has as a result of the subscriptions they have with us.
 
 Authentication is done via an Okta JWT header in the request, using the [identity module.](../../modules/identity/README.md)
 
 # Urls
+
 - PROD: user-benefits.guardianapis.com/benefits/me
-- CODE: user-benefits.code.dev-theguardian.com/benefits/me
+- CODE: user-benefits.code.dev-guardianapis.com/benefits/me


### PR DESCRIPTION
## What does this change?

Fix the CODE URL for the user benefits API in the README.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
