### PR TITLE
Add dependencyOverride for asyncHttpClient

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -362,7 +362,7 @@ def lambdaProject(
       riffRaffUploadManifestBucket := Option("riffraff-builds"),
       riffRaffManifestProjectName := s"support-service-lambdas::$projectName",
       riffRaffArtifactResources += (file(s"handlers/$projectName/$cfName"), s"cfn/$cfName"),
-      dependencyOverrides ++= jacksonDependencies,
+      dependencyOverrides ++= jacksonDependencies :+ asyncHttpClientOverride,
       libraryDependencies ++= externalDependencies ++ logging,
       Test / test := ((Test / test) dependsOn (projectDependencies.map(_.project / Test / test) *)).value,
       Test / testOnly := ((Test / testOnly) dependsOn (projectDependencies.map(_.project / Test / test) *)).evaluated,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,8 +56,13 @@ object Dependencies {
   // HTTP clients
   val sttp = "com.softwaremill.sttp.client3" %% "core" % sttpVersion
   val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpVersion
+
+  // Override to fix this vulnerability https://github.com/guardian/support-service-lambdas/security/dependabot/24
+  // This is a transitive dependency of async-http-client-backend-cats-ce2 so when we upgrade that we can remove this
+  val asyncHttpClientOverride = "org.asynchttpclient" % "async-http-client" % "2.12.4"
   val sttpAsyncHttpClientBackendCats =
     "com.softwaremill.sttp.client3" %% "async-http-client-backend-cats-ce2" % sttpVersion
+
   val sttpOkhttpBackend =
     "com.softwaremill.sttp.client3" %% "okhttp-backend" % sttpVersion
   val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "4.12.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add a dependency override to fix this vulnerability https://github.com/guardian/support-service-lambdas/security/dependabot/24
 
AsyncHttpClient is a transitive dependency of async-http-client-backend-cats-ce2 so when we upgrade that library we can probably remove this.