### PR TITLE
`soft-opt-in-consent-setter` CDK Migration (1)

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -23,6 +23,7 @@ jobs:
           - new-product-api
           - single-contribution-salesforce-writes
           - stripe-webhook-endpoints
+          - soft-opt-in-consent-setter
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -100,7 +101,6 @@ jobs:
           - sf-emails-to-s3-exporter
           - sf-gocardless-sync
           - sf-move-subscriptions-api
-          - soft-opt-in-consent-setter
           - zuora-callout-apis
           - zuora-datalake-export
           - zuora-rer

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -24,6 +24,7 @@ import { TicketTailorWebhook } from '../lib/ticket-tailor-webhook';
 import { UpdateSupporterPlusAmount } from '../lib/update-supporter-plus-amount';
 import { UserBenefits } from '../lib/user-benefits';
 import { ZuoraSalesforceLinkRemover } from '../lib/zuora-salesforce-link-remover';
+import { SoftOptInConsentSetter } from '../lib/soft-opt-in-consent-setter';
 
 const app = new App();
 const membershipHostedZoneId = 'Z1E4V12LQGXFEC';
@@ -59,6 +60,15 @@ export const prodProps: NewProductApiProps = {
 	fulfilmentDateCalculatorS3Resource:
 		'arn:aws:s3:::fulfilment-date-calculator-prod/*',
 };
