### PR TITLE
Discount expiry notifier - handle null values for workEmails

### DIFF
--- a/handlers/discount-expiry-notifier/src/handlers/alarmOnFailures.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/alarmOnFailures.ts
@@ -17,7 +17,7 @@ export const handler = async (event: {
 	console.log('event', event);
 
 	if (
-		await errorsOccurred(
+		await failuresOccurred(
 			event.discountProcessingAttempts,
 			event.uploadAttemptStatus,
 		)
@@ -27,14 +27,14 @@ export const handler = async (event: {
 	return {};
 };
 
-const errorsOccurred = async (
+const failuresOccurred = async (
 	discountProcessingAttempts: DiscountProcessingAttempt[],
 	uploadAttemptStatus: string,
 ): Promise<boolean> => {
 	return (
 		uploadAttemptStatus === 'error' ||
 		discountProcessingAttempts.some(
-			(attempt) => attempt.detail.emailSendAttempt.status === 'error',
+			(attempt) => attempt.detail.emailSendAttempt.status === 'skipped',
 		)
 	);
 };

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -15,10 +15,12 @@ export const handler = async (event: {
 		subStatus: string;
 	};
 }) => {
+	const emailSendEligibility = getEmailSendEligibility(
+		event.item.subStatus,
+		event.item.workEmail,
+	);
 
-	const emailSendEligibility = getEmailSendEligibility(event.item.subStatus, event.item.workEmail);
-
-	if(!emailSendEligibility.eligibleForEmailSend){
+	if (!emailSendEligibility.eligibleForEmailSend) {
 		return {
 			detail: {
 				event,
@@ -78,7 +80,10 @@ export const handler = async (event: {
 	}
 };
 
-function getIneligibilityReason(subStatus: string, workEmail: string | undefined) {
+function getIneligibilityReason(
+	subStatus: string,
+	workEmail: string | undefined,
+) {
 	if (subStatus === 'Cancelled') {
 		return 'Subscription status is cancelled';
 	}
@@ -90,12 +95,14 @@ function getIneligibilityReason(subStatus: string, workEmail: string | undefined
 	}
 	return '';
 }
-function getEmailSendEligibility(subStatus: string, workEmail: string | undefined) {
-
+function getEmailSendEligibility(
+	subStatus: string,
+	workEmail: string | undefined,
+) {
 	return {
 		eligibleForEmailSend: subStatus === 'Active' && !!workEmail,
-		ineligibilityReason: getIneligibilityReason(subStatus, workEmail)
-	};	
+		ineligibilityReason: getIneligibilityReason(subStatus, workEmail),
+	};
 	// if (subStatus === 'Cancelled') {
 	// 	return {
 	// 		detail: event,

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -18,7 +18,7 @@ export const handler = async (event: {
 
 	const emailSendEligibility = getEmailSendEligibility(event.item.subStatus, event.item.workEmail);
 
-	if(!emailSendEligibility.isEligibleForEmailSend){
+	if(!emailSendEligibility.eligibleForEmailSend){
 		return {
 			detail: {
 				event,
@@ -55,6 +55,7 @@ export const handler = async (event: {
 		return {
 			detail: {
 				event,
+				emailSendEligibility,
 				emailSendAttempt: {
 					status: 'success',
 					payload,
@@ -66,6 +67,7 @@ export const handler = async (event: {
 		return {
 			detail: {
 				event,
+				emailSendEligibility,
 				emailSendAttempt: {
 					status: 'error',
 					payload,
@@ -91,7 +93,7 @@ function getIneligibilityReason(subStatus: string, workEmail: string | undefined
 function getEmailSendEligibility(subStatus: string, workEmail: string | undefined) {
 
 	return {
-		isEligibleForEmailSend: subStatus === 'Active' && !!workEmail,
+		eligibleForEmailSend: subStatus === 'Active' && !!workEmail,
 		ineligibilityReason: getIneligibilityReason(subStatus, workEmail)
 	};	
 	// if (subStatus === 'Cancelled') {

--- a/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/initiateEmailSend.ts
@@ -81,6 +81,48 @@ export const handler = async (event: {
 	}
 };
 
+function getIneligibilityReason(subStatus: string, workEmail: string | undefined) {
+	if (subStatus === 'Cancelled') {
+		return 'Subscription status is cancelled';
+	}
+	if (subStatus === 'Error') {
+		return 'Error getting sub status from Zuora';
+	}
+	if (!workEmail) {
+		return 'No value for work email';
+	}
+	return '';
+
+}
+function getEmailSendEligibility(subStatus: string, workEmail: string | undefined) {
+
+	return {
+		isEligibleForEmailSend: subStatus === 'Active' && !!workEmail,
+		ineligibilityReason: 'Subscription status is cancelled'	
+	};	
+	// if (subStatus === 'Cancelled') {
+	// 	return {
+	// 		detail: event,
+	// 		emailSendAttempt: {
+	// 			status: 'skipped',
+	// 			payload: {},
+	// 			response: 'Subscription status is cancelled',
+	// 		},
+	// 	};
+	// }
+	// if (subStatus === 'Error') {
+	// 	return {
+	// 		detail: event,
+	// 		emailSendAttempt: {
+	// 			status: 'error',
+	// 			payload: {},
+	// 			response: 'Error getting sub status from Zuora',
+	// 		},
+	// 	};
+	// }
+	// return subStatus === 'Active' && !!workEmail;
+}
+
 function formatDate(inputDate: string): string {
 	return new Date(inputDate).toLocaleDateString('en-GB', {
 		day: '2-digit',


### PR DESCRIPTION
## What does this change?
- when there is no value for workEmail returned by bigquery, skip the email send for that discount, and notify devs 

Enhance the logic to determine whether an email send should be attempted or not, by creating an emailSendEligibilty object and using its contents to make that decision.

## How to test
remove the work email from one of the discount records, and verify that notification is sent to chat channel:

![image](https://github.com/user-attachments/assets/18f1ce48-d0be-4782-afbc-a8a9b1a52ffa)
