### PR TITLE
Update growth alarm mappings with bandit

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -38,6 +38,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'super-mode',
 		'support-reminders',
 		'ticker-calculator',
+		'bandit',
 	],
 	VALUE: [
 		'apps-metering-events',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

co-authored with @charleycampbell 

## What does this change?

This PR is part of the work to add Bandit data alarms ([related PR](https://github.com/guardian/support-analytics/pull/404)). With this change, if the alarm is triggered, a notification will be sent to the Growth team’s alarm channel.

Testing
To verify these changes, we:

Triggered the step function, which is currently failing and causing the alarm to activate.
Confirmed that the new alarm notification appeared in the Growth team’s alarm channel as expected.

![image](https://github.com/user-attachments/assets/35b7f7a2-c48f-4c00-80d2-ed1eb2c50ae4)
