### PR TITLE
Fix super-mode tag name

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -35,7 +35,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'sf-contact-merge',
 		'sf-emails-to-s3-exporter',
 		'sf-gocardless-sync',
-		'super-mode-calculator',
+		'super-mode',
 		'support-reminders',
 		'ticker-calculator',
 	],


### PR DESCRIPTION
the stack was re-implemented and the App tag is now just `super-mode`