### PR TITLE
Discount expiry notifier - remove email send for testing 

### DIFF
--- a/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
@@ -1,5 +1,5 @@
-import { DataExtensionNames, sendEmail } from '@modules/email/email';
-import { stageFromEnvironment } from '@modules/stage';
+/* eslint-disable @typescript-eslint/require-await -- this is required to ensure the lambda returns a value*/
+import { DataExtensionNames } from '@modules/email/email';
 import type { z } from 'zod';
 import { BaseRecordForEmailSendSchema } from '../types';
 
@@ -51,11 +51,6 @@ export const handler = async (event: SendEmailInput) => {
 	};
 
 	try {
-		const response = await sendEmail(stageFromEnvironment(), request);
-
-		if (response.$metadata.httpStatusCode !== 200) {
-			throw new Error('Failed to send email');
-		}
 		return {
 			record: parsedEvent,
 			emailSendEligibility,


### PR DESCRIPTION
## What does this changed?
We have decided that a module is required for determining the payment amount, and would like to test this with production data. In order to do that safely, we should remove the email send functionality to ensure that no emails get sent to customers.