### PR TITLE
Discount expiry notifier - identify follow-on discounts

### DIFF
--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -65,7 +65,7 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
   "Resources": {
     "alarmshandleralarm5F97F469": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
           {
             "Fn::Join": [

--- a/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
@@ -570,7 +570,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Sub status fetcher map":{"Type":"Map","ResultPath":"$.discountProcessingAttempts","Next":"Expiring discount processor map","Iterator":{"StartAt":"Get sub status","States":{"Get sub status":{"Next":"Get payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Sub status fetcher map":{"Type":"Map","ResultPath":"$.discountProcessingAttempts","Next":"Expiring discount processor map","Iterator":{"StartAt":"Get sub status","States":{"Get sub status":{"Next":"Get new payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -581,14 +581,14 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Get payment amount":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Get new payment amount":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
               ":states:::lambda:invoke","Parameters":{"FunctionName":"",
               {
                 "Fn::GetAtt": [
-                  "getpaymentamountlambdaD677D729",
+                  "getnewpaymentamountlambda2CBB8AA8",
                   "Arn",
                 ],
               },
@@ -867,7 +867,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "getpaymentamountlambdaD677D729",
+                    "getnewpaymentamountlambda2CBB8AA8",
                     "Arn",
                   ],
                 },
@@ -877,7 +877,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "getpaymentamountlambdaD677D729",
+                          "getnewpaymentamountlambda2CBB8AA8",
                           "Arn",
                         ],
                       },
@@ -1177,10 +1177,10 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "getpaymentamountlambdaD677D729": {
+    "getnewpaymentamountlambda2CBB8AA8": {
       "DependsOn": [
-        "getpaymentamountlambdaServiceRoleDefaultPolicy454BF626",
-        "getpaymentamountlambdaServiceRole7A988439",
+        "getnewpaymentamountlambdaServiceRoleDefaultPolicy6E0FDE1A",
+        "getnewpaymentamountlambdaServiceRoleC3565057",
       ],
       "Properties": {
         "Architectures": [
@@ -1200,12 +1200,12 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
             "Stage": "CODE",
           },
         },
-        "FunctionName": "discount-expiry-notifier-get-payment-amount-CODE",
-        "Handler": "getPaymentAmount.handler",
+        "FunctionName": "discount-expiry-notifier-get-new-payment-amount-CODE",
+        "Handler": "getNewPaymentAmount.handler",
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "getpaymentamountlambdaServiceRole7A988439",
+            "getnewpaymentamountlambdaServiceRoleC3565057",
             "Arn",
           ],
         },
@@ -1236,7 +1236,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "getpaymentamountlambdaServiceRole7A988439": {
+    "getnewpaymentamountlambdaServiceRoleC3565057": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -1289,7 +1289,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "getpaymentamountlambdaServiceRoleDefaultPolicy454BF626": {
+    "getnewpaymentamountlambdaServiceRoleDefaultPolicy6E0FDE1A": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -1400,10 +1400,10 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "getpaymentamountlambdaServiceRoleDefaultPolicy454BF626",
+        "PolicyName": "getnewpaymentamountlambdaServiceRoleDefaultPolicy6E0FDE1A",
         "Roles": [
           {
-            "Ref": "getpaymentamountlambdaServiceRole7A988439",
+            "Ref": "getnewpaymentamountlambdaServiceRoleC3565057",
           },
         ],
       },
@@ -2880,7 +2880,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Sub status fetcher map":{"Type":"Map","ResultPath":"$.discountProcessingAttempts","Next":"Expiring discount processor map","Iterator":{"StartAt":"Get sub status","States":{"Get sub status":{"Next":"Get payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Sub status fetcher map":{"Type":"Map","ResultPath":"$.discountProcessingAttempts","Next":"Expiring discount processor map","Iterator":{"StartAt":"Get sub status","States":{"Get sub status":{"Next":"Get new payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2891,14 +2891,14 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Get payment amount":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Get new payment amount":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
               ":states:::lambda:invoke","Parameters":{"FunctionName":"",
               {
                 "Fn::GetAtt": [
-                  "getpaymentamountlambdaD677D729",
+                  "getnewpaymentamountlambda2CBB8AA8",
                   "Arn",
                 ],
               },
@@ -3177,7 +3177,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "getpaymentamountlambdaD677D729",
+                    "getnewpaymentamountlambda2CBB8AA8",
                     "Arn",
                   ],
                 },
@@ -3187,7 +3187,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "getpaymentamountlambdaD677D729",
+                          "getnewpaymentamountlambda2CBB8AA8",
                           "Arn",
                         ],
                       },
@@ -3487,10 +3487,10 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "getpaymentamountlambdaD677D729": {
+    "getnewpaymentamountlambda2CBB8AA8": {
       "DependsOn": [
-        "getpaymentamountlambdaServiceRoleDefaultPolicy454BF626",
-        "getpaymentamountlambdaServiceRole7A988439",
+        "getnewpaymentamountlambdaServiceRoleDefaultPolicy6E0FDE1A",
+        "getnewpaymentamountlambdaServiceRoleC3565057",
       ],
       "Properties": {
         "Architectures": [
@@ -3510,12 +3510,12 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
             "Stage": "PROD",
           },
         },
-        "FunctionName": "discount-expiry-notifier-get-payment-amount-PROD",
-        "Handler": "getPaymentAmount.handler",
+        "FunctionName": "discount-expiry-notifier-get-new-payment-amount-PROD",
+        "Handler": "getNewPaymentAmount.handler",
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "getpaymentamountlambdaServiceRole7A988439",
+            "getnewpaymentamountlambdaServiceRoleC3565057",
             "Arn",
           ],
         },
