### PR TITLE
Revert "fix pre-push to compare with main on first push"

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,27 +1,13 @@
+# Fetch the latest changes from the remote without merging
 git fetch origin
 
+# Get the name of the current branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-git diff --exit-code --quiet origin/$CURRENT_BRANCH -- cdk/
-RC=$?
-if [ $RC -eq 0 ]; then
-  # no changes
+# Check if there are changes in the 'cdk' folder between the local branch and its remote
+if git diff --exit-code --quiet origin/$CURRENT_BRANCH -- cdk/; then
   echo "No changes detected in the 'cdk' folder. Skipping lint and test."
-elif [ $RC -eq 1 ]; then
+else
   echo "Changes detected in the 'cdk' folder. Running lint and test..."
   pnpm --filter cdk lint && pnpm --filter cdk test
-else
-  # something went wrong, maybe we haven't pushed our branch and are branching off main
-  # use main not origin/main as we don't care if others changed cdk dir
-  git diff --exit-code --quiet main -- cdk/
-  RC=$?
-    if [ $RC -eq 0 ]; then
-      # no changes
-      echo "(main) No changes detected in the 'cdk' folder. Skipping lint and test."
-    elif [ $RC -eq 1 ]; then
-      echo "(main) Changes detected in the 'cdk' folder. Running lint and test..."
-      pnpm --filter cdk lint && pnpm --filter cdk test
-    else
-      echo "Error: could not compare with upstream"
-    fi
 fi


### PR DESCRIPTION
Reverts guardian/support-service-lambdas#2605 , because it breaks pushing for me. 

```
support-service-lambdas % git push origin HEAD                 
fatal: bad revision 'origin/ph-20241219-1154-upgrade'
husky - pre-push script failed (code 128)
error: failed to push some refs to 'https://github.com/guardian/support-service-lambdas.git'
```