### PR TITLE
Don't run cdk package for every TypeScript lambda

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -33,6 +33,7 @@ jobs:
       - run: pnpm --filter "./modules/**" check-formatting
       - run: pnpm --filter "./modules/**" lint
       - run: pnpm --filter "./modules/**" test
+      - run: pnpm --filter cdk verify
 
   gu-cdk-build:
     needs: common
@@ -67,7 +68,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm --filter cdk package
+      - run: pnpm --filter cdk synth
       - run: pnpm --filter ${{ matrix.subproject }} package
 
       - name: Configure AWS credentials

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  common:
+  modules:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -30,13 +30,28 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm --filter "./modules/**" check-formatting
-      - run: pnpm --filter "./modules/**" lint
-      - run: pnpm --filter "./modules/**" test
+      - run: pnpm --filter cdk verify
+
+  cdk-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install --global corepack@0.31.0
+      - run: corepack enable
+        shell: bash
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install
       - run: pnpm --filter cdk verify
 
   gu-cdk-build:
-    needs: common
+    needs: [modules, cdk-checks]
     strategy:
       matrix:
         subproject:

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
     "synth": "cdk synth --path-metadata false --version-reporting false",
     "diff": "cdk diff --path-metadata false --version-reporting false",
+    "verify": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm synth",
     "fix-formatting": "prettier --write **.ts"
   },


### PR DESCRIPTION
## What does this change?

I noticed that the cdk package step is by far the slowest part of each TypeScript lambda build. The package script does type checking, formatting checking, linting, runs the tests and synths the Cloudformation. We don't need to do all of this for every lambda, so instead run all the checks in the common job and only synth the Cloudformation in the invidual lambda jobs (which we need to upload to Riff Raff).

This doesn't really improve the overall speed for a TypeScript build to complete as it just moves the cdk checks to the `common` job and the main TS builds still have to wait for `common` to complete. It does mean the combined overall time for runners is lower and provides slightly faster feedback in the case of a cdk issue (tests failing for example). It also means in the case of a cdk issue only one job (`common`) will fail, instead of repeating the same failure in the individual TS lambda jobs.

**Update 14/2:** I've now split the cdk checks and module checks (previously running sequentially in common) to separate jobs which run in parallel (there are no dependencies between them). Then when they're both successfully completed the individual lambda builds run. This _does_ have an overall speedup effect, and maintains the benefit of a cdk failure happening in only one place.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Picking on the ticket-tailor-webhook build as an example.

Before:
`CI-Typescript / common`: 1m23s
`CI-Typescript / gu-cdk-build (ticket-tailor-webhook)`: 1m27s

After:
`CI-Typescript / common`: 2m10s
`CI-Typescript / gu-cdk-build (ticket-tailor-webhook)`: 40s

Latest:
In parallel:
`CI-Typescript / modules`: 1m
`CI-Typescript / cdk-checks`: 1m
Then:
`CI-Typescript / gu-cdk-build (ticket-tailor-webhook)`: 37s

(There's some variability in build run times, so take these with a grain of salt. But there does seem to be an overall improvement).

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
