### PR TITLE
add sqs permission to product-switch lambda

### DIFF
--- a/cdk/lib/__snapshots__/product-switch-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/product-switch-api.test.ts.snap
@@ -181,6 +181,22 @@ exports[`The Product switch api stack matches the snapshot 1`] = `
                     ],
                   ],
                 },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":product-switch-salesforce-tracking-CODE",
+                    ],
+                  ],
+                },
               ],
             },
           ],
@@ -1206,6 +1222,22 @@ exports[`The Product switch api stack matches the snapshot 2`] = `
                         "Ref": "AWS::AccountId",
                       },
                       ":supporter-product-data-PROD",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":product-switch-salesforce-tracking-PROD",
                     ],
                   ],
                 },

--- a/cdk/lib/product-switch-api.ts
+++ b/cdk/lib/product-switch-api.ts
@@ -146,6 +146,7 @@ export class ProductSwitchApi extends GuStack {
 					resources: [
 						`arn:aws:sqs:${this.region}:${this.account}:braze-emails-${this.stage}`,
 						`arn:aws:sqs:${this.region}:${this.account}:supporter-product-data-${this.stage}`,
+						`arn:aws:sqs:${this.region}:${this.account}:product-switch-salesforce-tracking-${this.stage}`,
 					],
 				}),
 			],


### PR DESCRIPTION
We have noticed that product switch records were not in the datalake due to them not ending up in salesforce.

The switch lambda is designed to add a record to a queue which is later written to salesforce.  When it was moved over to the product-switch-api the extra permission needed to write to that queue was missed, and for some reason, writing to a queue that you don't have access silently discards the message.

This means that we didn't get any data between 9th May and when this PR is merged.  There are small numbers of records (1 a day or so) that may be from CSR switches.

This PR adds the permission so hopefully the records will be sent from now on.