### PR TITLE
allow salesforce to hit product-switch-api

### DIFF
--- a/handlers/product-switch-api/src/productSwitchEndpoint.ts
+++ b/handlers/product-switch-api/src/productSwitchEndpoint.ts
@@ -1,4 +1,3 @@
-import { getIfDefined } from '@modules/nullAndUndefined';
 import { prettyPrint } from '@modules/prettyPrint';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import type { Stage } from '@modules/stage';
@@ -16,10 +15,7 @@ export const contributionToSupporterPlusEndpoint = async (
 	body: string,
 	subscriptionNumber: string,
 ) => {
-	const identityId = getIfDefined(
-		headers['x-identity-id'],
-		'Identity ID not found in request',
-	);
+	const identityId = headers['x-identity-id'];
 	const zuoraClient = await ZuoraClient.create(stage);
 	console.log('Loading the product catalog');
 	const productCatalog = await getProductCatalogFromApi(stage);

--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -130,14 +130,17 @@ export const getSwitchInformationWithOwnerCheck = (
 	subscription: ZuoraSubscription,
 	account: ZuoraAccount,
 	productCatalog: ProductCatalog,
-	identityIdFromRequest: string,
+	identityIdFromRequest: string | undefined,
 	today: Dayjs = dayjs(),
 ): SwitchInformation => {
 	console.log(
 		`Checking subscription ${subscription.subscriptionNumber} is owned by the currently logged in user`,
 	);
 	const userInformation = getAccountInformation(account);
-	if (userInformation.identityId !== identityIdFromRequest) {
+	if (
+		identityIdFromRequest &&
+		userInformation.identityId !== identityIdFromRequest
+	) {
 		throw new ValidationError(
 			`Subscription ${subscription.subscriptionNumber} does not belong to identity ID ${identityIdFromRequest}`,
 		);

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -95,6 +95,43 @@ test('startNewTerm is only true when the termStartDate is before today', () => {
 	expect(switchInformation.startNewTerm).toEqual(false);
 });
 
+test('owner check is bypassed for salesforce calls', () => {
+	const today = dayjs('2024-05-09T23:10:10.663+01:00');
+	const subscription = zuoraSubscriptionResponseSchema.parse(subscriptionJson);
+	const account = zuoraAccountSchema.parse(accountJson);
+	const productCatalog = getProductCatalogFromFixture();
+
+	const switchInformation = getSwitchInformationWithOwnerCheck(
+		'CODE',
+		{ price: 95, preview: false },
+		subscription,
+		account,
+		productCatalog,
+		undefined, // salesforce doesn't send the header
+		today,
+	);
+	expect(switchInformation.startNewTerm).toEqual(false);
+});
+
+test("owner check doesn't allow incorrect owner", () => {
+	const today = dayjs('2024-05-09T23:10:10.663+01:00');
+	const subscription = zuoraSubscriptionResponseSchema.parse(subscriptionJson);
+	const account = zuoraAccountSchema.parse(accountJson);
+	const productCatalog = getProductCatalogFromFixture();
+
+	const switchInformation = () =>
+		getSwitchInformationWithOwnerCheck(
+			'CODE',
+			{ price: 95, preview: false },
+			subscription,
+			account,
+			productCatalog,
+			'12345', // incorrect identity id
+			today,
+		);
+	expect(switchInformation).toThrow(ValidationError);
+});
+
 test('preview amounts are correct', () => {
 	const subscription =
 		zuoraSubscriptionResponseSchema.parse(alreadySwitchedJson);


### PR DESCRIPTION
At the moment salesforce is stil using the old product-move-api for siwtching RC -> S+ wheras MMA uses the new product-switch-api.

This situation was working until we started allowing discount rateplans on RC, which the old API doesn't allow.

The new API however doesn't allow the x-identity-id header to be optional.  This is used in MMA to ensure that the user making the request actually owns the subscription.  This check is not needed in SF because the client is trusted.

This PR changes the identity id to be optional, and adds a couple of tests to make sure it's enforced appropriately.