### PR TITLE
infra: grant read access to Airflow Cloud Composer to Unifida's publi…

### DIFF
--- a/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
+++ b/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
@@ -105,6 +105,41 @@ exports[`The ObserverDataExport stack matches the snapshot 1`] = `
                 },
               ],
             },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Ref": "observerdataexportairflowcloudcomposeruserarn",
+                },
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/Public_keys/unifida_public_rsa_key.pem",
+                    ],
+                  ],
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -494,6 +529,41 @@ exports[`The ObserverDataExport stack matches the snapshot 2`] = `
                         ],
                       },
                       "/Observer_newsletter_eligible/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Ref": "observerdataexportairflowcloudcomposeruserarn",
+                },
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/Public_keys/unifida_public_rsa_key.pem",
                     ],
                   ],
                 },

--- a/cdk/lib/observer-data-export.ts
+++ b/cdk/lib/observer-data-export.ts
@@ -39,6 +39,11 @@ export class ObserverDataExport extends GuStack {
 			`Observer_newsletter_eligible/*`,
 		);
 
+		bucket.grantRead(
+			new ArnPrincipal(airflowCloudComposerUserArnParameter.valueAsString),
+			`Public_keys/unifida_public_rsa_key.pem`,
+		);
+
 		const lambdaDefaultConfig: Pick<
 			GuFunctionProps,
 			'app' | 'memorySize' | 'fileName' | 'runtime' | 'timeout' | 'environment'


### PR DESCRIPTION
## What does this change?

The cloud composer user needs access to Unifida's public RSA key (Tortoise's dev team) to be able to encrypt the AES key used to encrypt export files.