### PR TITLE
Discount expiry notifier - update invoice item types

### DIFF
--- a/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
@@ -1,7 +1,7 @@
 import { stageFromEnvironment } from '@modules/stage';
 import { getBillingPreview } from '@modules/zuora/billingPreview';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { InvoiceItem } from '@modules/zuora/zuoraSchemas';
+import type { BillingPreviewInvoiceItem } from '@modules/zuora/zuoraSchemas';
 import dayjs from 'dayjs';
 import type { z } from 'zod';
 import { BaseRecordForEmailSendSchema } from '../types';
@@ -43,10 +43,10 @@ export const handler = async (event: GetNewPaymentAmountInput) => {
 };
 
 const filterRecords = (
-	invoiceItems: InvoiceItem[],
+	invoiceItems: BillingPreviewInvoiceItem[],
 	subscriptionName: string,
 	firstPaymentDateAfterDiscountExpiry: string,
-): InvoiceItem[] => {
+): BillingPreviewInvoiceItem[] => {
 	return invoiceItems.filter(
 		(item) =>
 			item.subscriptionName === subscriptionName &&
@@ -57,6 +57,8 @@ const filterRecords = (
 	);
 };
 
-const getNewPaymentAmount = (invoiceItems: InvoiceItem[]): number => {
+const getNewPaymentAmount = (
+	invoiceItems: BillingPreviewInvoiceItem[],
+): number => {
 	return invoiceItems.reduce((total, item) => total + item.paymentAmount, 0);
 };

--- a/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
@@ -60,5 +60,8 @@ const filterRecords = (
 const getNewPaymentAmount = (
 	invoiceItems: BillingPreviewInvoiceItem[],
 ): number => {
-	return invoiceItems.reduce((total, item) => total + item.paymentAmount, 0);
+	return invoiceItems.reduce(
+		(total, record) => total + record.chargeAmount + record.taxAmount,
+		0,
+	);
 };

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -204,8 +204,10 @@ export const getPastInvoiceItems = async (
 	subName: string,
 	targetDate: string,
 ): Promise<QueryInvoiceItem[]> => {
-	const getInvoiceItemsResponse = queryResponseSchema.parse(
-		await doQuery<QueryResponse>(zuoraClient, query(subName, targetDate)),
+	const getInvoiceItemsResponse = await doQuery<QueryResponse>(
+		zuoraClient,
+		query(subName, targetDate),
+		queryResponseSchema,
 	);
 	return getInvoiceItemsResponse.records;
 };
@@ -277,18 +279,13 @@ const transformZuoraResponseKeys = (
 	}));
 };
 
-export const queryInvoiceItemSchema = z
-	.object({
-		Id: z.optional(z.string()),
-		SubscriptionName: z.string(),
-		ServiceStartDate: z.coerce.date(),
-		ChargeAmount: z.number(),
-		TaxAmount: z.number(),
-	})
-	.transform((item) => ({
-		...item,
-		paymentAmount: item.ChargeAmount + item.TaxAmount,
-	}));
+export const queryInvoiceItemSchema = z.object({
+	Id: z.optional(z.string()),
+	SubscriptionName: z.string(),
+	ServiceStartDate: z.coerce.date(),
+	ChargeAmount: z.number(),
+	TaxAmount: z.number(),
+});
 export type QueryInvoiceItem = z.infer<typeof queryInvoiceItemSchema>;
 export const queryResponseSchema = z.object({
 	size: z.number(),

--- a/modules/zuora/src/query.ts
+++ b/modules/zuora/src/query.ts
@@ -1,9 +1,10 @@
+import type { z } from 'zod';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { queryResponseSchema } from '@modules/zuora/zuoraSchemas';
 
 export const doQuery = async <T>(
 	zuoraClient: ZuoraClient,
 	query: string,
+	queryResponseSchema: z.Schema<T>,
 ): Promise<T> => {
 	console.log('Querying zuora...');
 	console.log('Query:', query);

--- a/modules/zuora/src/query.ts
+++ b/modules/zuora/src/query.ts
@@ -1,11 +1,10 @@
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { QueryResponse } from '@modules/zuora/zuoraSchemas';
 import { queryResponseSchema } from '@modules/zuora/zuoraSchemas';
 
-export const doQuery = async (
+export const doQuery = async <T>(
 	zuoraClient: ZuoraClient,
 	query: string,
-): Promise<QueryResponse> => {
+): Promise<T> => {
 	console.log('Querying zuora...');
 	console.log('Query:', query);
 
@@ -17,5 +16,5 @@ export const doQuery = async (
 		queryResponseSchema,
 	);
 
-	return result as QueryResponse;
+	return result as T;
 };

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -171,33 +171,23 @@ export const getInvoiceItemsSchema = z.object({
 
 export type GetInvoiceItemsResponse = z.infer<typeof getInvoiceItemsSchema>;
 
-export const invoiceItemSchema = z
-	.object({
-		id: z.optional(z.string()),
-		subscriptionName: z.string(),
-		serviceStartDate: z.coerce.date(),
-		serviceEndDate: z.coerce.date(),
-		chargeAmount: z.number(),
-		chargeName: z.string(),
-		taxAmount: z.number(),
-	})
-	.transform((item) => ({
-		...item,
-		paymentAmount: item.chargeAmount + item.taxAmount,
-	}));
+export const invoiceItemSchema = z.object({
+	id: z.optional(z.string()),
+	subscriptionName: z.string(),
+	serviceStartDate: z.coerce.date(),
+	serviceEndDate: z.coerce.date(),
+	chargeAmount: z.number(),
+	chargeName: z.string(),
+	taxAmount: z.number(),
+});
 // --------------- Billing preview ---------------
-export const billingPreviewInvoiceItemSchema = z
-	.object({
-		id: z.optional(z.string()),
-		subscriptionName: z.string(),
-		serviceStartDate: z.coerce.date(),
-		chargeAmount: z.number(),
-		taxAmount: z.number(),
-	})
-	.transform((item) => ({
-		...item,
-		paymentAmount: item.chargeAmount + item.taxAmount,
-	}));
+export const billingPreviewInvoiceItemSchema = z.object({
+	id: z.optional(z.string()),
+	subscriptionName: z.string(),
+	serviceStartDate: z.coerce.date(),
+	chargeAmount: z.number(),
+	taxAmount: z.number(),
+});
 
 export const billingPreviewSchema = z.object({
 	accountId: z.string(),

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -186,14 +186,28 @@ export const invoiceItemSchema = z
 		paymentAmount: item.chargeAmount + item.taxAmount,
 	}));
 // --------------- Billing preview ---------------
+export const billingPreviewInvoiceItemSchema = z
+	.object({
+		id: z.optional(z.string()),
+		subscriptionName: z.string(),
+		serviceStartDate: z.coerce.date(),
+		chargeAmount: z.number(),
+		taxAmount: z.number(),
+	})
+	.transform((item) => ({
+		...item,
+		paymentAmount: item.chargeAmount + item.taxAmount,
+	}));
 
 export const billingPreviewSchema = z.object({
 	accountId: z.string(),
-	invoiceItems: z.array(invoiceItemSchema),
+	invoiceItems: z.array(billingPreviewInvoiceItemSchema),
 });
 
 export type BillingPreview = z.infer<typeof billingPreviewSchema>;
-export type InvoiceItem = BillingPreview['invoiceItems'][number];
+export type BillingPreviewInvoiceItem = z.infer<
+	typeof billingPreviewInvoiceItemSchema
+>;
 
 // --------------- Add discount preview ---------------
 export const addDiscountPreviewSchema = z.object({
@@ -224,13 +238,3 @@ export const invoiceItemAdjustmentResultSchema = z.object({
 export type InvoiceItemAdjustmentResult = z.infer<
 	typeof invoiceItemAdjustmentResultSchema
 >;
-
-// --------------- query ---------------
-//refine this, records will not always be of invoiceItemSchema type
-export const queryResponseSchema = z.object({
-	size: z.number(),
-	records: z.array(invoiceItemSchema),
-	done: z.boolean(),
-});
-
-export type QueryResponse = z.infer<typeof queryResponseSchema>;


### PR DESCRIPTION
## What does this change?
Reconcile the difference in invoice item types. The invoice item definition for records returned by the query is different than that of the records returned by the billing-preview endpoint, in that one has uppercase first letter attributes and one has lowercase. 

Changes in this PR:
- in zuoraSchemas.ts, transform InvoiceItem type to a BillingPreviewInvoiceItem type (different functionality requires different levels of specification i.e. different attributes when it comes to invoice items)
- Introduce QueryInvoiceItem which is a type for invoice item with only the fields required for the query, and is is defined locally.
- introduce a transformer function that converts query invoice item results (with uppercase first letter attribute names) to more BillingPreviewInvoiceItem. This is applicable only when using the query to get invoice items related to a target date in the past.
- remove the paymentAmount attribute, this was complicating things when performing transformations. I'm sure it was possible to keep, but it was just taking to long to figure out how to maintain it.

## How to test
Will test in production

### Notes
- We should decide on a common approach to defining our zuora object types. For example, should we have only one invoiceItem type that is shared across all scenarios that require it, and thus have a type with all invoice item attributes, or should we have an invoice item type specific to each scenario, and have its attributes defined as needed.