### PR TITLE
Metric Push API: Only alarm on 2xx errors

### DIFF
--- a/handlers/metric-push-api/cfn.yaml
+++ b/handlers/metric-push-api/cfn.yaml
@@ -193,7 +193,7 @@ Resources:
               Stat: Sum
               Metric:
                 Namespace: AWS/ApiGateway
-                MetricName: 5XXError
+                MetricName: 4XXError
                 Dimensions:
                   - Name: ApiName
                     Value: !FindInMap [StageMap, !Ref Stage, ApiName]

--- a/handlers/metric-push-api/cfn.yaml
+++ b/handlers/metric-push-api/cfn.yaml
@@ -9,17 +9,16 @@ Parameters:
             - PROD
             - CODE
 
-Conditions:
-  CreateProdMonitoring: !Equals [ !Ref Stage, PROD ]
-
 Mappings:
     StageMap:
         CODE:
             ApiName: metric-push-api-api-CODE
             DomainName: metric-push-api-code.support.guardianapis.com
+            AlarmActionsEnabled: FALSE
         PROD:
             ApiName: metric-push-api-api-PROD
             DomainName: metric-push-api-prod.support.guardianapis.com
+            AlarmActionsEnabled: TRUE
     Constants:
       Alarm:
         Process: Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
@@ -122,10 +121,10 @@ Resources:
 
     5xxApiAlarm:
       Type: AWS::CloudWatch::Alarm
-      Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
           - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
+        ActionsEnabled: !FindInMap [StageMap, !Ref Stage, AlarmActionsEnabled]
         AlarmName: !Join
         - ' '
         - - !FindInMap [ Constants, Alarm, Urgent ]
@@ -148,10 +147,10 @@ Resources:
 
     HighClientSideErrorRateAlarm:
       Type: AWS::CloudWatch::Alarm
-      Condition: CreateProdMonitoring
       Properties:
         AlarmActions:
           - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
+        ActionsEnabled: !FindInMap [StageMap, !Ref Stage, AlarmActionsEnabled]
         AlarmName: !Join
           - ' '
           - - !FindInMap [ Constants, Alarm, Urgent ]
@@ -162,17 +161,46 @@ Resources:
           - - 'Impact - some or all browsers are failing to render support client side pages. Log in to Sentry to see these errors: https://the-guardian.sentry.io/discover/results/?project=1213654&query=%22Fatal%20error%20rendering%20page%22&queryDataset=error-events&sort=-count&statsPeriod=24h'
             - !FindInMap [ Constants, Alarm, Process ]
             - !FindInMap [StageMap, !Ref Stage, ApiName]
-        MetricName: Count
-        Namespace: AWS/ApiGateway
-        Dimensions:
-          - Name: ApiName
-            Value: !FindInMap [StageMap, !Ref Stage, ApiName]
+        Metrics:
+          - Id: mtotal2xx
+            Expression: 'mtotalcount - (m5xxcount + m4xxcount)'
+          - Id: mtotalcount
+            ReturnData: false
+            MetricStat:
+              Period: 60
+              Stat: Sum
+              Metric:
+                Namespace: AWS/ApiGateway
+                MetricName: Count
+                Dimensions:
+                  - Name: ApiName
+                    Value: !FindInMap [StageMap, !Ref Stage, ApiName]
+          - Id: m5xxcount
+            ReturnData: false
+            MetricStat:
+              Period: 60
+              Stat: Sum
+              Metric:
+                Namespace: AWS/ApiGateway
+                MetricName: 5XXError
+                Dimensions:
+                  - Name: ApiName
+                    Value: !FindInMap [StageMap, !Ref Stage, ApiName]
+          - Id: m4xxcount
+            ReturnData: false
+            MetricStat:
+              Period: 60
+              Stat: Sum
+              Metric:
+                Namespace: AWS/ApiGateway
+                MetricName: 5XXError
+                Dimensions:
+                  - Name: ApiName
+                    Value: !FindInMap [StageMap, !Ref Stage, ApiName]
         ComparisonOperator: GreaterThanOrEqualToThreshold
         Threshold: 2
         DatapointsToAlarm: 3
-        Period: 60
         EvaluationPeriods: 5
-        Statistic: Sum
         TreatMissingData: notBreaching
       DependsOn:
         - MetricPushAPI


### PR DESCRIPTION
## What does this change?

I'm attempting to make the metric push API alarm less noisy. The strategy will be to return a non-2xx response code for clients we don't care about. In order to make this work we'll need to be able to alarm only on genuine 2xx responses. 

## How to test

I've deployed to CODE and made several requests to the metric push API. 3 returned a 2xx, 1 returned a 4xx. This can be seen on the following graph:

<img width="945" alt="Screenshot 2025-01-28 at 11 55 00" src="https://github.com/user-attachments/assets/7c519373-3ca3-49d5-9b39-46ade77ad73a" />

Our new alarm metric `m2xxcount`, which we'll alarm on, reports a sum of 3 for the same period (i.e. total of 4 - 1 4xx error):

<img width="243" alt="Screenshot 2025-01-28 at 11 49 27" src="https://github.com/user-attachments/assets/0e3722bb-e23a-47cf-80d0-3efa3ff74a23" />

The alarm went into an alarm state as expected after 3 datapoints within 5 minutes were above the threshold:

<img width="929" alt="Screenshot 2025-01-28 at 12 04 04" src="https://github.com/user-attachments/assets/3758265c-510c-4267-920e-75454d7609ac" />
