### PR TITLE
import cas common into digi sub expiry lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -400,7 +400,7 @@ lazy val `identity-backfill` = lambdaProject(
 lazy val `digital-subscription-expiry` = lambdaProject(
   "digital-subscription-expiry",
   "check digital subscription expiration for authorisation purposes",
-  Seq(contentAuthCommon),
+  Seq(jodaTime, commonsIO, typesafeConfig),
   Seq(zuora, handler, effectsDepIncludingTestFolder, testDep),
 )
 

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/cas/Config.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/cas/Config.scala
@@ -1,0 +1,5 @@
+package com.gu.cas
+
+case class Config(config: com.typesafe.config.Config) {
+  val emergencySubscriberAuthPrefix = config.getString("emergency.subscriber.auth.prefix")
+}

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/cas/Token.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/cas/Token.scala
@@ -1,0 +1,118 @@
+package com.gu.cas
+
+import com.gu.cas.util.{BitReader, BitWriter, ByteArrayToAlphaStringEncoder}
+import org.apache.commons.io.IOUtils
+import org.joda.time.format.ISODateTimeFormat
+import org.joda.time.{Days, LocalDate, Weeks}
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+object TokenPayload {
+  val epoch = ISODateTimeFormat.dateTimeNoMillis.parseDateTime("2012-09-20T00:00:00Z")
+
+  val windowWrapSize = 2048
+
+  def apply(today: LocalDate)(period: Weeks, subscriptionCode: SubscriptionCode): TokenPayload = {
+    val creationDateOffset = Days.days(Days.daysBetween(epoch.toLocalDate, today).getDays % windowWrapSize)
+    TokenPayload(creationDateOffset, period, subscriptionCode)
+  }
+}
+
+case class TokenPayload(creationDateOffset: Days, period: Weeks, subscriptionCode: SubscriptionCode) {
+
+  import TokenPayload.windowWrapSize
+
+  def expiryDate(today: LocalDate): LocalDate = {
+    val daysSinceOriginalEpoch = Days.daysBetween(TokenPayload.epoch.toLocalDate, today).getDays
+    val codeStartIndexInWindow = creationDateOffset.getDays
+    val completeErasSinceFirstPossibleStart = (daysSinceOriginalEpoch - codeStartIndexInWindow) / windowWrapSize
+    val daysOfWrapAroundsNeeded = windowWrapSize * completeErasSinceFirstPossibleStart
+    val mostOptimisticExpiryDaysSinceEpoch =
+      Days.days(codeStartIndexInWindow + period.toStandardDays.getDays + daysOfWrapAroundsNeeded)
+
+    TokenPayload.epoch.toLocalDate.plus(mostOptimisticExpiryDaysSinceEpoch).plusDays(1)
+  }
+
+}
+
+object SubscriptionCode {
+  val all = List(SevenDay, Guardian)
+}
+sealed trait SubscriptionCode
+case object SevenDay extends SubscriptionCode
+case object Guardian extends SubscriptionCode
+
+sealed abstract class PayloadResult
+case class Valid(payload: TokenPayload) extends PayloadResult
+case class Invalid(payload: Option[TokenPayload]) extends PayloadResult
+
+case class PrefixedTokens(secretKey: String, emergencySubscriberAuthPrefix: String = "G99") {
+  val rawEncoder = RawTokenEncoder(secretKey)
+
+  def encode(tokenPayload: TokenPayload): String = {
+    emergencySubscriberAuthPrefix + rawEncoder.encode(tokenPayload)
+  }
+
+  def decode(prefixedToken: String): PayloadResult = {
+    rawEncoder.decode(prefixedToken.substring(emergencySubscriberAuthPrefix.length))
+  }
+}
+
+case class RawTokenEncoder(secretKey: String) {
+
+  val keySpec = new SecretKeySpec(secretKey.getBytes(), "HmacSHA1")
+
+  def encode(tokenPayload: TokenPayload): String = {
+    val subscriptionCodeNumber = SubscriptionCode.all.indexOf(tokenPayload.subscriptionCode)
+
+    val bw = new BitWriter()
+    bw.add(tokenPayload.creationDateOffset.getDays, 11) // 11 bits gives 2048 days - over 5 years
+    bw.add(tokenPayload.period.getWeeks, 6) // 6 bits gives 64 weeks
+    bw.add(subscriptionCodeNumber, 3) // 3 bits gives 8 possible subscription types
+    bw.add(
+      scala.util.Random.nextInt(4096),
+      12,
+    ) // 12 bits gives 4096 random vals - won't have more than 60 or so new codes a day
+
+    val payloadBytes = bw.v.toByteArray
+
+    val stream = new ByteArrayOutputStream()
+    stream.write(macFor(payloadBytes))
+    stream.write(payloadBytes)
+    stream.close()
+
+    ByteArrayToAlphaStringEncoder.byteArrayToAlphaString(stream.toByteArray)
+  }
+
+  def decode(token: String): PayloadResult = {
+    val messageBytes = ByteArrayToAlphaStringEncoder.alphaStringToByteArray(token.toUpperCase)
+    val s = new ByteArrayInputStream(messageBytes)
+    val mac: Byte = s.read().toByte
+    val payloadBytes = IOUtils.toByteArray(s)
+    s.close()
+
+    val expectedMac = macFor(payloadBytes)
+
+    val br = new BitReader(BigInt(payloadBytes))
+
+    val creationDateOffset = Days.days(br.read(11))
+    val period = Weeks.weeks(br.read(6))
+    val subscriptionCode = SubscriptionCode.all(br.read(3))
+
+    val payload = TokenPayload(creationDateOffset, period, subscriptionCode)
+    if (mac == expectedMac) {
+      Valid(payload)
+    } else {
+      Invalid(Option(payload))
+    }
+  }
+
+  def macFor(payloadBytes: Array[Byte]): Byte = {
+    val m = Mac.getInstance("HmacSHA1")
+    m.init(keySpec)
+    m.update(payloadBytes)
+    m.doFinal()(0) // only use the first 1 bytes of the mac - 256 variations is enough for us
+  }
+}

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/cas/util/BitBashing.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/cas/util/BitBashing.scala
@@ -1,0 +1,58 @@
+package com.gu.cas.util
+
+class BitWriter() {
+  var v: BigInt = 0
+  var offset = 0
+
+  def add(value: Int, bits: Int) {
+    val bigIntValue = BigInt(value)
+    val usedBitLength = bigIntValue.bitLength
+    if (usedBitLength > bits) {
+      throw new IllegalArgumentException(
+        "value " + value + " takes up " + usedBitLength + " bits, allocated only " + bits,
+      )
+    }
+    v = v | (bigIntValue << offset)
+    offset += bits
+  }
+}
+
+class BitReader(val v: BigInt) {
+  var offset = 0
+
+  def read(bits: Int): Int = {
+    val bitMask = BigInt((1 << bits) - 1)
+    val value: Int = ((v >> offset) & bitMask).toInt
+    offset += bits
+    value
+  }
+}
+
+object ByteArrayToAlphaStringEncoder {
+  val radix = 26
+  val jdkChars = "0123456789abcdefghijklmnop".toList
+  val alphaChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".toList
+
+  def from(c1: List[Char], c2: List[Char])(c: Char): Char = {
+    c2(c1.indexOf(c))
+  }
+
+  def byteArrayToAlphaString(ba: Array[Byte]): String = {
+    new String(new java.math.BigInteger(addByte(ba)).toString(radix).map(from(jdkChars, alphaChars)))
+  }
+
+  def alphaStringToByteArray(s: String): Array[Byte] = {
+    stripByte(new java.math.BigInteger(new String(s.map(from(alphaChars, jdkChars))), radix).toByteArray)
+  }
+
+  def addByte(ba: Array[Byte]): Array[Byte] = {
+    val h = new Array[Byte](1)
+    h(0) = 0x01
+    h ++ ba
+  }
+
+  def stripByte(ba: Array[Byte]): Array[Byte] = {
+    ba.slice(1, ba.size)
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,7 +78,6 @@ object Dependencies {
   val simpleConfig = "com.gu" %% "simple-configuration-ssm" % "2.0.0"
   val supportInternationalisation =
     "com.gu" %% "support-internationalisation" % "0.13"
-  val contentAuthCommon = "com.gu" %% "content-authorisation-common" % "0.6"
 
   // Other
   val zio = "dev.zio" %% "zio" % "1.0.17"
@@ -89,6 +88,9 @@ object Dependencies {
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.3.0"
   val stripe = "com.stripe" % "stripe-java" % "22.31.0"
   val parallelCollections = "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
+  val commonsIO = "commons-io" % "commons-io" % "2.18.0"
+  val jodaTime = "joda-time" % "joda-time" % "2.13.1"
+  val typesafeConfig = "com.typesafe" % "config" % "1.4.3"
 
   // Testing
   val diffx = "com.softwaremill.diffx" %% "diffx-scalatest-should" % "0.9.0" % Test


### PR DESCRIPTION
We have a [dependabot vulnerability](https://github.com/advisories/GHSA-78wr-2p64-hpwj) in commons.io via digital-subscription-expiry lambda which needed fixing.

It was coming via https://github.com/guardian/content-authorisation-common

That project was archived, and only used from the above lambda.

This PR copies in the code from the above repo and updates the dependency versions appropriately.