### PR TITLE
feat: add observer-data-export ownership to Platform

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -124,6 +124,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 
 		// misc
 		'discount-expiry-notifier',
+		'observer-data-export',
 	],
 };
 


### PR DESCRIPTION
## What does this change?

Add observer-data-export ownership to the Platform team.