### PR TITLE
Rename fewerSupportAsks to hideSupportMessaging

### DIFF
--- a/modules/product-benefits/src/productBenefit.ts
+++ b/modules/product-benefits/src/productBenefit.ts
@@ -11,7 +11,7 @@ export const supporterPlusBenefits: ProductBenefit[] = [
 	'adFree',
 	'liveApp',
 	'feastApp',
-	'fewerSupportAsks',
+	'hideSupportMessaging',
 	'rejectTracking',
 ];
 export const digitalSubscriptionBenefits = supporterPlusBenefits.concat([
@@ -31,17 +31,17 @@ export const productBenefitMapping: Record<ProductKey, ProductBenefit[]> = {
 	NationalDelivery: digitalSubscriptionBenefits,
 	NewspaperVoucher: digitalSubscriptionBenefits,
 	SubscriptionCard: digitalSubscriptionBenefits,
-	SupporterMembership: ['liveApp', 'fewerSupportAsks'],
-	PartnerMembership: ['liveApp', 'feastApp', 'fewerSupportAsks'],
+	SupporterMembership: ['liveApp', 'hideSupportMessaging'],
+	PartnerMembership: ['liveApp', 'feastApp', 'hideSupportMessaging'],
 	PatronMembership: digitalSubscriptionBenefits,
 	GuardianPatron: digitalSubscriptionBenefits,
-	GuardianWeeklyDomestic: ['fewerSupportAsks'],
-	GuardianWeeklyRestOfWorld: ['fewerSupportAsks'],
-	GuardianWeeklyZoneA: ['fewerSupportAsks'],
-	GuardianWeeklyZoneB: ['fewerSupportAsks'],
-	GuardianWeeklyZoneC: ['fewerSupportAsks'],
-	Contribution: ['fewerSupportAsks'],
-	OneTimeContribution: ['fewerSupportAsks'],
+	GuardianWeeklyDomestic: ['hideSupportMessaging'],
+	GuardianWeeklyRestOfWorld: ['hideSupportMessaging'],
+	GuardianWeeklyZoneA: ['hideSupportMessaging'],
+	GuardianWeeklyZoneB: ['hideSupportMessaging'],
+	GuardianWeeklyZoneC: ['hideSupportMessaging'],
+	Contribution: ['hideSupportMessaging'],
+	OneTimeContribution: ['hideSupportMessaging'],
 };
 
 const itemIsLessThanThreeMonthsOld = (item: SupporterRatePlanItem) =>

--- a/modules/product-benefits/src/schemas.ts
+++ b/modules/product-benefits/src/schemas.ts
@@ -7,7 +7,7 @@ export const productBenefitListSchema = z.enum([
 	'newspaperEdition',
 	'guardianWeeklyEdition',
 	'liveApp',
-	'fewerSupportAsks',
+	'hideSupportMessaging',
 	'rejectTracking',
 	'liveEvents',
 ]);

--- a/modules/product-benefits/test/getUserBenefits.test.ts
+++ b/modules/product-benefits/test/getUserBenefits.test.ts
@@ -66,7 +66,7 @@ test('getUserBenefitsFromUserProducts', () => {
 		tierThreeBenefits,
 	);
 	expect(getUserBenefitsFromUserProducts(['GuardianWeeklyDomestic'])).toEqual([
-		'fewerSupportAsks',
+		'hideSupportMessaging',
 	]);
 	expect(getUserBenefitsFromUserProducts([])).toEqual([]);
 });
@@ -83,5 +83,5 @@ test('getUserBenefitsFromUserProducts returns the union of two benefit sets', ()
 			'GuardianLight',
 			'GuardianWeeklyDomestic',
 		]),
-	).toEqual(['rejectTracking', 'fewerSupportAsks']);
+	).toEqual(['rejectTracking', 'hideSupportMessaging']);
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Dotcom uses the term 'hide support messaging' extensively to describe the benefit of not seeing banners and epics. Also the cookie is called `gu_hide_support_messaging` so I think it makes sense to use this terminology in the user benefits API.