### PR TITLE
widen and adjust alarm log link period

### DIFF
--- a/handlers/alarms-handler/test/index.test.ts
+++ b/handlers/alarms-handler/test/index.test.ts
@@ -84,7 +84,7 @@ describe('Handler', () => {
 			'🚨 *ALARM:* DISCOUNT-API-CODE Discount-api 5XX response has triggered!\n\n' +
 			'*Description:* Impact - Discount api returned a 5XX response check the logs for more information: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdiscount-api-CODE. Follow the process in https://docs.google.com/document/d/sdkjfhskjdfhksjdhf/edit\n\n' +
 			'*Reason:* Threshold Crossed: 1 datapoint [2.0 (09/10/24 07:18:00)] was greater than or equal to the threshold (1.0).\n\n' +
-			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmock-app-CODE/log-events$3Fstart$3D1728458296236$26filterPattern$3D$26end$3D1728458596236';
+			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmock-app-CODE/log-events$3Fstart$3D1728458220000$26filterPattern$3D$26end$3D1728458580000';
 		expect(result?.webhookUrls).toEqual([mockEnv.SRE_WEBHOOK]);
 		expect(result?.text).toEqual(expectedText);
 	});
@@ -130,8 +130,8 @@ describe('Handler', () => {
 			'🚨 *ALARM:* DISCOUNT-API-CODE Discount-api 5XX response has triggered!\n\n' +
 			'*Description:* Impact - Discount api returned a 5XX response check the logs for more information: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdiscount-api-CODE. Follow the process in https://docs.google.com/document/d/sdkjfhskjdfhksjdhf/edit\n\n' +
 			'*Reason:* Threshold Crossed: 1 datapoint [2.0 (09/10/24 07:18:00)] was greater than or equal to the threshold (1.0).\n\n' +
-			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmock-app-CODE/log-events$3Fstart$3D1728458296236$26filterPattern$3D$26end$3D1728458596236\n\n' +
-			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fanother-app-CODE/log-events$3Fstart$3D1728458296236$26filterPattern$3D$26end$3D1728458596236';
+			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmock-app-CODE/log-events$3Fstart$3D1728458220000$26filterPattern$3D$26end$3D1728458580000\n\n' +
+			'*LogLink*: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fanother-app-CODE/log-events$3Fstart$3D1728458220000$26filterPattern$3D$26end$3D1728458580000';
 		expect(result?.webhookUrls).toEqual([mockEnv.SRE_WEBHOOK]);
 		expect(result?.text).toEqual(expectedText);
 	});


### PR DESCRIPTION
following on from https://github.com/guardian/support-service-lambdas/pull/2641

## background

API gateway seems to put datapoints written in one minute, into the next minute. e.g. I saw this:

2025-01-29T16:13:45.169 the lamba finished (as is the Date header in the response)
2025-01-29 16:14:00 the metric was positive (covers 2025-01-29 16:14:00 until 2025-01-29 16:15:00)
2025-01-29T16:15:29.420 the alarm state changed (on a 1 minute period)

I think maybe

- the API gateway gathers metrics over a minute (starting at 25 seconds past e.g. 16:13:25 -> 16:14:24) and reports them at the end of the minute
- the metric itself covers a 1 minute period (starting at 00 seconds e.g. 16:14:00 -> 16:14:59), and
- the alarm state is checked once a minute (starting at 29 seconds e.g. 16:15:29)

none of them are guaranteed to line up because all jobs cannot run on the minute as it would cause huge spikes.

So if an alarm triggers at xx seconds past the minute, the metric period would end at 00 seconds past the minute.  But the data points written in that minute could have covered almost a minute before the start of the metric period.

## This PR

Rather than picking up the exact alarm time and subtracting the alarm coverage from it, it changes it so it truncates the alarm time back to the nearest minute, and subtracts the alarm coverage plus an extra minute.

