### PR TITLE
remove rounding

### DIFF
--- a/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
@@ -88,7 +88,7 @@ SELECT
     STRING_AGG(DISTINCT contactCountry) as contactCountry,
     STRING_AGG(DISTINCT firstName) as firstName,
     MIN(exp.nextPaymentDate) AS nextPaymentDate,
-    ROUND(SUM(tier.price), 2) AS paymentAmount,
+    SUM(tier.price) AS paymentAmount,
     STRING_AGG(DISTINCT paymentCurrency) as paymentCurrency,
     STRING_AGG(DISTINCT rate_plan_charge.billing_period) AS paymentFrequency,
     STRING_AGG(DISTINCT product.name) as productName,


### PR DESCRIPTION
## What does this change?
Remove the rounding in the query response because SQL rounds down on .5 e.g. outcome of rounding 1.555 is 1.55
<img width="419" alt="Screenshot 2025-02-24 at 12 20 28" src="https://github.com/user-attachments/assets/36d3c5af-3181-444b-9858-afc3024070ab" />


We do the necessary rounding in the typescript zod type definition:
<img width="815" alt="Screenshot 2025-02-24 at 12 22 20" src="https://github.com/user-attachments/assets/5bfe014c-6fd0-4c6a-91bd-68e2734d2f4d" />
