### PR TITLE
Revert "Update metric-push-api to accept HEAD requests"

### DIFF
--- a/handlers/metric-push-api/cfn.yaml
+++ b/handlers/metric-push-api/cfn.yaml
@@ -42,7 +42,7 @@ Resources:
             ApiKeyRequired: false
             RestApiId: !Ref MetricPushAPI
             ResourceId: !Ref MetricPushProxyResource
-            HttpMethod: HEAD
+            HttpMethod: GET
             Integration:
               Type: MOCK
               RequestTemplates:


### PR DESCRIPTION
Reverts guardian/support-service-lambdas#2652.

The alarm this was supposed to help quieten down has been noisier than ever overnight, so revert this change.