### PR TITLE
move test subscription creation into shared directory

### DIFF
--- a/handlers/discount-api/test/addDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/addDiscountIntegration.test.ts
@@ -9,7 +9,8 @@ import { addDiscount } from '@modules/zuora/addDiscount';
 import { getSubscription } from '@modules/zuora/getSubscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
-import { createDigitalSubscription, doPriceRise } from './helpers';
+import { createDigitalSubscription } from '../../../modules/zuora/test/it-helpers/createGuardianSubscription';
+import { doPriceRise } from './helpers';
 
 const stage: Stage = 'CODE';
 const subscribeDate = dayjs();

--- a/handlers/discount-api/test/applyDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/applyDiscountIntegration.test.ts
@@ -8,12 +8,12 @@ import { zuoraDateFormat } from '@modules/zuora/common';
 import { Logger } from '@modules/zuora/logger';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
-import { applyDiscountEndpoint } from '../src/discountEndpoint';
-import type { ApplyDiscountResponseBody } from '../src/responseSchema';
 import {
 	createDigitalSubscription,
 	createSupporterPlusSubscription,
-} from './helpers';
+} from '../../../modules/zuora/test/it-helpers/createGuardianSubscription';
+import { applyDiscountEndpoint } from '../src/discountEndpoint';
+import type { ApplyDiscountResponseBody } from '../src/responseSchema';
 
 const stage: Stage = 'CODE';
 const validIdentityId = '200175946';

