### PR TITLE
Add soft opt-in mapping for Ad-Lite

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -92,5 +92,8 @@ object ConsentsMapping {
       yourSupportOnboarding,
       similarGuardianProducts,
     ),
+    "Guardian Ad-Lite" -> Set(
+      yourSupportOnboarding,
+    ),
   )
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds mapping to the soft opt-in consent setter for `Guardian Ad-Lite` product
