### PR TITLE
Change benefit name from rejectTracking to allowRejectAll

### DIFF
--- a/modules/product-benefits/src/productBenefit.ts
+++ b/modules/product-benefits/src/productBenefit.ts
@@ -12,7 +12,7 @@ export const supporterPlusBenefits: ProductBenefit[] = [
 	'liveApp',
 	'feastApp',
 	'hideSupportMessaging',
-	'rejectTracking',
+	'allowRejectAll',
 ];
 export const digitalSubscriptionBenefits = supporterPlusBenefits.concat([
 	'newspaperEdition',
@@ -23,7 +23,7 @@ export const tierThreeBenefits = digitalSubscriptionBenefits.concat([
 ]);
 
 export const productBenefitMapping: Record<ProductKey, ProductBenefit[]> = {
-	GuardianAdLite: ['rejectTracking'],
+	GuardianAdLite: ['allowRejectAll'],
 	SupporterPlus: supporterPlusBenefits,
 	DigitalSubscription: digitalSubscriptionBenefits,
 	TierThree: tierThreeBenefits,

--- a/modules/product-benefits/src/schemas.ts
+++ b/modules/product-benefits/src/schemas.ts
@@ -8,7 +8,7 @@ export const productBenefitListSchema = z.enum([
 	'guardianWeeklyEdition',
 	'liveApp',
 	'hideSupportMessaging',
-	'rejectTracking',
+	'allowRejectAll',
 	'liveEvents',
 ]);
 

--- a/modules/product-benefits/test/getUserBenefits.test.ts
+++ b/modules/product-benefits/test/getUserBenefits.test.ts
@@ -57,7 +57,7 @@ test('getUserBenefitsFromUserProducts', () => {
 		digitalSubscriptionBenefits,
 	);
 	expect(getUserBenefitsFromUserProducts(['GuardianAdLite'])).toEqual([
-		'rejectTracking',
+		'allowRejectAll',
 	]);
 	expect(getUserBenefitsFromUserProducts(['SupporterPlus'])).toEqual(
 		supporterPlusBenefits,
@@ -83,5 +83,5 @@ test('getUserBenefitsFromUserProducts returns the union of two benefit sets', ()
 			'GuardianAdLite',
 			'GuardianWeeklyDomestic',
 		]),
-	).toEqual(['rejectTracking', 'hideSupportMessaging']);
+	).toEqual(['allowRejectAll', 'hideSupportMessaging']);
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
In a recent discussion we decided that `allowRejectAll` was a better name for this benefit that `rejectTracking`.