--- a/handlers/discount-api/test/helpers.ts
+++ b/handlers/discount-api/test/helpers.ts
@@ -1,116 +1,13 @@
-import { getIfDefined } from '@modules/nullAndUndefined';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type {
-	ZuoraSubscribeResponse,
 	ZuoraSubscription,
 	ZuoraSuccessResponse,
 } from '@modules/zuora/zuoraSchemas';
 import {
-	zuoraSubscribeResponseSchema,
 	zuoraSuccessResponseSchema,
 } from '@modules/zuora/zuoraSchemas';
 import type { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
-import { digiSubSubscribeBody } from './fixtures/request-bodies/digitalSub-subscribe-body-old-price';
-import { supporterPlusSubscribeBody } from './fixtures/request-bodies/supporterplus-subscribe-body-tier2';
 import { updateSubscriptionBody } from './fixtures/request-bodies/update-subscription-body';
-
-export const createDigitalSubscription = async (
-	zuoraClient: ZuoraClient,
-	createWithOldPrice: boolean,
-): Promise<string> => {
-	const subscribeResponse = await subscribe(
-		zuoraClient,
-		digiSubSubscribeBody(dayjs(), createWithOldPrice),
-	);
-	return getIfDefined(
-		subscribeResponse[0]?.SubscriptionNumber,
-		'SubscriptionNumber was undefined in response from Zuora',
-	);
-};
-
-export const createSupporterPlusSubscription = async (
-	zuoraClient: ZuoraClient,
-): Promise<string> => {
-	const subscribeResponse = await subscribe(
-		zuoraClient,
-		supporterPlusSubscribeBody(dayjs()),
-	);
-
-	return getIfDefined(
-		subscribeResponse[0]?.SubscriptionNumber,
-		'SubscriptionNumber was undefined in response from Zuora',
-	);
-};
-
-async function subscribe(
-	zuoraClient: ZuoraClient,
-	subscribeBody: {
-		subscribes: Array<{
-			Account: {
-				IdentityId__c: string;
-				InvoiceTemplateId: string;
-				AutoPay: boolean;
-				PaymentTerm: string;
-				CreatedRequestId__c: string;
-				Name: string;
-				sfContactId__c: string;
-				Batch: string;
-				PaymentGateway: string;
-				Currency: string;
-				BcdSettingOption: string;
-				BillCycleDay: number;
-				CrmId: string;
-			};
-			SubscribeOptions: { GenerateInvoice: boolean; ProcessPayments: boolean };
-			SubscriptionData: {
-				RatePlanData: Array<{
-					RatePlan: { ProductRatePlanId: string };
-					SubscriptionProductFeatureList: unknown[];
-				}>;
-				Subscription: {
-					ContractEffectiveDate: string;
-					ContractAcceptanceDate: string; // actually CustomerAcceptanceDate but zuora API has a typo
-					TermStartDate: string;
-					AutoRenew: boolean;
-					RenewalTerm: number;
-					InitialTerm: number;
-					ReaderType__c: string;
-					TermType: string;
-					CreatedRequestId__c: string;
-					InitialTermPeriodType: string;
-				};
-			};
-			PaymentMethod: {
-				BankTransferAccountName: string;
-				Type: string;
-				BankTransferAccountNumber: string;
-				FirstName: string;
-				PaymentGateway: string;
-				BankTransferType: string;
-				Country: string;
-				BankCode: string;
-				LastName: string;
-			};
-			BillToContact: {
-				FirstName: string;
-				Country: string;
-				LastName: string;
-				WorkEmail: string;
-			};
-		}>;
-	},
-) {
-	const path = `/v1/action/subscribe`;
-	const body = JSON.stringify(subscribeBody);
-
-	const subscribeResponse: ZuoraSubscribeResponse = await zuoraClient.post(
-		path,
-		body,
-		zuoraSubscribeResponseSchema,
-	);
-	return subscribeResponse;
-}
 
 export const doPriceRise = async (
 	zuoraClient: ZuoraClient,

--- a/handlers/discount-api/test/helpers.ts
+++ b/handlers/discount-api/test/helpers.ts
@@ -3,9 +3,7 @@ import type {
 	ZuoraSubscription,
 	ZuoraSuccessResponse,
 } from '@modules/zuora/zuoraSchemas';
-import {
-	zuoraSuccessResponseSchema,
-} from '@modules/zuora/zuoraSchemas';
+import { zuoraSuccessResponseSchema } from '@modules/zuora/zuoraSchemas';
 import type { Dayjs } from 'dayjs';
 import { updateSubscriptionBody } from './fixtures/request-bodies/update-subscription-body';
 

--- a/handlers/discount-api/test/previewDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/previewDiscountIntegration.test.ts
@@ -2,6 +2,10 @@
  * @group integration
  */
 import type { Stage } from '@modules/stage';
+import {
+	createDigitalSubscription,
+	createSupporterPlusSubscription,
+} from '@modules/zuora/../test/it-helpers/createGuardianSubscription';
 import { cancelSubscription } from '@modules/zuora/cancelSubscription';
 import { zuoraDateFormat } from '@modules/zuora/common';
 import { Logger } from '@modules/zuora/logger';
@@ -10,10 +14,6 @@ import dayjs from 'dayjs';
 import { previewDiscountEndpoint } from '../src/discountEndpoint';
 import { validationRequirements } from '../src/eligibilityChecker';
 import type { EligibilityCheckResponseBody } from '../src/responseSchema';
-import {
-	createDigitalSubscription,
-	createSupporterPlusSubscription,
-} from './helpers';
 
 const stage: Stage = 'CODE';
 const validIdentityId = '200175946';

--- a/modules/zuora/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
+++ b/modules/zuora/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
@@ -1,6 +1,6 @@
 import { zuoraDateFormat } from '@modules/zuora/common';
 import type { Dayjs } from 'dayjs';
-import { catalog } from '../../../src/productToDiscountMapping';
+import { catalog } from '../../../../../handlers/discount-api/src/productToDiscountMapping';
 
 export const digiSubSubscribeBody = (
 	subscriptionDate: Dayjs,

--- a/modules/zuora/test/fixtures/request-bodies/supporterplus-subscribe-body-tier2.ts
+++ b/modules/zuora/test/fixtures/request-bodies/supporterplus-subscribe-body-tier2.ts
@@ -1,6 +1,6 @@
 import { zuoraDateFormat } from '@modules/zuora/common';
 import type { Dayjs } from 'dayjs';
-import { catalog } from '../../../src/productToDiscountMapping';
+import { catalog } from '../../../../../handlers/discount-api/src/productToDiscountMapping';
 
 export const supporterPlusSubscribeBody = (subscriptionDate: Dayjs) => {
 	return {

--- a/modules/zuora/test/it-helpers/createGuardianSubscription.ts
+++ b/modules/zuora/test/it-helpers/createGuardianSubscription.ts
@@ -1,0 +1,103 @@
+import { getIfDefined } from "@modules/nullAndUndefined";
+import dayjs from "dayjs";
+import type { ZuoraClient } from "@modules/zuora/zuoraClient";
+import { type ZuoraSubscribeResponse, zuoraSubscribeResponseSchema } from "@modules/zuora/zuoraSchemas";
+import { digiSubSubscribeBody } from "../fixtures/request-bodies/digitalSub-subscribe-body-old-price";
+import { supporterPlusSubscribeBody } from "../fixtures/request-bodies/supporterplus-subscribe-body-tier2";
+
+export const createDigitalSubscription = async (
+	zuoraClient: ZuoraClient,
+	createWithOldPrice: boolean,
+): Promise<string> => {
+	const subscribeResponse = await subscribe(
+		zuoraClient,
+		digiSubSubscribeBody(dayjs(), createWithOldPrice),
+	);
+	return getIfDefined(
+		subscribeResponse[0]?.SubscriptionNumber,
+		'SubscriptionNumber was undefined in response from Zuora',
+	);
+};
+
+export const createSupporterPlusSubscription = async (
+	zuoraClient: ZuoraClient,
+): Promise<string> => {
+	const subscribeResponse = await subscribe(
+		zuoraClient,
+		supporterPlusSubscribeBody(dayjs()),
+	);
+
+	return getIfDefined(
+		subscribeResponse[0]?.SubscriptionNumber,
+		'SubscriptionNumber was undefined in response from Zuora',
+	);
+};
+
+async function subscribe(
+	zuoraClient: ZuoraClient,
+	subscribeBody: {
+		subscribes: Array<{
+			Account: {
+				IdentityId__c: string;
+				InvoiceTemplateId: string;
+				AutoPay: boolean;
+				PaymentTerm: string;
+				CreatedRequestId__c: string;
+				Name: string;
+				sfContactId__c: string;
+				Batch: string;
+				PaymentGateway: string;
+				Currency: string;
+				BcdSettingOption: string;
+				BillCycleDay: number;
+				CrmId: string;
+			};
+			SubscribeOptions: { GenerateInvoice: boolean; ProcessPayments: boolean };
+			SubscriptionData: {
+				RatePlanData: Array<{
+					RatePlan: { ProductRatePlanId: string };
+					SubscriptionProductFeatureList: unknown[];
+				}>;
+				Subscription: {
+					ContractEffectiveDate: string;
+					ContractAcceptanceDate: string; // actually CustomerAcceptanceDate but zuora API has a typo
+					TermStartDate: string;
+					AutoRenew: boolean;
+					RenewalTerm: number;
+					InitialTerm: number;
+					ReaderType__c: string;
+					TermType: string;
+					CreatedRequestId__c: string;
+					InitialTermPeriodType: string;
+				};
+			};
+			PaymentMethod: {
+				BankTransferAccountName: string;
+				Type: string;
+				BankTransferAccountNumber: string;
+				FirstName: string;
+				PaymentGateway: string;
+				BankTransferType: string;
+				Country: string;
+				BankCode: string;
+				LastName: string;
+			};
+			BillToContact: {
+				FirstName: string;
+				Country: string;
+				LastName: string;
+				WorkEmail: string;
+			};
+		}>;
+	},
+) {
+	const path = `/v1/action/subscribe`;
+	const body = JSON.stringify(subscribeBody);
+
+	const subscribeResponse: ZuoraSubscribeResponse = await zuoraClient.post(
+		path,
+		body,
+		zuoraSubscribeResponseSchema,
+	);
+	return subscribeResponse;
+}

--- a/modules/zuora/test/it-helpers/createGuardianSubscription.ts
+++ b/modules/zuora/test/it-helpers/createGuardianSubscription.ts
@@ -1,9 +1,12 @@
-import { getIfDefined } from "@modules/nullAndUndefined";
-import dayjs from "dayjs";
-import type { ZuoraClient } from "@modules/zuora/zuoraClient";
-import { type ZuoraSubscribeResponse, zuoraSubscribeResponseSchema } from "@modules/zuora/zuoraSchemas";
-import { digiSubSubscribeBody } from "../fixtures/request-bodies/digitalSub-subscribe-body-old-price";
-import { supporterPlusSubscribeBody } from "../fixtures/request-bodies/supporterplus-subscribe-body-tier2";
+import { getIfDefined } from '@modules/nullAndUndefined';
+import dayjs from 'dayjs';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import {
+	type ZuoraSubscribeResponse,
+	zuoraSubscribeResponseSchema,
+} from '@modules/zuora/zuoraSchemas';
+import { digiSubSubscribeBody } from '../fixtures/request-bodies/digitalSub-subscribe-body-old-price';
+import { supporterPlusSubscribeBody } from '../fixtures/request-bodies/supporterplus-subscribe-body-tier2';
 
 export const createDigitalSubscription = async (
 	zuoraClient: ZuoraClient,


### PR DESCRIPTION
## What does this change?

Moves the creation of the digital subscription and supporter plus test products into a shared directory so that they can be used in integration tests where we currently rely on a manually created subscription. This should enable a refactor of the (product-switch) integration tests so that they can be run in CI with dynically created test subs.