### PR TITLE
supporter plus update amount fix

### DIFF
--- a/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
+++ b/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
@@ -54,12 +54,12 @@ export const getSupporterPlusData = (
 		[supporterPlus.Monthly.id]: {
 			productRatePlan: supporterPlus.Monthly,
 			chargeToUpdateId: supporterPlus.Monthly.charges.Contribution.id,
-			baseChargeId: supporterPlus.Monthly.charges.Subscription.id
+			baseChargeId: supporterPlus.Monthly.charges.Subscription.id,
 		},
 		[supporterPlus.Annual.id]: {
 			productRatePlan: supporterPlus.Annual,
 			chargeToUpdateId: supporterPlus.Annual.charges.Contribution.id,
-			baseChargeId: supporterPlus.Annual.charges.Subscription.id
+			baseChargeId: supporterPlus.Annual.charges.Subscription.id,
 		},
 		[supporterPlus.V1DeprecatedMonthly.id]: {
 			productRatePlan: supporterPlus.V1DeprecatedMonthly,
@@ -110,13 +110,15 @@ export const getSupporterPlusData = (
 
 	logger.log('updatable charge', chargeToUpdate.id);
 
-	const basePriceMinorUnits = productData.baseChargeId ? getIfDefined(
-		ratePlan.ratePlanCharges.find(
-			(charge) =>
-				charge.productRatePlanChargeId === productData.baseChargeId,
-		)?.price,
-		`Could not find the base charge with price property (with the id ${productData.baseChargeId}) in this rate plan`,
-	) * 100 : 0;
+	const basePriceMinorUnits = productData.baseChargeId
+		? getIfDefined(
+				ratePlan.ratePlanCharges.find(
+					(charge) =>
+						charge.productRatePlanChargeId === productData.baseChargeId,
+				)?.price,
+				`Could not find the base charge with price property (with the id ${productData.baseChargeId}) in this rate plan`,
+			) * 100
+		: 0;
 
 	logger.log('basePriceMinorUnits', basePriceMinorUnits);
 
@@ -124,7 +126,7 @@ export const getSupporterPlusData = (
 		ratePlan,
 		productRatePlan: productData.productRatePlan,
 		chargeToUpdate,
-		basePriceMinorUnits
+		basePriceMinorUnits,
 	};
 };
 
@@ -204,7 +206,8 @@ export const updateSupporterPlusAmount = async (
 
 	validateNewAmount(newPaymentAmount, currency, billingPeriod);
 
-	const newContributionAmount = ((newPaymentAmount * 100) - supporterPlusData.basePriceMinorUnits) / 100;
+	const newContributionAmount =
+		(newPaymentAmount * 100 - supporterPlusData.basePriceMinorUnits) / 100;
 
 	const { chargeToUpdate } = supporterPlusData;
 

--- a/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
+++ b/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
@@ -99,7 +99,6 @@ export const getSupporterPlusData = (
 	);
 
 	const { ratePlan, productData } = relevantRatePlan;
-	const { productRatePlan } = productData;
 
 	const chargeToUpdate = getIfDefined(
 		ratePlan.ratePlanCharges.find(
@@ -123,7 +122,7 @@ export const getSupporterPlusData = (
 
 	return {
 		ratePlan,
-		productRatePlan,
+		productRatePlan: productData.productRatePlan,
 		chargeToUpdate,
 		basePriceMinorUnits
 	};

--- a/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
+++ b/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
@@ -35,13 +35,13 @@ export type SupporterPlusData = {
 	ratePlan: RatePlan;
 	productRatePlan: ProductRatePlan<'SupporterPlus', UpdatablePlans>;
 	chargeToUpdate: RatePlanCharge;
-	planHasSeparateContributionCharge: boolean;
+	basePriceMinorUnits: number;
 };
 
 type ProductData = {
 	productRatePlan: ProductRatePlan<'SupporterPlus', UpdatablePlans>;
 	chargeToUpdateId: string;
-	planHasSeparateContributionCharge: boolean;
+	baseChargeId?: string;
 };
 
 export const getSupporterPlusData = (
@@ -54,24 +54,22 @@ export const getSupporterPlusData = (
 		[supporterPlus.Monthly.id]: {
 			productRatePlan: supporterPlus.Monthly,
 			chargeToUpdateId: supporterPlus.Monthly.charges.Contribution.id,
-			planHasSeparateContributionCharge: true,
+			baseChargeId: supporterPlus.Monthly.charges.Subscription.id
 		},
 		[supporterPlus.Annual.id]: {
 			productRatePlan: supporterPlus.Annual,
 			chargeToUpdateId: supporterPlus.Annual.charges.Contribution.id,
-			planHasSeparateContributionCharge: true,
+			baseChargeId: supporterPlus.Annual.charges.Subscription.id
 		},
 		[supporterPlus.V1DeprecatedMonthly.id]: {
 			productRatePlan: supporterPlus.V1DeprecatedMonthly,
 			chargeToUpdateId:
 				supporterPlus.V1DeprecatedMonthly.charges.Subscription.id,
-			planHasSeparateContributionCharge: false,
 		},
 		[supporterPlus.V1DeprecatedAnnual.id]: {
 			productRatePlan: supporterPlus.V1DeprecatedAnnual,
 			chargeToUpdateId:
 				supporterPlus.V1DeprecatedAnnual.charges.Subscription.id,
-			planHasSeparateContributionCharge: false,
 		},
 	};
 
@@ -101,23 +99,33 @@ export const getSupporterPlusData = (
 	);
 
 	const { ratePlan, productData } = relevantRatePlan;
-	const { productRatePlan, planHasSeparateContributionCharge } = productData;
+	const { productRatePlan } = productData;
 
 	const chargeToUpdate = getIfDefined(
 		ratePlan.ratePlanCharges.find(
 			(charge) =>
 				charge.productRatePlanChargeId === productData.chargeToUpdateId,
 		),
-		`Could not find a charge with the id ${productData.chargeToUpdateId} in this rate plan`,
+		`Could not find the contribution charge (with the id ${productData.chargeToUpdateId}) in this rate plan`,
 	);
 
 	logger.log('updatable charge', chargeToUpdate.id);
+
+	const basePriceMinorUnits = productData.baseChargeId ? getIfDefined(
+		ratePlan.ratePlanCharges.find(
+			(charge) =>
+				charge.productRatePlanChargeId === productData.baseChargeId,
+		)?.price,
+		`Could not find the base charge with price property (with the id ${productData.baseChargeId}) in this rate plan`,
+	) * 100 : 0;
+
+	logger.log('basePriceMinorUnits', basePriceMinorUnits);
 
 	return {
 		ratePlan,
 		productRatePlan,
 		chargeToUpdate,
-		planHasSeparateContributionCharge,
+		basePriceMinorUnits
 	};
 };
 
@@ -197,14 +205,7 @@ export const updateSupporterPlusAmount = async (
 
 	validateNewAmount(newPaymentAmount, currency, billingPeriod);
 
-	const productPrice = getIfDefined(
-		supporterPlusData.productRatePlan.pricing[currency],
-		`SupporterPlus pricing was undefined for currency ${currency}`,
-	);
-	const newContributionAmount =
-		supporterPlusData.planHasSeparateContributionCharge
-			? newPaymentAmount - productPrice
-			: newPaymentAmount;
+	const newContributionAmount = ((newPaymentAmount * 100) - supporterPlusData.basePriceMinorUnits) / 100;
 
 	const { chargeToUpdate } = supporterPlusData;
 


### PR DESCRIPTION
## What does this change?

Subtract actual base price rather than catalog base price when updating supporter plus amount.

This solves an issue where customers that haven't had had a price rise applied yet try to update their supporter plus amount which appears to work but is actually less than the amount they chose.