### PR TITLE
Discount expiry notifier - add a retry for failure on getExpiringDiscounts lambda

### DIFF
--- a/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
@@ -549,7 +549,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
           "Fn::Join": [
             "",
             [
-              "{"StartAt":"Get expiring discounts","States":{"Get expiring discounts":{"Next":"Filter records by region","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "{"StartAt":"Get expiring discounts","States":{"Get expiring discounts":{"Next":"Filter records by region","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -3129,7 +3129,7 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
           "Fn::Join": [
             "",
             [
-              "{"StartAt":"Get expiring discounts","States":{"Get expiring discounts":{"Next":"Filter records by region","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "{"StartAt":"Get expiring discounts","States":{"Get expiring discounts":{"Next":"Filter records by region","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/discount-expiry-notifier.ts
+++ b/cdk/lib/discount-expiry-notifier.ts
@@ -239,7 +239,11 @@ export class DiscountExpiryNotifier extends GuStack {
 				lambdaFunction: getExpiringDiscountsLambda,
 				outputPath: '$.Payload',
 			},
-		);
+		).addRetry({
+			errors: ['States.ALL'],
+			interval: Duration.seconds(10),
+			maxAttempts: 2, // Retry only once (1 initial attempt + 1 retry)
+		});
 
 		const filterRecordsLambdaTask = new LambdaInvoke(
 			this,


### PR DESCRIPTION
## What does this change?
Add an automatic retry is getExpiringDiscounts lambda fails, as sometimes happens due to a query timeout, and then is successful when reran

![image](https://github.com/user-attachments/assets/09e9817f-cbd7-4d22-a107-3f135ed8d714)

### Notes
A better solution would be to optimise the query. We should do this when time allows.