### PR TITLE
Type active and inactive products in the catalog distinctly

### DIFF
--- a/modules/product-benefits/src/productBenefit.ts
+++ b/modules/product-benefits/src/productBenefit.ts
@@ -24,6 +24,7 @@ export const tierThreeBenefits = digitalSubscriptionBenefits.concat([
 
 export const productBenefitMapping: Record<ProductKey, ProductBenefit[]> = {
 	GuardianLight: ['rejectTracking'],
+	GuardianAdLite: ['rejectTracking'],
 	SupporterPlus: supporterPlusBenefits,
 	DigitalSubscription: digitalSubscriptionBenefits,
 	TierThree: tierThreeBenefits,

--- a/modules/product-catalog/package.json
+++ b/modules/product-catalog/package.json
@@ -2,7 +2,7 @@
   "name": "product-catalog",
   "version": "1.0.0",
   "scripts": {
-    "generateTypes": "ts-node src/generateTypeObjectCommand.ts",
+    "generateTypes": "ts-node src/generateTypeObjectCommand.ts && prettier --write src/typeObject.ts",
     "updateSnapshots": "jest -u --group=-integration",
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",

--- a/modules/product-catalog/src/generateTypeObject.ts
+++ b/modules/product-catalog/src/generateTypeObject.ts
@@ -7,6 +7,7 @@ import type {
 import { oneTimeContributionTypeObject } from '@modules/product-catalog/oneTimeContributionProduct';
 import { stripeTypeObject } from '@modules/product-catalog/stripeProducts';
 import {
+	activeProducts,
 	getProductRatePlanChargeKey,
 	getProductRatePlanKey,
 	getZuoraProductKey,
@@ -65,7 +66,7 @@ const getZuoraProduct = (productRatePlans: ZuoraProductRatePlan[]) => {
 		),
 	};
 };
-export const generateTypeObject = (catalog: ZuoraCatalog) => {
+export const generateTypeObjects = (catalog: ZuoraCatalog) => {
 	const supportedProducts = catalog.products.filter((product) =>
 		isSupportedProduct(product.name),
 	);
@@ -79,9 +80,30 @@ export const generateTypeObject = (catalog: ZuoraCatalog) => {
 
 	const zuoraTypeObject = arrayToObject(arrayVersion);
 
+	const activeProductKeys = Object.keys(zuoraTypeObject).filter((k) =>
+		activeProducts.includes(k),
+	);
+	const inactiveProductsKeys = Object.keys(zuoraTypeObject).filter(
+		(k) => !activeProducts.includes(k),
+	);
+
+	const reducer = (acc: typeof zuoraTypeObject, key: string) => {
+		if (zuoraTypeObject[key]) {
+			acc[key] = zuoraTypeObject[key];
+		}
+		return acc;
+	};
+	const activeZuoraTypeObject = activeProductKeys.reduce(reducer, {});
+	const inactiveZuoraTypeObject = inactiveProductsKeys.reduce(reducer, {});
+
 	return {
-		...oneTimeContributionTypeObject,
-		...zuoraTypeObject,
-		...stripeTypeObject,
+		active: {
+			...oneTimeContributionTypeObject,
+			...activeZuoraTypeObject,
+			...stripeTypeObject,
+		},
+		inactive: {
+			...inactiveZuoraTypeObject,
+		},
 	};
 };

--- a/modules/product-catalog/src/generateTypeObjectCommand.ts
+++ b/modules/product-catalog/src/generateTypeObjectCommand.ts
@@ -1,15 +1,16 @@
 import fs from 'fs';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
-import { generateTypeObject } from '@modules/product-catalog/generateTypeObject';
+import { generateTypeObjects } from '@modules/product-catalog/generateTypeObject';
 
 const writeTypesToFile = async () => {
 	const prodCatalog = await getZuoraCatalogFromS3('PROD');
-	const types = generateTypeObject(prodCatalog);
-	const typesString = JSON.stringify(types, null, 2);
+	const types = generateTypeObjects(prodCatalog);
+	const activeTypesString = JSON.stringify(types.active, null, 2);
+	const inactiveTypesString = JSON.stringify(types.inactive, null, 2);
 
 	fs.writeFileSync(
 		'./src/typeObject.ts',
-		`export const typeObject = ${typesString} as const;`,
+		`export const activeTypeObject = ${activeTypesString} as const;\nexport const inactiveTypesObject = ${inactiveTypesString} as const;`,
 	);
 };
 

--- a/modules/product-catalog/src/generateTypeObjectCommand.ts
+++ b/modules/product-catalog/src/generateTypeObjectCommand.ts
@@ -10,7 +10,7 @@ const writeTypesToFile = async () => {
 
 	fs.writeFileSync(
 		'./src/typeObject.ts',
-		`export const activeTypeObject = ${activeTypesString} as const;\nexport const inactiveTypesObject = ${inactiveTypesString} as const;`,
+		`export const activeTypeObject = ${activeTypesString} as const;\nexport const inactiveTypeObject = ${inactiveTypesString} as const;`,
 	);
 };
 

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -7,7 +7,7 @@ import {
 type ActiveTypeObject = typeof activeTypeObject;
 type InactiveTypeObject = typeof inactiveTypeObject;
 
-const typeObject = {
+export const typeObject = {
 	...activeTypeObject,
 	...inactiveTypeObject,
 };

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -1,9 +1,21 @@
 import type { Currency } from '@modules/internationalisation/currency';
-import { typeObject } from '@modules/product-catalog/typeObject';
+import {
+	activeTypeObject,
+	inactiveTypeObject,
+} from '@modules/product-catalog/typeObject';
 
+type ActiveTypeObject = typeof activeTypeObject;
+type InactiveTypeObject = typeof inactiveTypeObject;
+
+const typeObject = {
+	...activeTypeObject,
+	...inactiveTypeObject,
+};
 type TypeObject = typeof typeObject;
 
 export type ProductKey = keyof TypeObject;
+export type ActiveProductKey = keyof ActiveTypeObject;
+export type InactiveProductKey = keyof InactiveTypeObject;
 
 export type ProductRatePlanKey<P extends ProductKey> =
 	keyof TypeObject[P]['productRatePlans'];

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -36,6 +36,22 @@ export const productCatalogSchema = z.object({
 			}),
 		}),
 	}),
+	GuardianAdLite: z.object({
+		billingSystem: z.literal('zuora'),
+		active: z.boolean(),
+		ratePlans: z.object({
+			Monthly: z.object({
+				id: z.string(),
+				pricing: z.object({
+					GBP: z.number(),
+				}),
+				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
+				billingPeriod: z
+					.enum(typeObject.GuardianAdLite.billingPeriods)
+					.optional(),
+			}),
+		}),
+	}),
 	SupporterMembership: z.object({
 		billingSystem: z.literal('zuora'),
 		active: z.boolean(),

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { typeObject } from '@modules/product-catalog/typeObject';
+import { typeObject } from '@modules/product-catalog/productCatalog';
 
 export const productCatalogSchema = z.object({
 	GuardianPatron: z.object({

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -1,474 +1,534 @@
-export const typeObject = {
-	OneTimeContribution: {
-		billingPeriods: ['OneTime'],
-		productRatePlans: {
-			OneTime: {
-				Contribution: {},
-			},
-		},
-	},
-	GuardianLight: {
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Monthly: {
-				Subscription: {},
-			},
-		},
-	},
-	TierThree: {
-		billingPeriods: ['Annual', 'Month'],
-		productRatePlans: {
-			RestOfWorldAnnualV2: {
-				NewspaperArchive: {},
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			RestOfWorldMonthlyV2: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-				NewspaperArchive: {},
-			},
-			DomesticAnnualV2: {
-				NewspaperArchive: {},
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			DomesticMonthlyV2: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-				NewspaperArchive: {},
-			},
-			RestOfWorldMonthly: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			RestOfWorldAnnual: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			DomesticAnnual: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-			DomesticMonthly: {
-				SupporterPlus: {},
-				GuardianWeekly: {},
-			},
-		},
-	},
-	DigitalSubscription: {
-		billingPeriods: ['Quarter', 'Month', 'Annual'],
-		productRatePlans: {
-			Monthly: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-			ThreeMonthGift: {
-				Subscription: {},
-			},
-			OneYearGift: {
-				Subscription: {},
-			},
-		},
-	},
-	NationalDelivery: {
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Sixday: {
-				Monday: {},
-				Tuesday: {},
-				Wednesday: {},
-				Thursday: {},
-				Friday: {},
-				Saturday: {},
-			},
-			Weekend: {
-				Saturday: {},
-				Sunday: {},
-			},
-			Everyday: {
-				Monday: {},
-				Tuesday: {},
-				Wednesday: {},
-				Thursday: {},
-				Friday: {},
-				Saturday: {},
-				Sunday: {},
-			},
-		},
-	},
-	SupporterMembership: {
-		billingPeriods: ['Annual', 'Month'],
-		productRatePlans: {
-			Annual: {
-				Subscription: {},
-			},
-			Monthly: {
-				Subscription: {},
-			},
-			V2DeprecatedAnnual: {
-				Subscription: {},
-			},
-			V1DeprecatedAnnual: {
-				Subscription: {},
-			},
-			V1DeprecatedMonthly: {
-				Subscription: {},
-			},
-			V2DeprecatedMonthly: {
-				Subscription: {},
-			},
-		},
-	},
-	SupporterPlus: {
-		billingPeriods: ['Month', 'Annual'],
-		productRatePlans: {
-			V1DeprecatedMonthly: {
-				Subscription: {},
-			},
-			V1DeprecatedAnnual: {
-				Subscription: {},
-			},
-			Monthly: {
-				Subscription: {},
-				Contribution: {},
-			},
-			Annual: {
-				Contribution: {},
-				Subscription: {},
-			},
-		},
-	},
-	GuardianWeeklyRestOfWorld: {
-		billingPeriods: ['Month', 'Annual', 'Quarter'],
-		productRatePlans: {
-			Monthly: {
-				Monthly: {},
-			},
-			OneYearGift: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-			Quarterly: {
-				Subscription: {},
-			},
-			ThreeMonthGift: {
-				Subscription: {},
-			},
-		},
-	},
-	GuardianWeeklyDomestic: {
-		billingPeriods: ['Annual', 'Quarter', 'Month'],
-		productRatePlans: {
-			OneYearGift: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-			Quarterly: {
-				Subscription: {},
-			},
-			Monthly: {
-				Subscription: {},
-			},
-			ThreeMonthGift: {
-				Subscription: {},
-			},
-		},
-	},
-	SubscriptionCard: {
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Sixday: {
-				Friday: {},
-				Monday: {},
-				Tuesday: {},
-				Thursday: {},
-				Wednesday: {},
-				Saturday: {},
-			},
-			Everyday: {
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-				Thursday: {},
-				Friday: {},
-				Wednesday: {},
-				Sunday: {},
-			},
-			Weekend: {
-				Saturday: {},
-				Sunday: {},
-			},
-			Sunday: {
-				Sunday: {},
-			},
-			Saturday: {
-				Saturday: {},
-			},
-			'Everyday+': {
-				DigitalPack: {},
-				Saturday: {},
-				Tuesday: {},
-				Monday: {},
-				Thursday: {},
-				Wednesday: {},
-				Sunday: {},
-				Friday: {},
-			},
-			'Sixday+': {
-				DigitalPack: {},
-				Thursday: {},
-				Wednesday: {},
-				Friday: {},
-				Saturday: {},
-				Monday: {},
-				Tuesday: {},
-			},
-			'Sunday+': {
-				DigitalPack: {},
-				Sunday: {},
-			},
-			'Weekend+': {
-				DigitalPack: {},
-				Saturday: {},
-				Sunday: {},
-			},
-			'Saturday+': {
-				DigitalPack: {},
-				Saturday: {},
-			},
-		},
-	},
-	Contribution: {
-		billingPeriods: ['Annual', 'Month'],
-		productRatePlans: {
-			Annual: {
-				Contribution: {},
-			},
-			Monthly: {
-				Contribution: {},
-			},
-		},
-	},
-	GuardianWeeklyZoneA: {
-		billingPeriods: [
-			'Annual',
-			'Three_Years',
-			'Semi_Annual',
-			'Two_Years',
-			'Quarter',
-		],
-		productRatePlans: {
-			Annual: {
-				Subscription: {},
-			},
-			Quarterly: {
-				Subscription: {},
-			},
-		},
-	},
-	GuardianWeeklyZoneB: {
-		billingPeriods: [
-			'Annual',
-			'Three_Years',
-			'Two_Years',
-			'Semi_Annual',
-			'Quarter',
-		],
-		productRatePlans: {
-			Quarterly: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-		},
-	},
-	GuardianWeeklyZoneC: {
-		billingPeriods: ['Semi_Annual', 'Annual', 'Quarter'],
-		productRatePlans: {
-			Quarterly: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-		},
-	},
-	NewspaperVoucher: {
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Everyday: {
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-				Thursday: {},
-				Friday: {},
-				Wednesday: {},
-				Sunday: {},
-			},
-			'Everyday+': {
-				DigitalPack: {},
-				Saturday: {},
-				Tuesday: {},
-				Monday: {},
-				Thursday: {},
-				Wednesday: {},
-				Sunday: {},
-				Friday: {},
-			},
-			Sixday: {
-				Friday: {},
-				Monday: {},
-				Tuesday: {},
-				Thursday: {},
-				Wednesday: {},
-				Saturday: {},
-			},
-			'Sixday+': {
-				DigitalPack: {},
-				Thursday: {},
-				Wednesday: {},
-				Friday: {},
-				Saturday: {},
-				Monday: {},
-				Tuesday: {},
-			},
-			Weekend: {
-				Saturday: {},
-				Sunday: {},
-			},
-			'Weekend+': {
-				DigitalPack: {},
-				Saturday: {},
-				Sunday: {},
-			},
-			Sunday: {
-				Sunday: {},
-			},
-			'Sunday+': {
-				DigitalPack: {},
-				Sunday: {},
-			},
-			Saturday: {
-				Saturday: {},
-			},
-			'Saturday+': {
-				DigitalPack: {},
-				Saturday: {},
-			},
-		},
-	},
-	HomeDelivery: {
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Everyday: {
-				Sunday: {},
-				Wednesday: {},
-				Friday: {},
-				Thursday: {},
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-			},
-			Sunday: {
-				Sunday: {},
-			},
-			Sixday: {
-				Wednesday: {},
-				Friday: {},
-				Thursday: {},
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-			},
-			Weekend: {
-				Sunday: {},
-				Saturday: {},
-			},
-			Saturday: {
-				Saturday: {},
-			},
-			'Everyday+': {
-				DigitalPack: {},
-				Wednesday: {},
-				Friday: {},
-				Thursday: {},
-				Sunday: {},
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-			},
-			'Weekend+': {
-				DigitalPack: {},
-				Sunday: {},
-				Saturday: {},
-			},
-			'Sixday+': {
-				DigitalPack: {},
-				Wednesday: {},
-				Friday: {},
-				Thursday: {},
-				Monday: {},
-				Tuesday: {},
-				Saturday: {},
-			},
-			'Sunday+': {
-				DigitalPack: {},
-				Sunday: {},
-			},
-			'Saturday+': {
-				DigitalPack: {},
-				Saturday: {},
-			},
-		},
-	},
-	PatronMembership: {
-		billingPeriods: ['Month', 'Annual'],
-		productRatePlans: {
-			Monthly: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-			V1DeprecatedAnnual: {
-				Subscription: {},
-			},
-			V1DeprecatedMonthly: {
-				Subscription: {},
-			},
-		},
-	},
-	PartnerMembership: {
-		billingPeriods: ['Annual', 'Month'],
-		productRatePlans: {
-			V1DeprecatedAnnual: {
-				Subscription: {},
-			},
-			Monthly: {
-				Subscription: {},
-			},
-			Annual: {
-				Subscription: {},
-			},
-			V1DeprecatedMonthly: {
-				Subscription: {},
-			},
-		},
-	},
-	GuardianPatron: {
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			GuardianPatron: {
-				Subscription: {},
-			},
-		},
-	},
+export const activeTypeObject = {
+  "OneTimeContribution": {
+    "billingPeriods": [
+      "OneTime"
+    ],
+    "productRatePlans": {
+      "OneTime": {
+        "Contribution": {}
+      }
+    }
+  },
+  "GuardianAdLite": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "Subscription": {}
+      }
+    }
+  },
+  "GuardianLight": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "Subscription": {}
+      }
+    }
+  },
+  "TierThree": {
+    "billingPeriods": [
+      "Annual",
+      "Month"
+    ],
+    "productRatePlans": {
+      "RestOfWorldAnnualV2": {
+        "NewspaperArchive": {},
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "RestOfWorldMonthlyV2": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {},
+        "NewspaperArchive": {}
+      },
+      "DomesticAnnualV2": {
+        "NewspaperArchive": {},
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "DomesticMonthlyV2": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {},
+        "NewspaperArchive": {}
+      },
+      "RestOfWorldMonthly": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "RestOfWorldAnnual": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "DomesticAnnual": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      },
+      "DomesticMonthly": {
+        "SupporterPlus": {},
+        "GuardianWeekly": {}
+      }
+    }
+  },
+  "DigitalSubscription": {
+    "billingPeriods": [
+      "Quarter",
+      "Month",
+      "Annual"
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      },
+      "ThreeMonthGift": {
+        "Subscription": {}
+      },
+      "OneYearGift": {
+        "Subscription": {}
+      }
+    }
+  },
+  "NationalDelivery": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Sixday": {
+        "Monday": {},
+        "Tuesday": {},
+        "Wednesday": {},
+        "Thursday": {},
+        "Friday": {},
+        "Saturday": {}
+      },
+      "Weekend": {
+        "Saturday": {},
+        "Sunday": {}
+      },
+      "Everyday": {
+        "Monday": {},
+        "Tuesday": {},
+        "Wednesday": {},
+        "Thursday": {},
+        "Friday": {},
+        "Saturday": {},
+        "Sunday": {}
+      }
+    }
+  },
+  "SupporterPlus": {
+    "billingPeriods": [
+      "Month",
+      "Annual"
+    ],
+    "productRatePlans": {
+      "V1DeprecatedMonthly": {
+        "Subscription": {}
+      },
+      "V1DeprecatedAnnual": {
+        "Subscription": {}
+      },
+      "Monthly": {
+        "Subscription": {},
+        "Contribution": {}
+      },
+      "Annual": {
+        "Contribution": {},
+        "Subscription": {}
+      }
+    }
+  },
+  "GuardianWeeklyRestOfWorld": {
+    "billingPeriods": [
+      "Month",
+      "Annual",
+      "Quarter"
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "Monthly": {}
+      },
+      "OneYearGift": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      },
+      "Quarterly": {
+        "Subscription": {}
+      },
+      "ThreeMonthGift": {
+        "Subscription": {}
+      }
+    }
+  },
+  "GuardianWeeklyDomestic": {
+    "billingPeriods": [
+      "Annual",
+      "Quarter",
+      "Month"
+    ],
+    "productRatePlans": {
+      "OneYearGift": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      },
+      "Quarterly": {
+        "Subscription": {}
+      },
+      "Monthly": {
+        "Subscription": {}
+      },
+      "ThreeMonthGift": {
+        "Subscription": {}
+      }
+    }
+  },
+  "SubscriptionCard": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Sixday": {
+        "Friday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Thursday": {},
+        "Wednesday": {},
+        "Saturday": {}
+      },
+      "Everyday": {
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {},
+        "Thursday": {},
+        "Friday": {},
+        "Wednesday": {},
+        "Sunday": {}
+      },
+      "Weekend": {
+        "Saturday": {},
+        "Sunday": {}
+      },
+      "Sunday": {
+        "Sunday": {}
+      },
+      "Saturday": {
+        "Saturday": {}
+      },
+      "Everyday+": {
+        "DigitalPack": {},
+        "Saturday": {},
+        "Tuesday": {},
+        "Monday": {},
+        "Thursday": {},
+        "Wednesday": {},
+        "Sunday": {},
+        "Friday": {}
+      },
+      "Sixday+": {
+        "DigitalPack": {},
+        "Thursday": {},
+        "Wednesday": {},
+        "Friday": {},
+        "Saturday": {},
+        "Monday": {},
+        "Tuesday": {}
+      },
+      "Sunday+": {
+        "DigitalPack": {},
+        "Sunday": {}
+      },
+      "Weekend+": {
+        "DigitalPack": {},
+        "Saturday": {},
+        "Sunday": {}
+      },
+      "Saturday+": {
+        "DigitalPack": {},
+        "Saturday": {}
+      }
+    }
+  },
+  "Contribution": {
+    "billingPeriods": [
+      "Annual",
+      "Month"
+    ],
+    "productRatePlans": {
+      "Annual": {
+        "Contribution": {}
+      },
+      "Monthly": {
+        "Contribution": {}
+      }
+    }
+  },
+  "HomeDelivery": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Everyday": {
+        "Sunday": {},
+        "Wednesday": {},
+        "Friday": {},
+        "Thursday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {}
+      },
+      "Sunday": {
+        "Sunday": {}
+      },
+      "Sixday": {
+        "Wednesday": {},
+        "Friday": {},
+        "Thursday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {}
+      },
+      "Weekend": {
+        "Sunday": {},
+        "Saturday": {}
+      },
+      "Saturday": {
+        "Saturday": {}
+      },
+      "Everyday+": {
+        "DigitalPack": {},
+        "Wednesday": {},
+        "Friday": {},
+        "Thursday": {},
+        "Sunday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {}
+      },
+      "Weekend+": {
+        "DigitalPack": {},
+        "Sunday": {},
+        "Saturday": {}
+      },
+      "Sixday+": {
+        "DigitalPack": {},
+        "Wednesday": {},
+        "Friday": {},
+        "Thursday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {}
+      },
+      "Sunday+": {
+        "DigitalPack": {},
+        "Sunday": {}
+      },
+      "Saturday+": {
+        "DigitalPack": {},
+        "Saturday": {}
+      }
+    }
+  },
+  "GuardianPatron": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "GuardianPatron": {
+        "Subscription": {}
+      }
+    }
+  }
+} as const;
+export const inactiveTypesObject = {
+  "SupporterMembership": {
+    "billingPeriods": [
+      "Annual",
+      "Month"
+    ],
+    "productRatePlans": {
+      "Annual": {
+        "Subscription": {}
+      },
+      "Monthly": {
+        "Subscription": {}
+      },
+      "V2DeprecatedAnnual": {
+        "Subscription": {}
+      },
+      "V1DeprecatedAnnual": {
+        "Subscription": {}
+      },
+      "V1DeprecatedMonthly": {
+        "Subscription": {}
+      },
+      "V2DeprecatedMonthly": {
+        "Subscription": {}
+      }
+    }
+  },
+  "GuardianWeeklyZoneA": {
+    "billingPeriods": [
+      "Annual",
+      "Three_Years",
+      "Semi_Annual",
+      "Two_Years",
+      "Quarter"
+    ],
+    "productRatePlans": {
+      "Annual": {
+        "Subscription": {}
+      },
+      "Quarterly": {
+        "Subscription": {}
+      }
+    }
+  },
+  "GuardianWeeklyZoneB": {
+    "billingPeriods": [
+      "Annual",
+      "Three_Years",
+      "Two_Years",
+      "Semi_Annual",
+      "Quarter"
+    ],
+    "productRatePlans": {
+      "Quarterly": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      }
+    }
+  },
+  "GuardianWeeklyZoneC": {
+    "billingPeriods": [
+      "Semi_Annual",
+      "Annual",
+      "Quarter"
+    ],
+    "productRatePlans": {
+      "Quarterly": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      }
+    }
+  },
+  "NewspaperVoucher": {
+    "billingPeriods": [
+      "Month"
+    ],
+    "productRatePlans": {
+      "Everyday": {
+        "Monday": {},
+        "Tuesday": {},
+        "Saturday": {},
+        "Thursday": {},
+        "Friday": {},
+        "Wednesday": {},
+        "Sunday": {}
+      },
+      "Everyday+": {
+        "DigitalPack": {},
+        "Saturday": {},
+        "Tuesday": {},
+        "Monday": {},
+        "Thursday": {},
+        "Wednesday": {},
+        "Sunday": {},
+        "Friday": {}
+      },
+      "Sixday": {
+        "Friday": {},
+        "Monday": {},
+        "Tuesday": {},
+        "Thursday": {},
+        "Wednesday": {},
+        "Saturday": {}
+      },
+      "Sixday+": {
+        "DigitalPack": {},
+        "Thursday": {},
+        "Wednesday": {},
+        "Friday": {},
+        "Saturday": {},
+        "Monday": {},
+        "Tuesday": {}
+      },
+      "Weekend": {
+        "Saturday": {},
+        "Sunday": {}
+      },
+      "Weekend+": {
+        "DigitalPack": {},
+        "Saturday": {},
+        "Sunday": {}
+      },
+      "Sunday": {
+        "Sunday": {}
+      },
+      "Sunday+": {
+        "DigitalPack": {},
+        "Sunday": {}
+      },
+      "Saturday": {
+        "Saturday": {}
+      },
+      "Saturday+": {
+        "DigitalPack": {},
+        "Saturday": {}
+      }
+    }
+  },
+  "PatronMembership": {
+    "billingPeriods": [
+      "Month",
+      "Annual"
+    ],
+    "productRatePlans": {
+      "Monthly": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      },
+      "V1DeprecatedAnnual": {
+        "Subscription": {}
+      },
+      "V1DeprecatedMonthly": {
+        "Subscription": {}
+      }
+    }
+  },
+  "PartnerMembership": {
+    "billingPeriods": [
+      "Annual",
+      "Month"
+    ],
+    "productRatePlans": {
+      "V1DeprecatedAnnual": {
+        "Subscription": {}
+      },
+      "Monthly": {
+        "Subscription": {}
+      },
+      "Annual": {
+        "Subscription": {}
+      },
+      "V1DeprecatedMonthly": {
+        "Subscription": {}
+      }
+    }
+  }
 } as const;

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -349,7 +349,7 @@ export const activeTypeObject = {
     }
   }
 } as const;
