### PR TITLE
ensure consistent role names by avoiding referencing stack

### DIFF
--- a/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
+++ b/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
@@ -421,7 +421,7 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "RoleName": "SoftOptInConsentSetter-LambdaFunctionIAPRole",
+        "RoleName": "membership-TEST-soft-opt-in-consent-setter-LambdaFunctionIAPRole",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -509,7 +509,7 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "RoleName": "SoftOptInConsentSetter-LambdaFunctionRole",
+        "RoleName": "membership-TEST-soft-opt-in-consent-setter-LambdaFunctionRole",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -919,7 +919,7 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
             "PolicyName": "SQSAccess",
           },
         ],
-        "RoleName": "SoftOptInConsentSetter-QueueCrossAccountRole",
+        "RoleName": "membership-TEST-soft-opt-in-consent-setter-QueueCrossAccountRole",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/cdk/lib/soft-opt-in-consent-setter.ts
+++ b/cdk/lib/soft-opt-in-consent-setter.ts
@@ -68,7 +68,7 @@ export class SoftOptInConsentSetter extends GuStack {
 
 		// IAM Roles
 		new Role(this, 'SoftOptInsQueueCrossAccountRole', {
-			roleName: `${this.stackName}-QueueCrossAccountRole`,
+			roleName: `membership-${this.stage}-soft-opt-in-consent-setter-QueueCrossAccountRole`,
 			assumedBy: new AccountPrincipal(mobileAccountId),
 			inlinePolicies: {
 				SQSAccess: new PolicyDocument({
@@ -89,7 +89,7 @@ export class SoftOptInConsentSetter extends GuStack {
 		});
 
 		const lambdaFunctionRole = new Role(this, 'LambdaFunctionRole', {
-			roleName: `${this.stackName}-LambdaFunctionRole`,
+			roleName: `membership-${this.stage}-soft-opt-in-consent-setter-LambdaFunctionRole`,
 			assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
 			managedPolicies: [
 				ManagedPolicy.fromAwsManagedPolicyName(
@@ -112,7 +112,7 @@ export class SoftOptInConsentSetter extends GuStack {
 		);
 
 		const lambdaFunctionIAPRole = new Role(this, 'LambdaFunctionIAPRole', {
-			roleName: `${this.stackName}-LambdaFunctionIAPRole`,
+			roleName: `membership-${this.stage}-soft-opt-in-consent-setter-LambdaFunctionIAPRole`,
 			assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
 			managedPolicies: [
 				ManagedPolicy.fromAwsManagedPolicyName(


### PR DESCRIPTION
There was an issue where the mobile account coudln't assume the role to write to our SQS queue any more.  It turned out that the role had changed from 
membership-PROD-soft-opt-in-consent-setter-QueueCrossAccountRole
to
soft-opt-in-consent-setter-PROD-QueueCrossAccountRole
as the old one was using the AWS stack name at deploy time as a prefix, but the new one was using the CDK's local stack name parameter.

This is a small PR to adjust the names of AWS IAM Roles within the CDK definition. It seems that `this.stackName` differs from `AWS::StackName`. We are only referencing the stage dynamically, everything else is hard coded in the interest of clarity and predictability.