### PR TITLE
Discount expiry notifier - various improvements and fixes

### DIFF
--- a/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
@@ -462,7 +462,6 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "discount-expiry-notifier",
-            "FILTER_BY_PRODUCTS": "GW",
             "FILTER_BY_REGIONS": "US,USA",
             "STACK": "membership",
             "STAGE": "CODE",
@@ -2071,7 +2070,6 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "discount-expiry-notifier",
-            "FILTER_BY_PRODUCTS": "GW",
             "FILTER_BY_REGIONS": "US,USA",
             "STACK": "membership",
             "STAGE": "PROD",

--- a/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
@@ -462,7 +462,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "discount-expiry-notifier",
-            "FILTER_BY_REGIONS": "US,USA",
+            "FILTER_BY_REGIONS": "US,USA,United States,United States of America",
             "STACK": "membership",
             "STAGE": "CODE",
             "Stage": "CODE",
@@ -2070,7 +2070,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "discount-expiry-notifier",
-            "FILTER_BY_REGIONS": "US,USA",
+            "FILTER_BY_REGIONS": "US,USA,United States,United States of America",
             "STACK": "membership",
             "STAGE": "PROD",
             "Stage": "PROD",

--- a/cdk/lib/discount-expiry-notifier.ts
+++ b/cdk/lib/discount-expiry-notifier.ts
@@ -79,7 +79,6 @@ export class DiscountExpiryNotifier extends GuStack {
 			environment: {
 				Stage: this.stage,
 				FILTER_BY_REGIONS: 'US,USA',
-				FILTER_BY_PRODUCTS: 'GW',
 			},
 			handler: 'filterSubs.handler',
 			fileName: `${appName}.zip`,

--- a/cdk/lib/discount-expiry-notifier.ts
+++ b/cdk/lib/discount-expiry-notifier.ts
@@ -78,7 +78,7 @@ export class DiscountExpiryNotifier extends GuStack {
 			runtime: nodeVersion,
 			environment: {
 				Stage: this.stage,
-				FILTER_BY_REGIONS: 'US,USA',
+				FILTER_BY_REGIONS: 'US,USA,United States,United States of America',
 			},
 			handler: 'filterSubs.handler',
 			fileName: `${appName}.zip`,

--- a/handlers/discount-expiry-notifier/src/bigquery.ts
+++ b/handlers/discount-expiry-notifier/src/bigquery.ts
@@ -39,7 +39,7 @@ export const BigQueryResultDataSchema = z.array(
 		paymentFrequency: z.string(),
 		productName: z.string(),
 		sfContactId: z.string(),
-		subName: z.string(),
+		zuoraSubName: z.string(),
 		workEmail: z.string(),
 	}),
 );
