### PR TITLE
Use router module in user-benefits API handler

### DIFF
--- a/handlers/user-benefits/test/index.test.ts
+++ b/handlers/user-benefits/test/index.test.ts
@@ -1,6 +1,6 @@
 import type { UserBenefitsResponse } from '@modules/product-benefits/schemas';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
-import { handler } from '../src/index';
+import { userBenefitsHandler } from '../src/index';
 
 jest.mock('@modules/identity/apiGateway', () => ({
 	buildAuthenticate: () => (event: APIGatewayProxyEvent) => {
@@ -27,34 +27,20 @@ jest.mock('@modules/product-benefits/userBenefits', () => ({
 	getUserBenefits: () => ['adFree'],
 }));
 
-describe('handler', () => {
-	it('returns a 404 for an unrecognized path or HTTP method', async () => {
+describe('userBenefitsHandler', () => {
+	it('returns a 200 with user benefits', async () => {
 		const requestEvent = {
-			path: '/bad/path',
+			path: '/benefits/me',
 			httpMethod: 'GET',
-			headers: {},
+			headers: {
+				Authorization: 'Bearer good-token',
+			},
 		} as unknown as APIGatewayProxyEvent;
 
-		const response = await handler(requestEvent);
+		const response = await userBenefitsHandler(requestEvent);
 
-		expect(response.statusCode).toEqual(404);
-	});
-
-	describe('/benefits/me', () => {
-		it('returns a 200 with user benefits', async () => {
-			const requestEvent = {
-				path: '/benefits/me',
-				httpMethod: 'GET',
-				headers: {
-					Authorization: 'Bearer good-token',
-				},
-			} as unknown as APIGatewayProxyEvent;
-
-			const response = await handler(requestEvent);
-
-			expect(response.statusCode).toEqual(200);
-			const parsedBody = JSON.parse(response.body) as UserBenefitsResponse;
-			expect(parsedBody.benefits).toEqual(['adFree']);
-		});
+		expect(response.statusCode).toEqual(200);
+		const parsedBody = JSON.parse(response.body) as UserBenefitsResponse;
+		expect(parsedBody.benefits).toEqual(['adFree']);
 	});
 });


### PR DESCRIPTION
## What does this change?

Use the new router module in the user-benefits API handler. We can remove common error handling etc which the router now does for us.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
