### PR TITLE
Discount expiry notifier - only send error notifications for error scenarios

### DIFF
--- a/handlers/discount-expiry-notifier/src/handlers/alarmOnFailures.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/alarmOnFailures.ts
@@ -46,7 +46,7 @@ export const handler = async (event: AlarmOnFailuresInput) => {
 	return {};
 };
 
-const shouldSendErrorNotification = async (
+export const shouldSendErrorNotification = async (
 	discountProcessingAttempts: DiscountProcessingAttempt[],
 	s3UploadAttemptStatus: string,
 ): Promise<boolean> => {
@@ -54,7 +54,7 @@ const shouldSendErrorNotification = async (
 		s3UploadAttemptStatus === 'error' ||
 		discountProcessingAttempts.some(
 			(attempt) =>
-				attempt.emailSendAttempt.response?.status === 'skipped' &&
+				!attempt.emailSendEligibility.isEligible &&
 				ERROR_NOTIFICATION_REASONS.includes(
 					attempt.emailSendEligibility.ineligibilityReason,
 				),

--- a/handlers/discount-expiry-notifier/test/handlers/alarmOnFailures.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/alarmOnFailures.test.ts
@@ -1,0 +1,130 @@
+import { shouldSendErrorNotification } from '../../src/handlers/alarmOnFailures';
+import type { DiscountProcessingAttempt } from '../../src/types';
+
+describe('shouldSendErrorNotification', () => {
+	it('returns true when s3UploadAttemptStatus is "error"', async () => {
+		const discountProcessingAttempts: DiscountProcessingAttempt[] = [];
+		const s3UploadAttemptStatus = 'error';
+		const result = await shouldSendErrorNotification(
+			discountProcessingAttempts,
+			s3UploadAttemptStatus,
+		);
+		expect(result).toBe(true);
+	});
+
+	it('returns true when a discountProcessingAttempt isEligible is false and ineligibilityReason that warrants error notification', async () => {
+		const discountProcessingAttempts: DiscountProcessingAttempt[] = [
+			{
+				emailSendAttempt: {
+					response: { status: 'skipped' },
+				},
+				emailSendEligibility: {
+					ineligibilityReason: 'Error getting sub status from Zuora',
+					isEligible: false,
+				},
+				record: {
+					billingAccountId: '12345',
+					firstName: 'John',
+					firstPaymentDateAfterDiscountExpiry: '2023-01-01',
+					paymentCurrency: 'USD',
+					paymentFrequency: 'Monthly',
+					productName: 'Supporter Plus',
+					sfContactId: '67890',
+					zuoraSubName: 'A-S12345678',
+					workEmail: 'abc123@guardian.co.uk',
+					contactCountry: 'United States',
+					sfBuyerContactMailingCountry: 'United States',
+					sfBuyerContactOtherCountry: 'United States',
+					sfRecipientContactMailingCountry: 'United States',
+					sfRecipientContactOtherCountry: 'United States',
+					subStatus: 'active',
+					errorDetail: undefined,
+				},
+			},
+		];
+		const s3UploadAttemptStatus = 'success';
+		const result = await shouldSendErrorNotification(
+			discountProcessingAttempts,
+			s3UploadAttemptStatus,
+		);
+		expect(result).toBe(true);
+	});
+
+	it('returns false when no errors occurred and it was eligible for email send', async () => {
+		const discountProcessingAttempts: DiscountProcessingAttempt[] = [
+			{
+				emailSendAttempt: {
+					response: { status: 'success' },
+				},
+				emailSendEligibility: {
+					ineligibilityReason: '',
+					isEligible: true,
+				},
+				record: {
+					billingAccountId: '12345',
+					firstName: 'John',
+					firstPaymentDateAfterDiscountExpiry: '2023-01-01',
+					paymentCurrency: 'USD',
+					paymentFrequency: 'Monthly',
+					productName: 'Supporter Plus',
+					sfContactId: '67890',
+					zuoraSubName: 'A-S12345678',
+					workEmail: 'abc123@guardian.co.uk',
+					contactCountry: 'United States',
+					sfBuyerContactMailingCountry: 'United States',
+					sfBuyerContactOtherCountry: 'United States',
+					sfRecipientContactMailingCountry: 'United States',
+					sfRecipientContactOtherCountry: 'United States',
+					subStatus: 'active',
+					errorDetail: undefined,
+				},
+			},
+		];
+		const s3UploadAttemptStatus = 'success';
+		const result = await shouldSendErrorNotification(
+			discountProcessingAttempts,
+			s3UploadAttemptStatus,
+		);
+		expect(result).toBe(false);
+	});
+
+	it('returns false when ineligibilityReason is not one of error notification reasons', async () => {
+		const discountProcessingAttempts: DiscountProcessingAttempt[] = [
+			{
+				emailSendAttempt: {
+					response: { status: 'success' },
+				},
+				emailSendEligibility: {
+					ineligibilityReason: 'Subscription status is cancelled',
+					isEligible: false,
+				},
+				record: {
+					billingAccountId: '12345',
+					firstName: 'John',
+					firstPaymentDateAfterDiscountExpiry: '2023-01-01',
+					paymentCurrency: 'USD',
+					paymentFrequency: 'Monthly',
+					productName: 'Supporter Plus',
+					sfContactId: '67890',
+					zuoraSubName: 'A-S12345678',
+					workEmail: 'abc123@guardian.co.uk',
+					contactCountry: 'United States',
+					sfBuyerContactMailingCountry: 'United States',
+					sfBuyerContactOtherCountry: 'United States',
+					sfRecipientContactMailingCountry: 'United States',
+					sfRecipientContactOtherCountry: 'United States',
+					subStatus: 'active',
+					errorDetail: undefined,
+				},
+			},
+		];
+		const s3UploadAttemptStatus = 'success';
+
+		const result = await shouldSendErrorNotification(
+			discountProcessingAttempts,
+			s3UploadAttemptStatus,
+		);
+
+		expect(result).toBe(false);
+	});
+});

--- a/handlers/discount-expiry-notifier/test/handlers/alarmOnFailures.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/alarmOnFailures.test.ts
@@ -12,7 +12,7 @@ describe('shouldSendErrorNotification', () => {
 		expect(result).toBe(true);
 	});
 
-	it('returns true when a discountProcessingAttempt isEligible is false and ineligibilityReason that warrants error notification', async () => {
+	it('returns true when a discountProcessingAttempt isEligible is false and ineligibilityReason is one of error notification reasons', async () => {
 		const discountProcessingAttempts: DiscountProcessingAttempt[] = [
 			{
 				emailSendAttempt: {


### PR DESCRIPTION
## What does this change?
Refine the criteria for firing an alarm. Previously we were firing an alarm if any of the following criteria were met, for any customer in the cohort of expiring discounts:

1. sub had been cancelled 
2. the old payment amount and the new payment amount are the same
3. work email was null
4. error getting sub status from Zuora

It's been decided that we don't need to be notified when a sub has been cancelled or when the old payment amount and the new payment amount are the same.

## Testing
- automated tests have been added to test this expected behaviours