### PR TITLE
Discount expiry notifier - use sub number not sub name

### DIFF
--- a/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
@@ -44,12 +44,12 @@ export const handler = async (event: GetNewPaymentAmountInput) => {
 
 const filterRecords = (
 	invoiceItems: BillingPreviewInvoiceItem[],
-	subscriptionName: string,
+	subscriptionNumber: string,
 	firstPaymentDateAfterDiscountExpiry: string,
 ): BillingPreviewInvoiceItem[] => {
 	return invoiceItems.filter(
 		(item) =>
-			item.subscriptionName === subscriptionName &&
+			item.subscriptionNumber === subscriptionNumber &&
 			dayjs(item.serviceStartDate).isSame(
 				dayjs(firstPaymentDateAfterDiscountExpiry),
 				'day',

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -220,7 +220,7 @@ export const calculateTotalAmount = (records: BillingPreviewInvoiceItem[]) => {
 };
 
 const query = (subName: string, serviceStartDate: string): string =>
-	`SELECT chargeAmount, taxAmount, serviceStartDate, subscriptionNumber FROM InvoiceItem WHERE SubscriptionNumber = '${subName}' AND ServiceStartDate = '${serviceStartDate}' AND ChargeName!='Delivery-problem credit' AND ChargeName!='Holiday Credit'`;
+	`SELECT chargeAmount, taxAmount, serviceStartDate, subscriptionNumber FROM InvoiceItem WHERE subscriptionNumber = '${subName}' AND ServiceStartDate = '${serviceStartDate}' AND ChargeName!='Delivery-problem credit' AND ChargeName!='Holiday Credit'`;
 
 export function getLastPaymentDateBeforeDiscountExpiry(
 	firstPaymentDateAfterDiscountExpiry: string,

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -253,12 +253,12 @@ export function getLastPaymentDateBeforeDiscountExpiry(
 //this function is duplicated in getNewPaymentAmount.ts
 const filterRecords = (
 	invoiceItems: BillingPreviewInvoiceItem[],
-	subscriptionName: string,
+	subscriptionNumber: string,
 	firstPaymentDateAfterDiscountExpiry: string,
 ): BillingPreviewInvoiceItem[] => {
 	return invoiceItems.filter(
 		(item) =>
-			item.subscriptionName === subscriptionName &&
+			item.subscriptionNumber === subscriptionNumber &&
 			dayjs(item.serviceStartDate).isSame(
 				dayjs(firstPaymentDateAfterDiscountExpiry),
 				'day',
@@ -274,14 +274,14 @@ const transformZuoraResponseKeys = (
 		chargeAmount: record.ChargeAmount,
 		taxAmount: record.TaxAmount,
 		serviceStartDate: new Date(record.ServiceStartDate),
-		subscriptionName: record.SubscriptionName,
+		subscriptionNumber: record.subscriptionNumber,
 		paymentAmount: record.ChargeAmount + record.TaxAmount,
 	}));
 };
 
 export const queryInvoiceItemSchema = z.object({
 	Id: z.optional(z.string()),
-	SubscriptionName: z.string(),
+	subscriptionNumber: z.string(),
 	ServiceStartDate: z.coerce.date(),
 	ChargeAmount: z.number(),
 	TaxAmount: z.number(),

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -173,7 +173,7 @@ export type GetInvoiceItemsResponse = z.infer<typeof getInvoiceItemsSchema>;
 
 export const invoiceItemSchema = z.object({
 	id: z.optional(z.string()),
-	subscriptionName: z.string(),
+	subscriptionNumber: z.string(),
 	serviceStartDate: z.coerce.date(),
 	serviceEndDate: z.coerce.date(),
 	chargeAmount: z.number(),
@@ -183,7 +183,7 @@ export const invoiceItemSchema = z.object({
 // --------------- Billing preview ---------------
 export const billingPreviewInvoiceItemSchema = z.object({
 	id: z.optional(z.string()),
-	subscriptionName: z.string(),
+	subscriptionNumber: z.string(),
 	serviceStartDate: z.coerce.date(),
 	chargeAmount: z.number(),
 	taxAmount: z.number(),


### PR DESCRIPTION
## What does this change?
SubscriptionName does not exist for querying (although it does exist on billing-preview response), so we should use subscriptionNumber which exists on both query response and billing-preview response