### PR TITLE
Remove 4XX alarm from user-benefits api

### DIFF
--- a/_templates/new-lambda/api-gateway/cdk-lib.ejs.t
+++ b/_templates/new-lambda/api-gateway/cdk-lib.ejs.t
@@ -95,35 +95,6 @@ export class <%= PascalCase %> extends GuStack {
 		usagePlan.addApiKey(apiKey);
 	<% } %>
 
-		// ---- Alarms ---- //
-		const alarmName = (shortDescription: string) =>
-			`<%= lambdaName %>-${this.stage} ${shortDescription}`;
-
-		const alarmDescription = (description: string) =>
-			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
-
-		new GuAlarm(this, 'ApiGateway4XXAlarmCDK', {
-			app,
-			alarmName: alarmName('API gateway 4XX response'),
-			alarmDescription: alarmDescription(
-				'<%= h.changeCase.sentenceCase(lambdaName) %> received an invalid request',
-			),
-			evaluationPeriods: 1,
-			threshold: 1,
-			snsTopicName: `alarms-handler-topic-${this.stage}`,
-			actionsEnabled: this.stage === 'PROD',
-			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-			metric: new Metric({
-				metricName: '4XXError',
-				namespace: 'AWS/ApiGateway',
-				statistic: 'Sum',
-				period: Duration.seconds(300),
-				dimensionsMap: {
-					ApiName: nameWithStage,
-				},
-			}),
-		});
-
 		// ---- DNS ---- //
 		const certificateArn = `arn:aws:acm:eu-west-1:${this.account}:certificate/${props.certificateId}`;
 		const cfnDomainName = new CfnDomainName(this, 'DomainName', {

--- a/cdk/lib/__snapshots__/user-benefits.test.ts.snap
+++ b/cdk/lib/__snapshots__/user-benefits.test.ts.snap
@@ -10,7 +10,6 @@ exports[`The User benefits stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
       "GuApiGateway5xxPercentageAlarm",
-      "GuAlarm",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -51,45 +50,6 @@ exports[`The User benefits stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "ApiGateway4XXAlarmCDKC83EACCA": {
-      "Properties": {
-        "ActionsEnabled": false,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "Impact - User benefits received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "user-benefits-CODE API gateway 4XX response",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "ApiName",
-            "Value": "membership-CODE-user-benefits",
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "4XXError",
-        "Namespace": "AWS/ApiGateway",
-        "Period": 300,
-        "Statistic": "Sum",
-        "Threshold": 1,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "ApiGatewayHigh5xxPercentageAlarmUserbenefitsB3A2F7F7": {
       "Properties": {
         "ActionsEnabled": true,
@@ -1811,7 +1771,6 @@ exports[`The User benefits stack matches the snapshot 2`] = `
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
       "GuApiGateway5xxPercentageAlarm",
-      "GuAlarm",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -1852,45 +1811,6 @@ exports[`The User benefits stack matches the snapshot 2`] = `
     },
   },
   "Resources": {
-    "ApiGateway4XXAlarmCDKC83EACCA": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "Impact - User benefits received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "user-benefits-PROD API gateway 4XX response",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "ApiName",
-            "Value": "membership-PROD-user-benefits",
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "4XXError",
-        "Namespace": "AWS/ApiGateway",
-        "Period": 300,
-        "Statistic": "Sum",
-        "Threshold": 1,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "ApiGatewayHigh5xxPercentageAlarmUserbenefitsB3A2F7F7": {
       "Properties": {
         "ActionsEnabled": true,


### PR DESCRIPTION
## What does this change?
This PR removes the 4XX alarm for the user-benefits API - It is expected that we will return a 401 response for any request where the user's JWT token has expired. This will happen many times a day so there is no value in alarming on it.

I have also removed the 4XX alarm from the Hygen templates which we use to generate new lambdas. This is because we seem to always end up removing them anyway so there is no point generating them in the first place.
