### PR TITLE
feat: save md5 hex fingerprints in separate bucket indefinitely to ensure a reliable audit trail and strengthen data integrity assurance

### DIFF
--- a/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
+++ b/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
@@ -373,6 +373,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Environment": {
           "Variables": {
             "APP": "observer-data-export",
+            "Md5FingerprintsBucketName": {
+              "Ref": "Md5FingerprintsBucketBFF631AE",
+            },
             "ObserverNewspaperSubscribersFolder": "Observer_newspaper_subscribers",
             "STACK": "support",
             "STAGE": "CODE",
@@ -529,6 +532,24 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               },
             },
             {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "Md5FingerprintsBucketBFF631AE",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
               "Action": [
                 "sqs:ReceiveMessage",
                 "sqs:ChangeMessageVisibility",
@@ -653,6 +674,32 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         },
       },
       "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "Md5FingerprintsBucketBFF631AE": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketName": "observer-data-export-md5-fingerprints-code",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
     },
     "SalesforceObserverDataTransferBucketC46E06F4": {
       "DeletionPolicy": "Retain",
@@ -2023,6 +2070,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Environment": {
           "Variables": {
             "APP": "observer-data-export",
+            "Md5FingerprintsBucketName": {
+              "Ref": "Md5FingerprintsBucketBFF631AE",
+            },
             "ObserverNewspaperSubscribersFolder": "Observer_newspaper_subscribers",
             "STACK": "support",
             "STAGE": "PROD",
@@ -2179,6 +2229,24 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               },
             },
             {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "Md5FingerprintsBucketBFF631AE",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
               "Action": [
                 "sqs:ReceiveMessage",
                 "sqs:ChangeMessageVisibility",
@@ -2303,6 +2371,32 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         },
       },
       "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "Md5FingerprintsBucketBFF631AE": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketName": "observer-data-export-md5-fingerprints-prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
     },
     "SalesforceObserverDataTransferBucketC46E06F4": {
       "DeletionPolicy": "Retain",

--- a/handlers/observer-data-export/src/handlers/encryptAndUploadObserverData.ts
+++ b/handlers/observer-data-export/src/handlers/encryptAndUploadObserverData.ts
@@ -17,6 +17,7 @@ export const handler = async (event: SQSEvent) => {
 				process.env.UnifidaPublicRsaKeyFilePath;
 			const observerNewspaperSubscribersFolder =
 				process.env.ObserverNewspaperSubscribersFolder;
+			const md5FingerprintsBucketName = process.env.Md5FingerprintsBucketName;
 
 			const utcTimestamp = new Date().toISOString();
 			const todayDate = new Date().toISOString().split('T')[0];
@@ -93,6 +94,16 @@ export const handler = async (event: SQSEvent) => {
 							null,
 							2,
 						),
+					}),
+				),
+			);
+
+			await Promise.all(
+				uploadFolders.map((folder) =>
+					uploadFileToS3({
+						bucketName: md5FingerprintsBucketName,
+						filePath: `${folder}/data.md5`,
+						content: md5Hash,
 					}),
 				),
 			);


### PR DESCRIPTION
## MD5 Fingerprint Backup Bucket

[Trello](https://trello.com/c/PZlc2L7X/497-write-integration-to-transfer-data-from-salesforce-to-aws-and-then-encrypt-upload-objects)

In addition to uploading encrypted data to the shared bucket (UnifidaSharedBucketName), the system also generates and stores a `data.md5` file for each export. This file contains the MD5 hex fingerprint of the unencrypted CSV file before encryption.

The MD5 fingerprint is stored in a separate S3 bucket:

- `observer-data-export-md5-fingerprints-code`
- `observer-data-export-md5-fingerprints-prod`

This bucket mirrors the folder structure of the main shared bucket. For example:

```
observer-data-export-prod/
└── Observer_newspaper_subscribers/
    ├── 2025-04-14/data.csv.enc, ...
    └── latest/data.csv.enc, ...

observer-data-export-md5-fingerprints-prod/
└── Observer_newspaper_subscribers/
    ├── 2025-04-14/data.md5
    └── latest/data.md5
```

### Purpose

The `data.md5` file serves as a long-term, immutable reference to verify what data was shared with Unifida. Unlike the shared bucket (which enforces a 28-day expiration policy), the MD5 fingerprint bucket has no expiration policy, meaning these fingerprints are preserved indefinitely.

If Unifida later claims that a particular data export was not shared with them or was altered, we can use the MD5 fingerprint to confirm exactly what data was sent. This mechanism ensures a reliable audit trail and strengthens data integrity assurance.
