### PR TITLE
get all tags in alarm handler rather than just App

### DIFF
--- a/handlers/alarms-handler/src/cloudwatch.ts
+++ b/handlers/alarms-handler/src/cloudwatch.ts
@@ -49,10 +49,14 @@ const buildCloudwatchClient = (awsAccountId: string): CloudWatchClient => {
 	return new CloudWatchClient({ region: 'eu-west-1' });
 };
 
-const getTags = async (
+export type Tags = {
+	App?: string;
+};
+
+export const getTags = async (
 	alarmArn: string,
 	awsAccountId: string,
-): Promise<Tag[]> => {
+): Promise<Tags> => {
 	const client = buildCloudwatchClient(awsAccountId);
 
 	const request = new ListTagsForResourceCommand({
@@ -60,13 +64,9 @@ const getTags = async (
 	});
 
 	const response = await client.send(request);
-	return response.Tags ?? [];
-};
-
-export const getAppNameTag = async (
-	alarmArn: string,
-	awsAccountId: string,
-): Promise<string | undefined> => {
-	const tags = await getTags(alarmArn, awsAccountId);
-	return tags.find((tag: Tag) => tag.Key === 'App')?.Value;
+	const tags = response.Tags ?? [];
+	const entries = tags.flatMap((tag: Tag) =>
+		tag.Key && tag.Value ? [[tag.Key, tag.Value]] : [],
+	);
+	return Object.fromEntries(entries) as Tags;
 };

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -2,7 +2,7 @@ import type { SNSEventRecord, SQSEvent, SQSRecord } from 'aws-lambda';
 import { z } from 'zod';
 import type { AlarmMappings } from './alarmMappings';
 import { ProdAlarmMappings } from './alarmMappings';
-import { getAppNameTag } from './cloudwatch';
+import { getTags } from './cloudwatch';
 
 const cloudWatchAlarmMessageSchema = z.object({
 	AlarmArn: z.string(),
@@ -106,7 +106,7 @@ const handleCloudWatchAlarmMessage = async ({
 		AWSAccountId,
 	} = message;
 
-	const app = await getAppNameTag(AlarmArn, AWSAccountId);
+	const { App } = await getTags(AlarmArn, AWSAccountId);
 
 	const title =
 		NewStateValue === 'OK'
@@ -116,9 +116,9 @@ const handleCloudWatchAlarmMessage = async ({
 		AlarmDescription ?? ''
 	}\n\n*Reason:* ${NewStateReason}`;
 
-	console.log(`CloudWatch alarm from ${app}`);
+	console.log(`CloudWatch alarm from ${App}`);
 
-	return { app, text };
+	return { app: App, text };
 };
 
 const handleSnsPublishMessage = ({

--- a/handlers/alarms-handler/test/index.test.ts
+++ b/handlers/alarms-handler/test/index.test.ts
@@ -95,6 +95,7 @@ describe('Handler', () => {
 	});
 
 	it('should throw error if the fetch HTTP call fails', async () => {
+		(getTags as jest.Mock).mockResolvedValueOnce({ App: 'mock-app' });
 		jest
 			.spyOn(global, 'fetch')
 			.mockResolvedValue(Promise.reject(new Error('Fetch error')));

--- a/handlers/alarms-handler/test/index.test.ts
+++ b/handlers/alarms-handler/test/index.test.ts
@@ -1,7 +1,7 @@
 import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import { getChatMessages, handler } from '../src';
 import { AlarmMappings } from '../src/alarmMappings';
-import { getAppNameTag } from '../src/cloudwatch';
+import { getTags } from '../src/cloudwatch';
 
 jest.mock('../src/cloudwatch');
 
@@ -52,7 +52,7 @@ describe('Handler', () => {
 	});
 
 	it('should handle CloudWatch alarm message', async () => {
-		(getAppNameTag as jest.Mock).mockResolvedValueOnce('mock-app');
+		(getTags as jest.Mock).mockResolvedValueOnce({ App: 'mock-app' });
 
 		jest
 			.spyOn(global, 'fetch')
@@ -60,18 +60,19 @@ describe('Handler', () => {
 
 		await handler(mockCloudWatchAlarmEvent);
 
-		expect(getAppNameTag).toHaveBeenCalledWith('mock-arn', '111111');
+		expect(getTags).toHaveBeenCalledWith('mock-arn', '111111');
 		expect(fetch).toHaveBeenCalledWith(mockEnv.SRE_WEBHOOK, expect.any(Object));
 	});
+
 	it('should handle captured CloudWatch alarm message', async () => {
-		(getAppNameTag as jest.Mock).mockResolvedValueOnce('mock-app');
+		(getTags as jest.Mock).mockResolvedValueOnce({ App: 'mock-app' });
 
 		const result = await getChatMessages(
 			fullCloudWatchAlarmEvent,
 			AlarmMappings({ SRE: ['mock-app'] }),
 		);
 
-		expect(getAppNameTag).toHaveBeenCalledWith(
+		expect(getTags).toHaveBeenCalledWith(
 			'arn:aws:cloudwatch:eu-west-1:1234:alarm:DISCOUNT-API-CODE Discount-api 5XX response',
 			'1234',
 		);
@@ -104,7 +105,7 @@ describe('Handler', () => {
 	});
 
 	it('calls the webhook with the correct data for an OK action', async () => {
-		(getAppNameTag as jest.Mock).mockResolvedValueOnce('mock-app');
+		(getTags as jest.Mock).mockResolvedValueOnce({ App: 'mock-app' });
 		jest
 			.spyOn(global, 'fetch')
 			.mockResolvedValue(Promise.resolve(new Response(JSON.stringify({}))));


### PR DESCRIPTION
This PR follows on from https://github.com/guardian/support-service-lambdas/pull/2635 and is the next part split out from the old PR https://github.com/guardian/support-service-lambdas/pull/2487

In this PR I refactor the code that retrieves the tags on the alarm.  Rather than just selecting the `App` tag, this returns an object containing all defined tags.

This means that in the next PR we can look at a new tag to build a log URL.