### PR TITLE
keep all copies of licences from jackson-core

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -130,8 +130,8 @@ object Dependencies {
      * So it's redundant in a binary artefact.
      */
     case PathList("codegen-resources", _*) => MergeStrategy.discard
-    case PathList("META-INF", "FastDoubleParser-LICENSE") => MergeStrategy.discard
-    case PathList("META-INF", "FastDoubleParser-NOTICE") => MergeStrategy.discard
+    case PathList("META-INF", "FastDoubleParser-LICENSE") => MergeStrategy.concat
+    case PathList("META-INF", "FastDoubleParser-NOTICE") => MergeStrategy.concat
     case PathList("META-INF", "okio.kotlin_module") => MergeStrategy.discard
     case x =>
       val oldStrategy = (assembly / assemblyMergeStrategy).value


### PR DESCRIPTION
We are using jackson-core both directly, and via the shaded copy in AWS SDK for Java v2.
This means that we get multiple copies of the licence files with the same name (and similar content)

During the `assembly` task to produce a Jar file for lambda, we need to explicitly resolve any file conflicts.
```
[error] Deduplicate found different file contents in the following:
[error]   Jar name = jackson-core-2.17.2.jar, jar org = com.fasterxml.jackson.core, entry target = META-INF/FastDoubleParser-NOTICE
[error]   Jar name = third-party-jackson-core-2.27.24.jar, jar org = software.amazon.awssdk, entry target = META-INF/FastDoubleParser-NOTICE
[error] Total time: 2 s, completed 13 Feb 2025, 14:30:09
```

Previously we handled this by discarding the duplicates as it didn't cause any functionality issues, and the jar is only for internal use, however it has been pointed out in https://github.com/guardian/support-service-lambdas/issues/2456 that this is a breach of the licence agreement.

This PR updates the merge process so it will keep both by concatenation.  This will slightly push up the jar file size, but it shouldn't cause much slowdown in the grand scheme of things.