### PR TITLE
revert changes to zuora sar lambda made in #2586

### DIFF
--- a/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/S3Helper.scala
+++ b/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/S3Helper.scala
@@ -84,8 +84,9 @@ object S3Helper extends S3Service with LazyLogging {
   ): Either[S3Error, S3WriteSuccess] = {
     val completedPath = s"${config.resultsPath}/$initiationReference/completed/$keySuffix"
     UploadToS3
-      .putString(
+      .putStringWithAcl(
         S3Location(config.resultsBucket, completedPath),
+        ObjectCannedACL.BUCKET_OWNER_READ,
         "",
       ) match {
       case Failure(err) => Left(S3Error(err.getMessage))
@@ -133,8 +134,9 @@ object S3Helper extends S3Service with LazyLogging {
     val resultsPath = s"${config.resultsPath}/$initiationId/failed/$randomUUID"
     logger.info("Uploading file to failed path in S3.")
     UploadToS3
-      .putString(
+      .putStringWithAcl(
         S3Location(config.resultsBucket, resultsPath),
+        ObjectCannedACL.BUCKET_OWNER_READ,
         zuoraError.toString,
       )
       .toEither
@@ -152,8 +154,9 @@ object S3Helper extends S3Service with LazyLogging {
     val accountDetails = Seq(zuoraSarResponse.accountSummary, zuoraSarResponse.accountObj).mkString("\n")
     logger.info("Uploading successful account result to S3.")
     UploadToS3
-      .putString(
+      .putStringWithAcl(
         S3Location(config.resultsBucket, resultsPath),
+        ObjectCannedACL.BUCKET_OWNER_READ,
         accountDetails,
       )
       .toEither


### PR DESCRIPTION
Testing whether this is causing errors in one of our Baton-linked lambdas.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