-export const inactiveTypesObject = {
+export const inactiveTypeObject = {
   "SupporterMembership": {
     "billingPeriods": [
       "Annual",

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -1,534 +1,484 @@
 export const activeTypeObject = {
-  "OneTimeContribution": {
-    "billingPeriods": [
-      "OneTime"
-    ],
-    "productRatePlans": {
-      "OneTime": {
-        "Contribution": {}
-      }
-    }
-  },
-  "GuardianAdLite": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianLight": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {}
-      }
-    }
-  },
-  "TierThree": {
-    "billingPeriods": [
-      "Annual",
-      "Month"
-    ],
-    "productRatePlans": {
-      "RestOfWorldAnnualV2": {
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "RestOfWorldMonthlyV2": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {},
-        "NewspaperArchive": {}
-      },
-      "DomesticAnnualV2": {
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "DomesticMonthlyV2": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {},
-        "NewspaperArchive": {}
-      },
-      "RestOfWorldMonthly": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "RestOfWorldAnnual": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "DomesticAnnual": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      },
-      "DomesticMonthly": {
-        "SupporterPlus": {},
-        "GuardianWeekly": {}
-      }
-    }
-  },
-  "DigitalSubscription": {
-    "billingPeriods": [
-      "Quarter",
-      "Month",
-      "Annual"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      },
-      "OneYearGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "NationalDelivery": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Sixday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Saturday": {}
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Everyday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Saturday": {},
-        "Sunday": {}
-      }
-    }
-  },
-  "SupporterPlus": {
-    "billingPeriods": [
-      "Month",
-      "Annual"
-    ],
-    "productRatePlans": {
-      "V1DeprecatedMonthly": {
-        "Subscription": {}
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {}
-      },
-      "Monthly": {
-        "Subscription": {},
-        "Contribution": {}
-      },
-      "Annual": {
-        "Contribution": {},
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyRestOfWorld": {
-    "billingPeriods": [
-      "Month",
-      "Annual",
-      "Quarter"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Monthly": {}
-      },
-      "OneYearGift": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "Quarterly": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyDomestic": {
-    "billingPeriods": [
-      "Annual",
-      "Quarter",
-      "Month"
-    ],
-    "productRatePlans": {
-      "OneYearGift": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "Quarterly": {
-        "Subscription": {}
-      },
-      "Monthly": {
-        "Subscription": {}
-      },
-      "ThreeMonthGift": {
-        "Subscription": {}
-      }
-    }
-  },
-  "SubscriptionCard": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Thursday": {},
-        "Wednesday": {},
-        "Saturday": {}
-      },
-      "Everyday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Wednesday": {},
-        "Sunday": {}
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Sunday": {
-        "Sunday": {}
-      },
-      "Saturday": {
-        "Saturday": {}
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Tuesday": {},
-        "Monday": {},
-        "Thursday": {},
-        "Wednesday": {},
-        "Sunday": {},
-        "Friday": {}
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Thursday": {},
-        "Wednesday": {},
-        "Friday": {},
-        "Saturday": {},
-        "Monday": {},
-        "Tuesday": {}
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {}
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {}
-      }
-    }
-  },
-  "Contribution": {
-    "billingPeriods": [
-      "Annual",
-      "Month"
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Contribution": {}
-      },
-      "Monthly": {
-        "Contribution": {}
-      }
-    }
-  },
-  "HomeDelivery": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Sunday": {},
-        "Wednesday": {},
-        "Friday": {},
-        "Thursday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {}
-      },
-      "Sunday": {
-        "Sunday": {}
-      },
-      "Sixday": {
-        "Wednesday": {},
-        "Friday": {},
-        "Thursday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {}
-      },
-      "Weekend": {
-        "Sunday": {},
-        "Saturday": {}
-      },
-      "Saturday": {
-        "Saturday": {}
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Wednesday": {},
-        "Friday": {},
-        "Thursday": {},
-        "Sunday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {}
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Sunday": {},
-        "Saturday": {}
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Wednesday": {},
-        "Friday": {},
-        "Thursday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {}
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {}
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {}
-      }
-    }
-  },
-  "GuardianPatron": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "GuardianPatron": {
-        "Subscription": {}
-      }
-    }
-  }
+	OneTimeContribution: {
+		billingPeriods: ['OneTime'],
+		productRatePlans: {
+			OneTime: {
+				Contribution: {},
+			},
+		},
+	},
+	GuardianAdLite: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Monthly: {
+				Subscription: {},
+			},
+		},
+	},
+	GuardianLight: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Monthly: {
+				Subscription: {},
+			},
+		},
+	},
+	TierThree: {
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			RestOfWorldAnnualV2: {
+				NewspaperArchive: {},
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			RestOfWorldMonthlyV2: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+				NewspaperArchive: {},
+			},
+			DomesticAnnualV2: {
+				NewspaperArchive: {},
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			DomesticMonthlyV2: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+				NewspaperArchive: {},
+			},
+			RestOfWorldMonthly: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			RestOfWorldAnnual: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			DomesticAnnual: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+			DomesticMonthly: {
+				SupporterPlus: {},
+				GuardianWeekly: {},
+			},
+		},
+	},
+	DigitalSubscription: {
+		billingPeriods: ['Quarter', 'Month', 'Annual'],
+		productRatePlans: {
+			Monthly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+			OneYearGift: {
+				Subscription: {},
+			},
+		},
+	},
+	NationalDelivery: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Sixday: {
+				Monday: {},
+				Tuesday: {},
+				Wednesday: {},
+				Thursday: {},
+				Friday: {},
+				Saturday: {},
+			},
+			Weekend: {
+				Saturday: {},
+				Sunday: {},
+			},
+			Everyday: {
+				Monday: {},
+				Tuesday: {},
+				Wednesday: {},
+				Thursday: {},
+				Friday: {},
+				Saturday: {},
+				Sunday: {},
+			},
+		},
+	},
+	SupporterPlus: {
+		billingPeriods: ['Month', 'Annual'],
+		productRatePlans: {
+			V1DeprecatedMonthly: {
+				Subscription: {},
+			},
+			V1DeprecatedAnnual: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+				Contribution: {},
+			},
+			Annual: {
+				Contribution: {},
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyRestOfWorld: {
+		billingPeriods: ['Month', 'Annual', 'Quarter'],
+		productRatePlans: {
+			Monthly: {
+				Monthly: {},
+			},
+			OneYearGift: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			Quarterly: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyDomestic: {
+		billingPeriods: ['Annual', 'Quarter', 'Month'],
+		productRatePlans: {
+			OneYearGift: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			Quarterly: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+			},
+			ThreeMonthGift: {
+				Subscription: {},
+			},
+		},
+	},
+	SubscriptionCard: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Sixday: {
+				Friday: {},
+				Monday: {},
+				Tuesday: {},
+				Thursday: {},
+				Wednesday: {},
+				Saturday: {},
+			},
+			Everyday: {
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+				Thursday: {},
+				Friday: {},
+				Wednesday: {},
+				Sunday: {},
+			},
+			Weekend: {
+				Saturday: {},
+				Sunday: {},
+			},
+			Sunday: {
+				Sunday: {},
+			},
+			Saturday: {
+				Saturday: {},
+			},
+			'Everyday+': {
+				DigitalPack: {},
+				Saturday: {},
+				Tuesday: {},
+				Monday: {},
+				Thursday: {},
+				Wednesday: {},
+				Sunday: {},
+				Friday: {},
+			},
+			'Sixday+': {
+				DigitalPack: {},
+				Thursday: {},
+				Wednesday: {},
+				Friday: {},
+				Saturday: {},
+				Monday: {},
+				Tuesday: {},
+			},
+			'Sunday+': {
+				DigitalPack: {},
+				Sunday: {},
+			},
+			'Weekend+': {
+				DigitalPack: {},
+				Saturday: {},
+				Sunday: {},
+			},
+			'Saturday+': {
+				DigitalPack: {},
+				Saturday: {},
+			},
+		},
+	},
+	Contribution: {
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			Annual: {
+				Contribution: {},
+			},
+			Monthly: {
+				Contribution: {},
+			},
+		},
+	},
+	HomeDelivery: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Everyday: {
+				Sunday: {},
+				Wednesday: {},
+				Friday: {},
+				Thursday: {},
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+			},
+			Sunday: {
+				Sunday: {},
+			},
+			Sixday: {
+				Wednesday: {},
+				Friday: {},
+				Thursday: {},
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+			},
+			Weekend: {
+				Sunday: {},
+				Saturday: {},
+			},
+			Saturday: {
+				Saturday: {},
+			},
+			'Everyday+': {
+				DigitalPack: {},
+				Wednesday: {},
+				Friday: {},
+				Thursday: {},
+				Sunday: {},
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+			},
+			'Weekend+': {
+				DigitalPack: {},
+				Sunday: {},
+				Saturday: {},
+			},
+			'Sixday+': {
+				DigitalPack: {},
+				Wednesday: {},
+				Friday: {},
+				Thursday: {},
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+			},
+			'Sunday+': {
+				DigitalPack: {},
+				Sunday: {},
+			},
+			'Saturday+': {
+				DigitalPack: {},
+				Saturday: {},
+			},
+		},
+	},
+	GuardianPatron: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			GuardianPatron: {
+				Subscription: {},
+			},
+		},
+	},
 } as const;
 export const inactiveTypeObject = {
-  "SupporterMembership": {
-    "billingPeriods": [
-      "Annual",
-      "Month"
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {}
-      },
-      "Monthly": {
-        "Subscription": {}
-      },
-      "V2DeprecatedAnnual": {
-        "Subscription": {}
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {}
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {}
-      },
-      "V2DeprecatedMonthly": {
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyZoneA": {
-    "billingPeriods": [
-      "Annual",
-      "Three_Years",
-      "Semi_Annual",
-      "Two_Years",
-      "Quarter"
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {}
-      },
-      "Quarterly": {
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyZoneB": {
-    "billingPeriods": [
-      "Annual",
-      "Three_Years",
-      "Two_Years",
-      "Semi_Annual",
-      "Quarter"
-    ],
-    "productRatePlans": {
-      "Quarterly": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      }
-    }
-  },
-  "GuardianWeeklyZoneC": {
-    "billingPeriods": [
-      "Semi_Annual",
-      "Annual",
-      "Quarter"
-    ],
-    "productRatePlans": {
-      "Quarterly": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      }
-    }
-  },
-  "NewspaperVoucher": {
-    "billingPeriods": [
-      "Month"
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Monday": {},
-        "Tuesday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Friday": {},
-        "Wednesday": {},
-        "Sunday": {}
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Tuesday": {},
-        "Monday": {},
-        "Thursday": {},
-        "Wednesday": {},
-        "Sunday": {},
-        "Friday": {}
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Tuesday": {},
-        "Thursday": {},
-        "Wednesday": {},
-        "Saturday": {}
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Thursday": {},
-        "Wednesday": {},
-        "Friday": {},
-        "Saturday": {},
-        "Monday": {},
-        "Tuesday": {}
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Sunday": {}
-      },
-      "Sunday": {
-        "Sunday": {}
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {}
-      },
-      "Saturday": {
-        "Saturday": {}
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {}
-      }
-    }
-  },
-  "PatronMembership": {
-    "billingPeriods": [
-      "Month",
-      "Annual"
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {}
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {}
-      }
-    }
-  },
-  "PartnerMembership": {
-    "billingPeriods": [
-      "Annual",
-      "Month"
-    ],
-    "productRatePlans": {
-      "V1DeprecatedAnnual": {
-        "Subscription": {}
-      },
-      "Monthly": {
-        "Subscription": {}
-      },
-      "Annual": {
-        "Subscription": {}
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {}
-      }
-    }
-  }
+	SupporterMembership: {
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			Annual: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+			},
+			V2DeprecatedAnnual: {
+				Subscription: {},
+			},
+			V1DeprecatedAnnual: {
+				Subscription: {},
+			},
+			V1DeprecatedMonthly: {
+				Subscription: {},
+			},
+			V2DeprecatedMonthly: {
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyZoneA: {
+		billingPeriods: [
+			'Annual',
+			'Three_Years',
+			'Semi_Annual',
+			'Two_Years',
+			'Quarter',
+		],
+		productRatePlans: {
+			Annual: {
+				Subscription: {},
+			},
+			Quarterly: {
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyZoneB: {
+		billingPeriods: [
+			'Annual',
+			'Three_Years',
+			'Two_Years',
+			'Semi_Annual',
+			'Quarter',
+		],
+		productRatePlans: {
+			Quarterly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+		},
+	},
+	GuardianWeeklyZoneC: {
+		billingPeriods: ['Semi_Annual', 'Annual', 'Quarter'],
+		productRatePlans: {
+			Quarterly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+		},
+	},
+	NewspaperVoucher: {
+		billingPeriods: ['Month'],
+		productRatePlans: {
+			Everyday: {
+				Monday: {},
+				Tuesday: {},
+				Saturday: {},
+				Thursday: {},
+				Friday: {},
+				Wednesday: {},
+				Sunday: {},
+			},
+			'Everyday+': {
+				DigitalPack: {},
+				Saturday: {},
+				Tuesday: {},
+				Monday: {},
+				Thursday: {},
+				Wednesday: {},
+				Sunday: {},
+				Friday: {},
+			},
+			Sixday: {
+				Friday: {},
+				Monday: {},
+				Tuesday: {},
+				Thursday: {},
+				Wednesday: {},
+				Saturday: {},
+			},
+			'Sixday+': {
+				DigitalPack: {},
+				Thursday: {},
+				Wednesday: {},
+				Friday: {},
+				Saturday: {},
+				Monday: {},
+				Tuesday: {},
+			},
+			Weekend: {
+				Saturday: {},
+				Sunday: {},
+			},
+			'Weekend+': {
+				DigitalPack: {},
+				Saturday: {},
+				Sunday: {},
+			},
+			Sunday: {
+				Sunday: {},
+			},
+			'Sunday+': {
+				DigitalPack: {},
+				Sunday: {},
+			},
+			Saturday: {
+				Saturday: {},
+			},
+			'Saturday+': {
+				DigitalPack: {},
+				Saturday: {},
+			},
+		},
+	},
+	PatronMembership: {
+		billingPeriods: ['Month', 'Annual'],
+		productRatePlans: {
+			Monthly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			V1DeprecatedAnnual: {
+				Subscription: {},
+			},
+			V1DeprecatedMonthly: {
+				Subscription: {},
+			},
+		},
+	},
+	PartnerMembership: {
+		billingPeriods: ['Annual', 'Month'],
+		productRatePlans: {
+			V1DeprecatedAnnual: {
+				Subscription: {},
+			},
+			Monthly: {
+				Subscription: {},
+			},
+			Annual: {
+				Subscription: {},
+			},
+			V1DeprecatedMonthly: {
+				Subscription: {},
+			},
+		},
+	},
 } as const;

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -1710,550 +1710,554 @@ exports[`code Generated product catalog matches snapshot 1`] = `
 
 exports[`code Generated product catalog types match snapshot 1`] = `
 {
-  "Contribution": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Contribution": {},
+  "active": {
+    "Contribution": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Contribution": {},
+        },
+        "Monthly": {
+          "Contribution": {},
+        },
       },
-      "Monthly": {
-        "Contribution": {},
+    },
+    "DigitalSubscription": {
+      "billingPeriods": [
+        "Month",
+        "Annual",
+        "Quarter",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "OneYearGift": {
+          "Subscription": {},
+        },
+        "ThreeMonthGift": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianAdLite": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Monthly": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianLight": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Monthly": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianPatron": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "GuardianPatron": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianWeeklyDomestic": {
+      "billingPeriods": [
+        "Quarter",
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "OneYearGift": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
+        "ThreeMonthGift": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianWeeklyRestOfWorld": {
+      "billingPeriods": [
+        "Quarter",
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Monthly": {},
+        },
+        "OneYearGift": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
+        "ThreeMonthGift": {
+          "Subscription": {},
+        },
+      },
+    },
+    "HomeDelivery": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Everyday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Everyday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Saturday": {
+          "Saturday": {},
+        },
+        "Saturday+": {
+          "DigitalPack": {},
+          "Saturday": {},
+        },
+        "Sixday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sixday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sunday": {
+          "Sunday": {},
+        },
+        "Sunday+": {
+          "DigitalPack": {},
+          "Sunday": {},
+        },
+        "Weekend": {
+          "Saturday": {},
+          "Sunday": {},
+        },
+        "Weekend+": {
+          "DigitalPack": {},
+          "Saturday": {},
+          "Sunday": {},
+        },
+      },
+    },
+    "NationalDelivery": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Everyday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sixday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Weekend": {
+          "Saturday": {},
+          "Sunday": {},
+        },
+      },
+    },
+    "OneTimeContribution": {
+      "billingPeriods": [
+        "OneTime",
+      ],
+      "productRatePlans": {
+        "OneTime": {
+          "Contribution": {},
+        },
+      },
+    },
+    "SubscriptionCard": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Everyday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Everyday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Saturday": {
+          "Saturday": {},
+        },
+        "Saturday+": {
+          "DigitalPack": {},
+          "Saturday": {},
+        },
+        "Sixday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sixday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sunday": {
+          "Sunday": {},
+        },
+        "Sunday+": {
+          "DigitalPack": {},
+          "Sunday": {},
+        },
+        "Weekend": {
+          "Saturday": {},
+          "Sunday": {},
+        },
+        "Weekend+": {
+          "DigitalPack": {},
+          "Saturday": {},
+          "Sunday": {},
+        },
+      },
+    },
+    "SupporterPlus": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Contribution": {},
+          "Subscription": {},
+        },
+        "GuardianWeeklyDomesticAnnual": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "GuardianWeeklyDomesticMonthly": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "GuardianWeeklyRestOfWorldAnnual": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "GuardianWeeklyRestOfWorldMonthly": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "Monthly": {
+          "Contribution": {},
+          "Subscription": {},
+        },
+        "V1DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V1DeprecatedMonthly": {
+          "Subscription": {},
+        },
+      },
+    },
+    "TierThree": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "DomesticAnnual": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "DomesticAnnualV2": {
+          "GuardianWeekly": {},
+          "NewspaperArchive": {},
+          "SupporterPlus": {},
+        },
+        "DomesticMonthly": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "DomesticMonthlyV2": {
+          "GuardianWeekly": {},
+          "NewspaperArchive": {},
+          "SupporterPlus": {},
+        },
+        "RestOfWorldAnnual": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "RestOfWorldAnnualV2": {
+          "GuardianWeekly": {},
+          "NewspaperArchive": {},
+          "SupporterPlus": {},
+        },
+        "RestOfWorldMonthly": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "RestOfWorldMonthlyV2": {
+          "GuardianWeekly": {},
+          "NewspaperArchive": {},
+          "SupporterPlus": {},
+        },
       },
     },
   },