+
+new SoftOptInConsentSetter(app, 'soft-opt-in-consent-setter-CODE', {
+	stack: "membership",
+	stage: "CODE"
+});
+new SoftOptInConsentSetter(app, 'soft-opt-in-consent-setter-PROD', {
+	stack: "membership",
+	stage: "PROD"
+});
 
 new BatchEmailSender(app, 'batch-email-sender-CODE', {
 	stack: 'membership',

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -62,12 +62,12 @@ export const prodProps: NewProductApiProps = {
 };
 
 new SoftOptInConsentSetter(app, 'soft-opt-in-consent-setter-CODE', {
-	stack: "membership",
-	stage: "CODE"
+	stack: 'membership',
+	stage: 'CODE',
 });
 new SoftOptInConsentSetter(app, 'soft-opt-in-consent-setter-PROD', {
-	stack: "membership",
-	stage: "PROD"
+	stack: 'membership',
+	stage: 'PROD',
 });
 
 new BatchEmailSender(app, 'batch-email-sender-CODE', {

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -18,13 +18,13 @@ import {
 	APP_NAME as SINGLE_CONTRIBUTION_SALESFORCE_WRITES_APP_NAME,
 	SingleContributionSalesforceWrites,
 } from '../lib/single-contribution-salesforce-writes';
+import { SoftOptInConsentSetter } from '../lib/soft-opt-in-consent-setter';
 import type { StripeWebhookEndpointsProps } from '../lib/stripe-webhook-endpoints';
 import { StripeWebhookEndpoints } from '../lib/stripe-webhook-endpoints';
 import { TicketTailorWebhook } from '../lib/ticket-tailor-webhook';
 import { UpdateSupporterPlusAmount } from '../lib/update-supporter-plus-amount';
 import { UserBenefits } from '../lib/user-benefits';
 import { ZuoraSalesforceLinkRemover } from '../lib/zuora-salesforce-link-remover';
-import { SoftOptInConsentSetter } from '../lib/soft-opt-in-consent-setter';
 
 const app = new App();
 const membershipHostedZoneId = 'Z1E4V12LQGXFEC';

--- a/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
+++ b/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
@@ -55,9 +55,9 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
   "Resources": {
     "LambdaFunction": {
       "Properties": {
-        "CodeUri": {
-          "Bucket": "support-service-lambdas-dist",
-          "Key": {
+        "Code": {
+          "S3Bucket": "support-service-lambdas-dist",
+          "S3Key": {
             "Fn::Sub": "membership/\${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar",
           },
         },
@@ -70,89 +70,49 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
             "sfApiVersion": "v46.0",
           },
         },
-        "Events": {
-          "ScheduledRun": {
-            "Properties": {
-              "Description": "Runs Soft Opt-In Consent Setter",
-              "Enabled": true,
-              "Schedule": {
-                "Fn::FindInMap": [
-                  "StageMap",
-                  {
-                    "Ref": "Stage",
-                  },
-                  "Schedule",
-                ],
-              },
-            },
-            "Type": "Schedule",
-          },
-        },
         "FunctionName": {
           "Fn::Sub": "soft-opt-in-consent-setter-\${Stage}",
         },
         "Handler": "com.gu.soft_opt_in_consent_setter.Handler::handleRequest",
         "MemorySize": 512,
-        "Policies": [
+        "Role": {
+          "Fn::GetAtt": [
+            "LambdaFunctionRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
           {
-            "Statement": [
-              {
-                "Action": "cloudwatch:PutMetricData",
-                "Effect": "Allow",
-                "Resource": "*",
-              },
-            ],
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
           },
           {
-            "Statement": [
-              {
-                "Action": "s3:GetObject",
-                "Effect": "Allow",
-                "Resource": [
-                  "arn:aws:s3::*:membership-dist/*",
-                ],
-                "Sid": "readDeployedArtefact",
-              },
-            ],
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
           },
           {
-            "Statement": [
-              {
-                "Action": [
-                  "secretsmanager:DescribeSecret",
-                  "secretsmanager:GetSecretValue",
-                ],
-                "Effect": "Allow",
-                "Resource": [
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H",
-                ],
-              },
-            ],
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
           },
         ],
-        "Runtime": "java11",
-        "Tags": {
-          "Stack": "membership",
-          "Stage": "TEST",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/support-service-lambdas",
-        },
         "Timeout": 900,
       },
-      "Type": "AWS::Serverless::Function",
+      "Type": "AWS::Lambda::Function",
     },
     "LambdaFunctionIAP": {
       "Properties": {
-        "CodeUri": {
-          "Bucket": "support-service-lambdas-dist",
-          "Key": {
+        "Code": {
+          "S3Bucket": "support-service-lambdas-dist",
+          "S3Key": {
             "Fn::Sub": "membership/\${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar",
           },
         },
@@ -170,89 +130,313 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
         },
         "Handler": "com.gu.soft_opt_in_consent_setter.HandlerIAP::handleRequest",
         "MemorySize": 512,
-        "Policies": [
-          "AWSLambdaBasicExecutionRole",
+        "Role": {
+          "Fn::GetAtt": [
+            "LambdaFunctionIAPRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
           {
-            "Statement": [
-              {
-                "Action": [
-                  "dynamodb:PutItem",
-                ],
-                "Effect": "Allow",
-                "Resource": [
-                  {
-                    "Fn::Sub": "arn:aws:dynamodb:\${AWS::Region}:\${AWS::AccountId}:table/soft-opt-in-consent-setter-\${Stage}-logging",
-                  },
-                ],
-              },
-            ],
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
           },
           {
-            "Statement": [
-              {
-                "Action": "cloudwatch:PutMetricData",
-                "Effect": "Allow",
-                "Resource": "*",
-              },
-            ],
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
           },
           {
-            "Statement": [
-              {
-                "Action": "s3:GetObject",
-                "Effect": "Allow",
-                "Resource": [
-                  "arn:aws:s3::*:membership-dist/*",
-                ],
-                "Sid": "readDeployedArtefact",
-              },
-            ],
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
           },
           {
-            "Statement": {
-              "Action": [
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": "SoftOptInsQueue.Arn",
-              },
-            },
+            "Key": "Stack",
+            "Value": "membership",
           },
           {
-            "Statement": [
-              {
-                "Action": [
-                  "secretsmanager:DescribeSecret",
-                  "secretsmanager:GetSecretValue",
-                ],
-                "Effect": "Allow",
-                "Resource": [
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN",
-                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H",
-                ],
-              },
-            ],
+            "Key": "Stage",
+            "Value": "TEST",
           },
         ],
-        "Runtime": "java11",
-        "Tags": {
-          "Stack": "membership",
-          "Stage": "TEST",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/support-service-lambdas",
-        },
         "Timeout": 300,
       },
-      "Type": "AWS::Serverless::Function",
+      "Type": "AWS::Lambda::Function",
+    },
+    "LambdaFunctionIAPRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "dynamodb:PutItem",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:aws:dynamodb:\${AWS::Region}:\${AWS::AccountId}:table/soft-opt-in-consent-setter-\${Stage}-logging",
+                    },
+                  ],
+                },
+              ],
+            },
+            "PolicyName": "LambdaFunctionIAPRolePolicy1",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "cloudwatch:PutMetricData",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+            },
+            "PolicyName": "LambdaFunctionIAPRolePolicy2",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:s3::*:membership-dist/*",
+                  ],
+                  "Sid": "readDeployedArtefact",
+                },
+              ],
+            },
+            "PolicyName": "LambdaFunctionIAPRolePolicy3",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Action": [
+                  "sqs:DeleteMessage",
+                  "sqs:GetQueueAttributes",
+                  "sqs:ReceiveMessage",
+                ],
+                "Effect": "Allow",
+                "Resource": {
+                  "Fn::GetAtt": "SoftOptInsQueue.Arn",
+                },
+              },
+            },
+            "PolicyName": "LambdaFunctionIAPRolePolicy4",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "secretsmanager:DescribeSecret",
+                    "secretsmanager:GetSecretValue",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H",
+                  ],
+                },
+              ],
+            },
+            "PolicyName": "LambdaFunctionIAPRolePolicy5",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "cloudwatch:PutMetricData",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+            },
+            "PolicyName": "LambdaFunctionRolePolicy0",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:s3::*:membership-dist/*",
+                  ],
+                  "Sid": "readDeployedArtefact",
+                },
+              ],
+            },
+            "PolicyName": "LambdaFunctionRolePolicy1",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "secretsmanager:DescribeSecret",
+                    "secretsmanager:GetSecretValue",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN",
+                    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H",
+                  ],
+                },
+              ],
+            },
+            "PolicyName": "LambdaFunctionRolePolicy2",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LambdaFunctionScheduledRun": {
+      "Properties": {
+        "Description": "Runs Soft Opt-In Consent Setter",
+        "ScheduleExpression": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "Schedule",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "LambdaFunction",
+                "Arn",
+              ],
+            },
+            "Id": "LambdaFunctionScheduledRunLambdaTarget",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "LambdaFunctionScheduledRunPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "LambdaFunction",
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "LambdaFunctionScheduledRun",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "SQSTrigger": {
       "Properties": {
@@ -637,6 +821,5 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
       "Type": "AWS::CloudWatch::Alarm",
     },
   },
-  "Transform": "AWS::Serverless-2016-10-31",
 }
 `;

--- a/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
+++ b/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
@@ -1,0 +1,642 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
+{
+  "Conditions": {
+    "IsProd": {
+      "Fn::Equals": [
+        {
+          "Ref": "Stage",
+        },
+        "PROD",
+      ],
+    },
+  },
+  "Mappings": {
+    "StageMap": {
+      "CODE": {
+        "AppName": "AwsConnectorSandbox",
+        "IdentityStage": "CODE",
+        "MpapiStage": "CODE",
+        "SalesforceStage": "CODE",
+        "SalesforceUsername": "SoftOptInConsentSetterAPIUser",
+        "Schedule": "rate(365 days)",
+      },
+      "PROD": {
+        "AppName": "TouchpointUpdate",
+        "IdentityStage": "PROD",
+        "MpapiStage": "PROD",
+        "SalesforceStage": "PROD",
+        "SalesforceUsername": "SoftOptInConsentSetterAPIUser",
+        "Schedule": "rate(30 minutes)",
+      },
+    },
+  },
+  "Metadata": {
+    "gu:cdk:constructs": [],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "MobileAccountId": {
+      "Default": "mobileAccountId",
+      "Description": "The AWS Account ID of the mobile account",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "Stage": {
+      "AllowedValues": [
+        "PROD",
+        "CODE",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "LambdaFunction": {
+      "Properties": {
+        "CodeUri": {
+          "Bucket": "support-service-lambdas-dist",
+          "Key": {
+            "Fn::Sub": "membership/\${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar",
+          },
+        },
+        "Description": "Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation of Subscriptions in Salesforce",
+        "Environment": {
+          "Variables": {
+            "Stage": {
+              "Ref": "Stage",
+            },
+            "sfApiVersion": "v46.0",
+          },
+        },
+        "Events": {
+          "ScheduledRun": {
+            "Properties": {
+              "Description": "Runs Soft Opt-In Consent Setter",
+              "Enabled": true,
+              "Schedule": {
+                "Fn::FindInMap": [
+                  "StageMap",
+                  {
+                    "Ref": "Stage",
+                  },
+                  "Schedule",
+                ],
+              },
+            },
+            "Type": "Schedule",
+          },
+        },
+        "FunctionName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-\${Stage}",
+        },
+        "Handler": "com.gu.soft_opt_in_consent_setter.Handler::handleRequest",
+        "MemorySize": 512,
+        "Policies": [
+          {
+            "Statement": [
+              {
+                "Action": "cloudwatch:PutMetricData",
+                "Effect": "Allow",
+                "Resource": "*",
+              },
+            ],
+          },
+          {
+            "Statement": [
+              {
+                "Action": "s3:GetObject",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:aws:s3::*:membership-dist/*",
+                ],
+                "Sid": "readDeployedArtefact",
+              },
+            ],
+          },
+          {
+            "Statement": [
+              {
+                "Action": [
+                  "secretsmanager:DescribeSecret",
+                  "secretsmanager:GetSecretValue",
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H",
+                ],
+              },
+            ],
+          },
+        ],
+        "Runtime": "java11",
+        "Tags": {
+          "Stack": "membership",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/support-service-lambdas",
+        },
+        "Timeout": 900,
+      },
+      "Type": "AWS::Serverless::Function",
+    },
+    "LambdaFunctionIAP": {
+      "Properties": {
+        "CodeUri": {
+          "Bucket": "support-service-lambdas-dist",
+          "Key": {
+            "Fn::Sub": "membership/\${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar",
+          },
+        },
+        "Description": "Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation of Subscriptions based on a queue populated by Salesforce and the Mobile Purchases API",
+        "Environment": {
+          "Variables": {
+            "Stage": {
+              "Ref": "Stage",
+            },
+            "sfApiVersion": "v56.0",
+          },
+        },
+        "FunctionName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-IAP-\${Stage}",
+        },
+        "Handler": "com.gu.soft_opt_in_consent_setter.HandlerIAP::handleRequest",
+        "MemorySize": 512,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole",
+          {
+            "Statement": [
+              {
+                "Action": [
+                  "dynamodb:PutItem",
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                  {
+                    "Fn::Sub": "arn:aws:dynamodb:\${AWS::Region}:\${AWS::AccountId}:table/soft-opt-in-consent-setter-\${Stage}-logging",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Statement": [
+              {
+                "Action": "cloudwatch:PutMetricData",
+                "Effect": "Allow",
+                "Resource": "*",
+              },
+            ],
+          },
+          {
+            "Statement": [
+              {
+                "Action": "s3:GetObject",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:aws:s3::*:membership-dist/*",
+                ],
+                "Sid": "readDeployedArtefact",
+              },
+            ],
+          },
+          {
+            "Statement": {
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:ReceiveMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": "SoftOptInsQueue.Arn",
+              },
+            },
+          },
+          {
+            "Statement": [
+              {
+                "Action": [
+                  "secretsmanager:DescribeSecret",
+                  "secretsmanager:GetSecretValue",
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN",
+                  "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H",
+                ],
+              },
+            ],
+          },
+        ],
+        "Runtime": "java11",
+        "Tags": {
+          "Stack": "membership",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/support-service-lambdas",
+        },
+        "Timeout": 300,
+      },
+      "Type": "AWS::Serverless::Function",
+    },
+    "SQSTrigger": {
+      "Properties": {
+        "BatchSize": 1,
+        "Enabled": true,
+        "EventSourceArn": {
+          "Fn::GetAtt": "SoftOptInsQueue.Arn",
+        },
+        "FunctionName": {
+          "Ref": "LambdaFunctionIAP",
+        },
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "SoftOptInsDeadLetterQueue": {
+      "Properties": {
+        "MessageRetentionPeriod": 864000,
+        "QueueName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-dead-letter-queue-\${Stage}",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "SoftOptInsLoggingTable": {
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "timestamp",
+            "AttributeType": "N",
+          },
+          {
+            "AttributeName": "identityId",
+            "AttributeType": "S",
+          },
+          {
+            "AttributeName": "subscriptionId",
+            "AttributeType": "S",
+          },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "subscriptionId-index",
+            "KeySchema": [
+              {
+                "AttributeName": "subscriptionId",
+                "KeyType": "HASH",
+              },
+            ],
+            "Projection": {
+              "ProjectionType": "ALL",
+            },
+          },
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "identityId",
+            "KeyType": "HASH",
+          },
+          {
+            "AttributeName": "timestamp",
+            "KeyType": "RANGE",
+          },
+        ],
+        "PointInTimeRecoverySpecification": {
+          "PointInTimeRecoveryEnabled": true,
+        },
+        "SSESpecification": {
+          "SSEEnabled": true,
+        },
+        "TableName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-\${Stage}-logging",
+        },
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+    },
+    "SoftOptInsQueue": {
+      "Properties": {
+        "QueueName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-queue-\${Stage}",
+        },
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": "SoftOptInsDeadLetterQueue.Arn",
+          },
+          "maxReceiveCount": 3,
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VisibilityTimeout": 3000,
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "SoftOptInsQueueCrossAccountRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Sub": "\${MobileAccountId}",
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:SendMessage",
+                    "sqs:ReceiveMessage",
+                    "sqs:DeleteMessage",
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": "SoftOptInsQueue.Arn",
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "SQSAccess",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "\${AWS::StackName}-QueueCrossAccountRole",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "deadLetterBuildUpAlarmIAP": {
+      "Condition": "IsProd",
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-PROD",
+          },
+        ],
+        "AlarmDescription": "Five or more runs found an error and were unable to complete. See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm for possible causes, impacts and fixes.
+",
+        "AlarmName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-IAP-\${Stage} failed to run and sent the message to the dead letter queue.",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": "SoftOptInsDeadLetterQueue.QueueName",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "exceptionsAlarmIAP": {
+      "Condition": "IsProd",
+      "DependsOn": [
+        "LambdaFunctionIAP",
+      ],
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-PROD",
+          },
+        ],
+        "AlarmDescription": "Five or more runs found an error and were unable to complete. See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm for possible causes, impacts and fixes.
+",
+        "AlarmName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-IAP-\${Stage} threw an exception",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "LambdaFunctionIAP",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failedDynamoUpdateAlarm": {
+      "Condition": "IsProd",
+      "DependsOn": [
+        "LambdaFunction",
+      ],
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-PROD",
+          },
+        ],
+        "AlarmDescription": "A run failed to update (some) records in Salesforce in the last hour. See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedUpdateAlarm for possible causes, impacts and fixes.
+",
+        "AlarmName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-\${Stage} failed to update the Dynamo logging table.",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "Stage",
+            "Value": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "failed_dynamo_update",
+        "Namespace": "soft-opt-in-consent-setter",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failedRunAlarm": {
+      "Condition": "IsProd",
+      "DependsOn": [
+        "LambdaFunction",
+      ],
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-PROD",
+          },
+        ],
+        "AlarmDescription": "Five or more runs found an error and were unable to complete. See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm for possible causes, impacts and fixes.
+",
+        "AlarmName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-\${Stage} failed to run",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "LambdaFunction",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failedUpdateAlarm": {
+      "Condition": "IsProd",
+      "DependsOn": [
+        "LambdaFunction",
+      ],
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:alarms-handler-topic-PROD",
+          },
+        ],
+        "AlarmDescription": "A run failed to update (some) records in Salesforce in the last hour. See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedUpdateAlarm for possible causes, impacts and fixes.
+",
+        "AlarmName": {
+          "Fn::Sub": "soft-opt-in-consent-setter-\${Stage} failed to update Salesforce records",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "Stage",
+            "Value": {
+              "Fn::Sub": "\${Stage}",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "failed_salesforce_update",
+        "Namespace": "soft-opt-in-consent-setter",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+  },
+  "Transform": "AWS::Serverless-2016-10-31",
+}
+`;

--- a/cdk/lib/soft-opt-in-consent-setter.test.ts
+++ b/cdk/lib/soft-opt-in-consent-setter.test.ts
@@ -1,12 +1,15 @@
-import { App } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
-import { SoftOptInConsentSetter } from "./soft-opt-in-consent-setter";
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { SoftOptInConsentSetter } from './soft-opt-in-consent-setter';
 
-describe("The SoftOptInConsentSetter stack", () => {
-  it("matches the snapshot", () => {
-    const app = new App();
-    const stack = new SoftOptInConsentSetter(app, "SoftOptInConsentSetter", { stack: "membership", stage: "TEST" });
-    const template = Template.fromStack(stack);
-    expect(template.toJSON()).toMatchSnapshot();
-  });
+describe('The SoftOptInConsentSetter stack', () => {
+	it('matches the snapshot', () => {
+		const app = new App();
+		const stack = new SoftOptInConsentSetter(app, 'SoftOptInConsentSetter', {
+			stack: 'membership',
+			stage: 'TEST',
+		});
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
 });

--- a/cdk/lib/soft-opt-in-consent-setter.test.ts
+++ b/cdk/lib/soft-opt-in-consent-setter.test.ts
@@ -1,0 +1,12 @@
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { SoftOptInConsentSetter } from "./soft-opt-in-consent-setter";
+
+describe("The SoftOptInConsentSetter stack", () => {
+  it("matches the snapshot", () => {
+    const app = new App();
+    const stack = new SoftOptInConsentSetter(app, "SoftOptInConsentSetter", { stack: "membership", stage: "TEST" });
+    const template = Template.fromStack(stack);
+    expect(template.toJSON()).toMatchSnapshot();
+  });
+});

--- a/cdk/lib/soft-opt-in-consent-setter.ts
+++ b/cdk/lib/soft-opt-in-consent-setter.ts
@@ -1,15 +1,19 @@
-import { join } from "path";
-import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
-import { GuStack } from "@guardian/cdk/lib/constructs/core";
-import type { App } from "aws-cdk-lib";
-import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
+import { join } from 'path';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { App } from 'aws-cdk-lib';
+import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
 
 export class SoftOptInConsentSetter extends GuStack {
-  constructor(scope: App, id: string, props: GuStackProps) {
-    super(scope, id, props);
-    const yamlTemplateFilePath = join(__dirname, "../..", "/handlers/soft-opt-in-consent-setter/cfn.yaml");
-    new CfnInclude(this, "YamlTemplate", {
-      templateFile: yamlTemplateFilePath,
-    });
-  }
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+		const yamlTemplateFilePath = join(
+			__dirname,
+			'../..',
+			'/handlers/soft-opt-in-consent-setter/cfn.yaml',
+		);
+		new CfnInclude(this, 'YamlTemplate', {
+			templateFile: yamlTemplateFilePath,
+		});
+	}
 }

--- a/cdk/lib/soft-opt-in-consent-setter.ts
+++ b/cdk/lib/soft-opt-in-consent-setter.ts
@@ -1,0 +1,15 @@
+import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
+import { GuStack } from "@guardian/cdk/lib/constructs/core";
+import type { App } from "aws-cdk-lib";
+import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
+import { join } from "path";
+
+export class SoftOptInConsentSetter extends GuStack {
+  constructor(scope: App, id: string, props: GuStackProps) {
+    super(scope, id, props);
+    const yamlTemplateFilePath = join(__dirname, "../..", "/handlers/soft-opt-in-consent-setter/cfn.yaml");
+    new CfnInclude(this, "YamlTemplate", {
+      templateFile: yamlTemplateFilePath,
+    });
+  }
+}

--- a/cdk/lib/soft-opt-in-consent-setter.ts
+++ b/cdk/lib/soft-opt-in-consent-setter.ts
@@ -1,8 +1,8 @@
+import { join } from "path";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import type { App } from "aws-cdk-lib";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
-import { join } from "path";
 
 export class SoftOptInConsentSetter extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {

--- a/handlers/soft-opt-in-consent-setter/cfn.yaml
+++ b/handlers/soft-opt-in-consent-setter/cfn.yaml
@@ -1,5 +1,3 @@
-Transform: AWS::Serverless-2016-10-31
-
 Parameters:
   Stage:
     Description: Stage name
@@ -8,148 +6,39 @@ Parameters:
       - PROD
       - CODE
     Default: CODE
-
   MobileAccountId:
     Description: The AWS Account ID of the mobile account
     Type: AWS::SSM::Parameter::Value<String>
-    Default: 'mobileAccountId'
-
+    Default: mobileAccountId
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(30 minutes)'
+      Schedule: rate(30 minutes)
       SalesforceStage: PROD
       IdentityStage: PROD
       MpapiStage: PROD
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: TouchpointUpdate
     CODE:
-      Schedule: 'rate(365 days)'
+      Schedule: rate(365 days)
       SalesforceStage: CODE
       IdentityStage: CODE
       MpapiStage: CODE
       SalesforceUsername: SoftOptInConsentSetterAPIUser
       AppName: AwsConnectorSandbox
-
-Conditions:
-  IsProd: !Equals [ !Ref Stage, PROD ]
-
 Resources:
-  LambdaFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Description: Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation of Subscriptions in Salesforce
-      FunctionName: !Sub soft-opt-in-consent-setter-${Stage}
-      Handler: com.gu.soft_opt_in_consent_setter.Handler::handleRequest
-      CodeUri:
-        Bucket: support-service-lambdas-dist
-        Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
-      MemorySize: 512
-      Runtime: java11
-      Timeout: 900
-      Environment:
-        Variables:
-          Stage: !Ref Stage
-          sfApiVersion: v46.0
-      Events:
-        ScheduledRun:
-          Type: Schedule
-          Properties:
-            Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule]
-            Description: Runs Soft Opt-In Consent Setter
-            Enabled: True
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action: cloudwatch:PutMetricData
-              Resource: "*"
-        - Statement:
-            - Sid: readDeployedArtefact
-              Effect: Allow
-              Action: s3:GetObject
-              Resource:
-                - arn:aws:s3::*:membership-dist/*
-        - Statement:
-            - Effect: Allow
-              Action:
-                - secretsmanager:DescribeSecret
-                - secretsmanager:GetSecretValue
-              Resource:
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H"
-
-  LambdaFunctionIAP:
-    Type: AWS::Serverless::Function
-    Properties:
-      Description: Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation of Subscriptions based on a queue populated by Salesforce and the Mobile Purchases API
-      FunctionName: !Sub soft-opt-in-consent-setter-IAP-${Stage}
-      Handler: com.gu.soft_opt_in_consent_setter.HandlerIAP::handleRequest
-      CodeUri:
-        Bucket: support-service-lambdas-dist
-        Key: !Sub membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
-      MemorySize: 512
-      Runtime: java11
-      Timeout: 300
-      Environment:
-        Variables:
-          Stage: !Ref Stage
-          sfApiVersion: v56.0
-      Policies:
-        - AWSLambdaBasicExecutionRole
-        - Statement:
-            - Effect: Allow
-              Action:
-                - "dynamodb:PutItem"
-              Resource:
-                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/soft-opt-in-consent-setter-${Stage}-logging
-        - Statement:
-            - Effect: Allow
-              Action: cloudwatch:PutMetricData
-              Resource: "*"
-        - Statement:
-            - Sid: readDeployedArtefact
-              Effect: Allow
-              Action: s3:GetObject
-              Resource:
-                - arn:aws:s3::*:membership-dist/*
-        - Statement:
-            Effect: Allow
-            Action:
-              - sqs:DeleteMessage
-              - sqs:GetQueueAttributes
-              - sqs:ReceiveMessage
-            Resource: !GetAtt SoftOptInsQueue.Arn
-        - Statement:
-            - Effect: Allow
-              Action:
-                - secretsmanager:DescribeSecret
-                - secretsmanager:GetSecretValue
-              Resource:
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN"
-                - "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H"
-
   SoftOptInsQueueCrossAccountRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-QueueCrossAccountRole"
+      RoleName:
+        Fn::Sub: "${AWS::StackName}-QueueCrossAccountRole"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub ${MobileAccountId}
+              AWS:
+                Fn::Sub: "${MobileAccountId}"
             Action: sts:AssumeRole
       Policies:
         - PolicyName: SQSAccess
@@ -162,38 +51,41 @@ Resources:
                   - sqs:ReceiveMessage
                   - sqs:DeleteMessage
                   - sqs:GetQueueAttributes
-                Resource: !GetAtt SoftOptInsQueue.Arn
-
+                Resource:
+                  Fn::GetAtt: SoftOptInsQueue.Arn
   SoftOptInsQueue:
     Type: AWS::SQS::Queue
     Properties:
       VisibilityTimeout: 3000
-      QueueName: !Sub soft-opt-in-consent-setter-queue-${Stage}
+      QueueName:
+        Fn::Sub: soft-opt-in-consent-setter-queue-${Stage}
       RedrivePolicy:
-        deadLetterTargetArn: !GetAtt SoftOptInsDeadLetterQueue.Arn
+        deadLetterTargetArn:
+          Fn::GetAtt: SoftOptInsDeadLetterQueue.Arn
         maxReceiveCount: 3
-
   SoftOptInsDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub soft-opt-in-consent-setter-dead-letter-queue-${Stage}
+      QueueName:
+        Fn::Sub: soft-opt-in-consent-setter-dead-letter-queue-${Stage}
       MessageRetentionPeriod: 864000
-
   SQSTrigger:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
       BatchSize: 1
       Enabled: true
-      EventSourceArn: !GetAtt SoftOptInsQueue.Arn
-      FunctionName: !Ref LambdaFunctionIAP
-
+      EventSourceArn:
+        Fn::GetAtt: SoftOptInsQueue.Arn
+      FunctionName:
+        Ref: LambdaFunctionIAP
   SoftOptInsLoggingTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub soft-opt-in-consent-setter-${Stage}-logging
+      TableName:
+        Fn::Sub: soft-opt-in-consent-setter-${Stage}-logging
       AttributeDefinitions:
         - AttributeName: timestamp
-          AttributeType: N
+          AttributeType: "N"
         - AttributeName: identityId
           AttributeType: S
         - AttributeName: subscriptionId
@@ -217,10 +109,10 @@ Resources:
             ProjectionType: ALL
       Tags:
         - Key: Stage
-          Value: !Ref Stage
+          Value:
+            Ref: Stage
         - Key: devx-backup-enabled
           Value: true
-
   failedRunAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
@@ -228,16 +120,19 @@ Resources:
       - LambdaFunction
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
-      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to run
-      AlarmDescription: >
-        Five or more runs found an error and were unable to complete.
+        - Fn::Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      AlarmName:
+        Fn::Sub: soft-opt-in-consent-setter-${Stage} failed to run
+      AlarmDescription: 'Five or more runs found an error and were unable to complete.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm
         for possible causes, impacts and fixes.
+
+        '
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
-          Value: !Ref LambdaFunction
+          Value:
+            Ref: LambdaFunction
       EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda
@@ -245,7 +140,6 @@ Resources:
       Statistic: Sum
       Threshold: 5
       TreatMissingData: notBreaching
-
   exceptionsAlarmIAP:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
@@ -253,16 +147,19 @@ Resources:
       - LambdaFunctionIAP
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
-      AlarmName: !Sub soft-opt-in-consent-setter-IAP-${Stage} threw an exception
-      AlarmDescription: >
-        Five or more runs found an error and were unable to complete.
+        - Fn::Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      AlarmName:
+        Fn::Sub: soft-opt-in-consent-setter-IAP-${Stage} threw an exception
+      AlarmDescription: 'Five or more runs found an error and were unable to complete.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm
         for possible causes, impacts and fixes.
+
+        '
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
-          Value: !Ref LambdaFunctionIAP
+          Value:
+            Ref: LambdaFunctionIAP
       EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda
@@ -270,22 +167,25 @@ Resources:
       Statistic: Sum
       Threshold: 5
       TreatMissingData: notBreaching
-
   deadLetterBuildUpAlarmIAP:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
-      AlarmName: !Sub soft-opt-in-consent-setter-IAP-${Stage} failed to run and sent the message to the dead letter queue.
-      AlarmDescription: >
-        Five or more runs found an error and were unable to complete.
+        - Fn::Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      AlarmName:
+        Fn::Sub: soft-opt-in-consent-setter-IAP-${Stage} failed to run and sent the
+          message to the dead letter queue.
+      AlarmDescription: 'Five or more runs found an error and were unable to complete.
         See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedRunAlarm
         for possible causes, impacts and fixes.
+
+        '
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: QueueName
-          Value: !GetAtt SoftOptInsDeadLetterQueue.QueueName
+          Value:
+            Fn::GetAtt: SoftOptInsDeadLetterQueue.QueueName
       Period: 300
       EvaluationPeriods: 1
       MetricName: ApproximateNumberOfMessagesVisible
@@ -293,7 +193,6 @@ Resources:
       Statistic: Sum
       Threshold: 5
       TreatMissingData: notBreaching
-
   failedUpdateAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
@@ -301,16 +200,19 @@ Resources:
       - LambdaFunction
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
-      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
-      AlarmDescription: >
-        A run failed to update (some) records in Salesforce in the last hour.
-        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedUpdateAlarm
+        - Fn::Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      AlarmName:
+        Fn::Sub: soft-opt-in-consent-setter-${Stage} failed to update Salesforce records
+      AlarmDescription: 'A run failed to update (some) records in Salesforce in the
+        last hour. See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedUpdateAlarm
         for possible causes, impacts and fixes.
+
+        '
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: Stage
-          Value: !Sub ${Stage}
+          Value:
+            Fn::Sub: "${Stage}"
       EvaluationPeriods: 1
       MetricName: failed_salesforce_update
       Namespace: soft-opt-in-consent-setter
@@ -318,7 +220,6 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
-
   failedDynamoUpdateAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
@@ -326,16 +227,20 @@ Resources:
       - LambdaFunction
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
-      AlarmName: !Sub soft-opt-in-consent-setter-${Stage} failed to update the Dynamo logging table.
-      AlarmDescription: >
-        A run failed to update (some) records in Salesforce in the last hour.
-        See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedUpdateAlarm
+        - Fn::Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      AlarmName:
+        Fn::Sub: soft-opt-in-consent-setter-${Stage} failed to update the Dynamo logging
+          table.
+      AlarmDescription: 'A run failed to update (some) records in Salesforce in the
+        last hour. See https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/README.md#failedUpdateAlarm
         for possible causes, impacts and fixes.
+
+        '
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: Stage
-          Value: !Sub ${Stage}
+          Value:
+            Fn::Sub: "${Stage}"
       EvaluationPeriods: 1
       MetricName: failed_dynamo_update
       Namespace: soft-opt-in-consent-setter
@@ -343,3 +248,204 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: support-service-lambdas-dist
+        S3Key:
+          Fn::Sub: membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
+      Description: Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation
+        of Subscriptions in Salesforce
+      FunctionName:
+        Fn::Sub: soft-opt-in-consent-setter-${Stage}
+      Handler: com.gu.soft_opt_in_consent_setter.Handler::handleRequest
+      MemorySize: 512
+      Role:
+        Fn::GetAtt:
+          - LambdaFunctionRole
+          - Arn
+      Runtime: java11
+      Timeout: 900
+      Environment:
+        Variables:
+          Stage:
+            Ref: Stage
+          sfApiVersion: v46.0
+      Tags:
+        - Key: lambda:createdBy
+          Value: SAM
+  LambdaFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: LambdaFunctionRolePolicy0
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:PutMetricData
+                Resource: "*"
+        - PolicyName: LambdaFunctionRolePolicy1
+          PolicyDocument:
+            Statement:
+              - Sid: readDeployedArtefact
+                Effect: Allow
+                Action: s3:GetObject
+                Resource:
+                  - arn:aws:s3::*:membership-dist/*
+        - PolicyName: LambdaFunctionRolePolicy2
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:DescribeSecret
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H
+      Tags:
+        - Key: lambda:createdBy
+          Value: SAM
+  LambdaFunctionScheduledRun:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Runs Soft Opt-In Consent Setter
+      ScheduleExpression:
+        Fn::FindInMap:
+          - StageMap
+          - Ref: Stage
+          - Schedule
+      State: ENABLED
+      Targets:
+        - Arn:
+            Fn::GetAtt:
+              - LambdaFunction
+              - Arn
+          Id: LambdaFunctionScheduledRunLambdaTarget
+  LambdaFunctionScheduledRunPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Ref: LambdaFunction
+      Principal: events.amazonaws.com
+      SourceArn:
+        Fn::GetAtt:
+          - LambdaFunctionScheduledRun
+          - Arn
+  LambdaFunctionIAP:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: support-service-lambdas-dist
+        S3Key:
+          Fn::Sub: membership/${Stage}/soft-opt-in-consent-setter/soft-opt-in-consent-setter.jar
+      Description: Updates Identity Soft Opt-In Consents upon Acquisition and Cancellation
+        of Subscriptions based on a queue populated by Salesforce and the Mobile Purchases
+        API
+      FunctionName:
+        Fn::Sub: soft-opt-in-consent-setter-IAP-${Stage}
+      Handler: com.gu.soft_opt_in_consent_setter.HandlerIAP::handleRequest
+      MemorySize: 512
+      Role:
+        Fn::GetAtt:
+          - LambdaFunctionIAPRole
+          - Arn
+      Runtime: java11
+      Timeout: 300
+      Environment:
+        Variables:
+          Stage:
+            Ref: Stage
+          sfApiVersion: v56.0
+      Tags:
+        - Key: lambda:createdBy
+          Value: SAM
+  LambdaFunctionIAPRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: LambdaFunctionIAPRolePolicy1
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                Resource:
+                  - Fn::Sub: arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/soft-opt-in-consent-setter-${Stage}-logging
+        - PolicyName: LambdaFunctionIAPRolePolicy2
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:PutMetricData
+                Resource: "*"
+        - PolicyName: LambdaFunctionIAPRolePolicy3
+          PolicyDocument:
+            Statement:
+              - Sid: readDeployedArtefact
+                Effect: Allow
+                Action: s3:GetObject
+                Resource:
+                  - arn:aws:s3::*:membership-dist/*
+        - PolicyName: LambdaFunctionIAPRolePolicy4
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - sqs:DeleteMessage
+                - sqs:GetQueueAttributes
+                - sqs:ReceiveMessage
+              Resource:
+                Fn::GetAtt: SoftOptInsQueue.Arn
+        - PolicyName: LambdaFunctionIAPRolePolicy5
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:DescribeSecret
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/ConnectedApp/AwsConnectorSandbox-jaCgRl
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/ConnectedApp/TouchpointUpdate-lolLqP
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Salesforce/User/SoftOptInConsentSetterAPIUser-KjHQBG
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Salesforce/User/SoftOptInConsentSetterAPIUser-EonJb0
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Identity/SoftOptInConsentAPI-n7Elrb
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Identity/SoftOptInConsentAPI-sJJo2s
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/MobilePurchasesAPI/User/GetSubscriptions-iCUzGN
+                  - arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/MobilePurchasesAPI/User/GetSubscriptions-HZuC6H
+      Tags:
+        - Key: lambda:createdBy
+          Value: SAM
+Conditions:
+  IsProd:
+    Fn::Equals:
+      - Ref: Stage
+      - PROD

--- a/handlers/soft-opt-in-consent-setter/riff-raff.yaml
+++ b/handlers/soft-opt-in-consent-setter/riff-raff.yaml
@@ -6,19 +6,21 @@ allowedStages:
   - CODE
   - PROD
 deployments:
-  cfn:
+  soft-opt-in-consent-setter-cloudformation:
     type: cloud-formation
     app: soft-opt-in-consent-setter
     parameters:
-      templatePath: cfn.yaml
+      templateStagePaths:
+        CODE: soft-opt-in-consent-setter-CODE.template.json
+        PROD: soft-opt-in-consent-setter-PROD.template.json
 
   soft-opt-in-consent-setter:
     type: aws-lambda
     parameters:
       fileName: soft-opt-in-consent-setter.jar
-      bucket: support-service-lambdas-dist
+      bucketSsmLookup: true
       prefixStack: false
       functionNames:
         - soft-opt-in-consent-setter-
         - soft-opt-in-consent-setter-IAP-
-    dependencies: [ cfn ]
+    dependencies: [soft-opt-in-consent-setter-cloudformation]


### PR DESCRIPTION
This is the initial step in migrating the existing `soft-opt-in-consent-setter` CloudFormation template to use the GuCDK instead. This passes the existing vanilla CFN YAML file into the CDK, which generates a CDK-style template from it.

To ensure this new old template deploys correctly the relevant CI and Riff-Raff configs have been adjusted.