### PR TITLE
let people cancel supporter plus even if they switched earlier in the day

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -65,7 +65,7 @@ object SubscriptionCancelEndpoint {
 
   // run this to test locally via console with some hard coded data
   def main(args: Array[String]): Unit = LambdaEndpoint.runTest(
-    run(
+    run(() => LocalDate.now)(
       "A-S00878246",
       ExpectedInput(
         "mma_value_for_money", // valid pick list value
@@ -128,10 +128,10 @@ object SubscriptionCancelEndpoint {
           """Cancels the existing subscription at the default/soonest date.
             |Also manages all the service comms associated with the cancellation.""".stripMargin,
         )
-    endpointDescription.serverLogic[Task](run)
+    endpointDescription.serverLogic[Task](run(() => LocalDate.now()))
   }
 
-  private def run(
+  private def run(today: () => LocalDate)(
       subscriptionName: String,
       postData: ExpectedInput,
       identityId: IdentityId,
@@ -152,6 +152,7 @@ object SubscriptionCancelEndpoint {
       sqs,
       stage,
       zuoraSetCancellationReason,
+      today(),
     ).subscriptionCancel(SubscriptionName(subscriptionName), postData, identityId)
       .tapEither(result => ZIO.log(s"OUTPUT: $subscriptionName: " + result))
   } yield Right(res))

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -94,9 +94,10 @@ import scala.language.postfixOps
 object HandlerSpec extends ZIOSpecDefault {
 
   def spec = {
-    val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 10, 10, 2), ZoneOffset.ofHours(0)).toInstant
-    val time2 = OffsetDateTime.of(LocalDateTime.of(2023, 2, 6, 10, 2), ZoneOffset.ofHours(0)).toInstant
-    val time3 = OffsetDateTime.of(LocalDateTime.of(2021, 2, 15, 5, 2), ZoneOffset.ofHours(0)).toInstant
+    val zoneOffset = ZoneOffset.ofHours(0)
+    val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 10, 10, 2), zoneOffset).toInstant
+    val time2 = OffsetDateTime.of(LocalDateTime.of(2023, 2, 6, 10, 2), zoneOffset).toInstant
+    val time3 = OffsetDateTime.of(LocalDateTime.of(2021, 2, 15, 5, 2), zoneOffset).toInstant
     val subscriptionName = SubscriptionName("A-S00339056")
 
     def getSubscriptionStubs(subscriptionResponse: GetSubscriptionResponse = getSubscriptionResponse) = {
@@ -588,6 +589,7 @@ object HandlerSpec extends ZIOSpecDefault {
             zuoraSetCancellationReason = new MockZuoraSetCancellationReason(
               Map((SubscriptionName("A-S00339056"), 2, "mma_other") -> UpdateResponse(true)),
             ),
+            LocalDate.ofInstant(time, zoneOffset),
           ).subscriptionCancel(subscriptionName, input, someIdentityId.get)
         } yield {
           assert(output)(

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointStepsSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointStepsSpec.scala
@@ -59,6 +59,7 @@ object SubscriptionCancelEndpointStepsSpec extends ZIOSpecDefault {
       null,
       null,
       null,
+      LocalDate.now(),
     ).subscriptionCancel(
       SubscriptionName(sub),
       null,

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionCancelSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionCancelSpec.scala
@@ -24,7 +24,7 @@ import zio.*
 import zio.test.Assertion.equalTo
 import zio.test.{Spec, TestAspect, TestClock, TestEnvironment, ZIOSpecDefault, assert}
 
-import java.time.{LocalDateTime, ZoneOffset}
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 
 object SubscriptionCancelSpec extends ZIOAppDefault {
 
@@ -49,6 +49,7 @@ object SubscriptionCancelSpec extends ZIOAppDefault {
         sqs,
         stage,
         zuoraSetCancellationReason,
+        LocalDate.now(),
       )
         .subscriptionCancel(
           SubscriptionName("A-S00499867"),


### PR DESCRIPTION
We had some alarms in produce-move-api where a customer had subscribed to recurring contribution, then switched to supporter plus, and then tried to cancel, all in the same day.

The cancellation was throwing an error saying there were two rateplans on the subscription, and refusing to cancel.

After investigation, we discovered that zuora returns charges that ended the same day, even though the docs say it shouldn't [1]

The call was added in this PR [2] in order to make sure we use the currently active charges rather than future active charges

This PR filters out the erroneous charges in the lambda code.

We discussed whether to add a test and decided not to in the end, as it's such an edge case that the cost of the test would be more than the chance of regression.  
Testing in CODE worked fine by following the steps the customer did.

[1] https://developer.zuora.com/v1-api-reference/api/operation/GET_SubscriptionsByKey/#:~:text=current%2Dsegment%3A%20The%20segmented%20charge%20that%20is%20active%20on%20today%E2%80%99s%20date%20(effectiveStartDate%20%3C%3D%20today%E2%80%99s%20date%20%3C%20effectiveEndDate)

[2] https://github.com/guardian/support-service-lambdas/pull/2127

