### PR TITLE
Fix Annual Contribution plan showing as having a Monthly Billing Period in new-product-api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/ContributionsPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/ContributionsPlans.scala
@@ -16,7 +16,7 @@ class ContributionsPlans(today: LocalDate) {
 
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
     (MonthlyContribution, PlanDescription("Monthly"), rule, Monthly),
-    (AnnualContribution, PlanDescription("Annual"), rule, Monthly),
+    (AnnualContribution, PlanDescription("Annual"), rule, Annual),
   )
 
 }


### PR DESCRIPTION
## What does this change?
Fixes a typo where the annual contribution plan was set to have a monthly billing period in the product-catalog endpoint for new-product-api.

This only impacts the "product catalog", not the actual subscriptions that were created so this is just a bit of a UI bug. There's code in the Salesforce-side to workaround this, but I'd prefer the new CSR acquisitions tool to not have to do this.

## How to test
Calling the /product-catalog endpoint should return the Annual Contribution plan with `Annual` billingPeriod values, not `Monthly`. 

Before:
<img width="743" alt="Screenshot 2025-02-26 at 16 47 47" src="https://github.com/user-attachments/assets/23d37c70-78bc-4154-8090-0b39c8a8282a" />

After:
<img width="699" alt="Screenshot 2025-02-26 at 16 57 08" src="https://github.com/user-attachments/assets/05fc3b70-aa20-4527-aa35-dd04a1df57c0" />

## How can we measure success?
Correct catalog values are returned to Salesforce from new-product-api

## Have we considered potential risks?
This should not impact the existing CSR acquisition functionality, and we'll check that this is the case in code.