### PR TITLE
Add benefits/list endpoint to user-benefits API

### DIFF
--- a/cdk/lib/__snapshots__/user-benefits.test.ts.snap
+++ b/cdk/lib/__snapshots__/user-benefits.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
       "GuApiGateway5xxPercentageAlarm",
       "GuAlarm",
@@ -337,11 +338,14 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5031b9cf7f6c14f2d0d67b7159f1361a7d5": {
+    "RestApiDeployment180EC503083d8867dcf3eaf28c8354449f7bf8c9": {
       "DependsOn": [
         "RestApibenefitsidentityIdGET09FA095A",
         "RestApibenefitsidentityIdOPTIONSE3678C12",
         "RestApibenefitsidentityIdAB0AD6FB",
+        "RestApibenefitslistGET10FFF7DB",
+        "RestApibenefitslistOPTIONSA9AA31E7",
+        "RestApibenefitslist3028CFAD",
         "RestApibenefitsmeGETE1668978",
         "RestApibenefitsmeOPTIONSB9A61D09",
         "RestApibenefitsmeD17C4853",
@@ -363,7 +367,7 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5031b9cf7f6c14f2d0d67b7159f1361a7d5",
+          "Ref": "RestApiDeployment180EC503083d8867dcf3eaf28c8354449f7bf8c9",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -685,6 +689,187 @@ exports[`The User benefits stack matches the snapshot 1`] = `
         ],
         "ResourceId": {
           "Ref": "RestApibenefitsidentityIdAB0AD6FB",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslist3028CFAD": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApibenefits030C9A78",
+        },
+        "PathPart": "list",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApibenefitslistGET10FFF7DB": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "userbenefitslistlambdaD183B4B4",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApibenefitslist3028CFAD",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslistGETApiPermissionTestuserbenefitsCODERestApi6C1D688CGETbenefitslist5D6B93EE": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/benefits/list",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistGETApiPermissionuserbenefitsCODERestApi6C1D688CGETbenefitslist5DF2619B": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/benefits/list",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistOPTIONSA9AA31E7": {
+      "Properties": {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'GET'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://m.code.dev-theguardian.com'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "ResponseTemplates": {
+                "application/json": "#set($origin = $input.params().header.get("Origin"))
+#if($origin == "")
+  #set($origin = $input.params().header.get("origin"))
+#end
+#if($origin == "https://m.thegulocal.com" || $origin == "https://profile.code.dev-theguardian.com" || $origin == "https://profile.thegulocal.com" || $origin == "https://support.code.dev-theguardian.com" || $origin == "https://support.thegulocal.com")
+  #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)
+#end",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApibenefitslist3028CFAD",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -1174,6 +1359,225 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "userbenefitslistlambdaD183B4B4": {
+      "DependsOn": [
+        "userbenefitslistlambdaServiceRoleDefaultPolicy616E830D",
+        "userbenefitslistlambdaServiceRoleB51F7775",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/CODE/user-benefits/user-benefits.zip",
+        },
+        "Description": "An API Gateway triggered lambda to get the benefits of the user identified in the request path",
+        "Environment": {
+          "Variables": {
+            "APP": "user-benefits",
+            "App": "user-benefits",
+            "STACK": "membership",
+            "STAGE": "CODE",
+            "Stack": "membership",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "user-benefits-list-CODE",
+        "Handler": "index.benefitsListHandler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaServiceRoleB51F7775",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "user-benefits",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "userbenefitslistlambdaServiceRoleB51F7775": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "user-benefits",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "userbenefitslistlambdaServiceRoleDefaultPolicy616E830D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "dynamodb:Query",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "supporter-product-data-tables-CODE-SupporterProductDataTable",
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/CODE/user-benefits/user-benefits.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/membership/user-benefits",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/membership/user-benefits/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "userbenefitslistlambdaServiceRoleDefaultPolicy616E830D",
+        "Roles": [
+          {
+            "Ref": "userbenefitslistlambdaServiceRoleB51F7775",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "userbenefitsmelambdaC38B824F": {
       "DependsOn": [
         "userbenefitsmelambdaServiceRoleDefaultPolicy0A47ED04",
@@ -1402,6 +1806,7 @@ exports[`The User benefits stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
+      "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
@@ -1734,11 +2139,14 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5032d4d5ec416a5fa8ac8a06493468f87fc": {
+    "RestApiDeployment180EC503e6ef9f661f8798863fda585ce7299270": {
       "DependsOn": [
         "RestApibenefitsidentityIdGET09FA095A",
         "RestApibenefitsidentityIdOPTIONSE3678C12",
         "RestApibenefitsidentityIdAB0AD6FB",
+        "RestApibenefitslistGET10FFF7DB",
+        "RestApibenefitslistOPTIONSA9AA31E7",
+        "RestApibenefitslist3028CFAD",
         "RestApibenefitsmeGETE1668978",
         "RestApibenefitsmeOPTIONSB9A61D09",
         "RestApibenefitsmeD17C4853",
@@ -1760,7 +2168,7 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5032d4d5ec416a5fa8ac8a06493468f87fc",
+          "Ref": "RestApiDeployment180EC503e6ef9f661f8798863fda585ce7299270",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -2082,6 +2490,187 @@ exports[`The User benefits stack matches the snapshot 2`] = `
         ],
         "ResourceId": {
           "Ref": "RestApibenefitsidentityIdAB0AD6FB",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslist3028CFAD": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApibenefits030C9A78",
+        },
+        "PathPart": "list",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApibenefitslistGET10FFF7DB": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "userbenefitslistlambdaD183B4B4",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApibenefitslist3028CFAD",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslistGETApiPermissionTestuserbenefitsPRODRestApi85285150GETbenefitslist51A9DD2D": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/benefits/list",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistGETApiPermissionuserbenefitsPRODRestApi85285150GETbenefitslist3E532CCB": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/benefits/list",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistOPTIONSA9AA31E7": {
+      "Properties": {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'GET'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://www.theguardian.com'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "ResponseTemplates": {
+                "application/json": "#set($origin = $input.params().header.get("Origin"))
+#if($origin == "")
+  #set($origin = $input.params().header.get("origin"))
+#end
+#if($origin == "https://interactive.guim.co.uk" || $origin == "https://profile.theguardian.com" || $origin == "https://support.theguardian.com")
+  #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)
+#end",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApibenefitslist3028CFAD",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -2566,6 +3155,225 @@ exports[`The User benefits stack matches the snapshot 2`] = `
         "Roles": [
           {
             "Ref": "userbenefitsidentityidlambdaServiceRole58C38F77",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "userbenefitslistlambdaD183B4B4": {
+      "DependsOn": [
+        "userbenefitslistlambdaServiceRoleDefaultPolicy616E830D",
+        "userbenefitslistlambdaServiceRoleB51F7775",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/PROD/user-benefits/user-benefits.zip",
+        },
+        "Description": "An API Gateway triggered lambda to get the benefits of the user identified in the request path",
+        "Environment": {
+          "Variables": {
+            "APP": "user-benefits",
+            "App": "user-benefits",
+            "STACK": "membership",
+            "STAGE": "PROD",
+            "Stack": "membership",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "user-benefits-list-PROD",
+        "Handler": "index.benefitsListHandler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaServiceRoleB51F7775",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "user-benefits",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "userbenefitslistlambdaServiceRoleB51F7775": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "user-benefits",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "userbenefitslistlambdaServiceRoleDefaultPolicy616E830D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "dynamodb:Query",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "supporter-product-data-tables-PROD-SupporterProductDataTable",
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/PROD/user-benefits/user-benefits.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/membership/user-benefits",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/membership/user-benefits/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "userbenefitslistlambdaServiceRoleDefaultPolicy616E830D",
+        "Roles": [
+          {
+            "Ref": "userbenefitslistlambdaServiceRoleB51F7775",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/user-benefits.test.ts.snap
+++ b/cdk/lib/__snapshots__/user-benefits.test.ts.snap
@@ -338,12 +338,14 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503083d8867dcf3eaf28c8354449f7bf8c9": {
+    "RestApiDeployment180EC503ff102c6d983194ceda9c7309eac5da4c": {
       "DependsOn": [
         "RestApibenefitsidentityIdGET09FA095A",
         "RestApibenefitsidentityIdOPTIONSE3678C12",
         "RestApibenefitsidentityIdAB0AD6FB",
-        "RestApibenefitslistGET10FFF7DB",
+        "RestApibenefitslistformatGET314DBDDE",
+        "RestApibenefitslistformatOPTIONS1D8F30DF",
+        "RestApibenefitslistformat61856B2C",
         "RestApibenefitslistOPTIONSA9AA31E7",
         "RestApibenefitslist3028CFAD",
         "RestApibenefitsmeGETE1668978",
@@ -367,7 +369,7 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503083d8867dcf3eaf28c8354449f7bf8c9",
+          "Ref": "RestApiDeployment180EC503ff102c6d983194ceda9c7309eac5da4c",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -708,124 +710,6 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "RestApibenefitslistGET10FFF7DB": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "userbenefitslistlambdaD183B4B4",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Ref": "RestApibenefitslist3028CFAD",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApibenefitslistGETApiPermissionTestuserbenefitsCODERestApi6C1D688CGETbenefitslist5D6B93EE": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "userbenefitslistlambdaD183B4B4",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/test-invoke-stage/GET/benefits/list",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApibenefitslistGETApiPermissionuserbenefitsCODERestApi6C1D688CGETbenefitslist5DF2619B": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "userbenefitslistlambdaD183B4B4",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/",
-              {
-                "Ref": "RestApiDeploymentStageprod3855DE66",
-              },
-              "/GET/benefits/list",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
     "RestApibenefitslistOPTIONSA9AA31E7": {
       "Properties": {
         "ApiKeyRequired": false,
@@ -870,6 +754,187 @@ exports[`The User benefits stack matches the snapshot 1`] = `
         ],
         "ResourceId": {
           "Ref": "RestApibenefitslist3028CFAD",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslistformat61856B2C": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApibenefitslist3028CFAD",
+        },
+        "PathPart": "{format+}",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApibenefitslistformatGET314DBDDE": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "userbenefitslistlambdaD183B4B4",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApibenefitslistformat61856B2C",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslistformatGETApiPermissionTestuserbenefitsCODERestApi6C1D688CGETbenefitslistformat9431D5AC": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/benefits/list/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistformatGETApiPermissionuserbenefitsCODERestApi6C1D688CGETbenefitslistformatC5090FB3": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/benefits/list/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistformatOPTIONS1D8F30DF": {
+      "Properties": {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'GET'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://m.code.dev-theguardian.com'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "ResponseTemplates": {
+                "application/json": "#set($origin = $input.params().header.get("Origin"))
+#if($origin == "")
+  #set($origin = $input.params().header.get("origin"))
+#end
+#if($origin == "https://m.thegulocal.com" || $origin == "https://profile.code.dev-theguardian.com" || $origin == "https://profile.thegulocal.com" || $origin == "https://support.code.dev-theguardian.com" || $origin == "https://support.thegulocal.com")
+  #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)
+#end",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApibenefitslistformat61856B2C",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -2139,12 +2204,14 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503e6ef9f661f8798863fda585ce7299270": {
+    "RestApiDeployment180EC5030e8f60bb73be61d189b5cc0a522673f8": {
       "DependsOn": [
         "RestApibenefitsidentityIdGET09FA095A",
         "RestApibenefitsidentityIdOPTIONSE3678C12",
         "RestApibenefitsidentityIdAB0AD6FB",
-        "RestApibenefitslistGET10FFF7DB",
+        "RestApibenefitslistformatGET314DBDDE",
+        "RestApibenefitslistformatOPTIONS1D8F30DF",
+        "RestApibenefitslistformat61856B2C",
         "RestApibenefitslistOPTIONSA9AA31E7",
         "RestApibenefitslist3028CFAD",
         "RestApibenefitsmeGETE1668978",
@@ -2168,7 +2235,7 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503e6ef9f661f8798863fda585ce7299270",
+          "Ref": "RestApiDeployment180EC5030e8f60bb73be61d189b5cc0a522673f8",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -2509,124 +2576,6 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "RestApibenefitslistGET10FFF7DB": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "userbenefitslistlambdaD183B4B4",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Ref": "RestApibenefitslist3028CFAD",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApibenefitslistGETApiPermissionTestuserbenefitsPRODRestApi85285150GETbenefitslist51A9DD2D": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "userbenefitslistlambdaD183B4B4",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/test-invoke-stage/GET/benefits/list",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApibenefitslistGETApiPermissionuserbenefitsPRODRestApi85285150GETbenefitslist3E532CCB": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "userbenefitslistlambdaD183B4B4",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/",
-              {
-                "Ref": "RestApiDeploymentStageprod3855DE66",
-              },
-              "/GET/benefits/list",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
     "RestApibenefitslistOPTIONSA9AA31E7": {
       "Properties": {
         "ApiKeyRequired": false,
@@ -2671,6 +2620,187 @@ exports[`The User benefits stack matches the snapshot 2`] = `
         ],
         "ResourceId": {
           "Ref": "RestApibenefitslist3028CFAD",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslistformat61856B2C": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApibenefitslist3028CFAD",
+        },
+        "PathPart": "{format+}",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApibenefitslistformatGET314DBDDE": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "userbenefitslistlambdaD183B4B4",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApibenefitslistformat61856B2C",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslistformatGETApiPermissionTestuserbenefitsPRODRestApi85285150GETbenefitslistformat46167936": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/benefits/list/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistformatGETApiPermissionuserbenefitsPRODRestApi85285150GETbenefitslistformatB06101F1": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/benefits/list/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistformatOPTIONS1D8F30DF": {
+      "Properties": {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'GET'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://www.theguardian.com'",
+                "method.response.header.Vary": "'Origin'",
+              },
+              "ResponseTemplates": {
+                "application/json": "#set($origin = $input.params().header.get("Origin"))
+#if($origin == "")
+  #set($origin = $input.params().header.get("origin"))
+#end
+#if($origin == "https://interactive.guim.co.uk" || $origin == "https://profile.theguardian.com" || $origin == "https://support.theguardian.com")
+  #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)
+#end",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Vary": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApibenefitslistformat61856B2C",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",

--- a/cdk/lib/__snapshots__/user-benefits.test.ts.snap
+++ b/cdk/lib/__snapshots__/user-benefits.test.ts.snap
@@ -338,14 +338,12 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503ff102c6d983194ceda9c7309eac5da4c": {
+    "RestApiDeployment180EC503083d8867dcf3eaf28c8354449f7bf8c9": {
       "DependsOn": [
         "RestApibenefitsidentityIdGET09FA095A",
         "RestApibenefitsidentityIdOPTIONSE3678C12",
         "RestApibenefitsidentityIdAB0AD6FB",
-        "RestApibenefitslistformatGET314DBDDE",
-        "RestApibenefitslistformatOPTIONS1D8F30DF",
-        "RestApibenefitslistformat61856B2C",
+        "RestApibenefitslistGET10FFF7DB",
         "RestApibenefitslistOPTIONSA9AA31E7",
         "RestApibenefitslist3028CFAD",
         "RestApibenefitsmeGETE1668978",
@@ -369,7 +367,7 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503ff102c6d983194ceda9c7309eac5da4c",
+          "Ref": "RestApiDeployment180EC503083d8867dcf3eaf28c8354449f7bf8c9",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -710,6 +708,124 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
+    "RestApibenefitslistGET10FFF7DB": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "userbenefitslistlambdaD183B4B4",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApibenefitslist3028CFAD",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslistGETApiPermissionTestuserbenefitsCODERestApi6C1D688CGETbenefitslist5D6B93EE": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/benefits/list",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistGETApiPermissionuserbenefitsCODERestApi6C1D688CGETbenefitslist5DF2619B": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/benefits/list",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "RestApibenefitslistOPTIONSA9AA31E7": {
       "Properties": {
         "ApiKeyRequired": false,
@@ -754,187 +870,6 @@ exports[`The User benefits stack matches the snapshot 1`] = `
         ],
         "ResourceId": {
           "Ref": "RestApibenefitslist3028CFAD",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApibenefitslistformat61856B2C": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "RestApibenefitslist3028CFAD",
-        },
-        "PathPart": "{format+}",
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "RestApibenefitslistformatGET314DBDDE": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "userbenefitslistlambdaD183B4B4",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Ref": "RestApibenefitslistformat61856B2C",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApibenefitslistformatGETApiPermissionTestuserbenefitsCODERestApi6C1D688CGETbenefitslistformat9431D5AC": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "userbenefitslistlambdaD183B4B4",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/test-invoke-stage/GET/benefits/list/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApibenefitslistformatGETApiPermissionuserbenefitsCODERestApi6C1D688CGETbenefitslistformatC5090FB3": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "userbenefitslistlambdaD183B4B4",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/",
-              {
-                "Ref": "RestApiDeploymentStageprod3855DE66",
-              },
-              "/GET/benefits/list/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApibenefitslistformatOPTIONS1D8F30DF": {
-      "Properties": {
-        "ApiKeyRequired": false,
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": {
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Access-Control-Allow-Headers": "'*'",
-                "method.response.header.Access-Control-Allow-Methods": "'GET'",
-                "method.response.header.Access-Control-Allow-Origin": "'https://m.code.dev-theguardian.com'",
-                "method.response.header.Vary": "'Origin'",
-              },
-              "ResponseTemplates": {
-                "application/json": "#set($origin = $input.params().header.get("Origin"))
-#if($origin == "")
-  #set($origin = $input.params().header.get("origin"))
-#end
-#if($origin == "https://m.thegulocal.com" || $origin == "https://profile.code.dev-theguardian.com" || $origin == "https://profile.thegulocal.com" || $origin == "https://support.code.dev-theguardian.com" || $origin == "https://support.thegulocal.com")
-  #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)
-#end",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": [
-          {
-            "ResponseParameters": {
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-              "method.response.header.Vary": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": {
-          "Ref": "RestApibenefitslistformat61856B2C",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -2204,14 +2139,12 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5030e8f60bb73be61d189b5cc0a522673f8": {
+    "RestApiDeployment180EC503e6ef9f661f8798863fda585ce7299270": {
       "DependsOn": [
         "RestApibenefitsidentityIdGET09FA095A",
         "RestApibenefitsidentityIdOPTIONSE3678C12",
         "RestApibenefitsidentityIdAB0AD6FB",
-        "RestApibenefitslistformatGET314DBDDE",
-        "RestApibenefitslistformatOPTIONS1D8F30DF",
-        "RestApibenefitslistformat61856B2C",
+        "RestApibenefitslistGET10FFF7DB",
         "RestApibenefitslistOPTIONSA9AA31E7",
         "RestApibenefitslist3028CFAD",
         "RestApibenefitsmeGETE1668978",
@@ -2235,7 +2168,7 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5030e8f60bb73be61d189b5cc0a522673f8",
+          "Ref": "RestApiDeployment180EC503e6ef9f661f8798863fda585ce7299270",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -2576,6 +2509,124 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
+    "RestApibenefitslistGET10FFF7DB": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "userbenefitslistlambdaD183B4B4",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApibenefitslist3028CFAD",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApibenefitslistGETApiPermissionTestuserbenefitsPRODRestApi85285150GETbenefitslist51A9DD2D": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/benefits/list",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApibenefitslistGETApiPermissionuserbenefitsPRODRestApi85285150GETbenefitslist3E532CCB": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "userbenefitslistlambdaD183B4B4",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/benefits/list",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "RestApibenefitslistOPTIONSA9AA31E7": {
       "Properties": {
         "ApiKeyRequired": false,
@@ -2620,187 +2671,6 @@ exports[`The User benefits stack matches the snapshot 2`] = `
         ],
         "ResourceId": {
           "Ref": "RestApibenefitslist3028CFAD",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApibenefitslistformat61856B2C": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "RestApibenefitslist3028CFAD",
-        },
-        "PathPart": "{format+}",
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "RestApibenefitslistformatGET314DBDDE": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "userbenefitslistlambdaD183B4B4",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Ref": "RestApibenefitslistformat61856B2C",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApibenefitslistformatGETApiPermissionTestuserbenefitsPRODRestApi85285150GETbenefitslistformat46167936": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "userbenefitslistlambdaD183B4B4",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/test-invoke-stage/GET/benefits/list/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApibenefitslistformatGETApiPermissionuserbenefitsPRODRestApi85285150GETbenefitslistformatB06101F1": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "userbenefitslistlambdaD183B4B4",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/",
-              {
-                "Ref": "RestApiDeploymentStageprod3855DE66",
-              },
-              "/GET/benefits/list/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApibenefitslistformatOPTIONS1D8F30DF": {
-      "Properties": {
-        "ApiKeyRequired": false,
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": {
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Access-Control-Allow-Headers": "'*'",
-                "method.response.header.Access-Control-Allow-Methods": "'GET'",
-                "method.response.header.Access-Control-Allow-Origin": "'https://www.theguardian.com'",
-                "method.response.header.Vary": "'Origin'",
-              },
-              "ResponseTemplates": {
-                "application/json": "#set($origin = $input.params().header.get("Origin"))
-#if($origin == "")
-  #set($origin = $input.params().header.get("origin"))
-#end
-#if($origin == "https://interactive.guim.co.uk" || $origin == "https://profile.theguardian.com" || $origin == "https://support.theguardian.com")
-  #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)
-#end",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": [
-          {
-            "ResponseParameters": {
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-              "method.response.header.Vary": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": {
-          "Ref": "RestApibenefitslistformat61856B2C",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",

--- a/cdk/lib/__snapshots__/user-benefits.test.ts.snap
+++ b/cdk/lib/__snapshots__/user-benefits.test.ts.snap
@@ -1371,7 +1371,7 @@ exports[`The User benefits stack matches the snapshot 1`] = `
           },
           "S3Key": "membership/CODE/user-benefits/user-benefits.zip",
         },
-        "Description": "An API Gateway triggered lambda to get the benefits of the user identified in the request path",
+        "Description": "An API Gateway triggered lambda to return the full list of benefits for each product in html or json format",
         "Environment": {
           "Variables": {
             "APP": "user-benefits",
@@ -3172,7 +3172,7 @@ exports[`The User benefits stack matches the snapshot 2`] = `
           },
           "S3Key": "membership/PROD/user-benefits/user-benefits.zip",
         },
-        "Description": "An API Gateway triggered lambda to get the benefits of the user identified in the request path",
+        "Description": "An API Gateway triggered lambda to return the full list of benefits for each product in html or json format",
         "Environment": {
           "Variables": {
             "APP": "user-benefits",

--- a/cdk/lib/user-benefits.ts
+++ b/cdk/lib/user-benefits.ts
@@ -102,7 +102,7 @@ export class UserBenefits extends GuStack {
 					apiKeyRequired: true,
 				},
 				{
-					path: '/benefits/list/{format+}',
+					path: '/benefits/list',
 					httpMethod: 'GET',
 					lambda: userBenefitsListLambda,
 				},

--- a/cdk/lib/user-benefits.ts
+++ b/cdk/lib/user-benefits.ts
@@ -102,7 +102,7 @@ export class UserBenefits extends GuStack {
 					apiKeyRequired: true,
 				},
 				{
-					path: '/benefits/list',
+					path: '/benefits/list/{format+}',
 					httpMethod: 'GET',
 					lambda: userBenefitsListLambda,
 				},

--- a/cdk/lib/user-benefits.ts
+++ b/cdk/lib/user-benefits.ts
@@ -80,7 +80,7 @@ export class UserBenefits extends GuStack {
 			`user-benefits-list-lambda`,
 			{
 				description:
-					'An API Gateway triggered lambda to get the benefits of the user identified in the request path',
+					'An API Gateway triggered lambda to return the full list of benefits for each product in html or json format',
 				functionName: `user-benefits-list-${this.stage}`,
 				handler: 'index.benefitsListHandler',
 				...commonLambdaProps,

--- a/cdk/lib/user-benefits.ts
+++ b/cdk/lib/user-benefits.ts
@@ -75,6 +75,17 @@ export class UserBenefits extends GuStack {
 				...commonLambdaProps,
 			},
 		);
+		const userBenefitsListLambda = new GuLambdaFunction(
+			this,
+			`user-benefits-list-lambda`,
+			{
+				description:
+					'An API Gateway triggered lambda to get the benefits of the user identified in the request path',
+				functionName: `user-benefits-list-${this.stage}`,
+				handler: 'index.benefitsListHandler',
+				...commonLambdaProps,
+			},
+		);
 		const apiGateway = new GuApiGatewayWithLambdaByPath(this, {
 			app,
 			targets: [
@@ -89,6 +100,11 @@ export class UserBenefits extends GuStack {
 					httpMethod: 'GET',
 					lambda: userBenefitsIdentityIdLambda,
 					apiKeyRequired: true,
+				},
+				{
+					path: '/benefits/list',
+					httpMethod: 'GET',
+					lambda: userBenefitsListLambda,
 				},
 			],
 			defaultCorsPreflightOptions: {

--- a/handlers/user-benefits/riff-raff.yaml
+++ b/handlers/user-benefits/riff-raff.yaml
@@ -23,4 +23,5 @@ deployments:
       functionNames:
       - user-benefits-me-
       - user-benefits-identity-id-
+      - user-benefits-list-
     dependencies: [user-benefits-cloudformation]

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -1,9 +1,9 @@
 import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 
-export const benefitsListHandler = (
+export const benefitsListHandler = async (
 	event: APIGatewayProxyEvent,
-): APIGatewayProxyResult => {
+): Promise<APIGatewayProxyResult> => {
 	console.log(`Input is ${JSON.stringify(event)}`);
 
 	const returnHtml = event.headers.accept?.includes('text/html');
@@ -16,15 +16,15 @@ export const benefitsListHandler = (
 const getHttpResponse = (
 	body: string,
 	contentType?: string,
-): APIGatewayProxyResult => {
-	return {
+): Promise<APIGatewayProxyResult> => {
+	return Promise.resolve({
 		statusCode: 200,
 		headers: {
 			'Content-Type': contentType ?? 'application/json',
 			'Cache-Control': 'max-age=60',
 		},
 		body,
-	};
+	});
 };
 
 const getHtmlBody = (): string => {

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -1,0 +1,13 @@
+import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+
+export const benefitsListHandler = async (
+	event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> => {
+	console.log(`Input is ${JSON.stringify(event)}`);
+
+	return Promise.resolve({
+		statusCode: 200,
+		body: JSON.stringify(productBenefitMapping),
+	});
+};

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -6,8 +6,37 @@ export const benefitsListHandler = async (
 ): Promise<APIGatewayProxyResult> => {
 	console.log(`Input is ${JSON.stringify(event)}`);
 
+	const format = event.queryStringParameters?.format;
+	if (format !== 'html') {
+		return Promise.resolve({
+			statusCode: 200,
+			headers: {
+				'Content-Type': 'text/html',
+			},
+			body: getHtmlBody(),
+		});
+	}
 	return Promise.resolve({
 		statusCode: 200,
 		body: JSON.stringify(productBenefitMapping),
 	});
+};
+
+const getHtmlBody = (): string => {
+	return `
+		<!DOCTYPE html>
+		<html>
+			<head>
+				<title>Benefits List</title>
+			</head>
+			<body>
+				<h1>Benefits List</h1>
+				<ul>
+					${Object.entries(productBenefitMapping)
+						.map(([key, value]) => `<li>${key}: ${value.join(',')}</li>`)
+						.join('')}
+				</ul>
+			</body>
+		</html>
+	`;
 };

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -6,8 +6,8 @@ export const benefitsListHandler = async (
 ): Promise<APIGatewayProxyResult> => {
 	console.log(`Input is ${JSON.stringify(event)}`);
 
-	const format = event.queryStringParameters?.format;
-	if (format !== 'html') {
+	const format = event.pathParameters?.format;
+	if (format === 'html') {
 		return getHttpResponse(getHtmlBody(), 'text/html');
 	}
 	return getHttpResponse(JSON.stringify(productBenefitMapping));

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -8,17 +8,22 @@ export const benefitsListHandler = async (
 
 	const format = event.queryStringParameters?.format;
 	if (format !== 'html') {
-		return Promise.resolve({
-			statusCode: 200,
-			headers: {
-				'Content-Type': 'text/html',
-			},
-			body: getHtmlBody(),
-		});
+		return getHttpResponse(getHtmlBody(), 'text/html');
 	}
+	return getHttpResponse(JSON.stringify(productBenefitMapping));
+};
+
+const getHttpResponse = (
+	body: string,
+	contentType?: string,
+): Promise<APIGatewayProxyResult> => {
 	return Promise.resolve({
 		statusCode: 200,
-		body: JSON.stringify(productBenefitMapping),
+		headers: {
+			'Content-Type': contentType ?? 'application/json',
+			'Cache-Control': 'max-age=60',
+		},
+		body,
 	});
 };
 
@@ -30,12 +35,19 @@ const getHtmlBody = (): string => {
 				<title>Benefits List</title>
 			</head>
 			<body>
-				<h1>Benefits List</h1>
-				<ul>
+				<h1>Product Benefits List</h1>
+				<table>
+				<tbody>
+					<tr>
+						<th>Product</th>
+						<th>Benefits</th>
 					${Object.entries(productBenefitMapping)
-						.map(([key, value]) => `<li>${key}: ${value.join(',')}</li>`)
+						.map(
+							([key, value]) =>
+								`<tr><td>${key}</td><td>${value.join(',')}</td></tr>`,
+						)
 						.join('')}
-				</ul>
+				</table>
 			</body>
 		</html>
 	`;

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -1,9 +1,9 @@
 import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 
-export const benefitsListHandler = async (
+export const benefitsListHandler = (
 	event: APIGatewayProxyEvent,
-): Promise<APIGatewayProxyResult> => {
+): APIGatewayProxyResult => {
 	console.log(`Input is ${JSON.stringify(event)}`);
 
 	const returnHtml = event.headers.accept?.includes('text/html');
@@ -16,15 +16,15 @@ export const benefitsListHandler = async (
 const getHttpResponse = (
 	body: string,
 	contentType?: string,
-): Promise<APIGatewayProxyResult> => {
-	return Promise.resolve({
+): APIGatewayProxyResult => {
+	return {
 		statusCode: 200,
 		headers: {
 			'Content-Type': contentType ?? 'application/json',
 			'Cache-Control': 'max-age=60',
 		},
 		body,
-	});
+	};
 };
 
 const getHtmlBody = (): string => {

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -6,8 +6,8 @@ export const benefitsListHandler = async (
 ): Promise<APIGatewayProxyResult> => {
 	console.log(`Input is ${JSON.stringify(event)}`);
 
-	const format = event.pathParameters?.format;
-	if (format === 'html') {
+	const returnHtml = event.headers.accept?.includes('text/html');
+	if (returnHtml) {
 		return getHttpResponse(getHtmlBody(), 'text/html');
 	}
 	return getHttpResponse(JSON.stringify(productBenefitMapping));

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -30,9 +30,26 @@ const getHttpResponse = (
 const getHtmlBody = (): string => {
 	return `
 		<!DOCTYPE html>
-		<html>
+		<html lang="en">
 			<head>
-				<title>Benefits List</title>
+				<title>Product Benefits List</title>
+				<meta name="robots" content="noindex">
+				<style>
+					table {
+						border-collapse: collapse;
+					}
+					th, td {
+						border: 1px solid black;
+						padding: 8px;
+						text-align: left;
+					}
+					th {
+						background-color: #CCC;
+					}
+					tr:nth-child(odd) {
+ 						background-color: #EEE;
+					}
+				</style>
 			</head>
 			<body>
 				<h1>Product Benefits List</h1>
@@ -41,12 +58,12 @@ const getHtmlBody = (): string => {
 					<tr>
 						<th>Product</th>
 						<th>Benefits</th>
-					${Object.entries(productBenefitMapping)
-						.map(
-							([key, value]) =>
-								`<tr><td>${key}</td><td>${value.join(',')}</td></tr>`,
-						)
-						.join('')}
+						${Object.entries(productBenefitMapping)
+							.map(
+								([key, value]) =>
+									`<tr><td>${key}</td><td>${value.join(', ')}</td></tr>`,
+							)
+							.join('')}
 				</table>
 			</body>
 		</html>

--- a/handlers/user-benefits/src/index.ts
+++ b/handlers/user-benefits/src/index.ts
@@ -1,2 +1,3 @@
 export { benefitsMeHandler } from './benefitsMe';
 export { benefitsIdentityIdHandler } from './benefitsIdentityId';
+export { benefitsListHandler } from './benefitsList';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a new endpoint to the user-benefits api to return a list of all benefits by product.

The response of the endpoint can be in HTML or JSON depending on the accept header of the request, if the accept header includes 'text/html' the API will return HTML, otherwise it will return JSON.

### HTML response
![Screenshot 2025-01-29 at 10 52 53](https://github.com/user-attachments/assets/247ba6fa-27bb-4778-a91f-dc575a79d600)

### Partial JSON response
![Screenshot 2025-01-29 at 10 53 51](https://github.com/user-attachments/assets/9ec456ab-391b-4123-b3e6-2f953e0193f7)

