### PR TITLE
aid alarms-handler testability by making the main logic a more pure function

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -143,9 +143,9 @@ export type AlarmMappings = {
 	getTeamWebhookUrl: (team: Team) => string;
 };
 
-export const AlarmMappings: (
+export const buildAlarmMappings = (
 	mappings: Record<string, string[]>,
-) => AlarmMappings = (mappings: Record<string, string[]>) => {
+): AlarmMappings => {
 	const appToTeamMappings: Record<string, Team[]> =
 		buildAppToTeamMappings(mappings);
 
@@ -167,4 +167,4 @@ export const AlarmMappings: (
 	return { getTeams, getTeamWebhookUrl };
 };
 
-export const ProdAlarmMappings = AlarmMappings(teamToAppMappings);
+export const ProdAlarmMappings = buildAlarmMappings(teamToAppMappings);

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -167,4 +167,4 @@ export const buildAlarmMappings = (
 	return { getTeams, getTeamWebhookUrl };
 };
 
-export const ProdAlarmMappings = buildAlarmMappings(teamToAppMappings);
+export const prodAlarmMappings = buildAlarmMappings(teamToAppMappings);

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -44,7 +44,7 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 export async function getChatMessages(
 	record: SQSRecord,
 	alarmMappings: AlarmMappings,
-) {
+): Promise<{ webhookUrls: string[]; text: string } | undefined> {
 	console.log('sqsRecord', record);
 
 	const { Message, MessageAttributes } = JSON.parse(

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -1,7 +1,7 @@
 import type { SNSEventRecord, SQSEvent, SQSRecord } from 'aws-lambda';
 import { z } from 'zod';
 import type { AlarmMappings } from './alarmMappings';
-import { ProdAlarmMappings } from './alarmMappings';
+import { prodAlarmMappings } from './alarmMappings';
 import { getAppNameTag } from './cloudwatch';
 
 const cloudWatchAlarmMessageSchema = z.object({
@@ -20,7 +20,7 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 		for (const record of event.Records) {
 			const maybeChatMessages = await getChatMessages(
 				record,
-				ProdAlarmMappings,
+				prodAlarmMappings,
 			);
 
 			if (maybeChatMessages) {
@@ -61,9 +61,9 @@ export async function getChatMessages(
 
 	let message;
 	if (parsedMessage) {
-		message = await handleCloudWatchAlarmMessage({ message: parsedMessage });
+		message = await buildCloudWatchAlarmMessage({ message: parsedMessage });
 	} else {
-		message = handleSnsPublishMessage({
+		message = buildSnsPublishMessage({
 			message: Message,
 			messageAttributes: MessageAttributes,
 		});
@@ -71,7 +71,7 @@ export async function getChatMessages(
 
 	if (message) {
 		const teams = alarmMappings.getTeams(message.app);
-		console.log('sending message to teams', teams);
+		console.log(`app ${message.app} is assigned to teams ${teams.join(', ')}`);
 		const webhookUrls = teams.map(alarmMappings.getTeamWebhookUrl);
 		return { webhookUrls, text: message.text };
 	} else {
@@ -92,7 +92,7 @@ const attemptToParseMessageString = ({
 	}
 };
 
-const handleCloudWatchAlarmMessage = async ({
+const buildCloudWatchAlarmMessage = async ({
 	message,
 }: {
 	message: CloudWatchAlarmMessage;
@@ -121,7 +121,7 @@ const handleCloudWatchAlarmMessage = async ({
 	return { app, text };
 };
 
-const handleSnsPublishMessage = ({
+const buildSnsPublishMessage = ({
 	message,
 	messageAttributes,
 }: {
@@ -136,9 +136,7 @@ const handleSnsPublishMessage = ({
 
 	const app = messageAttributes.app?.Value;
 
-	const text = message;
-
 	console.log(`SNS publish message from ${app}`);
 
-	return { app, text };
+	return { app, text: message };
 };

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -1,6 +1,7 @@
-import type { SNSEventRecord, SQSEvent } from 'aws-lambda';
+import type { SNSEventRecord, SQSEvent, SQSRecord } from 'aws-lambda';
 import { z } from 'zod';
-import { getTeams, getTeamWebhookUrl } from './alarmMappings';
+import type { AlarmMappings } from './alarmMappings';
+import { ProdAlarmMappings } from './alarmMappings';
 import { getAppNameTag } from './cloudwatch';
 
 const cloudWatchAlarmMessageSchema = z.object({
@@ -17,23 +18,21 @@ type CloudWatchAlarmMessage = z.infer<typeof cloudWatchAlarmMessageSchema>;
 export const handler = async (event: SQSEvent): Promise<void> => {
 	try {
 		for (const record of event.Records) {
-			console.log(record);
+			const maybeChatMessages = await getChatMessages(
+				record,
+				ProdAlarmMappings,
+			);
 
-			const { Message, MessageAttributes } = JSON.parse(
-				record.body,
-			) as SNSEventRecord['Sns'];
-
-			const parsedMessage = attemptToParseMessageString({
-				messageString: Message,
-			});
-
-			if (parsedMessage) {
-				await handleCloudWatchAlarmMessage({ message: parsedMessage });
-			} else {
-				await handleSnsPublishMessage({
-					message: Message,
-					messageAttributes: MessageAttributes,
-				});
+			if (maybeChatMessages) {
+				await Promise.all(
+					maybeChatMessages.webhookUrls.map((webhookUrl) => {
+						return fetch(webhookUrl, {
+							method: 'POST',
+							headers: { 'Content-Type': 'application/json' },
+							body: JSON.stringify({ text: maybeChatMessages.text }),
+						});
+					}),
+				);
 			}
 		}
 	} catch (error) {
@@ -41,6 +40,44 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 		throw error;
 	}
 };
+
+export async function getChatMessages(
+	record: SQSRecord,
+	alarmMappings: AlarmMappings,
+) {
+	console.log('sqsRecord', record);
+
+	const { Message, MessageAttributes } = JSON.parse(
+		record.body,
+	) as SNSEventRecord['Sns'];
+
+	console.log('snsEvent', Message, MessageAttributes);
+
+	const parsedMessage = attemptToParseMessageString({
+		messageString: Message,
+	});
+
+	console.log('parsedMessage', parsedMessage);
+
+	let message;
+	if (parsedMessage) {
+		message = await handleCloudWatchAlarmMessage({ message: parsedMessage });
+	} else {
+		message = handleSnsPublishMessage({
+			message: Message,
+			messageAttributes: MessageAttributes,
+		});
+	}
+
+	if (message) {
+		const teams = alarmMappings.getTeams(message.app);
+		console.log('sending message to teams', teams);
+		const webhookUrls = teams.map(alarmMappings.getTeamWebhookUrl);
+		return { webhookUrls, text: message.text };
+	} else {
+		return undefined;
+	}
+}
 
 const attemptToParseMessageString = ({
 	messageString,
@@ -70,32 +107,21 @@ const handleCloudWatchAlarmMessage = async ({
 	} = message;
 
 	const app = await getAppNameTag(AlarmArn, AWSAccountId);
-	const teams = getTeams(app);
 
-	await Promise.all(
-		teams.map((team) => {
-			const webhookUrl = getTeamWebhookUrl(team);
+	const title =
+		NewStateValue === 'OK'
+			? `✅ *ALARM OK:* ${AlarmName} has recovered!`
+			: `🚨 *ALARM:* ${AlarmName} has triggered!`;
+	const text = `${title}\n\n*Description:* ${
+		AlarmDescription ?? ''
+	}\n\n*Reason:* ${NewStateReason}`;
 
-			const title =
-				NewStateValue === 'OK'
-					? `✅ *ALARM OK:* ${AlarmName} has recovered!`
-					: `🚨 *ALARM:* ${AlarmName} has triggered!`;
-			const text = `${title}\n\n*Description:* ${
-				AlarmDescription ?? ''
-			}\n\n*Reason:* ${NewStateReason}`;
+	console.log(`CloudWatch alarm from ${app}`);
 
-			console.log(`CloudWatch alarm from ${app} owned by ${team}`);
-
-			return fetch(webhookUrl, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ text }),
-			});
-		}),
-	);
+	return { app, text };
 };
 
-const handleSnsPublishMessage = async ({
+const handleSnsPublishMessage = ({
 	message,
 	messageAttributes,
 }: {
@@ -109,21 +135,10 @@ const handleSnsPublishMessage = async ({
 	}
 
 	const app = messageAttributes.app?.Value;
-	const teams = getTeams(app);
 
-	await Promise.all(
-		teams.map((team) => {
-			const webhookUrl = getTeamWebhookUrl(team);
+	const text = message;
 
-			const text = message;
+	console.log(`SNS publish message from ${app}`);
 
-			console.log(`SNS publish message from ${app} owned by ${team}`);
-
-			return fetch(webhookUrl, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ text }),
-			});
-		}),
-	);
+	return { app, text };
 };

--- a/handlers/alarms-handler/test/alarmMappings.test.ts
+++ b/handlers/alarms-handler/test/alarmMappings.test.ts
@@ -1,10 +1,10 @@
-import { getTeams } from '../src/alarmMappings';
+import { ProdAlarmMappings } from '../src/alarmMappings';
 
 describe('getTeam', () => {
 	it('returns the correct team for a given app', () => {
 		const app = 'apps-metering';
 
-		const team = getTeams(app);
+		const team = ProdAlarmMappings.getTeams(app);
 
 		expect(team).toEqual(['GROWTH']);
 	});
@@ -12,7 +12,7 @@ describe('getTeam', () => {
 	it('returns SRE if the app does not have a team owner', () => {
 		const app = 'foo';
 
-		const team = getTeams(app);
+		const team = ProdAlarmMappings.getTeams(app);
 
 		expect(team).toEqual(['SRE']);
 	});
@@ -20,7 +20,7 @@ describe('getTeam', () => {
 	it('returns SRE if there is no app tag', () => {
 		const app = undefined;
 
-		const team = getTeams(app);
+		const team = ProdAlarmMappings.getTeams(app);
 
 		expect(team).toEqual(['SRE']);
 	});

--- a/handlers/alarms-handler/test/alarmMappings.test.ts
+++ b/handlers/alarms-handler/test/alarmMappings.test.ts
@@ -1,10 +1,10 @@
-import { ProdAlarmMappings } from '../src/alarmMappings';
+import { prodAlarmMappings } from '../src/alarmMappings';
 
 describe('getTeam', () => {
 	it('returns the correct team for a given app', () => {
 		const app = 'apps-metering';
 
-		const team = ProdAlarmMappings.getTeams(app);
+		const team = prodAlarmMappings.getTeams(app);
 
 		expect(team).toEqual(['GROWTH']);
 	});
@@ -12,7 +12,7 @@ describe('getTeam', () => {
 	it('returns SRE if the app does not have a team owner', () => {
 		const app = 'foo';
 
-		const team = ProdAlarmMappings.getTeams(app);
+		const team = prodAlarmMappings.getTeams(app);
 
 		expect(team).toEqual(['SRE']);
 	});
@@ -20,7 +20,7 @@ describe('getTeam', () => {
 	it('returns SRE if there is no app tag', () => {
 		const app = undefined;
 
-		const team = ProdAlarmMappings.getTeams(app);
+		const team = prodAlarmMappings.getTeams(app);
 
 		expect(team).toEqual(['SRE']);
 	});

--- a/handlers/alarms-handler/test/index.test.ts
+++ b/handlers/alarms-handler/test/index.test.ts
@@ -1,6 +1,6 @@
 import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import { getChatMessages, handler } from '../src';
-import { AlarmMappings } from '../src/alarmMappings';
+import { buildAlarmMappings } from '../src/alarmMappings';
 import { getAppNameTag } from '../src/cloudwatch';
 
 jest.mock('../src/cloudwatch');
@@ -68,7 +68,7 @@ describe('Handler', () => {
 
 		const result = await getChatMessages(
 			fullCloudWatchAlarmEvent,
-			AlarmMappings({ SRE: ['mock-app'] }),
+			buildAlarmMappings({ SRE: ['mock-app'] }),
 		);
 
 		expect(getAppNameTag).toHaveBeenCalledWith(


### PR DESCRIPTION
A while ago I proposed a new feature in alarms handler to send relevant log links to chat as well.

I [made a PR](https://github.com/guardian/support-service-lambdas/pull/2487) but it got very cluttered with pre-refactoring so I will pull out individual changes to make it easier to review.


This is the first PR
Second PR is here: https://github.com/guardian/support-service-lambdas/pull/2636
Third PR is here: https://github.com/guardian/support-service-lambdas/pull/2641

Regarding this PR
1. the new tests I needed required parameterising the alarm mappings, so I pulled out the main lambda logic into a function and added that parameter
2. To make it easier to check what messages should be sent, I made the above return the message list rather than having to trap the HTTP fetch callouts.  i.e. pure-ish function, and then the effects can sit at the edge.
3. As part of that, some duplication naturally fell out between the code paths.

Tested in CODE and still sends alarms