@@ -3546,7 +3546,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "getpaymentamountlambdaServiceRole7A988439": {
+    "getnewpaymentamountlambdaServiceRoleC3565057": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -3599,7 +3599,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "getpaymentamountlambdaServiceRoleDefaultPolicy454BF626": {
+    "getnewpaymentamountlambdaServiceRoleDefaultPolicy6E0FDE1A": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -3710,10 +3710,10 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "getpaymentamountlambdaServiceRoleDefaultPolicy454BF626",
+        "PolicyName": "getnewpaymentamountlambdaServiceRoleDefaultPolicy6E0FDE1A",
         "Roles": [
           {
-            "Ref": "getpaymentamountlambdaServiceRole7A988439",
+            "Ref": "getnewpaymentamountlambdaServiceRoleC3565057",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
@@ -121,6 +121,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -570,7 +571,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Sub status fetcher map":{"Type":"Map","ResultPath":"$.discountProcessingAttempts","Next":"Expiring discount processor map","Iterator":{"StartAt":"Get sub status","States":{"Get sub status":{"Next":"Get new payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Sub status fetcher map":{"Type":"Map","ResultPath":"$.discountProcessingAttempts","Next":"Expiring discount processor map","Iterator":{"StartAt":"Get sub status","States":{"Get sub status":{"Next":"Get old payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -578,6 +579,17 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
               {
                 "Fn::GetAtt": [
                   "getsubstatuslambda62C74216",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Get old payment amount":{"Next":"Get new payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "getoldpaymentamountlambda48C1589A",
                   "Arn",
                 ],
               },
@@ -852,6 +864,32 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
                       {
                         "Fn::GetAtt": [
                           "getsubstatuslambda62C74216",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "getoldpaymentamountlambda48C1589A",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "getoldpaymentamountlambda48C1589A",
                           "Arn",
                         ],
                       },
@@ -1404,6 +1442,238 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
         "Roles": [
           {
             "Ref": "getnewpaymentamountlambdaServiceRoleC3565057",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "getoldpaymentamountlambda48C1589A": {
+      "DependsOn": [
+        "getoldpaymentamountlambdaServiceRoleDefaultPolicyD4E95238",
+        "getoldpaymentamountlambdaServiceRole2FC8D752",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/CODE/discount-expiry-notifier/discount-expiry-notifier.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "discount-expiry-notifier",
+            "STACK": "membership",
+            "STAGE": "CODE",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "discount-expiry-notifier-get-old-payment-amount-CODE",
+        "Handler": "getOldPaymentAmount.handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "getoldpaymentamountlambdaServiceRole2FC8D752",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "discount-expiry-notifier",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "getoldpaymentamountlambdaServiceRole2FC8D752": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "discount-expiry-notifier",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "getoldpaymentamountlambdaServiceRoleDefaultPolicyD4E95238": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/CODE/discount-expiry-notifier/discount-expiry-notifier.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/membership/discount-expiry-notifier",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/membership/discount-expiry-notifier/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "getoldpaymentamountlambdaServiceRoleDefaultPolicyD4E95238",
+        "Roles": [
+          {
+            "Ref": "getoldpaymentamountlambdaServiceRole2FC8D752",
           },
         ],
       },
@@ -2431,6 +2701,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -2880,7 +3151,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Sub status fetcher map":{"Type":"Map","ResultPath":"$.discountProcessingAttempts","Next":"Expiring discount processor map","Iterator":{"StartAt":"Get sub status","States":{"Get sub status":{"Next":"Get new payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Sub status fetcher map":{"Type":"Map","ResultPath":"$.discountProcessingAttempts","Next":"Expiring discount processor map","Iterator":{"StartAt":"Get sub status","States":{"Get sub status":{"Next":"Get old payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2888,6 +3159,17 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
               {
                 "Fn::GetAtt": [
                   "getsubstatuslambda62C74216",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Get old payment amount":{"Next":"Get new payment amount","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "getoldpaymentamountlambda48C1589A",
                   "Arn",
                 ],
               },
@@ -3162,6 +3444,32 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
                       {
                         "Fn::GetAtt": [
                           "getsubstatuslambda62C74216",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "getoldpaymentamountlambda48C1589A",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "getoldpaymentamountlambda48C1589A",
                           "Arn",
                         ],
                       },
@@ -3714,6 +4022,238 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
         "Roles": [
           {
             "Ref": "getnewpaymentamountlambdaServiceRoleC3565057",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "getoldpaymentamountlambda48C1589A": {
+      "DependsOn": [
+        "getoldpaymentamountlambdaServiceRoleDefaultPolicyD4E95238",
+        "getoldpaymentamountlambdaServiceRole2FC8D752",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "membership/PROD/discount-expiry-notifier/discount-expiry-notifier.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "discount-expiry-notifier",
+            "STACK": "membership",
+            "STAGE": "PROD",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "discount-expiry-notifier-get-old-payment-amount-PROD",
+        "Handler": "getOldPaymentAmount.handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "getoldpaymentamountlambdaServiceRole2FC8D752",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "discount-expiry-notifier",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "getoldpaymentamountlambdaServiceRole2FC8D752": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "discount-expiry-notifier",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "getoldpaymentamountlambdaServiceRoleDefaultPolicyD4E95238": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/membership/PROD/discount-expiry-notifier/discount-expiry-notifier.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/membership/discount-expiry-notifier",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/membership/discount-expiry-notifier/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "getoldpaymentamountlambdaServiceRoleDefaultPolicyD4E95238",
+        "Roles": [
+          {
+            "Ref": "getoldpaymentamountlambdaServiceRole2FC8D752",
           },
         ],
       },

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -158,7 +158,7 @@ export class AlarmsHandler extends GuStack {
 			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
 			threshold: 0,
 			evaluationPeriods: 24,
-			actionsEnabled: this.stage === 'PROD' || this.stage === 'CODE', //while testing discount-expiry-notifier
+			actionsEnabled: this.stage === 'PROD',
 		});
 	}
 }

--- a/cdk/lib/discount-expiry-notifier.ts
+++ b/cdk/lib/discount-expiry-notifier.ts
@@ -131,17 +131,17 @@ export class DiscountExpiryNotifier extends GuStack {
 			},
 		);
 
-		const getPaymentAmountLambda = new GuLambdaFunction(
+		const getNewPaymentAmountLambda = new GuLambdaFunction(
 			this,
-			'get-payment-amount-lambda',
+			'get-new-payment-amount-lambda',
 			{
 				app: appName,
-				functionName: `${appName}-get-payment-amount-${this.stage}`,
+				functionName: `${appName}-get-new-payment-amount-${this.stage}`,
 				runtime: nodeVersion,
 				environment: {
 					Stage: this.stage,
 				},
-				handler: 'getPaymentAmount.handler',
+				handler: 'getNewPaymentAmount.handler',
 				fileName: `${appName}.zip`,
 				architecture: Architecture.ARM_64,
 				initialPolicy: [
@@ -232,11 +232,11 @@ export class DiscountExpiryNotifier extends GuStack {
 			outputPath: '$.Payload',
 		});
 
-		const getPaymentAmountLambdaTask = new LambdaInvoke(
+		const getNewPaymentAmountLambdaTask = new LambdaInvoke(
 			this,
-			'Get payment amount',
+			'Get new payment amount',
 			{
-				lambdaFunction: getPaymentAmountLambda,
+				lambdaFunction: getNewPaymentAmountLambda,
 				outputPath: '$.Payload',
 			},
 		);
@@ -277,7 +277,7 @@ export class DiscountExpiryNotifier extends GuStack {
 		);
 
 		subStatusFetcherMap.iterator(
-			getSubStatusLambdaTask.next(getPaymentAmountLambdaTask),
+			getSubStatusLambdaTask.next(getNewPaymentAmountLambdaTask),
 		);
 		expiringDiscountProcessorMap.iterator(sendEmailLambdaTask);
 

--- a/handlers/discount-expiry-notifier/riff-raff.yaml
+++ b/handlers/discount-expiry-notifier/riff-raff.yaml
@@ -23,7 +23,7 @@ deployments:
         - discount-expiry-notifier-get-expiring-discounts-
         - discount-expiry-notifier-filter-records-
         - discount-expiry-notifier-get-sub-status-
-        - discount-expiry-notifier-get-payment-amount-
+        - discount-expiry-notifier-get-new-payment-amount-
         - discount-expiry-notifier-send-email-
         - discount-expiry-notifier-save-results-
         - discount-expiry-notifier-alarm-on-failures-

--- a/handlers/discount-expiry-notifier/riff-raff.yaml
+++ b/handlers/discount-expiry-notifier/riff-raff.yaml
@@ -23,6 +23,7 @@ deployments:
         - discount-expiry-notifier-get-expiring-discounts-
         - discount-expiry-notifier-filter-records-
         - discount-expiry-notifier-get-sub-status-
+        - discount-expiry-notifier-get-old-payment-amount-
         - discount-expiry-notifier-get-new-payment-amount-
         - discount-expiry-notifier-send-email-
         - discount-expiry-notifier-save-results-

--- a/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
@@ -72,6 +72,7 @@ WITH expiringDiscounts AS (
         sfBuyerContact.billing_country as sfBuyerContactOtherCountry,
         sfRecipientContact.mailing_country as sfRecipientContactMailingCountry,
         sfRecipientContact.billing_country as sfRecipientContactOtherCountry,
+        
     FROM 
         datatech-fivetran.zuora.rate_plan_charge charge
     INNER JOIN datatech-fivetran.zuora.rate_plan rate_plan 

--- a/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
@@ -61,7 +61,7 @@ WITH expiringDiscounts AS (
     SELECT
         contact.country as contactCountry,
         contact.first_name as firstName,
-        DATE_ADD(charge.effective_start_date, INTERVAL charge.up_to_periods MONTH) AS nextPaymentDate,
+        DATE_ADD(charge.effective_start_date, INTERVAL charge.up_to_periods MONTH) AS firstPaymentDateAfterDiscountExpiry,
         account.account_number as billingAccountId,
         account.currency as paymentCurrency,
         account.sf_contact_id_c as sfContactId,
@@ -103,7 +103,7 @@ SELECT
     STRING_AGG(DISTINCT billingAccountId) as billingAccountId,
     STRING_AGG(DISTINCT contactCountry) as contactCountry,
     STRING_AGG(DISTINCT firstName) as firstName,
-    MIN(exp.nextPaymentDate) AS nextPaymentDate,
+    MIN(exp.firstPaymentDateAfterDiscountExpiry) AS firstPaymentDateAfterDiscountExpiry,
     STRING_AGG(DISTINCT paymentCurrency) as paymentCurrency,
     STRING_AGG(DISTINCT rate_plan_charge.billing_period) AS paymentFrequency,
     STRING_AGG(DISTINCT product.name) as productName,

--- a/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
@@ -72,7 +72,6 @@ WITH expiringDiscounts AS (
         sfBuyerContact.billing_country as sfBuyerContactOtherCountry,
         sfRecipientContact.mailing_country as sfRecipientContactMailingCountry,
         sfRecipientContact.billing_country as sfRecipientContactOtherCountry,
-        
     FROM 
         datatech-fivetran.zuora.rate_plan_charge charge
     INNER JOIN datatech-fivetran.zuora.rate_plan rate_plan 

--- a/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
@@ -16,13 +16,13 @@ export const handler = async (event: GetNewPaymentAmountInput) => {
 		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
 		const getBillingPreviewResponse = await getBillingPreview(
 			zuoraClient,
-			dayjs(parsedEvent.nextPaymentDate),
+			dayjs(parsedEvent.firstPaymentDateAfterDiscountExpiry),
 			parsedEvent.billingAccountId,
 		);
 		const invoiceItemsForSubscription = filterRecords(
 			getBillingPreviewResponse.invoiceItems,
 			parsedEvent.zuoraSubName,
-			parsedEvent.nextPaymentDate,
+			parsedEvent.firstPaymentDateAfterDiscountExpiry,
 		);
 		const newPaymentAmount = getNewPaymentAmount(invoiceItemsForSubscription);
 
@@ -45,12 +45,15 @@ export const handler = async (event: GetNewPaymentAmountInput) => {
 const filterRecords = (
 	invoiceItems: InvoiceItem[],
 	subscriptionName: string,
-	nextPaymentDate: string,
+	firstPaymentDateAfterDiscountExpiry: string,
 ): InvoiceItem[] => {
 	return invoiceItems.filter(
 		(item) =>
 			item.subscriptionName === subscriptionName &&
-			dayjs(item.serviceStartDate).isSame(dayjs(nextPaymentDate), 'day'),
+			dayjs(item.serviceStartDate).isSame(
+				dayjs(firstPaymentDateAfterDiscountExpiry),
+				'day',
+			),
 	);
 };
 

--- a/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
@@ -32,12 +32,12 @@ export const handler = async (event: GetNewPaymentAmountInput) => {
 		};
 	} catch (error) {
 		console.log('error:', error);
-
+		const errorMessage =
+			'Error getting new payment amount:' +
+			(error instanceof Error ? error.message : JSON.stringify(error, null, 2));
 		return {
 			...event,
-			subStatus: 'Error',
-			errorDetail:
-				error instanceof Error ? error.message : JSON.stringify(error, null, 2),
+			errorDetail: errorMessage,
 		};
 	}
 };

--- a/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
@@ -28,7 +28,7 @@ export const handler = async (event: GetNewPaymentAmountInput) => {
 
 		return {
 			...parsedEvent,
-			newPaymentAmount: newPaymentAmount,
+			newPaymentAmount,
 		};
 	} catch (error) {
 		console.log('error:', error);

--- a/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
@@ -6,11 +6,11 @@ import dayjs from 'dayjs';
 import type { z } from 'zod';
 import { BaseRecordForEmailSendSchema } from '../types';
 
-export type GetPaymentAmountInput = z.infer<
+export type GetNewPaymentAmountInput = z.infer<
 	typeof BaseRecordForEmailSendSchema
 >;
 
-export const handler = async (event: GetPaymentAmountInput) => {
+export const handler = async (event: GetNewPaymentAmountInput) => {
 	try {
 		const parsedEvent = BaseRecordForEmailSendSchema.parse(event);
 		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
@@ -24,11 +24,11 @@ export const handler = async (event: GetPaymentAmountInput) => {
 			parsedEvent.zuoraSubName,
 			parsedEvent.nextPaymentDate,
 		);
-		const paymentAmount = getPaymentAmount(invoiceItemsForSubscription);
+		const newPaymentAmount = getNewPaymentAmount(invoiceItemsForSubscription);
 
 		return {
 			...parsedEvent,
-			paymentAmount,
+			newPaymentAmount: newPaymentAmount,
 		};
 	} catch (error) {
 		console.log('error:', error);
@@ -54,6 +54,6 @@ const filterRecords = (
 	);
 };
 
-const getPaymentAmount = (invoiceItems: InvoiceItem[]): number => {
+const getNewPaymentAmount = (invoiceItems: InvoiceItem[]): number => {
 	return invoiceItems.reduce((total, item) => total + item.paymentAmount, 0);
 };

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -15,7 +15,7 @@ export const handler = async (event: GetOldPaymentAmountInput) => {
 		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
 		const lastPaymentDateBeforeDiscountExpiry =
 			getLastPaymentDateBeforeDiscountExpiry(
-				parsedEvent.nextPaymentDate,
+				parsedEvent.firstPaymentDateAfterDiscountExpiry,
 				parsedEvent.paymentFrequency,
 			);
 		console.log(
@@ -25,7 +25,10 @@ export const handler = async (event: GetOldPaymentAmountInput) => {
 
 		const getInvoiceItemsResponse = await doQuery(
 			zuoraClient,
-			query(parsedEvent.zuoraSubName, parsedEvent.nextPaymentDate),
+			query(
+				parsedEvent.zuoraSubName,
+				parsedEvent.firstPaymentDateAfterDiscountExpiry,
+			),
 		);
 		const oldPaymentAmount = calculateTotalAmount(
 			getInvoiceItemsResponse.records,

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -34,6 +34,7 @@ export const handler = async (event: GetOldPaymentAmountInput) => {
 		console.log('getInvoiceItemsResponse:', getInvoiceItemsResponse);
 		return {
 			...parsedEvent,
+			lastPaymentDateBeforeDiscountExpiry,
 			oldPaymentAmount,
 		};
 	} catch (error) {
@@ -82,7 +83,7 @@ export function getLastPaymentDateBeforeDiscountExpiry(
 		date.setDate(28);
 	}
 
-	switch (paymentFrequency) {
+	switch (paymentFrequency.toLowerCase()) {
 		case 'annual':
 			date.setFullYear(date.getFullYear() - 1);
 			break;

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -1,8 +1,6 @@
 import { stageFromEnvironment } from '@modules/stage';
 import { doQuery } from '@modules/zuora/query';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { InvoiceItem } from '@modules/zuora/zuoraSchemas';
-import dayjs from 'dayjs';
 import type { z } from 'zod';
 import { BaseRecordForEmailSendSchema } from '../types';
 
@@ -29,20 +27,4 @@ export const handler = async (event: GetOldPaymentAmountInput) => {
 				error instanceof Error ? error.message : JSON.stringify(error, null, 2),
 		};
 	}
-};
-
-const filterRecords = (
-	invoiceItems: InvoiceItem[],
-	subscriptionName: string,
-	nextPaymentDate: string,
-): InvoiceItem[] => {
-	return invoiceItems.filter(
-		(item) =>
-			item.subscriptionName === subscriptionName &&
-			dayjs(item.serviceStartDate).isSame(dayjs(nextPaymentDate), 'day'),
-	);
-};
-
-const getNewPaymentAmount = (invoiceItems: InvoiceItem[]): number => {
-	return invoiceItems.reduce((total, item) => total + item.paymentAmount, 0);
 };

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -63,10 +63,10 @@ const query = (subName: string, serviceStartDate: string): string =>
 	`SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = '${subName}' AND ServiceStartDate = '${serviceStartDate}' ANDChargeName!='Delivery-problem credit' AND ChargeName!='Holiday Credit'`;
 
 export function getLastPaymentDateBeforeDiscountExpiry(
-	nextPaymentDate: string,
+	firstPaymentDateAfterDiscountExpiry: string,
 	paymentFrequency: string,
 ): string {
-	const date = new Date(nextPaymentDate);
+	const date = new Date(firstPaymentDateAfterDiscountExpiry);
 
 	//if the date is a leap year, set the last day of February
 	if (date.getMonth() === 1 && date.getDate() === 29) {

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -39,12 +39,12 @@ export const handler = async (event: GetOldPaymentAmountInput) => {
 		};
 	} catch (error) {
 		console.log('error:', error);
-
+		const errorMessage =
+			'Error getting old payment amount:' +
+			(error instanceof Error ? error.message : JSON.stringify(error, null, 2));
 		return {
 			...event,
-			subStatus: 'Error',
-			errorDetail:
-				error instanceof Error ? error.message : JSON.stringify(error, null, 2),
+			errorDetail: errorMessage,
 		};
 	}
 };

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -1,21 +1,32 @@
 import { stageFromEnvironment } from '@modules/stage';
 import { doQuery } from '@modules/zuora/query';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import type { InvoiceItemRecord } from '@modules/zuora/zuoraSchemas';
 import type { z } from 'zod';
 import { BaseRecordForEmailSendSchema } from '../types';
 
 export type GetOldPaymentAmountInput = z.infer<
 	typeof BaseRecordForEmailSendSchema
 >;
-
+const calculateTotalAmount = (records: InvoiceItemRecord[]) => {
+	return records.reduce(
+		(total, record) => total + record.ChargeAmount + record.TaxAmount,
+		0,
+	);
+};
 export const handler = async (event: GetOldPaymentAmountInput) => {
 	try {
 		const parsedEvent = BaseRecordForEmailSendSchema.parse(event);
 		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
 		const getInvoiceItemsResponse = await doQuery(zuoraClient);
+		const oldPaymentAmount = calculateTotalAmount(
+			getInvoiceItemsResponse.records,
+		);
+
 		console.log('getInvoiceItemsResponse:', getInvoiceItemsResponse);
 		return {
 			...parsedEvent,
+			oldPaymentAmount,
 		};
 	} catch (error) {
 		console.log('error:', error);

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -57,20 +57,7 @@ const calculateTotalAmount = (records: InvoiceItemRecord[]) => {
 };
 
 const query = (subName: string, serviceStartDate: string): string =>
-	`
-	SELECT 
-		ChargeAmount, 
-		TaxAmount, 
-		ServiceStartDate, 
-		SubscriptionNumber 
-	FROM 
-		InvoiceItem 
-	WHERE 
-		SubscriptionNumber = '${subName}' AND 
-		ServiceStartDate = '${serviceStartDate}' AND
-		ChargeName!='Delivery-problem credit' AND 
-		ChargeName!='Holiday Credit'
-	`;
+	`SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = '${subName}' AND ServiceStartDate = '${serviceStartDate}' ANDChargeName!='Delivery-problem credit' AND ChargeName!='Holiday Credit'`;
 
 export function getLastPaymentDateBeforeDiscountExpiry(
 	nextPaymentDate: string,

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -23,6 +23,8 @@ export const handler = async (event: GetOldPaymentAmountInput) => {
 			lastPaymentDateBeforeDiscountExpiry,
 		);
 
+		//todo if lastPaymentDateBeforeDiscountExpiry is in the past of now,
+		//use query to get invoice items, otherwise use billing-preview endpoint
 		const getInvoiceItemsResponse = await doQuery(
 			zuoraClient,
 			query(

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -1,0 +1,48 @@
+import { stageFromEnvironment } from '@modules/stage';
+import { doQuery } from '@modules/zuora/query';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import type { InvoiceItem } from '@modules/zuora/zuoraSchemas';
+import dayjs from 'dayjs';
+import type { z } from 'zod';
+import { BaseRecordForEmailSendSchema } from '../types';
+
+export type GetOldPaymentAmountInput = z.infer<
+	typeof BaseRecordForEmailSendSchema
+>;
+
+export const handler = async (event: GetOldPaymentAmountInput) => {
+	try {
+		const parsedEvent = BaseRecordForEmailSendSchema.parse(event);
+		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
+		const getInvoiceItemsResponse = await doQuery(zuoraClient);
+		console.log('getInvoiceItemsResponse:', getInvoiceItemsResponse);
+		return {
+			...parsedEvent,
+		};
+	} catch (error) {
+		console.log('error:', error);
+
+		return {
+			...event,
+			subStatus: 'Error',
+			errorDetail:
+				error instanceof Error ? error.message : JSON.stringify(error, null, 2),
+		};
+	}
+};
+
+const filterRecords = (
+	invoiceItems: InvoiceItem[],
+	subscriptionName: string,
+	nextPaymentDate: string,
+): InvoiceItem[] => {
+	return invoiceItems.filter(
+		(item) =>
+			item.subscriptionName === subscriptionName &&
+			dayjs(item.serviceStartDate).isSame(dayjs(nextPaymentDate), 'day'),
+	);
+};
+
+const getNewPaymentAmount = (invoiceItems: InvoiceItem[]): number => {
+	return invoiceItems.reduce((total, item) => total + item.paymentAmount, 0);
+};

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -62,7 +62,7 @@ const calculateTotalAmount = (records: InvoiceItemRecord[]) => {
 };
 
 const query = (subName: string, serviceStartDate: string): string =>
-	`SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = '${subName}' AND ServiceStartDate = '${serviceStartDate}' ANDChargeName!='Delivery-problem credit' AND ChargeName!='Holiday Credit'`;
+	`SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = '${subName}' AND ServiceStartDate = '${serviceStartDate}' AND ChargeName!='Delivery-problem credit' AND ChargeName!='Holiday Credit'`;
 
 export function getLastPaymentDateBeforeDiscountExpiry(
 	firstPaymentDateAfterDiscountExpiry: string,

--- a/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
@@ -38,7 +38,7 @@ export const handler = async (event: SendEmailInput) => {
 				ContactAttributes: {
 					SubscriberAttributes: {
 						EmailAddress: parsedEvent.workEmail ?? '',
-						payment_amount: `${currencySymbol}${parsedEvent.paymentAmount}`,
+						payment_amount: `${currencySymbol}${parsedEvent.newPaymentAmount}`,
 						first_name: parsedEvent.firstName,
 						next_payment_date: formatDate(parsedEvent.nextPaymentDate),
 						payment_frequency: parsedEvent.paymentFrequency.toLowerCase(),

--- a/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
@@ -40,7 +40,9 @@ export const handler = async (event: SendEmailInput) => {
 						EmailAddress: parsedEvent.workEmail ?? '',
 						payment_amount: `${currencySymbol}${parsedEvent.newPaymentAmount}`,
 						first_name: parsedEvent.firstName,
-						next_payment_date: formatDate(parsedEvent.nextPaymentDate),
+						next_payment_date: formatDate(
+							parsedEvent.firstPaymentDateAfterDiscountExpiry,
+						),
 						payment_frequency: parsedEvent.paymentFrequency.toLowerCase(),
 					},
 				},

--- a/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
@@ -15,6 +15,8 @@ export const handler = async (event: SendEmailInput) => {
 	const emailSendEligibility = getEmailSendEligibility(
 		parsedEvent.subStatus,
 		parsedEvent.workEmail,
+		parsedEvent.oldPaymentAmount,
+		parsedEvent.newPaymentAmount,
 	);
 
 	if (!emailSendEligibility.isEligible) {
@@ -81,6 +83,8 @@ export const handler = async (event: SendEmailInput) => {
 function getIneligibilityReason(
 	subStatus: string,
 	workEmail: string | null | undefined,
+	oldPaymentAmount: number,
+	newPaymentAmount: number,
 ) {
 	if (subStatus === 'Cancelled') {
 		return 'Subscription status is cancelled';
@@ -91,15 +95,28 @@ function getIneligibilityReason(
 	if (!workEmail) {
 		return 'No value for work email';
 	}
+	if (oldPaymentAmount === newPaymentAmount) {
+		return 'Old and new payment amounts are the same';
+	}
 	return '';
 }
 function getEmailSendEligibility(
 	subStatus: string,
 	workEmail: string | null | undefined,
+	oldPaymentAmount: number,
+	newPaymentAmount: number,
 ) {
 	return {
-		isEligible: subStatus === 'Active' && !!workEmail,
-		ineligibilityReason: getIneligibilityReason(subStatus, workEmail),
+		isEligible:
+			subStatus === 'Active' &&
+			!!workEmail &&
+			oldPaymentAmount !== newPaymentAmount,
+		ineligibilityReason: getIneligibilityReason(
+			subStatus,
+			workEmail,
+			oldPaymentAmount,
+			newPaymentAmount,
+		),
 	};
 }
 

--- a/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
@@ -12,6 +12,12 @@ export const handler = async (event: SendEmailInput) => {
 		throw new Error('Invalid event data');
 	}
 	const parsedEvent = parsedEventResult.data;
+	if (
+		parsedEvent.oldPaymentAmount === undefined ||
+		parsedEvent.newPaymentAmount === undefined
+	) {
+		throw new Error('Payment amounts must be defined');
+	}
 	const emailSendEligibility = getEmailSendEligibility(
 		parsedEvent.subStatus,
 		parsedEvent.workEmail,

--- a/handlers/discount-expiry-notifier/src/types.ts
+++ b/handlers/discount-expiry-notifier/src/types.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const BigQueryRecordSchema = z.object({
 	billingAccountId: z.string(),
 	firstName: z.string(),
-	nextPaymentDate: z
+	firstPaymentDateAfterDiscountExpiry: z
 		.union([
 			z.object({
 				value: z.string(),

--- a/handlers/discount-expiry-notifier/src/types.ts
+++ b/handlers/discount-expiry-notifier/src/types.ts
@@ -11,6 +11,7 @@ export const BigQueryRecordSchema = z.object({
 			z.string(),
 		])
 		.transform((val) => (typeof val === 'string' ? val : val.value)),
+	oldPaymentAmount: z.number().optional(),
 	paymentAmount: z.number().optional(),
 	paymentCurrency: z.string(),
 	paymentFrequency: z.string(),

--- a/handlers/discount-expiry-notifier/src/types.ts
+++ b/handlers/discount-expiry-notifier/src/types.ts
@@ -11,6 +11,7 @@ export const BigQueryRecordSchema = z.object({
 			z.string(),
 		])
 		.transform((val) => (typeof val === 'string' ? val : val.value)),
+	lastPaymentDateBeforeDiscountExpiry: z.string().optional(),
 	oldPaymentAmount: z.number().optional(),
 	newPaymentAmount: z.number().optional(),
 	paymentCurrency: z.string(),

--- a/handlers/discount-expiry-notifier/src/types.ts
+++ b/handlers/discount-expiry-notifier/src/types.ts
@@ -12,7 +12,7 @@ export const BigQueryRecordSchema = z.object({
 		])
 		.transform((val) => (typeof val === 'string' ? val : val.value)),
 	oldPaymentAmount: z.number().optional(),
-	paymentAmount: z.number().optional(),
+	newPaymentAmount: z.number().optional(),
 	paymentCurrency: z.string(),
 	paymentFrequency: z.string(),
 	productName: z.string(),

--- a/handlers/discount-expiry-notifier/test/handlers/data/filterRecords/allRecordsFromBigQuery.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/data/filterRecords/allRecordsFromBigQuery.ts
@@ -2,7 +2,7 @@ export const allRecordsFromBigQuery = [
 	{
 		billingAccountId: 'A00265729',
 		firstName: 'David',
-		nextPaymentDate: '2025-03-22',
+		firstPaymentDateAfterDiscountExpiry: '2025-03-22',
 		paymentAmount: 1.23,
 		paymentCurrency: 'GBP',
 		paymentFrequency: 'Month',
@@ -19,7 +19,7 @@ export const allRecordsFromBigQuery = [
 	{
 		billingAccountId: 'A00900236',
 		firstName: 'Graham',
-		nextPaymentDate: '2025-02-28',
+		firstPaymentDateAfterDiscountExpiry: '2025-02-28',
 		paymentAmount: 4.56,
 		paymentCurrency: 'USD',
 		paymentFrequency: 'Month',
@@ -36,7 +36,7 @@ export const allRecordsFromBigQuery = [
 	{
 		billingAccountId: 'A00512380',
 		firstName: 'Robert',
-		nextPaymentDate: '2025-02-28',
+		firstPaymentDateAfterDiscountExpiry: '2025-02-28',
 		paymentAmount: 7.89,
 		paymentCurrency: 'USD',
 		paymentFrequency: 'Month',

--- a/handlers/discount-expiry-notifier/test/handlers/data/functionalTestQueryResponse.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/data/functionalTestQueryResponse.ts
@@ -3,7 +3,7 @@ export const functionalTestQueryResponse = [
 	{
 		billingAccountId: 'A00265729',
 		firstName: 'David',
-		nextPaymentDate: '2025-03-22',
+		firstPaymentDateAfterDiscountExpiry: '2025-03-22',
 		paymentAmount: 1.23,
 		paymentCurrency: 'GBP',
 		paymentFrequency: 'Month',
@@ -20,7 +20,7 @@ export const functionalTestQueryResponse = [
 	{
 		billingAccountId: 'A00900236',
 		firstName: 'Graham',
-		nextPaymentDate: '2025-02-28',
+		firstPaymentDateAfterDiscountExpiry: '2025-02-28',
 		paymentAmount: 4.56,
 		paymentCurrency: 'USD',
 		paymentFrequency: 'Month',
@@ -37,7 +37,7 @@ export const functionalTestQueryResponse = [
 	{
 		billingAccountId: 'A00512380',
 		firstName: 'Robert',
-		nextPaymentDate: '2025-02-28',
+		firstPaymentDateAfterDiscountExpiry: '2025-02-28',
 		paymentAmount: 7.89,
 		paymentCurrency: 'USD',
 		paymentFrequency: 'Month',

--- a/handlers/discount-expiry-notifier/test/handlers/data/getExpiringDiscounts/testQueryResponse.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/data/getExpiringDiscounts/testQueryResponse.ts
@@ -3,7 +3,7 @@ export const testQueryResponse = [
 		{
 			billingAccountId: 'A00265729',
 			firstName: 'David',
-			nextPaymentDate: '2025-03-22',
+			firstPaymentDateAfterDiscountExpiry: '2025-03-22',
 			paymentAmount: 1.23,
 			paymentCurrency: 'GBP',
 			paymentFrequency: 'Month',
@@ -20,7 +20,7 @@ export const testQueryResponse = [
 		{
 			billingAccountId: 'A00900236',
 			firstName: 'Graham',
-			nextPaymentDate: '2025-02-28',
+			firstPaymentDateAfterDiscountExpiry: '2025-02-28',
 			paymentAmount: 4.56,
 			paymentCurrency: 'USD',
 			paymentFrequency: 'Month',
@@ -37,7 +37,7 @@ export const testQueryResponse = [
 		{
 			billingAccountId: 'A00512380',
 			firstName: 'Robert',
-			nextPaymentDate: '2025-02-28',
+			firstPaymentDateAfterDiscountExpiry: '2025-02-28',
 			paymentAmount: 7.89,
 			paymentCurrency: 'USD',
 			paymentFrequency: 'Month',

--- a/handlers/discount-expiry-notifier/test/handlers/data/getSubStatus/event.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/data/getSubStatus/event.ts
@@ -1,7 +1,7 @@
 export const mockEvent = {
 	billingAccountId: 'A-S001',
 	firstName: 'David',
-	nextPaymentDate: '2025-03-22',
+	firstPaymentDateAfterDiscountExpiry: '2025-03-22',
 	paymentAmount: 1.23,
 	paymentCurrency: 'GBP',
 	paymentFrequency: 'Month',

--- a/handlers/discount-expiry-notifier/test/handlers/getOldPaymentAmount.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/getOldPaymentAmount.test.ts
@@ -1,0 +1,41 @@
+import { getLastPaymentDateBeforeDiscountExpiry } from '../../src/handlers/getOldPaymentAmount';
+
+describe('getLastPaymentDateBeforeDiscountExpiry', () => {
+	test('should return the date one year before for annual frequency', () => {
+		const result = getLastPaymentDateBeforeDiscountExpiry(
+			'2025-03-04',
+			'annual',
+		);
+		expect(result).toBe('2024-03-04');
+	});
+
+	test('should return the date three months before for quarter frequency', () => {
+		const result = getLastPaymentDateBeforeDiscountExpiry(
+			'2025-03-04',
+			'quarter',
+		);
+		expect(result).toBe('2024-12-04');
+	});
+
+	test('should return the date one month before for month frequency', () => {
+		const result = getLastPaymentDateBeforeDiscountExpiry(
+			'2025-03-04',
+			'month',
+		);
+		expect(result).toBe('2025-02-04');
+	});
+
+	test('should handle leap year correctly for annual frequency', () => {
+		const result = getLastPaymentDateBeforeDiscountExpiry(
+			'2024-02-29',
+			'annual',
+		);
+		expect(result).toBe('2023-02-28');
+	});
+
+	test('should throw an error for invalid payment frequency', () => {
+		expect(() => {
+			getLastPaymentDateBeforeDiscountExpiry('2025-03-04', 'weekly');
+		}).toThrow('Invalid payment frequency');
+	});
+});

--- a/modules/zuora/src/query.ts
+++ b/modules/zuora/src/query.ts
@@ -6,7 +6,9 @@ export const doQuery = async (
 	zuoraClient: ZuoraClient,
 	query: string,
 ): Promise<QueryResponse> => {
-	console.log(`Querying zuora for invoice items...`);
+	console.log('Querying zuora...');
+	console.log('Query:', query);
+
 	const result = await zuoraClient.post(
 		'/v1/action/query',
 		JSON.stringify({
@@ -14,9 +16,6 @@ export const doQuery = async (
 		}),
 		queryResponseSchema,
 	);
-	console.log('Query result:', result);
+
 	return result as QueryResponse;
-	// if (!result.Success) {
-	// 	throw new Error('An error occurred while creating the payment');
-	// }
 };

--- a/modules/zuora/src/query.ts
+++ b/modules/zuora/src/query.ts
@@ -1,7 +1,10 @@
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { invoiceItemResponseSchema } from '@modules/zuora/zuoraSchemas';
+import type { QueryResponse } from '@modules/zuora/zuoraSchemas';
+import { queryResponseSchema } from '@modules/zuora/zuoraSchemas';
 
-export const doQuery = async (zuoraClient: ZuoraClient): Promise<void> => {
+export const doQuery = async (
+	zuoraClient: ZuoraClient,
+): Promise<QueryResponse> => {
 	console.log(`Querying zuora for invoice items...`);
 	const result = await zuoraClient.post(
 		'/v1/action/query',
@@ -9,10 +12,10 @@ export const doQuery = async (zuoraClient: ZuoraClient): Promise<void> => {
 			queryString:
 				"SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = 'A-S00424163' and ChargeName!='Delivery-problem credit' and ChargeName!='Holiday Credit' and ServiceStartDate = '2025-02-22' ",
 		}),
-		invoiceItemResponseSchema,
+		queryResponseSchema,
 	);
 	console.log('Query result:', result);
-
+	return result as QueryResponse;
 	// if (!result.Success) {
 	// 	throw new Error('An error occurred while creating the payment');
 	// }

--- a/modules/zuora/src/query.ts
+++ b/modules/zuora/src/query.ts
@@ -1,0 +1,19 @@
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { invoiceItemResponseSchema } from '@modules/zuora/zuoraSchemas';
+
+export const doQuery = async (zuoraClient: ZuoraClient): Promise<void> => {
+	console.log(`Querying zuora for invoice items...`);
+	const result = await zuoraClient.post(
+		'/v1/action/query',
+		JSON.stringify({
+			queryString:
+				"SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = 'A-S00424163' and ChargeName!='Delivery-problem credit' and ChargeName!='Holiday Credit' and ServiceStartDate = '2025-02-22'' ",
+		}),
+		invoiceItemResponseSchema,
+	);
+	console.log('Query result:', result);
+
+	// if (!result.Success) {
+	// 	throw new Error('An error occurred while creating the payment');
+	// }
+};

--- a/modules/zuora/src/query.ts
+++ b/modules/zuora/src/query.ts
@@ -4,13 +4,13 @@ import { queryResponseSchema } from '@modules/zuora/zuoraSchemas';
 
 export const doQuery = async (
 	zuoraClient: ZuoraClient,
+	query: string,
 ): Promise<QueryResponse> => {
 	console.log(`Querying zuora for invoice items...`);
 	const result = await zuoraClient.post(
 		'/v1/action/query',
 		JSON.stringify({
-			queryString:
-				"SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = 'A-S00424163' and ChargeName!='Delivery-problem credit' and ChargeName!='Holiday Credit' and ServiceStartDate = '2025-02-22' ",
+			queryString: query,
 		}),
 		queryResponseSchema,
 	);

--- a/modules/zuora/src/query.ts
+++ b/modules/zuora/src/query.ts
@@ -7,7 +7,7 @@ export const doQuery = async (zuoraClient: ZuoraClient): Promise<void> => {
 		'/v1/action/query',
 		JSON.stringify({
 			queryString:
-				"SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = 'A-S00424163' and ChargeName!='Delivery-problem credit' and ChargeName!='Holiday Credit' and ServiceStartDate = '2025-02-22'' ",
+				"SELECT ChargeAmount, TaxAmount, ServiceStartDate, SubscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = 'A-S00424163' and ChargeName!='Delivery-problem credit' and ChargeName!='Holiday Credit' and ServiceStartDate = '2025-02-22' ",
 		}),
 		invoiceItemResponseSchema,
 	);

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -149,26 +149,47 @@ export type ZuoraSuccessResponse = z.infer<typeof zuoraSuccessResponseSchema>;
 export type ZuoraUpperCaseSuccessResponse = z.infer<
 	typeof zuoraUpperCaseSuccessResponseSchema
 >;
+// --------------- Invoice Items ---------------
+export const getInvoiceSchema = z.object({
+	success: z.boolean(),
+	id: z.string(),
+	amount: z.number(),
+	amountWithoutTax: z.number(),
+});
 
+export type GetInvoiceResponse = z.infer<typeof getInvoiceSchema>;
+
+export const getInvoiceItemsSchema = z.object({
+	success: z.boolean(),
+	invoiceItems: z.array(
+		z.object({
+			id: z.string(),
+			productRatePlanChargeId: z.string(),
+		}),
+	),
+});
+
+export type GetInvoiceItemsResponse = z.infer<typeof getInvoiceItemsSchema>;
+
+export const invoiceItemSchema = z
+	.object({
+		id: z.optional(z.string()),
+		subscriptionName: z.string(),
+		serviceStartDate: z.coerce.date(),
+		serviceEndDate: z.coerce.date(),
+		chargeAmount: z.number(),
+		chargeName: z.string(),
+		taxAmount: z.number(),
+	})
+	.transform((item) => ({
+		...item,
+		paymentAmount: item.chargeAmount + item.taxAmount,
+	}));
 // --------------- Billing preview ---------------
+
 export const billingPreviewSchema = z.object({
 	accountId: z.string(),
-	invoiceItems: z.array(
-		z
-			.object({
-				id: z.optional(z.string()),
-				subscriptionName: z.string(),
-				serviceStartDate: z.coerce.date(),
-				serviceEndDate: z.coerce.date(),
-				chargeAmount: z.number(),
-				chargeName: z.string(),
-				taxAmount: z.number(),
-			})
-			.transform((item) => ({
-				...item,
-				paymentAmount: item.chargeAmount + item.taxAmount,
-			})),
-	),
+	invoiceItems: z.array(invoiceItemSchema),
 });
 
 export type BillingPreview = z.infer<typeof billingPreviewSchema>;
@@ -193,28 +214,6 @@ export const addDiscountPreviewSchema = z.object({
 });
 
 export type AddDiscountPreview = z.infer<typeof addDiscountPreviewSchema>;
-
-// --------------- Invoice Items ---------------
-export const getInvoiceSchema = z.object({
-	success: z.boolean(),
-	id: z.string(),
-	amount: z.number(),
-	amountWithoutTax: z.number(),
-});
-
-export type GetInvoiceResponse = z.infer<typeof getInvoiceSchema>;
-
-export const getInvoiceItemsSchema = z.object({
-	success: z.boolean(),
-	invoiceItems: z.array(
-		z.object({
-			id: z.string(),
-			productRatePlanChargeId: z.string(),
-		}),
-	),
-});
-
-export type GetInvoiceItemsResponse = z.infer<typeof getInvoiceItemsSchema>;
 
 // --------------- Invoice Item Adjustment ---------------
 export const invoiceItemAdjustmentResultSchema = z.object({

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -225,3 +225,20 @@ export const invoiceItemAdjustmentResultSchema = z.object({
 export type InvoiceItemAdjustmentResult = z.infer<
 	typeof invoiceItemAdjustmentResultSchema
 >;
+
+// --------------- query ---------------
+export const invoiceItemRecordSchema = z.object({
+	SubscriptionNumber: z.string(),
+	ChargeAmount: z.number(),
+	TaxAmount: z.number(),
+	ServiceStartDate: z.string(),
+});
+
+export const invoiceItemResponseSchema = z.object({
+	size: z.number(),
+	records: z.array(invoiceItemRecordSchema),
+	done: z.boolean(),
+});
+
+export type InvoiceItemRecord = z.infer<typeof invoiceItemRecordSchema>;
+export type InvoiceItemResponse = z.infer<typeof invoiceItemResponseSchema>;

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -234,11 +234,12 @@ export const invoiceItemRecordSchema = z.object({
 	ServiceStartDate: z.string(),
 });
 
-export const invoiceItemResponseSchema = z.object({
+export const queryResponseSchema = z.object({
 	size: z.number(),
 	records: z.array(invoiceItemRecordSchema),
 	done: z.boolean(),
 });
 
+//refine this
 export type InvoiceItemRecord = z.infer<typeof invoiceItemRecordSchema>;
-export type InvoiceItemResponse = z.infer<typeof invoiceItemResponseSchema>;
+export type QueryResponse = z.infer<typeof queryResponseSchema>;


### PR DESCRIPTION
## What does this change?
- add logic to determine if there will be another discount starting when the current discount finishes

<img width="612" alt="Screenshot 2025-03-04 at 15 25 08" src="https://github.com/user-attachments/assets/32e5a482-6011-46e6-a244-c04a907dc9a0" />


### Changes
- add logic to get the last payment date of the current discount, and the amount being paid
- evaluate the amount being paid against the amount that will be paid on the first payment date after the current discount ends
- if the amounts are the same, mark the record as ineligible for email send

### Coming up next
- testing the correctness of old payment amounts in production
- Probably we will need to tweak the logic a bit because if the last payment date for the current discount is in the future (of execution run), then we'll need to use the billing-preview to get the payment amount, rather than the query which is part of the changes in this PR. The query is good for payment dates in the past only.