@@ -56,7 +56,7 @@ export const runQuery = async (
 		paymentFrequency: string;
 		productName: string;
 		sfContactId: string;
-		subName: string;
+		zuoraSubName: string;
 		workEmail: string;
 	}>
 > => {

--- a/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
@@ -26,15 +26,15 @@ export const handler = async (event: {
 			'FILTER_BY_REGIONS environment variable not set',
 		);
 
-		const filterByRegions = FILTER_BY_REGIONS.split(',');
+		const filterByRegions = FILTER_BY_REGIONS.toLowerCase().split(',');
 
 		const filteredSubs = event.expiringDiscountsToProcess.filter(
 			(sub) =>
-				filterByRegions.includes(sub.contactCountry) ||
-				filterByRegions.includes(sub.sfBuyerContactMailingCountry) ||
-				filterByRegions.includes(sub.sfBuyerContactOtherCountry) ||
-				filterByRegions.includes(sub.sfRecipientContactMailingCountry) ||
-				filterByRegions.includes(sub.sfRecipientContactOtherCountry),
+				filterByRegions.includes(sub.contactCountry.toLowerCase()) ||
+                filterByRegions.includes(sub.sfBuyerContactMailingCountry.toLowerCase()) ||
+                filterByRegions.includes(sub.sfBuyerContactOtherCountry.toLowerCase()) ||
+                filterByRegions.includes(sub.sfRecipientContactMailingCountry.toLowerCase()) ||
+                filterByRegions.includes(sub.sfRecipientContactOtherCountry.toLowerCase()),
 		);
 
 		return {

--- a/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
@@ -25,25 +25,16 @@ export const handler = async (event: {
 			process.env.FILTER_BY_REGIONS,
 			'FILTER_BY_REGIONS environment variable not set',
 		);
-		const FILTER_BY_PRODUCTS = getIfDefined<string>(
-			process.env.FILTER_BY_PRODUCTS,
-			'FILTER_BY_PRODUCTS environment variable not set',
-		);
 
 		const filterByRegions = FILTER_BY_REGIONS.split(',');
-		const filterByProducts = FILTER_BY_PRODUCTS.split(',');
 
-		const subsFilteredByRegions = event.expiringDiscountsToProcess.filter(
+		const filteredSubs = event.expiringDiscountsToProcess.filter(
 			(sub) =>
 				filterByRegions.includes(sub.contactCountry) ||
 				filterByRegions.includes(sub.sfBuyerContactMailingCountry) ||
 				filterByRegions.includes(sub.sfBuyerContactOtherCountry) ||
 				filterByRegions.includes(sub.sfRecipientContactMailingCountry) ||
 				filterByRegions.includes(sub.sfRecipientContactOtherCountry),
-		);
-
-		const filteredSubs = subsFilteredByRegions.filter((sub) =>
-			filterByProducts.includes(sub.productName),
 		);
 
 		return {

--- a/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
@@ -11,7 +11,7 @@ export const handler = async (event: {
 		paymentFrequency: string;
 		productName: string;
 		sfContactId: string;
-		subName: string;
+		zuoraSubName: string;
 		workEmail: string;
 		contactCountry: string;
 		sfBuyerContactMailingCountry: string;

--- a/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
@@ -31,10 +31,18 @@ export const handler = async (event: {
 		const filteredSubs = event.expiringDiscountsToProcess.filter(
 			(sub) =>
 				filterByRegions.includes(sub.contactCountry.toLowerCase()) ||
-                filterByRegions.includes(sub.sfBuyerContactMailingCountry.toLowerCase()) ||
-                filterByRegions.includes(sub.sfBuyerContactOtherCountry.toLowerCase()) ||
-                filterByRegions.includes(sub.sfRecipientContactMailingCountry.toLowerCase()) ||
-                filterByRegions.includes(sub.sfRecipientContactOtherCountry.toLowerCase()),
+				filterByRegions.includes(
+					sub.sfBuyerContactMailingCountry.toLowerCase(),
+				) ||
+				filterByRegions.includes(
+					sub.sfBuyerContactOtherCountry.toLowerCase(),
+				) ||
+				filterByRegions.includes(
+					sub.sfRecipientContactMailingCountry.toLowerCase(),
+				) ||
+				filterByRegions.includes(
+					sub.sfRecipientContactOtherCountry.toLowerCase(),
+				),
 		);
 
 		return {

--- a/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/filterSubs.ts
@@ -39,6 +39,7 @@ export const handler = async (event: {
 
 		return {
 			...event,
+			filteredSubsCount: filteredSubs.length,
 			filteredSubs,
 		};
 	} catch (error) {

--- a/handlers/discount-expiry-notifier/src/handlers/getSubsWithExpiringDiscounts.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getSubsWithExpiringDiscounts.ts
@@ -26,7 +26,7 @@ export const handler = async (event: { discountExpiresOnDate?: string }) => {
 		};
 	} catch (error) {
 		console.error('Error:', error);
-		// throw error;
+		throw error;
 	}
 	return {
 		discountExpiresOnDate: '2025-03-10',

--- a/handlers/discount-expiry-notifier/src/handlers/getSubsWithExpiringDiscounts.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getSubsWithExpiringDiscounts.ts
@@ -22,17 +22,13 @@ export const handler = async (event: { discountExpiresOnDate?: string }) => {
 		console.log('result', result);
 		return {
 			discountExpiresOnDate,
+			expiringDiscountsToProcessCount: testQueryResponse.length,
 			expiringDiscountsToProcess: testQueryResponse,
 		};
 	} catch (error) {
 		console.error('Error:', error);
 		throw error;
 	}
-	return {
-		discountExpiresOnDate: '2025-03-10',
-		expiringDiscountsToProcessCount: testQueryResponse.length,
-		expiringDiscountsToProcess: testQueryResponse,
-	};
 };
 
 const addDays = (date: Date, days: number): string => {

--- a/handlers/discount-expiry-notifier/src/handlers/getSubsWithExpiringDiscounts.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getSubsWithExpiringDiscounts.ts
@@ -30,6 +30,7 @@ export const handler = async (event: { discountExpiresOnDate?: string }) => {
 	}
 	return {
 		discountExpiresOnDate: '2025-03-10',
+		expiringDiscountsToProcessCount: testQueryResponse.length,
 		expiringDiscountsToProcess: testQueryResponse,
 	};
 };

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -25,6 +25,16 @@ export const handler = async (event: {
 			},
 		};
 	}
+	if (event.item.subStatus === 'Error') {
+		return {
+			detail: event,
+			emailSendAttempt: {
+				status: 'error',
+				payload: {},
+				response: 'Error getting sub status from Zuora',
+			},
+		};
+	}
 	const currencySymbol = getCurrencySymbol(event.item.paymentCurrency);
 
 	const payload = {
@@ -91,3 +101,4 @@ function getCurrencySymbol(currencyCode: string): string {
 	};
 	return symbols[currencyCode] ?? '';
 }
+

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -34,10 +34,10 @@ export const handler = async (event: {
 				ContactAttributes: {
 					SubscriberAttributes: {
 						EmailAddress: event.item.workEmail,
-						paymentAmount: `${currencySymbol}${event.item.paymentAmount}`,
+						payment_amount: `${currencySymbol}${event.item.paymentAmount}`,
 						first_name: event.item.firstName,
-						date_of_payment: formatDate(event.item.nextPaymentDate),
-						paymentFrequency: event.item.paymentFrequency,
+						next_payment_date: formatDate(event.item.nextPaymentDate),
+						payment_frequency: event.item.paymentFrequency,
 					},
 				},
 			},

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -10,14 +10,11 @@ export const handler = async (event: {
 		paymentFrequency: string;
 		productName: string;
 		sfContactId: string;
-		subName: string;
+		zuoraSubName: string;
 		workEmail: string;
 		subStatus: string;
 	};
 }) => {
-	console.log('event:', event);
-	console.log('event.item.firstName:', event.item.firstName);
-	console.log('event.item.subStatus:', event.item.subStatus);
 	if (event.item.subStatus === 'Cancelled') {
 		return {
 			detail: event,
@@ -44,7 +41,6 @@ export const handler = async (event: {
 					},
 				},
 			},
-			// subscriptionCancelledEmail used for testing. will update data extension to active one when published
 			DataExtensionName: DataExtensionNames.discountExpiryNotificationEmail,
 		},
 		SfContactId: event.item.sfContactId,

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -45,7 +45,7 @@ export const handler = async (event: {
 				},
 			},
 			// subscriptionCancelledEmail used for testing. will update data extension to active one when published
-			DataExtensionName: DataExtensionNames.subscriptionCancelledEmail,
+			DataExtensionName: DataExtensionNames.DiscountExpiryNotificationEmail,
 		},
 		SfContactId: event.item.sfContactId,
 	};

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -45,7 +45,7 @@ export const handler = async (event: {
 				},
 			},
 			// subscriptionCancelledEmail used for testing. will update data extension to active one when published
-			DataExtensionName: DataExtensionNames.DiscountExpiryNotificationEmail,
+			DataExtensionName: DataExtensionNames.discountExpiryNotificationEmail,
 		},
 		SfContactId: event.item.sfContactId,
 	};

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -101,4 +101,3 @@ function getCurrencySymbol(currencyCode: string): string {
 	};
 	return symbols[currencyCode] ?? '';
 }
-

--- a/handlers/discount-expiry-notifier/src/handlers/saveResults.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/saveResults.ts
@@ -12,7 +12,7 @@ export const handler = async (event: {
 		paymentFrequency: string;
 		productName: string;
 		sfContactId: string;
-		subName: string;
+		zuoraSubName: string;
 		workEmail: string;
 	}>;
 	expiringDiscountProcessingAttempts: Array<{

--- a/handlers/discount-expiry-notifier/src/handlers/subIsActive.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/subIsActive.ts
@@ -18,15 +18,17 @@ export const handler = async (event: {
 	try {
 		const subName = event.item.zuoraSubName;
 		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
-		const getSubResponse = await getSubscription(zuoraClient, subName);
+		const getSubResponse = await getSubscription(zuoraClient, subName + '1');
 
 		return {
 			...event.item,
 			subStatus: getSubResponse.status,
 		};
 	} catch (error) {
-		throw new Error(
-			`Error retrieving sub from Zuora: ${JSON.stringify(error)}`,
-		);
+		return {
+			...event.item,
+			subStatus: 'Error',
+			errorDetail: JSON.stringify(error, null, 2),
+		};
 	}
 };

--- a/handlers/discount-expiry-notifier/src/handlers/subIsActive.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/subIsActive.ts
@@ -11,12 +11,12 @@ export const handler = async (event: {
 		paymentFrequency: string;
 		productName: string;
 		sfContactId: string;
-		subName: string;
+		zuoraSubName: string;
 		workEmail: string;
 	};
 }) => {
 	try {
-		const subName = event.item.subName;
+		const subName = event.item.zuoraSubName;
 		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
 		const getSubResponse = await getSubscription(zuoraClient, subName);
 

--- a/handlers/discount-expiry-notifier/src/testQueryResponse.ts
+++ b/handlers/discount-expiry-notifier/src/testQueryResponse.ts
@@ -7,7 +7,7 @@ export const testQueryResponse = [
 		paymentFrequency: 'Month',
 		productName: 'GW',
 		sfContactId: '0039E00001HiIGlQAN',
-		subName: 'A-S00886188', // Active sub in dev sandbox
+		zuoraSubName: 'A-S00886188', // Active sub in dev sandbox
 		workEmail: 'david.pepper+david@guardian.co.uk',
 		contactCountry: 'USA',
 		sfBuyerContactMailingCountry: 'USA',
@@ -23,7 +23,7 @@ export const testQueryResponse = [
 		paymentFrequency: 'Month',
 		productName: 'Supporter Plus',
 		sfContactId: '0039E00001HwhM9QAJ',
-		subName: 'A-S00886159', // Active subscription in dev sandbox
+		zuoraSubName: 'A-S00886159', // Active subscription in dev sandbox
 		workEmail: 'graham.hopgood@guardian.co.uk',
 		contactCountry: 'US',
 		sfBuyerContactMailingCountry: 'US',
@@ -39,7 +39,7 @@ export const testQueryResponse = [
 		paymentFrequency: 'Month',
 		productName: 'Supporter Plus',
 		sfContactId: '0039E00001lNoXrQAK',
-		subName: 'A-S00515481', // cancelled subscription in dev sandbox
+		zuoraSubName: 'A-S00515481', // cancelled subscription in dev sandbox
 		workEmail: 'david.pepper+3003+1@guardian.co.uk',
 		contactCountry: 'Germany',
 		sfBuyerContactMailingCountry: 'Germany',

--- a/handlers/discount-expiry-notifier/src/testQueryResponse.ts
+++ b/handlers/discount-expiry-notifier/src/testQueryResponse.ts
@@ -9,11 +9,11 @@ export const testQueryResponse = [
 		sfContactId: '0039E00001HiIGlQAN',
 		zuoraSubName: 'A-S00886188', // Active sub in dev sandbox
 		workEmail: 'david.pepper+david@guardian.co.uk',
-		contactCountry: 'USA',
-		sfBuyerContactMailingCountry: 'USA',
-		sfBuyerContactOtherCountry: 'USA',
-		sfRecipientContactMailingCountry: 'USA',
-		sfRecipientContactOtherCountry: 'USA',
+		contactCountry: 'united states of america',
+		sfBuyerContactMailingCountry: 'united states of america',
+		sfBuyerContactOtherCountry: 'united states of america',
+		sfRecipientContactMailingCountry: 'united states of america',
+		sfRecipientContactOtherCountry: 'united states of america',
 	},
 	{
 		firstName: 'Mary',
@@ -25,11 +25,11 @@ export const testQueryResponse = [
 		sfContactId: '0039E00001HwhM9QAJ',
 		zuoraSubName: 'A-S00886159', // Active subscription in dev sandbox
 		workEmail: 'graham.hopgood@guardian.co.uk',
-		contactCountry: 'US',
-		sfBuyerContactMailingCountry: 'US',
-		sfBuyerContactOtherCountry: 'US',
-		sfRecipientContactMailingCountry: 'US',
-		sfRecipientContactOtherCountry: 'US',
+		contactCountry: 'United States',
+		sfBuyerContactMailingCountry: 'United States',
+		sfBuyerContactOtherCountry: 'United States',
+		sfRecipientContactMailingCountry: 'United States',
+		sfRecipientContactOtherCountry: 'United States',
 	},
 	{
 		firstName: 'Robert',

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -10,7 +10,6 @@ describe('filterSubs handler', () => {
 		process.env.FILTER_BY_REGIONS = 'United States,United States of America';
 	});
 
-	//todo update logic to be case-agnostic (united states of america fails when using lowercase)
 	it('should filter subscriptions based on region (USA)', async () => {
 		(getIfDefined as jest.Mock).mockImplementation((envVar, errorMessage) => {
 			if (envVar === process.env.FILTER_BY_REGIONS) {

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -11,76 +11,82 @@ describe('filterSubs handler', () => {
 	});
 
 	it('should filter subscriptions based on region', async () => {
-        (getIfDefined as jest.Mock).mockImplementation((envVar, errorMessage) => {
-            if (envVar === process.env.FILTER_BY_REGIONS) {
-                return process.env.FILTER_BY_REGIONS;
-            }
-            throw new Error(errorMessage as string);
-        });
+		(getIfDefined as jest.Mock).mockImplementation((envVar, errorMessage) => {
+			if (envVar === process.env.FILTER_BY_REGIONS) {
+				return process.env.FILTER_BY_REGIONS;
+			}
+			throw new Error(errorMessage as string);
+		});
 
-        const event = {
-            discountExpiresOnDate: '2024-03-21',
-            expiringDiscountsToProcess: [
-                {
-                    firstName: 'John',
-                    nextPaymentDate: '2024-04-21',
-                    paymentAmount: 100,
-                    paymentCurrency: 'USD',
-                    paymentFrequency: 'Monthly',
-                    productName: 'Product A',
-                    sfContactId: '001',
-                    zuoraSubName: 'A-S001',
-                    workEmail: 'john@example.com',
-                    contactCountry: 'United States',
-                    sfBuyerContactMailingCountry: 'Canada',
-                    sfBuyerContactOtherCountry: 'Mexico',
-                    sfRecipientContactMailingCountry: 'Brazil',
-                    sfRecipientContactOtherCountry: 'Argentina',
-                },
-                {
-                    firstName: 'Jane',
-                    nextPaymentDate: '2024-05-21',
-                    paymentAmount: 200,
-                    paymentCurrency: 'USD',
-                    paymentFrequency: 'Monthly',
-                    productName: 'Product B',
-                    sfContactId: '002',
-                    zuoraSubName: 'A-S002',
-                    workEmail: 'jane@example.com',
-                    contactCountry: 'Canada',
-                    sfBuyerContactMailingCountry: 'United States of America',
-                    sfBuyerContactOtherCountry: 'Mexico',
-                    sfRecipientContactMailingCountry: 'Brazil',
-                    sfRecipientContactOtherCountry: 'Argentina',
-                },
-                {
-                    firstName: 'Doe',
-                    nextPaymentDate: '2024-06-21',
-                    paymentAmount: 300,
-                    paymentCurrency: 'USD',
-                    paymentFrequency: 'Monthly',
-                    productName: 'Product C',
-                    sfContactId: '003',
-                    zuoraSubName: 'A-S003',
-                    workEmail: 'doe@example.com',
-                    contactCountry: 'Canada',
-                    sfBuyerContactMailingCountry: 'Mexico',
-                    sfBuyerContactOtherCountry: 'Mexico',
-                    sfRecipientContactMailingCountry: 'Brazil',
-                    sfRecipientContactOtherCountry: 'Argentina',
-                },
-            ],
-        };
+		const event = {
+			discountExpiresOnDate: '2024-03-21',
+			expiringDiscountsToProcess: [
+				{
+					firstName: 'John',
+					nextPaymentDate: '2024-04-21',
+					paymentAmount: 100,
+					paymentCurrency: 'USD',
+					paymentFrequency: 'Monthly',
+					productName: 'Product A',
+					sfContactId: '001',
+					zuoraSubName: 'A-S001',
+					workEmail: 'john@example.com',
+					contactCountry: 'United States',
+					sfBuyerContactMailingCountry: 'Canada',
+					sfBuyerContactOtherCountry: 'Mexico',
+					sfRecipientContactMailingCountry: 'Brazil',
+					sfRecipientContactOtherCountry: 'Argentina',
+				},
+				{
+					firstName: 'Jane',
+					nextPaymentDate: '2024-05-21',
+					paymentAmount: 200,
+					paymentCurrency: 'USD',
+					paymentFrequency: 'Monthly',
+					productName: 'Product B',
+					sfContactId: '002',
+					zuoraSubName: 'A-S002',
+					workEmail: 'jane@example.com',
+					contactCountry: 'Canada',
+					sfBuyerContactMailingCountry: 'United States of America',
+					sfBuyerContactOtherCountry: 'Mexico',
+					sfRecipientContactMailingCountry: 'Brazil',
+					sfRecipientContactOtherCountry: 'Argentina',
+				},
+				{
+					firstName: 'Doe',
+					nextPaymentDate: '2024-06-21',
+					paymentAmount: 300,
+					paymentCurrency: 'USD',
+					paymentFrequency: 'Monthly',
+					productName: 'Product C',
+					sfContactId: '003',
+					zuoraSubName: 'A-S003',
+					workEmail: 'doe@example.com',
+					contactCountry: 'Canada',
+					sfBuyerContactMailingCountry: 'Mexico',
+					sfBuyerContactOtherCountry: 'Mexico',
+					sfRecipientContactMailingCountry: 'Brazil',
+					sfRecipientContactOtherCountry: 'Argentina',
+				},
+			],
+		};
 
-        const result = await handler(event);
+		const result = await handler(event);
 
-        expect(result).toBeDefined();
-        expect(result.filteredSubs).toBeInstanceOf(Array);
-        expect(result.filteredSubs.length).toBe(2);
-        expect(result.filteredSubs.some(sub => sub.zuoraSubName === 'A-S001')).toBe(true);
-        expect(result.filteredSubs.some(sub => sub.zuoraSubName === 'A-S002')).toBe(true);
-        expect(result.filteredSubs.some(sub => sub.zuoraSubName === 'A-S003')).toBe(false);
-    });
+		expect(result).toBeDefined();
+		expect(result.filteredSubs).toBeInstanceOf(Array);
+		expect(result.filteredSubs.length).toBe(2);
+		expect(
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S001'),
+		).toBe(true);
+		expect(
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S002'),
+		).toBe(true);
+		expect(
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S003'),
+		).toBe(false);
+	});
 
 	it('should return an empty array if no subscriptions match the regions', async () => {
 		(getIfDefined as jest.Mock).mockReturnValue('UK');

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -39,13 +39,13 @@ describe('filterSubs handler', () => {
 			),
 		).toBe(true);
 		expect(
-			result.filteredSubs.some((sub) => sub.subName === 'A-S00886188'),
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886188'),
 		).toBe(true);
 		expect(
-			result.filteredSubs.some((sub) => sub.subName === 'A-S00886159'),
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886159'),
 		).toBe(false);
 		expect(
-			result.filteredSubs.some((sub) => sub.subName === 'A-S00515481'),
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00515481'),
 		).toBe(false);
 	});
 

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -18,10 +18,11 @@ describe('filterSubs handler', () => {
 			}
 			throw new Error(errorMessage as string);
 		});
-		if(process.env.FILTER_BY_REGIONS===undefined){
+		if (process.env.FILTER_BY_REGIONS === undefined) {
 			throw new Error('FILTER_BY_REGIONS environment variable not set');
 		}
-		const filterByRegions = process.env.FILTER_BY_REGIONS.toLowerCase().split(',');
+		const filterByRegions =
+			process.env.FILTER_BY_REGIONS.toLowerCase().split(',');
 
 		const event = {
 			discountExpiresOnDate: '2024-03-21',
@@ -39,9 +40,15 @@ describe('filterSubs handler', () => {
 				filterByRegions.includes(sub.contactCountry.toLowerCase()),
 			),
 		).toBe(true);
-		expect(result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886188'),).toBe(true);
-		expect(result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886159'),).toBe(true);
-		expect(result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00515481'),).toBe(false);
+		expect(
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886188'),
+		).toBe(true);
+		expect(
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886159'),
+		).toBe(true);
+		expect(
+			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00515481'),
+		).toBe(false);
 	});
 
 	it('should return an empty array if no subscriptions match the regions', async () => {

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -7,16 +7,21 @@ jest.mock('@modules/nullAndUndefined');
 describe('filterSubs handler', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
-		process.env.FILTER_BY_REGIONS = 'US,USA';
+		process.env.FILTER_BY_REGIONS = 'United States,United States of America';
 	});
 
-	it('should filter subscriptions based on region (USA) and product (GW)', async () => {
+	//todo update logic to be case-agnostic (united states of america fails when using lowercase)
+	it('should filter subscriptions based on region (USA)', async () => {
 		(getIfDefined as jest.Mock).mockImplementation((envVar, errorMessage) => {
 			if (envVar === process.env.FILTER_BY_REGIONS) {
 				return process.env.FILTER_BY_REGIONS;
 			}
 			throw new Error(errorMessage as string);
 		});
+		if(process.env.FILTER_BY_REGIONS===undefined){
+			throw new Error('FILTER_BY_REGIONS environment variable not set');
+		}
+		const filterByRegions = process.env.FILTER_BY_REGIONS.toLowerCase().split(',');
 
 		const event = {
 			discountExpiresOnDate: '2024-03-21',
@@ -31,47 +36,41 @@ describe('filterSubs handler', () => {
 		expect(result.filteredSubs.length).toBeGreaterThan(0);
 		expect(
 			result.filteredSubs.every((sub) =>
-				['US', 'USA'].includes(sub.contactCountry),
+				filterByRegions.includes(sub.contactCountry.toLowerCase()),
 			),
 		).toBe(true);
-		expect(
-			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886188'),
-		).toBe(true);
-		expect(
-			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886159'),
-		).toBe(true);
-		expect(
-			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00515481'),
-		).toBe(false);
+		expect(result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886188'),).toBe(true);
+		expect(result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886159'),).toBe(true);
+		expect(result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00515481'),).toBe(false);
 	});
 
-	it('should return an empty array if no subscriptions match the regions', async () => {
-		(getIfDefined as jest.Mock).mockReturnValue('UK');
+	// it('should return an empty array if no subscriptions match the regions', async () => {
+	// 	(getIfDefined as jest.Mock).mockReturnValue('UK');
 
-		const event = {
-			discountExpiresOnDate: '2024-03-21',
-			expiringDiscountsToProcess: testQueryResponse,
-		};
+	// 	const event = {
+	// 		discountExpiresOnDate: '2024-03-21',
+	// 		expiringDiscountsToProcess: testQueryResponse,
+	// 	};
 
-		const result = await handler(event);
+	// 	const result = await handler(event);
 
-		expect(result).toBeDefined();
-		expect(result.filteredSubs).toBeInstanceOf(Array);
-		expect(result.filteredSubs.length).toBe(0);
-	});
+	// 	expect(result).toBeDefined();
+	// 	expect(result.filteredSubs).toBeInstanceOf(Array);
+	// 	expect(result.filteredSubs.length).toBe(0);
+	// });
 
-	it('should throw an error if FILTER_BY_REGIONS is not set', async () => {
-		(getIfDefined as jest.Mock).mockImplementation(() => {
-			throw new Error('FILTER_BY_REGIONS environment variable not set');
-		});
+	// it('should throw an error if FILTER_BY_REGIONS is not set', async () => {
+	// 	(getIfDefined as jest.Mock).mockImplementation(() => {
+	// 		throw new Error('FILTER_BY_REGIONS environment variable not set');
+	// 	});
 
-		const event = {
-			discountExpiresOnDate: '2024-03-21',
-			expiringDiscountsToProcess: testQueryResponse,
-		};
+	// 	const event = {
+	// 		discountExpiresOnDate: '2024-03-21',
+	// 		expiringDiscountsToProcess: testQueryResponse,
+	// 	};
 
-		await expect(handler(event)).rejects.toThrow(
-			'FILTER_BY_REGIONS environment variable not set',
-		);
-	});
+	// 	await expect(handler(event)).rejects.toThrow(
+	// 		'FILTER_BY_REGIONS environment variable not set',
+	// 	);
+	// });
 });

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -39,7 +39,7 @@ describe('filterSubs handler', () => {
 		).toBe(true);
 		expect(
 			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886159'),
-		).toBe(false);
+		).toBe(true);
 		expect(
 			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00515481'),
 		).toBe(false);

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -8,16 +8,12 @@ describe('filterSubs handler', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 		process.env.FILTER_BY_REGIONS = 'US,USA';
-		process.env.FILTER_BY_PRODUCTS = 'GW';
 	});
 
 	it('should filter subscriptions based on region (USA) and product (GW)', async () => {
 		(getIfDefined as jest.Mock).mockImplementation((envVar, errorMessage) => {
 			if (envVar === process.env.FILTER_BY_REGIONS) {
 				return process.env.FILTER_BY_REGIONS;
-			}
-			if (envVar === process.env.FILTER_BY_PRODUCTS) {
-				return process.env.FILTER_BY_PRODUCTS;
 			}
 			throw new Error(errorMessage as string);
 		});

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -44,33 +44,33 @@ describe('filterSubs handler', () => {
 		expect(result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00515481'),).toBe(false);
 	});
 
-	// it('should return an empty array if no subscriptions match the regions', async () => {
-	// 	(getIfDefined as jest.Mock).mockReturnValue('UK');
+	it('should return an empty array if no subscriptions match the regions', async () => {
+		(getIfDefined as jest.Mock).mockReturnValue('UK');
 
-	// 	const event = {
-	// 		discountExpiresOnDate: '2024-03-21',
-	// 		expiringDiscountsToProcess: testQueryResponse,
-	// 	};
+		const event = {
+			discountExpiresOnDate: '2024-03-21',
+			expiringDiscountsToProcess: testQueryResponse,
+		};
 
-	// 	const result = await handler(event);
+		const result = await handler(event);
 
-	// 	expect(result).toBeDefined();
-	// 	expect(result.filteredSubs).toBeInstanceOf(Array);
-	// 	expect(result.filteredSubs.length).toBe(0);
-	// });
+		expect(result).toBeDefined();
+		expect(result.filteredSubs).toBeInstanceOf(Array);
+		expect(result.filteredSubs.length).toBe(0);
+	});
 
-	// it('should throw an error if FILTER_BY_REGIONS is not set', async () => {
-	// 	(getIfDefined as jest.Mock).mockImplementation(() => {
-	// 		throw new Error('FILTER_BY_REGIONS environment variable not set');
-	// 	});
+	it('should throw an error if FILTER_BY_REGIONS is not set', async () => {
+		(getIfDefined as jest.Mock).mockImplementation(() => {
+			throw new Error('FILTER_BY_REGIONS environment variable not set');
+		});
 
-	// 	const event = {
-	// 		discountExpiresOnDate: '2024-03-21',
-	// 		expiringDiscountsToProcess: testQueryResponse,
-	// 	};
+		const event = {
+			discountExpiresOnDate: '2024-03-21',
+			expiringDiscountsToProcess: testQueryResponse,
+		};
 
-	// 	await expect(handler(event)).rejects.toThrow(
-	// 		'FILTER_BY_REGIONS environment variable not set',
-	// 	);
-	// });
+		await expect(handler(event)).rejects.toThrow(
+			'FILTER_BY_REGIONS environment variable not set',
+		);
+	});
 });

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -10,45 +10,77 @@ describe('filterSubs handler', () => {
 		process.env.FILTER_BY_REGIONS = 'United States,United States of America';
 	});
 
-	it('should filter subscriptions based on region (USA)', async () => {
-		(getIfDefined as jest.Mock).mockImplementation((envVar, errorMessage) => {
-			if (envVar === process.env.FILTER_BY_REGIONS) {
-				return process.env.FILTER_BY_REGIONS;
-			}
-			throw new Error(errorMessage as string);
-		});
-		if (process.env.FILTER_BY_REGIONS === undefined) {
-			throw new Error('FILTER_BY_REGIONS environment variable not set');
-		}
-		const filterByRegions =
-			process.env.FILTER_BY_REGIONS.toLowerCase().split(',');
+	it('should filter subscriptions based on region', async () => {
+        (getIfDefined as jest.Mock).mockImplementation((envVar, errorMessage) => {
+            if (envVar === process.env.FILTER_BY_REGIONS) {
+                return process.env.FILTER_BY_REGIONS;
+            }
+            throw new Error(errorMessage as string);
+        });
 
-		const event = {
-			discountExpiresOnDate: '2024-03-21',
-			expiringDiscountsToProcess: testQueryResponse,
-		};
+        const event = {
+            discountExpiresOnDate: '2024-03-21',
+            expiringDiscountsToProcess: [
+                {
+                    firstName: 'John',
+                    nextPaymentDate: '2024-04-21',
+                    paymentAmount: 100,
+                    paymentCurrency: 'USD',
+                    paymentFrequency: 'Monthly',
+                    productName: 'Product A',
+                    sfContactId: '001',
+                    zuoraSubName: 'A-S001',
+                    workEmail: 'john@example.com',
+                    contactCountry: 'United States',
+                    sfBuyerContactMailingCountry: 'Canada',
+                    sfBuyerContactOtherCountry: 'Mexico',
+                    sfRecipientContactMailingCountry: 'Brazil',
+                    sfRecipientContactOtherCountry: 'Argentina',
+                },
+                {
+                    firstName: 'Jane',
+                    nextPaymentDate: '2024-05-21',
+                    paymentAmount: 200,
+                    paymentCurrency: 'USD',
+                    paymentFrequency: 'Monthly',
+                    productName: 'Product B',
+                    sfContactId: '002',
+                    zuoraSubName: 'A-S002',
+                    workEmail: 'jane@example.com',
+                    contactCountry: 'Canada',
+                    sfBuyerContactMailingCountry: 'United States of America',
+                    sfBuyerContactOtherCountry: 'Mexico',
+                    sfRecipientContactMailingCountry: 'Brazil',
+                    sfRecipientContactOtherCountry: 'Argentina',
+                },
+                {
+                    firstName: 'Doe',
+                    nextPaymentDate: '2024-06-21',
+                    paymentAmount: 300,
+                    paymentCurrency: 'USD',
+                    paymentFrequency: 'Monthly',
+                    productName: 'Product C',
+                    sfContactId: '003',
+                    zuoraSubName: 'A-S003',
+                    workEmail: 'doe@example.com',
+                    contactCountry: 'Canada',
+                    sfBuyerContactMailingCountry: 'Mexico',
+                    sfBuyerContactOtherCountry: 'Mexico',
+                    sfRecipientContactMailingCountry: 'Brazil',
+                    sfRecipientContactOtherCountry: 'Argentina',
+                },
+            ],
+        };
 
-		const result = await handler(event);
+        const result = await handler(event);
 
-		expect(result).toBeDefined();
-
-		expect(result.filteredSubs).toBeInstanceOf(Array);
-		expect(result.filteredSubs.length).toBeGreaterThan(0);
-		expect(
-			result.filteredSubs.every((sub) =>
-				filterByRegions.includes(sub.contactCountry.toLowerCase()),
-			),
-		).toBe(true);
-		expect(
-			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886188'),
-		).toBe(true);
-		expect(
-			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00886159'),
-		).toBe(true);
-		expect(
-			result.filteredSubs.some((sub) => sub.zuoraSubName === 'A-S00515481'),
-		).toBe(false);
-	});
+        expect(result).toBeDefined();
+        expect(result.filteredSubs).toBeInstanceOf(Array);
+        expect(result.filteredSubs.length).toBe(2);
+        expect(result.filteredSubs.some(sub => sub.zuoraSubName === 'A-S001')).toBe(true);
+        expect(result.filteredSubs.some(sub => sub.zuoraSubName === 'A-S002')).toBe(true);
+        expect(result.filteredSubs.some(sub => sub.zuoraSubName === 'A-S003')).toBe(false);
+    });
 
 	it('should return an empty array if no subscriptions match the regions', async () => {
 		(getIfDefined as jest.Mock).mockReturnValue('UK');

--- a/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/filterSubs.test.ts
@@ -48,7 +48,7 @@ describe('filterSubs handler', () => {
 					zuoraSubName: 'A-S002',
 					workEmail: 'jane@example.com',
 					contactCountry: 'Canada',
-					sfBuyerContactMailingCountry: 'United States of America',
+					sfBuyerContactMailingCountry: 'United states of america',
 					sfBuyerContactOtherCountry: 'Mexico',
 					sfRecipientContactMailingCountry: 'Brazil',
 					sfRecipientContactOtherCountry: 'Argentina',

--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -39,7 +39,7 @@ export const DataExtensionNames = {
 		'digipack-monthly-discount-confirmation-email',
 	supporterPlusAnnualDiscountConfirmationEmail:
 		'supporter-plus-annual-discount-confirmation-email',
-	DiscountExpiryNotificationEmail: 'discount-expiry-email',
+	discountExpiryNotificationEmail: 'discount-expiry-email',
 } as const;
 
 export type DataExtensionName =

--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -39,8 +39,7 @@ export const DataExtensionNames = {
 		'digipack-monthly-discount-confirmation-email',
 	supporterPlusAnnualDiscountConfirmationEmail:
 		'supporter-plus-annual-discount-confirmation-email',
-	DiscountExpiryNotificationsGuardianWeekly:
-		'SV_GW_DiscountExpiryNotifications_2015',
+	DiscountExpiryNotificationEmail: 'discount-expiry-email',
 } as const;
 
 export type DataExtensionName =


### PR DESCRIPTION
## What does this change?

Some low-level fixes/improvements:

- Fix campaign id for CODE
- add some record counts to the object at the JSON path to help with logging (total subs count, filtered subs count)
- remove the product filtering as per updated requirement to only filter by region (anod not by product)
- update a variable name to match the query response schema (subName -> zuoraSubName)
- fix braze merge fields for email campaign
- update logic to handle lowercase country names
- handle error on callout to zuora to get sub status
- throw error on error when grabbing records from bigquery

### Notes
- we are using an older version of the email campaign at the moment for testing (the GW-specific version). The most up to date, product-agnostic, version is currently having its copy reviewed.