-  "DigitalSubscription": {
-    "billingPeriods": [
-      "Month",
-      "Annual",
-      "Quarter",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "OneYearGift": {
-        "Subscription": {},
-      },
-      "ThreeMonthGift": {
-        "Subscription": {},
+  "inactive": {
+    "GuardianWeeklyZoneA": {
+      "billingPeriods": [
+        "Semi_Annual",
+        "Two_Years",
+        "Annual",
+        "Three_Years",
+        "Quarter",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianAdLite": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {},
+    "GuardianWeeklyZoneB": {
+      "billingPeriods": [
+        "Semi_Annual",
+        "Three_Years",
+        "Two_Years",
+        "Annual",
+        "Quarter",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianLight": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {},
+    "GuardianWeeklyZoneC": {
+      "billingPeriods": [
+        "Annual",
+        "Quarter",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianPatron": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "GuardianPatron": {
-        "Subscription": {},
+    "NewspaperVoucher": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Everyday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Everyday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Saturday": {
+          "Saturday": {},
+        },
+        "Saturday+": {
+          "DigitalPack": {},
+          "Saturday": {},
+        },
+        "Sixday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sixday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sunday": {
+          "Sunday": {},
+        },
+        "Sunday+": {
+          "DigitalPack": {},
+          "Sunday": {},
+        },
+        "Weekend": {
+          "Saturday": {},
+          "Sunday": {},
+        },
+        "Weekend+": {
+          "DigitalPack": {},
+          "Saturday": {},
+          "Sunday": {},
+        },
       },
     },
-  },
-  "GuardianWeeklyDomestic": {
-    "billingPeriods": [
-      "Quarter",
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "OneYearGift": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-      "ThreeMonthGift": {
-        "Subscription": {},
+    "PartnerMembership": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "V1DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V1DeprecatedMonthly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianWeeklyRestOfWorld": {
-    "billingPeriods": [
-      "Quarter",
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Monthly": {},
-      },
-      "OneYearGift": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-      "ThreeMonthGift": {
-        "Subscription": {},
+    "PatronMembership": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "V1DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V1DeprecatedMonthly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianWeeklyZoneA": {
-    "billingPeriods": [
-      "Semi_Annual",
-      "Two_Years",
-      "Annual",
-      "Three_Years",
-      "Quarter",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "GuardianWeeklyZoneB": {
-    "billingPeriods": [
-      "Semi_Annual",
-      "Three_Years",
-      "Two_Years",
-      "Annual",
-      "Quarter",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "GuardianWeeklyZoneC": {
-    "billingPeriods": [
-      "Annual",
-      "Quarter",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "HomeDelivery": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Saturday": {
-        "Saturday": {},
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {},
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sunday": {
-        "Sunday": {},
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {},
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {},
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Sunday": {},
-      },
-    },
-  },
-  "NationalDelivery": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {},
-      },
-    },
-  },
-  "NewspaperVoucher": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Saturday": {
-        "Saturday": {},
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {},
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sunday": {
-        "Sunday": {},
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {},
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {},
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Sunday": {},
-      },
-    },
-  },
-  "OneTimeContribution": {
-    "billingPeriods": [
-      "OneTime",
-    ],
-    "productRatePlans": {
-      "OneTime": {
-        "Contribution": {},
-      },
-    },
-  },
-  "PartnerMembership": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "PatronMembership": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "SubscriptionCard": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Saturday": {
-        "Saturday": {},
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {},
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sunday": {
-        "Sunday": {},
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {},
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {},
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Sunday": {},
-      },
-    },
-  },
-  "SupporterMembership": {
-    "billingPeriods": [
-      "Month",
-      "Annual",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {},
-      },
-      "V2DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V2DeprecatedMonthly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "SupporterPlus": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Contribution": {},
-        "Subscription": {},
-      },
-      "GuardianWeeklyDomesticAnnual": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "GuardianWeeklyDomesticMonthly": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "GuardianWeeklyRestOfWorldAnnual": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "GuardianWeeklyRestOfWorldMonthly": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "Monthly": {
-        "Contribution": {},
-        "Subscription": {},
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "TierThree": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "DomesticAnnual": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "DomesticAnnualV2": {
-        "GuardianWeekly": {},
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-      },
-      "DomesticMonthly": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "DomesticMonthlyV2": {
-        "GuardianWeekly": {},
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-      },
-      "RestOfWorldAnnual": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "RestOfWorldAnnualV2": {
-        "GuardianWeekly": {},
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-      },
-      "RestOfWorldMonthly": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "RestOfWorldMonthlyV2": {
-        "GuardianWeekly": {},
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
+    "SupporterMembership": {
+      "billingPeriods": [
+        "Month",
+        "Annual",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "V1DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V1DeprecatedMonthly": {
+          "Subscription": {},
+        },
+        "V2DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V2DeprecatedMonthly": {
+          "Subscription": {},
+        },
       },
     },
   },
@@ -3898,533 +3902,537 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
 
 exports[`prod Generated product catalog types match snapshot 1`] = `
 {
-  "Contribution": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Contribution": {},
+  "active": {
+    "Contribution": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Contribution": {},
+        },
+        "Monthly": {
+          "Contribution": {},
+        },
       },
-      "Monthly": {
-        "Contribution": {},
+    },
+    "DigitalSubscription": {
+      "billingPeriods": [
+        "Quarter",
+        "Month",
+        "Annual",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "OneYearGift": {
+          "Subscription": {},
+        },
+        "ThreeMonthGift": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianAdLite": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Monthly": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianLight": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Monthly": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianPatron": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "GuardianPatron": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianWeeklyDomestic": {
+      "billingPeriods": [
+        "Annual",
+        "Quarter",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "OneYearGift": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
+        "ThreeMonthGift": {
+          "Subscription": {},
+        },
+      },
+    },
+    "GuardianWeeklyRestOfWorld": {
+      "billingPeriods": [
+        "Month",
+        "Annual",
+        "Quarter",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Monthly": {},
+        },
+        "OneYearGift": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
+        "ThreeMonthGift": {
+          "Subscription": {},
+        },
+      },
+    },
+    "HomeDelivery": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Everyday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Everyday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Saturday": {
+          "Saturday": {},
+        },
+        "Saturday+": {
+          "DigitalPack": {},
+          "Saturday": {},
+        },
+        "Sixday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sixday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sunday": {
+          "Sunday": {},
+        },
+        "Sunday+": {
+          "DigitalPack": {},
+          "Sunday": {},
+        },
+        "Weekend": {
+          "Saturday": {},
+          "Sunday": {},
+        },
+        "Weekend+": {
+          "DigitalPack": {},
+          "Saturday": {},
+          "Sunday": {},
+        },
+      },
+    },
+    "NationalDelivery": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Everyday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sixday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Weekend": {
+          "Saturday": {},
+          "Sunday": {},
+        },
+      },
+    },
+    "OneTimeContribution": {
+      "billingPeriods": [
+        "OneTime",
+      ],
+      "productRatePlans": {
+        "OneTime": {
+          "Contribution": {},
+        },
+      },
+    },
+    "SubscriptionCard": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Everyday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Everyday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Saturday": {
+          "Saturday": {},
+        },
+        "Saturday+": {
+          "DigitalPack": {},
+          "Saturday": {},
+        },
+        "Sixday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sixday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sunday": {
+          "Sunday": {},
+        },
+        "Sunday+": {
+          "DigitalPack": {},
+          "Sunday": {},
+        },
+        "Weekend": {
+          "Saturday": {},
+          "Sunday": {},
+        },
+        "Weekend+": {
+          "DigitalPack": {},
+          "Saturday": {},
+          "Sunday": {},
+        },
+      },
+    },
+    "SupporterPlus": {
+      "billingPeriods": [
+        "Month",
+        "Annual",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Contribution": {},
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Contribution": {},
+          "Subscription": {},
+        },
+        "V1DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V1DeprecatedMonthly": {
+          "Subscription": {},
+        },
+      },
+    },
+    "TierThree": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "DomesticAnnual": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "DomesticAnnualV2": {
+          "GuardianWeekly": {},
+          "NewspaperArchive": {},
+          "SupporterPlus": {},
+        },
+        "DomesticMonthly": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "DomesticMonthlyV2": {
+          "GuardianWeekly": {},
+          "NewspaperArchive": {},
+          "SupporterPlus": {},
+        },
+        "RestOfWorldAnnual": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "RestOfWorldAnnualV2": {
+          "GuardianWeekly": {},
+          "NewspaperArchive": {},
+          "SupporterPlus": {},
+        },
+        "RestOfWorldMonthly": {
+          "GuardianWeekly": {},
+          "SupporterPlus": {},
+        },
+        "RestOfWorldMonthlyV2": {
+          "GuardianWeekly": {},
+          "NewspaperArchive": {},
+          "SupporterPlus": {},
+        },
       },
     },
   },
-  "DigitalSubscription": {
-    "billingPeriods": [
-      "Quarter",
-      "Month",
-      "Annual",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "OneYearGift": {
-        "Subscription": {},
-      },
-      "ThreeMonthGift": {
-        "Subscription": {},
+  "inactive": {
+    "GuardianWeeklyZoneA": {
+      "billingPeriods": [
+        "Annual",
+        "Three_Years",
+        "Semi_Annual",
+        "Two_Years",
+        "Quarter",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianAdLite": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {},
+    "GuardianWeeklyZoneB": {
+      "billingPeriods": [
+        "Annual",
+        "Three_Years",
+        "Two_Years",
+        "Semi_Annual",
+        "Quarter",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianLight": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Monthly": {
-        "Subscription": {},
+    "GuardianWeeklyZoneC": {
+      "billingPeriods": [
+        "Semi_Annual",
+        "Annual",
+        "Quarter",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Quarterly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianPatron": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "GuardianPatron": {
-        "Subscription": {},
+    "NewspaperVoucher": {
+      "billingPeriods": [
+        "Month",
+      ],
+      "productRatePlans": {
+        "Everyday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Everyday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Sunday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Saturday": {
+          "Saturday": {},
+        },
+        "Saturday+": {
+          "DigitalPack": {},
+          "Saturday": {},
+        },
+        "Sixday": {
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sixday+": {
+          "DigitalPack": {},
+          "Friday": {},
+          "Monday": {},
+          "Saturday": {},
+          "Thursday": {},
+          "Tuesday": {},
+          "Wednesday": {},
+        },
+        "Sunday": {
+          "Sunday": {},
+        },
+        "Sunday+": {
+          "DigitalPack": {},
+          "Sunday": {},
+        },
+        "Weekend": {
+          "Saturday": {},
+          "Sunday": {},
+        },
+        "Weekend+": {
+          "DigitalPack": {},
+          "Saturday": {},
+          "Sunday": {},
+        },
       },
     },
-  },
-  "GuardianWeeklyDomestic": {
-    "billingPeriods": [
-      "Annual",
-      "Quarter",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "OneYearGift": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-      "ThreeMonthGift": {
-        "Subscription": {},
+    "PartnerMembership": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "V1DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V1DeprecatedMonthly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianWeeklyRestOfWorld": {
-    "billingPeriods": [
-      "Month",
-      "Annual",
-      "Quarter",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Monthly": {},
-      },
-      "OneYearGift": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-      "ThreeMonthGift": {
-        "Subscription": {},
+    "PatronMembership": {
+      "billingPeriods": [
+        "Month",
+        "Annual",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "V1DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V1DeprecatedMonthly": {
+          "Subscription": {},
+        },
       },
     },
-  },
-  "GuardianWeeklyZoneA": {
-    "billingPeriods": [
-      "Annual",
-      "Three_Years",
-      "Semi_Annual",
-      "Two_Years",
-      "Quarter",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "GuardianWeeklyZoneB": {
-    "billingPeriods": [
-      "Annual",
-      "Three_Years",
-      "Two_Years",
-      "Semi_Annual",
-      "Quarter",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "GuardianWeeklyZoneC": {
-    "billingPeriods": [
-      "Semi_Annual",
-      "Annual",
-      "Quarter",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Quarterly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "HomeDelivery": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Saturday": {
-        "Saturday": {},
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {},
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sunday": {
-        "Sunday": {},
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {},
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {},
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Sunday": {},
-      },
-    },
-  },
-  "NationalDelivery": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {},
-      },
-    },
-  },
-  "NewspaperVoucher": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Saturday": {
-        "Saturday": {},
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {},
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sunday": {
-        "Sunday": {},
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {},
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {},
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Sunday": {},
-      },
-    },
-  },
-  "OneTimeContribution": {
-    "billingPeriods": [
-      "OneTime",
-    ],
-    "productRatePlans": {
-      "OneTime": {
-        "Contribution": {},
-      },
-    },
-  },
-  "PartnerMembership": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "PatronMembership": {
-    "billingPeriods": [
-      "Month",
-      "Annual",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "SubscriptionCard": {
-    "billingPeriods": [
-      "Month",
-    ],
-    "productRatePlans": {
-      "Everyday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Everyday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Sunday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Saturday": {
-        "Saturday": {},
-      },
-      "Saturday+": {
-        "DigitalPack": {},
-        "Saturday": {},
-      },
-      "Sixday": {
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sixday+": {
-        "DigitalPack": {},
-        "Friday": {},
-        "Monday": {},
-        "Saturday": {},
-        "Thursday": {},
-        "Tuesday": {},
-        "Wednesday": {},
-      },
-      "Sunday": {
-        "Sunday": {},
-      },
-      "Sunday+": {
-        "DigitalPack": {},
-        "Sunday": {},
-      },
-      "Weekend": {
-        "Saturday": {},
-        "Sunday": {},
-      },
-      "Weekend+": {
-        "DigitalPack": {},
-        "Saturday": {},
-        "Sunday": {},
-      },
-    },
-  },
-  "SupporterMembership": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Subscription": {},
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {},
-      },
-      "V2DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V2DeprecatedMonthly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "SupporterPlus": {
-    "billingPeriods": [
-      "Month",
-      "Annual",
-    ],
-    "productRatePlans": {
-      "Annual": {
-        "Contribution": {},
-        "Subscription": {},
-      },
-      "Monthly": {
-        "Contribution": {},
-        "Subscription": {},
-      },
-      "V1DeprecatedAnnual": {
-        "Subscription": {},
-      },
-      "V1DeprecatedMonthly": {
-        "Subscription": {},
-      },
-    },
-  },
-  "TierThree": {
-    "billingPeriods": [
-      "Annual",
-      "Month",
-    ],
-    "productRatePlans": {
-      "DomesticAnnual": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "DomesticAnnualV2": {
-        "GuardianWeekly": {},
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-      },
-      "DomesticMonthly": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "DomesticMonthlyV2": {
-        "GuardianWeekly": {},
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-      },
-      "RestOfWorldAnnual": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "RestOfWorldAnnualV2": {
-        "GuardianWeekly": {},
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
-      },
-      "RestOfWorldMonthly": {
-        "GuardianWeekly": {},
-        "SupporterPlus": {},
-      },
-      "RestOfWorldMonthlyV2": {
-        "GuardianWeekly": {},
-        "NewspaperArchive": {},
-        "SupporterPlus": {},
+    "SupporterMembership": {
+      "billingPeriods": [
+        "Annual",
+        "Month",
+      ],
+      "productRatePlans": {
+        "Annual": {
+          "Subscription": {},
+        },
+        "Monthly": {
+          "Subscription": {},
+        },
+        "V1DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V1DeprecatedMonthly": {
+          "Subscription": {},
+        },
+        "V2DeprecatedAnnual": {
+          "Subscription": {},
+        },
+        "V2DeprecatedMonthly": {
+          "Subscription": {},
+        },
       },
     },
   },

--- a/modules/product-catalog/test/generateProductCatalog.test.ts
+++ b/modules/product-catalog/test/generateProductCatalog.test.ts
@@ -1,6 +1,6 @@
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
-import { generateTypeObject } from '@modules/product-catalog/generateTypeObject';
+import { generateTypeObjects } from '@modules/product-catalog/generateTypeObject';
 import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 import prod from '../../zuora-catalog/test/fixtures/catalog-prod.json';
 
@@ -14,7 +14,7 @@ describe('prod', () => {
 
 	test('Generated product catalog types match snapshot', () => {
 		const prodZuoraCatalog = zuoraCatalogSchema.parse(prod);
-		const prodTypeObject = generateTypeObject(prodZuoraCatalog);
+		const prodTypeObject = generateTypeObjects(prodZuoraCatalog);
 		expect(prodTypeObject).toMatchSnapshot();
 	});
 });
@@ -29,7 +29,7 @@ describe('code', () => {
 
 	test('Generated product catalog types match snapshot', () => {
 		const codeZuoraCatalog = zuoraCatalogSchema.parse(code);
-		const codeTypeObject = generateTypeObject(codeZuoraCatalog);
+		const codeTypeObject = generateTypeObjects(codeZuoraCatalog);
 		expect(codeTypeObject).toMatchSnapshot();
 	});
 });


### PR DESCRIPTION
## What does this change?

In the product catalog a distinction is already made between active and inactive products, where active == products we're still selling and inactive == products we aren't, but which people may still have. However, this distinction isn't available at the type level.

In support-frontend, where we consume the product catalog data, we use the `ProductKey` type. Currently this includes all products and in cases where we have a `Record<ProductKey, A>` we have to provide an entry for all products, even inactive ones, which doesn't really make sense if we aren't selling them as the data won't be used. We could move to a `Partial<Record<ProductKey, A>>` but this means we have to handle undefined when looking up by a product (even if we know in practice this won't happen. I think a better approach would be to have separate types for active and inactive products. This would support `Record<ActiveProductKey, A>` meaning we'd only have to provide data about active products and not deprecated products.

So, this PR splits the single generated typeObject to two - one for active products and one for inactive. We then derived separate (and combined) types from these two objects.

This PR also adds GuardianAdLite, which is now in the type object (an active project) since it's now in the Zuora data.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
