### PR TITLE
fix pre-push to compare with main on first push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,7 +5,7 @@ git fetch origin
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 # Check if there are changes in the 'cdk' folder between the local branch and its remote
-if git diff --exit-code --quiet origin/$CURRENT_BRANCH -- cdk/; then
+if git diff --exit-code --quiet main -- cdk/; then
   echo "No changes detected in the 'cdk' folder. Skipping lint and test."
 else
   echo "Changes detected in the 'cdk' folder. Running lint and test..."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,13 +1,27 @@
-# Fetch the latest changes from the remote without merging
 git fetch origin
 
-# Get the name of the current branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-# Check if there are changes in the 'cdk' folder between the local branch and its remote
-if git diff --exit-code --quiet main -- cdk/; then
+git diff --exit-code --quiet origin/$CURRENT_BRANCH -- cdk/
+RC=$?
+if [ $RC -eq 0 ]; then
+  # no changes
   echo "No changes detected in the 'cdk' folder. Skipping lint and test."
-else
+elif [ $RC -eq 1 ]; then
   echo "Changes detected in the 'cdk' folder. Running lint and test..."
   pnpm --filter cdk lint && pnpm --filter cdk test
+else
+  # something went wrong, maybe we haven't pushed our branch and are branching off main
+  # use main not origin/main as we don't care if others changed cdk dir
+  git diff --exit-code --quiet main -- cdk/
+  RC=$?
+    if [ $RC -eq 0 ]; then
+      # no changes
+      echo "(main) No changes detected in the 'cdk' folder. Skipping lint and test."
+    elif [ $RC -eq 1 ]; then
+      echo "(main) Changes detected in the 'cdk' folder. Running lint and test..."
+      pnpm --filter cdk lint && pnpm --filter cdk test
+    else
+      echo "Error: could not compare with upstream"
+    fi
 fi


### PR DESCRIPTION
Following on from https://github.com/guardian/support-service-lambdas/pull/2546

I noticed it wasn't actually working, the pushes were still taking ages.

It turned out from looking at the output, the AI generated script was assuming there was always an upstream `origin/MY_BRANCH_NAME` branch, but this isn't the case until you push it.

This meant a chicken and egg situation where when you pushed your new branch, it would run the command, get a nonzero exit code (128), and therefore run the tests!
```
 % git diff --exit-code --quiet origin/jd-pre-push-condition -- cdk/; echo $?
fatal: bad revision 'origin/jd-pre-push-condition'
128
```

This PR changes it to try the `main` branch, if the similarly named origin branch doesn't exist.

Even trying main is not bulletproof, as you might have pulled CDK related updates to main and not merged them into your branch.  Or you might have fetched them and merged them in to your branch, without updating the `main` branch.  But I think this should cover most of our typical use cases in the way that we would expect.

## Testing
I have tested both of a new branch and an extra push, on both of with and without changes in the CDK folder, and all combinations work as expected.