### PR TITLE
use alarm tags to add diagnostic urls to chat messages

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -143,9 +143,9 @@ export type AlarmMappings = {
 	getTeamWebhookUrl: (team: Team) => string;
 };
 
-export const AlarmMappings: (
+export const buildAlarmMappings = (
 	mappings: Record<string, string[]>,
-) => AlarmMappings = (mappings: Record<string, string[]>) => {
+): AlarmMappings => {
 	const appToTeamMappings: Record<string, Team[]> =
 		buildAppToTeamMappings(mappings);
 
@@ -167,4 +167,4 @@ export const AlarmMappings: (
 	return { getTeams, getTeamWebhookUrl };
 };
 
-export const ProdAlarmMappings = AlarmMappings(teamToAppMappings);
+export const ProdAlarmMappings = buildAlarmMappings(teamToAppMappings);

--- a/handlers/alarms-handler/src/cloudwatch.ts
+++ b/handlers/alarms-handler/src/cloudwatch.ts
@@ -51,6 +51,7 @@ const buildCloudwatchClient = (awsAccountId: string): CloudWatchClient => {
 
 export type Tags = {
 	App?: string;
+	DiagnosticUrls?: string;
 };
 
 export const getTags = async (

--- a/handlers/alarms-handler/test/index.test.ts
+++ b/handlers/alarms-handler/test/index.test.ts
@@ -1,6 +1,6 @@
 import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import { getChatMessages, handler } from '../src';
-import { AlarmMappings } from '../src/alarmMappings';
+import { buildAlarmMappings } from '../src/alarmMappings';
 import { getTags } from '../src/cloudwatch';
 
 jest.mock('../src/cloudwatch');
@@ -74,7 +74,7 @@ describe('Handler', () => {
 
 		const result = await getChatMessages(
 			fullCloudWatchAlarmEvent,
-			AlarmMappings({ SRE: ['mock-app'] }),
+			buildAlarmMappings({ SRE: ['mock-app'] }),
 		);
 
 		expect(getTags).toHaveBeenCalledWith(
@@ -95,7 +95,7 @@ describe('Handler', () => {
 
 		const result = await getChatMessages(
 			fullCloudWatchAlarmEvent,
-			AlarmMappings({ SRE: ['mock-app'] }),
+			buildAlarmMappings({ SRE: ['mock-app'] }),
 		);
 
 		expect(getTags).toHaveBeenCalledWith(
@@ -121,7 +121,7 @@ describe('Handler', () => {
 
 		const result = await getChatMessages(
 			fullCloudWatchAlarmEvent,
-			AlarmMappings({ SRE: ['mock-app'] }),
+			buildAlarmMappings({ SRE: ['mock-app'] }),
 		);
 
 		expect(getTags).toHaveBeenCalledWith(

--- a/handlers/alarms-handler/test/index.test.ts
+++ b/handlers/alarms-handler/test/index.test.ts
@@ -24,6 +24,7 @@ describe('Handler', () => {
 						NewStateValue: 'ALARM',
 						AlarmDescription: 'description',
 						AWSAccountId: '111111',
+						StateChangeTime: '2024-10-09T07:23:16.236+0000',
 					}),
 				}),
 			},
@@ -65,6 +66,31 @@ describe('Handler', () => {
 	});
 
 	it('should handle captured CloudWatch alarm message', async () => {
+		(getTags as jest.Mock).mockResolvedValueOnce({
+			App: 'mock-app',
+			DiagnosticUrls:
+				'https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmock-app-CODE/log-events$3Fstart$3D$startMillis$26filterPattern$3D$26end$3D$endMillis',
+		});
+
+		const result = await getChatMessages(
+			fullCloudWatchAlarmEvent,
+			AlarmMappings({ SRE: ['mock-app'] }),
+		);
+
+		expect(getTags).toHaveBeenCalledWith(
+			'arn:aws:cloudwatch:eu-west-1:1234:alarm:DISCOUNT-API-CODE Discount-api 5XX response',
+			'1234',
+		);
+		const expectedText =
+			'🚨 *ALARM:* DISCOUNT-API-CODE Discount-api 5XX response has triggered!\n\n' +
+			'*Description:* Impact - Discount api returned a 5XX response check the logs for more information: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdiscount-api-CODE. Follow the process in https://docs.google.com/document/d/sdkjfhskjdfhksjdhf/edit\n\n' +
+			'*Reason:* Threshold Crossed: 1 datapoint [2.0 (09/10/24 07:18:00)] was greater than or equal to the threshold (1.0).\n\n' +
+			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmock-app-CODE/log-events$3Fstart$3D1728458296236$26filterPattern$3D$26end$3D1728458596236';
+		expect(result?.webhookUrls).toEqual([mockEnv.SRE_WEBHOOK]);
+		expect(result?.text).toEqual(expectedText);
+	});
+
+	it('should not insert if the DiagnosticUrls are empty', async () => {
 		(getTags as jest.Mock).mockResolvedValueOnce({ App: 'mock-app' });
 
 		const result = await getChatMessages(
@@ -80,6 +106,34 @@ describe('Handler', () => {
 			'🚨 *ALARM:* DISCOUNT-API-CODE Discount-api 5XX response has triggered!\n\n' +
 			'*Description:* Impact - Discount api returned a 5XX response check the logs for more information: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdiscount-api-CODE. Follow the process in https://docs.google.com/document/d/sdkjfhskjdfhksjdhf/edit\n\n' +
 			'*Reason:* Threshold Crossed: 1 datapoint [2.0 (09/10/24 07:18:00)] was greater than or equal to the threshold (1.0).';
+		expect(result?.webhookUrls).toEqual([mockEnv.SRE_WEBHOOK]);
+		expect(result?.text).toEqual(expectedText);
+	});
+
+	it('should add multiple urls where specified', async () => {
+		(getTags as jest.Mock).mockResolvedValueOnce({
+			App: 'mock-app',
+			DiagnosticUrls: [
+				'https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmock-app-CODE/log-events$3Fstart$3D$startMillis$26filterPattern$3D$26end$3D$endMillis',
+				'https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fanother-app-CODE/log-events$3Fstart$3D$startMillis$26filterPattern$3D$26end$3D$endMillis',
+			].join(','),
+		});
+
+		const result = await getChatMessages(
+			fullCloudWatchAlarmEvent,
+			AlarmMappings({ SRE: ['mock-app'] }),
+		);
+
+		expect(getTags).toHaveBeenCalledWith(
+			'arn:aws:cloudwatch:eu-west-1:1234:alarm:DISCOUNT-API-CODE Discount-api 5XX response',
+			'1234',
+		);
+		const expectedText =
+			'🚨 *ALARM:* DISCOUNT-API-CODE Discount-api 5XX response has triggered!\n\n' +
+			'*Description:* Impact - Discount api returned a 5XX response check the logs for more information: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdiscount-api-CODE. Follow the process in https://docs.google.com/document/d/sdkjfhskjdfhksjdhf/edit\n\n' +
+			'*Reason:* Threshold Crossed: 1 datapoint [2.0 (09/10/24 07:18:00)] was greater than or equal to the threshold (1.0).\n\n' +
+			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmock-app-CODE/log-events$3Fstart$3D1728458296236$26filterPattern$3D$26end$3D1728458596236\n\n' +
+			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fanother-app-CODE/log-events$3Fstart$3D1728458296236$26filterPattern$3D$26end$3D1728458596236';
 		expect(result?.webhookUrls).toEqual([mockEnv.SRE_WEBHOOK]);
 		expect(result?.text).toEqual(expectedText);
 	});
@@ -121,6 +175,7 @@ describe('Handler', () => {
 							NewStateValue: 'OK',
 							AlarmDescription: 'description',
 							AWSAccountId: '111111',
+							StateChangeTime: '2024-10-09T07:23:16.236+0000',
 						}),
 					}),
 				},


### PR DESCRIPTION
EDIT: superseded by https://github.com/guardian/support-service-lambdas/pull/2641 which I think is a much better solution.  However I will keep this here in case people prefer it.

--

This PR follows on from https://github.com/guardian/support-service-lambdas/pull/2636 which follows https://github.com/guardian/support-service-lambdas/pull/2635 and is the next part split out from the old PR https://github.com/guardian/support-service-lambdas/pull/2487

In this PR I add the logic to read the DiagnosticsUrls tag from the alarm, and template in the start/end times when we are building a log link.

Question: I have done it as templating a url rather than telling the lambda that it's a cloudwatch log, which is quite flexible but also you end up with very verbose tag values.  I am wondering whether it would be better to just say "it's a lambda log and this is its name", then it can calculate the url in the code?