### PR TITLE
Handle `Referer` or `referer` header in the metric-push-api

### DIFF
--- a/handlers/metric-push-api/src/index.ts
+++ b/handlers/metric-push-api/src/index.ts
@@ -21,10 +21,9 @@ const router = new Router([
 		handler: async (event: APIGatewayProxyEvent) => {
 			console.log(`Input is ${JSON.stringify(event)}`);
 
-			if (
-				event.headers.referer &&
-				validReferers.includes(event.headers.referer)
-			) {
+			const referer = event.headers.referer ?? event.headers.Referer;
+
+			if (referer && validReferers.includes(referer)) {
 				await putMetric('metric-push-api-client-side-error');
 				return Promise.resolve(buildResponse(201));
 			} else {

--- a/handlers/metric-push-api/test/index.test.ts
+++ b/handlers/metric-push-api/test/index.test.ts
@@ -32,7 +32,7 @@ describe('handler', () => {
 	});
 
 	describe('GET /', () => {
-		describe('if the referred is valid', () => {
+		describe('if the referer header is valid', () => {
 			it('returns 201 Accepted', async () => {
 				const requestEvent = {
 					path: '/metric-push-api',
@@ -61,6 +61,22 @@ describe('handler', () => {
 				expect(putMetric).toHaveBeenCalledWith(
 					'metric-push-api-client-side-error',
 				);
+			});
+
+			describe('and the header starts with a capital letter', () => {
+				it('returns 201 Accepted', async () => {
+					const requestEvent = {
+						path: '/metric-push-api',
+						httpMethod: 'GET',
+						headers: {
+							Referer: 'https://support.thegulocal.com/',
+						},
+					} as unknown as APIGatewayProxyEvent;
+
+					const response = await handler(requestEvent);
+
+					expect(response.statusCode).toEqual(201);
+				});
 			});
 		});
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In the metric push API check both `Referer` and `referer` headers. I noticed a case in prod the request was valid but we didn't emit the metric because `Referer` was sent (my browser sends `referer`).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
