### PR TITLE
Update metric-push-api to accept HEAD requests

### DIFF
--- a/handlers/metric-push-api/cfn.yaml
+++ b/handlers/metric-push-api/cfn.yaml
@@ -42,7 +42,7 @@ Resources:
             ApiKeyRequired: false
             RestApiId: !Ref MetricPushAPI
             ResourceId: !Ref MetricPushProxyResource
-            HttpMethod: GET
+            HttpMethod: HEAD
             Integration:
               Type: MOCK
               RequestTemplates:


### PR DESCRIPTION
## What does this change?

This endpoint is open to the internet and sometimes gets crawled/visited. This results in false positive metrics getting recorded. Change this to API destination endpoint to accept HEAD requests which I think we're less likely to see.

## How to test

Using `curl` make a HEAD request and see the metric get recorded. Make a GET request and see it not get recorded. ✅ 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
