### PR TITLE
Migrate metric-push-api cloudformation to cdk/ci-typescript workflow

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -93,7 +93,6 @@ jobs:
           - holiday-stop-processor
           - identity-backfill
           - identity-retention
-          - metric-push-api
           - product-move-api
           - sf-api-user-credentials-setter
           - sf-contact-merge

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -50,6 +50,7 @@ jobs:
           - salesforce-disaster-recovery
           - salesforce-disaster-recovery-health-check
           - zuora-salesforce-link-remover
+          - metric-push-api
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/build.sbt
+++ b/build.sbt
@@ -683,9 +683,6 @@ lazy val `product-move-api` = lambdaProject(
     }
   }
 
-lazy val `metric-push-api` =
-  lambdaProject("metric-push-api", "HTTP API to push a metric to cloudwatch so we can alarm on errors")
-
 lazy val `sf-move-subscriptions-api` = lambdaProject(
   "sf-move-subscriptions-api",
   "API for for moving subscriptions in ZUORA from SalesForce",

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,6 +6,7 @@ import { CancellationSfCasesApi } from '../lib/cancellation-sf-cases-api';
 import { DiscountApi } from '../lib/discount-api';
 import { DiscountExpiryNotifier } from '../lib/discount-expiry-notifier';
 import { GenerateProductCatalog } from '../lib/generate-product-catalog';
+import { MetricPushApi } from '../lib/metric-push-api';
 import type { NewProductApiProps } from '../lib/new-product-api';
 import { NewProductApi } from '../lib/new-product-api';
 import { PressReaderEntitlements } from '../lib/press-reader-entitlements';
@@ -293,6 +294,14 @@ new DiscountExpiryNotifier(app, 'discount-expiry-notifier-CODE', {
 	stage: 'CODE',
 });
 new DiscountExpiryNotifier(app, 'discount-expiry-notifier-PROD', {
+	stack: 'support',
+	stage: 'PROD',
+});
+new MetricPushApi(app, 'metric-push-api-CODE', {
+	stack: 'support',
+	stage: 'CODE',
+});
+new MetricPushApi(app, 'metric-push-api-PROD', {
 	stack: 'support',
 	stage: 'PROD',
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -298,10 +298,12 @@ new DiscountExpiryNotifier(app, 'discount-expiry-notifier-PROD', {
 	stage: 'PROD',
 });
 new MetricPushApi(app, 'metric-push-api-CODE', {
-	stack: 'support',
+	stack: 'membership',
 	stage: 'CODE',
+	cloudFormationStackName: 'membership-CODE-metric-push-api',
 });
 new MetricPushApi(app, 'metric-push-api-PROD', {
-	stack: 'support',
+	stack: 'membership',
 	stage: 'PROD',
+	cloudFormationStackName: 'membership-PROD-metric-push-api',
 });

--- a/cdk/lib/__snapshots__/metric-push-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/metric-push-api.test.ts.snap
@@ -289,7 +289,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "support",
+            "Value": "membership",
           },
           {
             "Key": "Stage",
@@ -345,7 +345,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "support",
+            "Value": "membership",
           },
           {
             "Key": "Stage",
@@ -435,7 +435,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "support",
+            "Value": "membership",
           },
           {
             "Key": "Stage",
@@ -796,7 +796,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "support",
+            "Value": "membership",
           },
           {
             "Key": "Stage",
@@ -852,7 +852,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "support",
+            "Value": "membership",
           },
           {
             "Key": "Stage",
@@ -942,7 +942,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "support",
+            "Value": "membership",
           },
           {
             "Key": "Stage",

--- a/cdk/lib/__snapshots__/metric-push-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/metric-push-api.test.ts.snap
@@ -1,0 +1,1015 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The MetricPushApi stack matches the snapshot 1`] = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "HTTP API to push a metric to cloudwatch so we can alarm on errors",
+  "Mappings": {
+    "Constants": {
+      "Alarm": {
+        "Process": "Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "Urgent": "URGENT 9-5 -",
+      },
+    },
+    "StageMap": {
+      "CODE": {
+        "AlarmActionsEnabled": false,
+        "ApiName": "metric-push-api-api-CODE",
+        "DomainName": "metric-push-api-code.support.guardianapis.com",
+      },
+      "PROD": {
+        "AlarmActionsEnabled": true,
+        "ApiName": "metric-push-api-api-PROD",
+        "DomainName": "metric-push-api-prod.support.guardianapis.com",
+      },
+    },
+  },
+  "Metadata": {
+    "gu:cdk:constructs": [],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "Stage": {
+      "AllowedValues": [
+        "PROD",
+        "CODE",
+      ],
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "5xxApiAlarm": {
+      "Properties": {
+        "ActionsEnabled": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "AlarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-\${Stage}",
+          },
+        ],
+        "AlarmName": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Fn::FindInMap": [
+                  "Constants",
+                  "Alarm",
+                  "Urgent",
+                ],
+              },
+              {
+                "Ref": "Stage",
+              },
+              {
+                "Fn::FindInMap": [
+                  "StageMap",
+                  {
+                    "Ref": "Stage",
+                  },
+                  "ApiName",
+                ],
+              },
+              "API Gateway is returning 5XX errors",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": {
+              "Fn::FindInMap": [
+                "StageMap",
+                {
+                  "Ref": "Stage",
+                },
+                "ApiName",
+              ],
+            },
+          },
+          {
+            "Name": "Stage",
+            "Value": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 2,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "HighClientSideErrorRateAlarm": {
+      "DependsOn": [
+        "MetricPushAPI",
+      ],
+      "Properties": {
+        "ActionsEnabled": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "AlarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-\${Stage}",
+          },
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            " ",
+            [
+              "Impact - some or all browsers are failing to render support client side pages. Log in to Sentry to see these errors: https://the-guardian.sentry.io/discover/results/?project=1213654&query=%22Fatal%20error%20rendering%20page%22&queryDataset=error-events&sort=-count&statsPeriod=24h",
+              {
+                "Fn::FindInMap": [
+                  "Constants",
+                  "Alarm",
+                  "Process",
+                ],
+              },
+              {
+                "Fn::FindInMap": [
+                  "StageMap",
+                  {
+                    "Ref": "Stage",
+                  },
+                  "ApiName",
+                ],
+              },
+            ],
+          ],
+        },
+        "AlarmName": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Fn::FindInMap": [
+                  "Constants",
+                  "Alarm",
+                  "Urgent",
+                ],
+              },
+              {
+                "Ref": "Stage",
+              },
+              "client-side fatal errors are being reported to sentry for support-frontend",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 5,
+        "Metrics": [
+          {
+            "Expression": "mtotalcount - (m5xxcount + m4xxcount)",
+            "Id": "mtotal2xx",
+          },
+          {
+            "Id": "mtotalcount",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": {
+                      "Fn::FindInMap": [
+                        "StageMap",
+                        {
+                          "Ref": "Stage",
+                        },
+                        "ApiName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m5xxcount",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": {
+                      "Fn::FindInMap": [
+                        "StageMap",
+                        {
+                          "Ref": "Stage",
+                        },
+                        "ApiName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m4xxcount",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": {
+                      "Fn::FindInMap": [
+                        "StageMap",
+                        {
+                          "Ref": "Stage",
+                        },
+                        "ApiName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "4XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 2,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MetricPushAPI": {
+      "Properties": {
+        "Description": "HTTP API to push a metric to cloudwatch so we can alarm on errors",
+        "Name": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "ApiName",
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "MetricPushAPIDeployment": {
+      "DependsOn": [
+        "MetricPushMethod",
+      ],
+      "Properties": {
+        "Description": "Deploys metric-push-api into an environment/stage",
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "MetricPushAPIStage": {
+      "DependsOn": [
+        "MetricPushMethod",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MetricPushAPIDeployment",
+        },
+        "Description": "Stage for metric-push-api",
+        "MethodSettings": [
+          {
+            "DataTraceEnabled": true,
+            "HttpMethod": "*",
+            "LoggingLevel": "ERROR",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+        "StageName": {
+          "Fn::Sub": "\${Stage}",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "MetricPushBasePathMapping": {
+      "DependsOn": [
+        "MetricPushAPI",
+        "MetricPushAPIStage",
+        "MetricPushDomainName",
+      ],
+      "Properties": {
+        "DomainName": {
+          "Ref": "MetricPushDomainName",
+        },
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+        "Stage": {
+          "Fn::Sub": "\${Stage}",
+        },
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping",
+    },
+    "MetricPushDNSRecord": {
+      "DependsOn": [
+        "MetricPushDomainName",
+      ],
+      "Properties": {
+        "Comment": {
+          "Fn::Sub": "CNAME for metric-push-api API \${Stage}",
+        },
+        "HostedZoneName": "support.guardianapis.com.",
+        "Name": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "DomainName",
+          ],
+        },
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "MetricPushDomainName",
+              "RegionalDomainName",
+            ],
+          },
+        ],
+        "TTL": "120",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "MetricPushDomainName": {
+      "Properties": {
+        "DomainName": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "DomainName",
+          ],
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": {
+          "Fn::Sub": "arn:aws:acm:\${AWS::Region}:\${AWS::AccountId}:certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
+    "MetricPushMethod": {
+      "DependsOn": [
+        "MetricPushAPI",
+        "MetricPushProxyResource",
+      ],
+      "Properties": {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Cache-control": "'no-cache'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{"statusCode": 200}",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Cache-control": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "MetricPushProxyResource",
+        },
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "MetricPushProxyResource": {
+      "DependsOn": [
+        "MetricPushAPI",
+      ],
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "MetricPushAPI",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "metric-push-api",
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+  },
+}
+`;
+
+exports[`The MetricPushApi stack matches the snapshot 2`] = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "HTTP API to push a metric to cloudwatch so we can alarm on errors",
+  "Mappings": {
+    "Constants": {
+      "Alarm": {
+        "Process": "Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "Urgent": "URGENT 9-5 -",
+      },
+    },
+    "StageMap": {
+      "CODE": {
+        "AlarmActionsEnabled": false,
+        "ApiName": "metric-push-api-api-CODE",
+        "DomainName": "metric-push-api-code.support.guardianapis.com",
+      },
+      "PROD": {
+        "AlarmActionsEnabled": true,
+        "ApiName": "metric-push-api-api-PROD",
+        "DomainName": "metric-push-api-prod.support.guardianapis.com",
+      },
+    },
+  },
+  "Metadata": {
+    "gu:cdk:constructs": [],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "Stage": {
+      "AllowedValues": [
+        "PROD",
+        "CODE",
+      ],
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "5xxApiAlarm": {
+      "Properties": {
+        "ActionsEnabled": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "AlarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-\${Stage}",
+          },
+        ],
+        "AlarmName": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Fn::FindInMap": [
+                  "Constants",
+                  "Alarm",
+                  "Urgent",
+                ],
+              },
+              {
+                "Ref": "Stage",
+              },
+              {
+                "Fn::FindInMap": [
+                  "StageMap",
+                  {
+                    "Ref": "Stage",
+                  },
+                  "ApiName",
+                ],
+              },
+              "API Gateway is returning 5XX errors",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": {
+              "Fn::FindInMap": [
+                "StageMap",
+                {
+                  "Ref": "Stage",
+                },
+                "ApiName",
+              ],
+            },
+          },
+          {
+            "Name": "Stage",
+            "Value": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 2,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "HighClientSideErrorRateAlarm": {
+      "DependsOn": [
+        "MetricPushAPI",
+      ],
+      "Properties": {
+        "ActionsEnabled": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "AlarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-\${Stage}",
+          },
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            " ",
+            [
+              "Impact - some or all browsers are failing to render support client side pages. Log in to Sentry to see these errors: https://the-guardian.sentry.io/discover/results/?project=1213654&query=%22Fatal%20error%20rendering%20page%22&queryDataset=error-events&sort=-count&statsPeriod=24h",
+              {
+                "Fn::FindInMap": [
+                  "Constants",
+                  "Alarm",
+                  "Process",
+                ],
+              },
+              {
+                "Fn::FindInMap": [
+                  "StageMap",
+                  {
+                    "Ref": "Stage",
+                  },
+                  "ApiName",
+                ],
+              },
+            ],
+          ],
+        },
+        "AlarmName": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Fn::FindInMap": [
+                  "Constants",
+                  "Alarm",
+                  "Urgent",
+                ],
+              },
+              {
+                "Ref": "Stage",
+              },
+              "client-side fatal errors are being reported to sentry for support-frontend",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 5,
+        "Metrics": [
+          {
+            "Expression": "mtotalcount - (m5xxcount + m4xxcount)",
+            "Id": "mtotal2xx",
+          },
+          {
+            "Id": "mtotalcount",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": {
+                      "Fn::FindInMap": [
+                        "StageMap",
+                        {
+                          "Ref": "Stage",
+                        },
+                        "ApiName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m5xxcount",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": {
+                      "Fn::FindInMap": [
+                        "StageMap",
+                        {
+                          "Ref": "Stage",
+                        },
+                        "ApiName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m4xxcount",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": {
+                      "Fn::FindInMap": [
+                        "StageMap",
+                        {
+                          "Ref": "Stage",
+                        },
+                        "ApiName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "4XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 2,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MetricPushAPI": {
+      "Properties": {
+        "Description": "HTTP API to push a metric to cloudwatch so we can alarm on errors",
+        "Name": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "ApiName",
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "MetricPushAPIDeployment": {
+      "DependsOn": [
+        "MetricPushMethod",
+      ],
+      "Properties": {
+        "Description": "Deploys metric-push-api into an environment/stage",
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "MetricPushAPIStage": {
+      "DependsOn": [
+        "MetricPushMethod",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MetricPushAPIDeployment",
+        },
+        "Description": "Stage for metric-push-api",
+        "MethodSettings": [
+          {
+            "DataTraceEnabled": true,
+            "HttpMethod": "*",
+            "LoggingLevel": "ERROR",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+        "StageName": {
+          "Fn::Sub": "\${Stage}",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "MetricPushBasePathMapping": {
+      "DependsOn": [
+        "MetricPushAPI",
+        "MetricPushAPIStage",
+        "MetricPushDomainName",
+      ],
+      "Properties": {
+        "DomainName": {
+          "Ref": "MetricPushDomainName",
+        },
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+        "Stage": {
+          "Fn::Sub": "\${Stage}",
+        },
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping",
+    },
+    "MetricPushDNSRecord": {
+      "DependsOn": [
+        "MetricPushDomainName",
+      ],
+      "Properties": {
+        "Comment": {
+          "Fn::Sub": "CNAME for metric-push-api API \${Stage}",
+        },
+        "HostedZoneName": "support.guardianapis.com.",
+        "Name": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "DomainName",
+          ],
+        },
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "MetricPushDomainName",
+              "RegionalDomainName",
+            ],
+          },
+        ],
+        "TTL": "120",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "MetricPushDomainName": {
+      "Properties": {
+        "DomainName": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "DomainName",
+          ],
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": {
+          "Fn::Sub": "arn:aws:acm:\${AWS::Region}:\${AWS::AccountId}:certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
+    "MetricPushMethod": {
+      "DependsOn": [
+        "MetricPushAPI",
+        "MetricPushProxyResource",
+      ],
+      "Properties": {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Cache-control": "'no-cache'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{"statusCode": 200}",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Cache-control": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "MetricPushProxyResource",
+        },
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "MetricPushProxyResource": {
+      "DependsOn": [
+        "MetricPushAPI",
+      ],
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "MetricPushAPI",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "metric-push-api",
+        "RestApiId": {
+          "Ref": "MetricPushAPI",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+  },
+}
+`;

--- a/cdk/lib/metric-push-api.test.ts
+++ b/cdk/lib/metric-push-api.test.ts
@@ -7,12 +7,14 @@ describe('The MetricPushApi stack', () => {
 		const app = new App();
 
 		const codeStack = new MetricPushApi(app, 'metric-push-api-CODE', {
-			stack: 'support',
+			stack: 'membership',
 			stage: 'CODE',
+			cloudFormationStackName: 'membership-CODE-metric-push-api',
 		});
 		const prodStack = new MetricPushApi(app, 'metric-push-api-PROD', {
-			stack: 'support',
+			stack: 'membership',
 			stage: 'PROD',
+			cloudFormationStackName: 'membership-PROD-metric-push-api',
 		});
 
 		expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();

--- a/cdk/lib/metric-push-api.test.ts
+++ b/cdk/lib/metric-push-api.test.ts
@@ -1,0 +1,21 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { MetricPushApi } from './metric-push-api';
+
+describe('The MetricPushApi stack', () => {
+	it('matches the snapshot', () => {
+		const app = new App();
+
+		const codeStack = new MetricPushApi(app, 'metric-push-api-CODE', {
+			stack: 'support',
+			stage: 'CODE',
+		});
+		const prodStack = new MetricPushApi(app, 'metric-push-api-PROD', {
+			stack: 'support',
+			stage: 'PROD',
+		});
+
+		expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
+		expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();
+	});
+});

--- a/cdk/lib/metric-push-api.ts
+++ b/cdk/lib/metric-push-api.ts
@@ -1,0 +1,18 @@
+import { join } from 'path';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { App } from 'aws-cdk-lib';
+import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
+
+export class MetricPushApi extends GuStack {
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+		const yamlTemplateFilePath = join(
+			__dirname,
+			'../../handlers/metric-push-api/cfn.yaml',
+		);
+		new CfnInclude(this, 'YamlTemplate', {
+			templateFile: yamlTemplateFilePath,
+		});
+	}
+}

--- a/handlers/metric-push-api/package.json
+++ b/handlers/metric-push-api/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "metric-push-api",
+	"scripts": {
+		"package": "touch target/metric-push-api.zip"
+	},
+	"dependencies": {},
+	"devDependencies": {}
+}

--- a/handlers/metric-push-api/package.json
+++ b/handlers/metric-push-api/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "metric-push-api",
 	"scripts": {
-		"package": "touch target/metric-push-api.zip"
+		"package": "mkdir target && touch target/metric-push-api.zip"
 	},
 	"dependencies": {},
 	"devDependencies": {}

--- a/handlers/metric-push-api/riff-raff.yaml
+++ b/handlers/metric-push-api/riff-raff.yaml
@@ -1,12 +1,12 @@
 stacks:
-- membership
+  - membership
 regions:
-- eu-west-1
+  - eu-west-1
 allowedStages:
   - CODE
   - PROD
 deployments:
-  cfn:
+  metric-push-api-cloudformation:
     type: cloud-formation
     app: metric-push-api
     parameters:

--- a/handlers/metric-push-api/riff-raff.yaml
+++ b/handlers/metric-push-api/riff-raff.yaml
@@ -10,4 +10,6 @@ deployments:
     type: cloud-formation
     app: metric-push-api
     parameters:
-      templatePath: cfn.yaml
+      templateStagePaths:
+        CODE: metric-push-api-CODE.template.json
+        PROD: metric-push-api-PROD.template.json


### PR DESCRIPTION
## What does this change?

This creates a cdk stack which simply wraps the existing cloudformation as described here:
https://github.com/guardian/cdk/blob/main/docs/migration-guide.md. We also move the metric-push-api build to the ci-typescript workflow.

This is the first step to introducing a lambda deployment to the metric-push-api. We'd like to introduce a little more complexity to the alarm and have decided that'll be most straightforward to do with a lambda (for example do different things depending on the Origin header of the request).

## How to test

Deployed to CODE and checked everything is working as expected. Using curl to make requests to the endpoint results in expected metrics being created:

![Screenshot 2025-01-31 at 15 19 24](https://github.com/user-attachments/assets/06280d74-690b-4be6-9cfb-29ae513e996a)

The cloudformation changeset preview showed only tags being added to various resources, as expected with `@guardian/cdk`.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
