### PR TITLE
update AWS sdk v2 version to latest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbtassembly.AssemblyPlugin.autoImport.{MergeStrategy, assemblyMergeStrate
 import sbtassembly.PathList
 
 object Dependencies {
-  val awsSdkVersion = "2.27.24"
+  val awsSdkVersion = "2.31.1"
   val circeVersion = "0.14.10"
   val sttpVersion = "3.10.1"
   val http4sVersion = "0.22.15" // keep version 0.22.15, later versions pull in cats effect 3 which is not compatible


### PR DESCRIPTION
we need the latest version of netty to avoid https://github.com/advisories/GHSA-4g8c-wm8x-jfhw