### PR TITLE
Remove Guardian Light from type object and catalog schema

### DIFF
--- a/modules/product-benefits/src/productBenefit.ts
+++ b/modules/product-benefits/src/productBenefit.ts
@@ -23,7 +23,6 @@ export const tierThreeBenefits = digitalSubscriptionBenefits.concat([
 ]);
 
 export const productBenefitMapping: Record<ProductKey, ProductBenefit[]> = {
-	GuardianLight: ['rejectTracking'],
 	GuardianAdLite: ['rejectTracking'],
 	SupporterPlus: supporterPlusBenefits,
 	DigitalSubscription: digitalSubscriptionBenefits,

--- a/modules/product-benefits/test/getUserBenefits.test.ts
+++ b/modules/product-benefits/test/getUserBenefits.test.ts
@@ -56,7 +56,7 @@ test('getUserBenefitsFromUserProducts', () => {
 	expect(getUserBenefitsFromUserProducts(['DigitalSubscription'])).toEqual(
 		digitalSubscriptionBenefits,
 	);
-	expect(getUserBenefitsFromUserProducts(['GuardianLight'])).toEqual([
+	expect(getUserBenefitsFromUserProducts(['GuardianAdLite'])).toEqual([
 		'rejectTracking',
 	]);
 	expect(getUserBenefitsFromUserProducts(['SupporterPlus'])).toEqual(
@@ -80,7 +80,7 @@ test('getUserBenefitsFromUserProducts returns distinct benefits', () => {
 test('getUserBenefitsFromUserProducts returns the union of two benefit sets', () => {
 	expect(
 		getUserBenefitsFromUserProducts([
-			'GuardianLight',
+			'GuardianAdLite',
 			'GuardianWeeklyDomestic',
 		]),
 	).toEqual(['rejectTracking', 'hideSupportMessaging']);

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -20,22 +20,6 @@ export const productCatalogSchema = z.object({
 			}),
 		}),
 	}),
-	GuardianLight: z.object({
-		billingSystem: z.literal('zuora'),
-		active: z.boolean(),
-		ratePlans: z.object({
-			Monthly: z.object({
-				id: z.string(),
-				pricing: z.object({
-					GBP: z.number(),
-				}),
-				charges: z.object({ Subscription: z.object({ id: z.string() }) }),
-				billingPeriod: z
-					.enum(typeObject.GuardianLight.billingPeriods)
-					.optional(),
-			}),
-		}),
-	}),
 	GuardianAdLite: z.object({
 		billingSystem: z.literal('zuora'),
 		active: z.boolean(),

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -15,14 +15,6 @@ export const activeTypeObject = {
 			},
 		},
 	},
-	GuardianLight: {
-		billingPeriods: ['Month'],
-		productRatePlans: {
-			Monthly: {
-				Subscription: {},
-			},
-		},
-	},
 	TierThree: {
 		billingPeriods: ['Annual', 'Month'],
 		productRatePlans: {

--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -1,7 +1,6 @@
 import { getIfDefined } from '@modules/nullAndUndefined';
 
 const zuoraCatalogToProductKey: Record<string, string> = {
-	'Guardian Light': 'GuardianLight',
 	'Guardian Ad-Lite': 'GuardianAdLite',
 	Contributor: 'Contribution',
 	'Supporter Plus': 'SupporterPlus',
@@ -28,7 +27,6 @@ export const activeProducts = [
 	'SupporterPlus',
 	'DigitalSubscription',
 	'TierThree',
-	'GuardianLight',
 	'GuardianAdLite',
 	'GuardianWeeklyRestOfWorld',
 	'GuardianWeeklyDomestic',
@@ -99,7 +97,6 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	'Sunday+': 'Sunday+',
 	'Weekend+': 'Weekend+',
 	'Sixday+': 'Sixday+',
-	'Guardian Light Monthly': 'Monthly',
 	'Guardian Ad-Lite Monthly': 'Monthly',
 	// Membership rate plans
 	'Supporter - monthly': 'V1DeprecatedMonthly',
@@ -166,7 +163,6 @@ const zuoraCatalogToProductRatePlanChargeKey: Record<string, string> = {
 	'Supporter Plus': 'SupporterPlus',
 	'Guardian Weekly': 'GuardianWeekly',
 	'Newspaper Archive': 'NewspaperArchive',
-	'Guardian Light': 'Subscription',
 	'Guardian Ad-Lite': 'Subscription',
 	'Supporter Membership - Annual': 'Subscription',
 	'Supporter Membership - Monthly': 'Subscription',

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -132,24 +132,6 @@ exports[`code Generated product catalog matches snapshot 1`] = `
       },
     },
   },
-  "GuardianLight": {
-    "active": true,
-    "billingSystem": "zuora",
-    "ratePlans": {
-      "Monthly": {
-        "billingPeriod": "Month",
-        "charges": {
-          "Subscription": {
-            "id": "71a1c43a10792b28f702b3bf5d380037",
-          },
-        },
-        "id": "71a1c43a1e192b28f702b3b47113000a",
-        "pricing": {
-          "GBP": 2,
-        },
-      },
-    },
-  },
   "GuardianPatron": {
     "active": true,
     "billingSystem": "stripe",
@@ -1756,16 +1738,6 @@ exports[`code Generated product catalog types match snapshot 1`] = `
         },
       },
     },
-    "GuardianLight": {
-      "billingPeriods": [
-        "Month",
-      ],
-      "productRatePlans": {
-        "Monthly": {
-          "Subscription": {},
-        },
-      },
-    },
     "GuardianPatron": {
       "billingPeriods": [
         "Month",
@@ -2392,24 +2364,6 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
         "id": "8a1285e294443da501944b04cb692c9e",
         "pricing": {
           "GBP": 5,
-        },
-      },
-    },
-  },
-  "GuardianLight": {
-    "active": true,
-    "billingSystem": "zuora",
-    "ratePlans": {
-      "Monthly": {
-        "billingPeriod": "Month",
-        "charges": {
-          "Subscription": {
-            "id": "8a129b7892c35f170192dd3225572b97",
-          },
-        },
-        "id": "8a12831492c341730192dd1c39207038",
-        "pricing": {
-          "GBP": 2,
         },
       },
     },
@@ -3939,16 +3893,6 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
       },
     },
     "GuardianAdLite": {
-      "billingPeriods": [
-        "Month",
-      ],
-      "productRatePlans": {
-        "Monthly": {
-          "Subscription": {},
-        },
-      },
-    },
-    "GuardianLight": {
       "billingPeriods": [
         "Month",
       ],


### PR DESCRIPTION
## What does this change?

This removes the old Guardian Light product from the catalog, type object and schema. We've moved over to using the new product GuardianAdLite in support-frontend, so the old product is no longer needed here. Once this is merged we can remove or deactivate the product in Zuora.

## How to test

Next step will be to use an updated support-service-lambdas package in support-frontend and verify all is working well.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
