### PR TITLE
Give Feast access to supporter members

### DIFF
--- a/modules/product-benefits/src/productBenefit.ts
+++ b/modules/product-benefits/src/productBenefit.ts
@@ -31,7 +31,7 @@ export const productBenefitMapping: Record<ProductKey, ProductBenefit[]> = {
 	NationalDelivery: digitalSubscriptionBenefits,
 	NewspaperVoucher: digitalSubscriptionBenefits,
 	SubscriptionCard: digitalSubscriptionBenefits,
-	SupporterMembership: ['liveApp', 'hideSupportMessaging'],
+	SupporterMembership: ['liveApp', 'feastApp', 'hideSupportMessaging'],
 	PartnerMembership: ['liveApp', 'feastApp', 'hideSupportMessaging'],
 	PatronMembership: digitalSubscriptionBenefits,
 	GuardianPatron: digitalSubscriptionBenefits,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We want to give access to the Feast app to Supporter members. This PR does that in the user-benefits API