### PR TITLE
Update zuoraCatalogToProductRatePlanKey and zuoraCatalogToProductRate…

### DIFF
--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -42,6 +42,7 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	// Digital Pack rate plans
 	'Digital Pack Monthly': 'Monthly',
 	'Digital Pack Annual': 'Annual',
+	'Digital Pack Quarterly': 'Quarterly',
 	'Digital Subscription One Year Fixed - One Time Charge': 'OneYearGift',
 	'Digital Subscription Three Month Fixed - One Time Charge': 'ThreeMonthGift',
 	// Supporter Plus rate plans
@@ -120,6 +121,7 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 const zuoraCatalogToProductRatePlanChargeKey: Record<string, string> = {
 	'Digital Pack Monthly': 'Subscription',
 	'Digital Pack Annual': 'Subscription',
+	'Digital Pack Quarterly': 'Subscription',
 	'Digital Subscription One Year Fixed - One Time Charge': 'Subscription',
 	'Digital Subscription Three Month Fixed - One Time Charge': 'Subscription',
 	'Digital Subscription Three Month Fixed - One Time': 'Subscription',


### PR DESCRIPTION
This updates `zuoraCatalogToProductRatePlanKey` and `zuoraCatalogToProductRatePlanChargeKey` with missing entries for Quarterly products.

Done with @graham228221 :)