### PR TITLE
Discount expiry notifier - Use subscription name not subscription number

### DIFF
--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -220,7 +220,7 @@ export const calculateTotalAmount = (records: BillingPreviewInvoiceItem[]) => {
 };
 
 const query = (subName: string, serviceStartDate: string): string =>
-	`SELECT chargeAmount, taxAmount, serviceStartDate, subscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = '${subName}' AND ServiceStartDate = '${serviceStartDate}' AND ChargeName!='Delivery-problem credit' AND ChargeName!='Holiday Credit'`;
+	`SELECT chargeAmount, taxAmount, serviceStartDate, SubscriptionName FROM InvoiceItem WHERE SubscriptionName = '${subName}' AND ServiceStartDate = '${serviceStartDate}' AND ChargeName!='Delivery-problem credit' AND ChargeName!='Holiday Credit'`;
 
 export function getLastPaymentDateBeforeDiscountExpiry(
 	firstPaymentDateAfterDiscountExpiry: string,


### PR DESCRIPTION
## What does this change?
Ensure atteibute name is consistent across query and type definition