### PR TITLE
fix: copy string without ACL

### DIFF
--- a/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/S3Helper.scala
+++ b/handlers/zuora-sar/src/main/scala/com/gu/zuora/sar/S3Helper.scala
@@ -111,10 +111,9 @@ object S3Helper extends S3Service with LazyLogging {
             pendingKeys.traverse { pendingKey =>
               val completedKey = pendingKey.value.replace("pending", "completed")
               CopyS3Objects
-                .copyStringWithAcl(
+                .copyString(
                   S3Location(config.resultsBucket, pendingKey.value),
                   S3Location(config.resultsBucket, completedKey),
-                  ObjectCannedACL.BUCKET_OWNER_READ,
                 )
                 .toEither
                 .left

--- a/lib/effects-s3/src/main/scala/com/gu/effects/AwsS3.scala
+++ b/lib/effects-s3/src/main/scala/com/gu/effects/AwsS3.scala
@@ -107,17 +107,15 @@ object CopyS3Objects extends LazyLogging {
     copyRequest
   }
 
-  def copyStringWithAcl(
+  def copyString(
       originS3Location: S3Location,
       destinationS3Location: S3Location,
-      cannedAcl: ObjectCannedACL,
   ): Try[CopyObjectResponse] = {
     copyObject(
       CopyObjectRequest.builder
         .copySource(s"${originS3Location.bucket}/${originS3Location.key}")
         .destinationBucket(destinationS3Location.bucket)
         .destinationKey(destinationS3Location.key)
-        .acl(cannedAcl)
         .build(),
     )
   }


### PR DESCRIPTION
## What does this change?

Copy S3 object string without ACL.