### PR TITLE
Allow dynamic creation of test contributions for use in integration tests

### DIFF
--- a/handlers/discount-api/src/productToDiscountMapping.ts
+++ b/handlers/discount-api/src/productToDiscountMapping.ts
@@ -66,6 +66,7 @@ export const catalog = {
 		},
 		recurringContribution: {
 			Month: '2c92c0f85a6b134e015a7fcd9f0c7855',
+			Annual: '2c92c0f85e2d19af015e3896e824092c',
 		},
 	},
 	PROD: {
@@ -80,6 +81,7 @@ export const catalog = {
 		},
 		recurringContribution: {
 			Month: '2c92a0fc5aacfadd015ad24db4ff5e97',
+			Annual: '2c92a0fc5e1dc084015e37f58c200eea',
 		},
 	},
 };

--- a/handlers/product-switch-api/jest.config.js
+++ b/handlers/product-switch-api/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
 		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
 		'@modules/(.*)$': '<rootDir>/../../modules/$1',
 	},
+    testTimeout: 1000 * 15 
 };

--- a/handlers/product-switch-api/src/contributionToSupporterPlus.ts
+++ b/handlers/product-switch-api/src/contributionToSupporterPlus.ts
@@ -192,7 +192,7 @@ export const doSwitch = async (
 
 	const requestBody = buildSwitchRequestBody(dayjs(), productSwitchInformation);
 	const zuoraResponse: ZuoraSwitchResponse = await zuoraClient.post(
-		'v1/orders',
+		'v1/orders?returnIds=true',
 		JSON.stringify(requestBody),
 		zuoraSwitchResponseSchema,
 	);

--- a/handlers/product-switch-api/src/payment.ts
+++ b/handlers/product-switch-api/src/payment.ts
@@ -45,14 +45,13 @@ export const takePaymentOrAdjustInvoice = async (
 	accountId: string,
 	paymentMethodId: string,
 ): Promise<number> => {
-	const invoiceNumber = getIfDefined(
-		switchResponse.invoiceNumbers?.at(0),
+	const invoiceId = getIfDefined(
+		switchResponse.invoiceIds?.at(0),
 		'No invoice number found in the switch response',
 	);
 
-	const invoice = await getInvoice(zuoraClient, invoiceNumber);
+	const invoice = await getInvoice(zuoraClient, invoiceId);
 	const amountPayableToday = invoice.amount;
-	const invoiceId = invoice.id;
 
 	if (amountPayableToday === 0) {
 		// Nothing to do, we don't need to take a payment and the account balance will be correct

--- a/handlers/product-switch-api/src/schemas.ts
+++ b/handlers/product-switch-api/src/schemas.ts
@@ -54,7 +54,7 @@ export type ZuoraPreviewResponse = z.infer<typeof zuoraPreviewResponseSchema>;
 
 export const zuoraSwitchResponseSchema = z.object({
 	success: z.boolean(),
-	invoiceNumbers: z.optional(z.array(z.string())),
+	invoiceIds: z.optional(z.array(z.string())),
 	reasons: z.optional(z.array(z.object({ message: z.string() }))),
 });
 

--- a/handlers/product-switch-api/test/contributionToSupporterPlusIntegration.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlusIntegration.test.ts
@@ -10,10 +10,19 @@ import { getAccount } from '@modules/zuora/getAccount';
 import { getSubscription } from '@modules/zuora/getSubscription';
 import { createPayment } from '@modules/zuora/payment';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
 import dayjs from 'dayjs';
+import { createContribution } from '../../../modules/zuora/test/it-helpers/createGuardianSubscription';
 import { doSwitch, preview } from '../src/contributionToSupporterPlus';
 import { adjustNonCollectedInvoice } from '../src/payment';
+import type { SwitchInformation } from '../src/switchInformation';
 import { getSwitchInformationWithOwnerCheck } from '../src/switchInformation';
+
+interface ContributionCreationDetails {
+	zuoraClient: ZuoraClient;
+	subscription: ZuoraSubscription;
+	switchInformation: SwitchInformation;
+}
 
 const jestConsole = console;
 beforeEach(() => {
@@ -24,78 +33,68 @@ afterEach(() => {
 });
 
 const stage = 'CODE';
+const contributionIdentityId = '200175946';
+
+const createTestContribution = async (
+	price: number,
+	switchPrice: number,
+	preview: boolean,
+): Promise<ContributionCreationDetails> => {
+	const zuoraClient = await ZuoraClient.create(stage);
+
+	console.log('Creating a new contribution');
+	const subscriptionNumber = await createContribution(zuoraClient, price);
+
+	const input = { price: switchPrice, preview };
+	const productCatalog = await getProductCatalogFromApi(stage);
+	const subscription = await getSubscription(zuoraClient, subscriptionNumber);
+	const account = await getAccount(zuoraClient, subscription.accountNumber);
+
+	const switchInformation = getSwitchInformationWithOwnerCheck(
+		stage,
+		input,
+		subscription,
+		account,
+		productCatalog,
+		contributionIdentityId,
+	);
+	return { zuoraClient, switchInformation, subscription };
+};
+
 describe('product-switching behaviour', () => {
 	it('can preview an annual recurring contribution switch with an additional contribution element', async () => {
-		const subscriptionNumber = 'A-S00527544';
-		const identityId = '200110678';
-		const input = { price: 20, preview: true };
-		const zuoraClient = await ZuoraClient.create(stage);
-		const productCatalog = await getProductCatalogFromApi(stage);
-		const subscription = await getSubscription(zuoraClient, subscriptionNumber);
-		const account = await getAccount(zuoraClient, subscription.accountNumber);
-
-		const switchInformation = getSwitchInformationWithOwnerCheck(
-			stage,
-			input,
-			subscription,
-			account,
-			productCatalog,
-			identityId,
-		);
+		const contributionPrice = 20;
+		const { zuoraClient, switchInformation, subscription } =
+			await createTestContribution(contributionPrice, contributionPrice, true);
 
 		const result = await preview(zuoraClient, switchInformation, subscription);
 
-		expect(result.supporterPlusPurchaseAmount).toEqual(20);
+		expect(result.supporterPlusPurchaseAmount).toEqual(contributionPrice);
 	});
-	it('can preview an annual recurring contribution switch at catalog price', async () => {
-		const subscriptionNumber = 'A-S00695309';
-		const identityId = '200111098';
-		const input = { price: 120, preview: true };
-		const zuoraClient = await ZuoraClient.create('CODE');
-		const productCatalog = await getProductCatalogFromApi('CODE');
-		const subscription = await getSubscription(zuoraClient, subscriptionNumber);
-		const account = await getAccount(zuoraClient, subscription.accountNumber);
 
-		const switchInformation = getSwitchInformationWithOwnerCheck(
-			stage,
-			input,
-			subscription,
-			account,
-			productCatalog,
-			identityId,
-		);
+	it('can preview an annual recurring contribution switch at catalog price', async () => {
+		const contributionPrice = 120;
+		const { zuoraClient, switchInformation, subscription } =
+			await createTestContribution(contributionPrice, contributionPrice, true);
 
 		const result = await preview(zuoraClient, switchInformation, subscription);
 
 		const expectedResult = {
-			supporterPlusPurchaseAmount: 120,
+			supporterPlusPurchaseAmount: contributionPrice,
 			nextPaymentDate: zuoraDateFormat(dayjs().add(1, 'year').endOf('day')),
 		};
 
 		expect(result).toMatchObject(expectedResult);
 	});
+
 	it(
 		'can switch a recurring contribution',
 		async () => {
-			// To run this test you will need to find a recurring contribution which hasn't been switched to supporter plus
-			const subscriptionNumber = 'A-S00296219';
-			const identityId = '200003401';
-			const input = { price: 10, preview: false };
-			const zuoraClient = await ZuoraClient.create('CODE');
-			const productCatalog = await getProductCatalogFromApi('CODE');
-			const subscription = await getSubscription(
-				zuoraClient,
-				subscriptionNumber,
-			);
-			const account = await getAccount(zuoraClient, subscription.accountNumber);
-
-			const switchInformation = getSwitchInformationWithOwnerCheck(
-				stage,
-				input,
-				subscription,
-				account,
-				productCatalog,
-				identityId,
+			const contributionPrice = 10;
+			const { zuoraClient, switchInformation } = await createTestContribution(
+				contributionPrice,
+				contributionPrice,
+				true,
 			);
 
 			const response = await doSwitch(zuoraClient, switchInformation);
@@ -103,21 +102,25 @@ describe('product-switching behaviour', () => {
 		},
 		1000 * 60,
 	);
+
 	it(
 		'can take a payment after a switch',
 		async () => {
-			// To run this test you will need to find a recurring contribution which has been switched to supporter plus but payment hasn't been taken
-			const accountId = '8ad08e01852870ed01852acfb3113c90';
-			const zuoraClient = await ZuoraClient.create('CODE');
-			const invoiceId = '8ad093fb8f0f4d13018f10416bf103a8';
-			const defaultPaymentMethodId = '8ad08e01852870ed01852acfb32f3c94';
+			const contributionPrice = 2;
+			const { zuoraClient, switchInformation } = await createTestContribution(
+				contributionPrice,
+				5,
+				false,
+			);
+
+			const response = await doSwitch(zuoraClient, switchInformation);
 
 			await createPayment(
 				zuoraClient,
-				invoiceId,
-				5,
-				accountId,
-				defaultPaymentMethodId,
+				response.invoiceIds?.[0] ?? '',
+				3,
+				switchInformation.account.id,
+				switchInformation.account.defaultPaymentMethodId,
 				dayjs(),
 			);
 		},
@@ -126,15 +129,20 @@ describe('product-switching behaviour', () => {
 	it(
 		'can adjust an invoice to zero',
 		async () => {
-			// To run this test you will need to find a recurring contribution which has been switched to supporter plus but payment hasn't been taken
-			const zuoraClient = await ZuoraClient.create('CODE');
-			const invoiceId = '8ad093788f0f4d2b018f105fe4357ff1';
+			const contributionPrice = 2;
+			const { zuoraClient, switchInformation } = await createTestContribution(
+				contributionPrice,
+				2.1,
+				false,
+			);
+
+			const switchResponse = await doSwitch(zuoraClient, switchInformation);
 
 			const response = await adjustNonCollectedInvoice(
 				zuoraClient,
-				invoiceId,
-				1.33,
-				'8ad08cbd8586721c01858804e3715378',
+				switchResponse.invoiceIds?.[0] ?? '',
+				0.1,
+				'8ad08e1a858672180185880566606fad',
 			);
 
 			expect(response.Success).toBe(true);

--- a/modules/zuora/test/fixtures/request-bodies/contribution-subscribe-body.ts
+++ b/modules/zuora/test/fixtures/request-bodies/contribution-subscribe-body.ts
@@ -2,7 +2,10 @@ import type { Dayjs } from 'dayjs';
 import { zuoraDateFormat } from '@modules/zuora/common';
 import { catalog } from '../../../../../handlers/discount-api/src/productToDiscountMapping';
 
-export const supporterPlusSubscribeBody = (subscriptionDate: Dayjs) => {
+export const contributionSubscribeBody = (
+	subscriptionDate: Dayjs,
+	price?: number,
+) => {
 	return {
 		subscribes: [
 			{
@@ -24,7 +27,7 @@ export const supporterPlusSubscribeBody = (subscriptionDate: Dayjs) => {
 				BillToContact: {
 					FirstName: 'Test',
 					LastName: 'User',
-					WorkEmail: 'test.user@thegulocal.com',
+					WorkEmail: 'test.user+zuora-contrib-it-creation@thegulocal.com',
 					Country: 'GB',
 				},
 				PaymentMethod: {
@@ -42,16 +45,22 @@ export const supporterPlusSubscribeBody = (subscriptionDate: Dayjs) => {
 					RatePlanData: [
 						{
 							RatePlan: {
-								ProductRatePlanId: catalog.CODE.supporterPlus.Month,
+								ProductRatePlanId: catalog.CODE.recurringContribution.Annual,
 							},
+							RatePlanChargeData: [
+								{
+									RatePlanCharge: {
+										Price: price ?? 100,
+										ProductRatePlanChargeId: '2c92c0f85e2d19af015e3896e84d092e',
+									},
+								},
+							],
 							SubscriptionProductFeatureList: [],
 						},
 					],
 					Subscription: {
 						ContractEffectiveDate: zuoraDateFormat(subscriptionDate),
-						ContractAcceptanceDate: zuoraDateFormat(
-							subscriptionDate.add(16, 'day'),
-						),
+						ContractAcceptanceDate: zuoraDateFormat(subscriptionDate),
 						TermStartDate: zuoraDateFormat(subscriptionDate),
 						AutoRenew: true,
 						InitialTermPeriodType: 'Month',

--- a/modules/zuora/test/it-helpers/createGuardianSubscription.ts
+++ b/modules/zuora/test/it-helpers/createGuardianSubscription.ts
@@ -5,6 +5,7 @@ import {
 	type ZuoraSubscribeResponse,
 	zuoraSubscribeResponseSchema,
 } from '@modules/zuora/zuoraSchemas';
+import { contributionSubscribeBody } from '../fixtures/request-bodies/contribution-subscribe-body';
 import { digiSubSubscribeBody } from '../fixtures/request-bodies/digitalSub-subscribe-body-old-price';
 import { supporterPlusSubscribeBody } from '../fixtures/request-bodies/supporterplus-subscribe-body-tier2';
 
@@ -30,6 +31,20 @@ export const createSupporterPlusSubscription = async (
 		supporterPlusSubscribeBody(dayjs()),
 	);
 
+	return getIfDefined(
+		subscribeResponse[0]?.SubscriptionNumber,
+		'SubscriptionNumber was undefined in response from Zuora',
+	);
+};
+
+export const createContribution = async (
+	zuoraClient: ZuoraClient,
+	price?: number,
+): Promise<string> => {
+	const subscribeResponse = await subscribe(
+		zuoraClient,
+		contributionSubscribeBody(dayjs(), price),
+	);
 	return getIfDefined(
 		subscribeResponse[0]?.SubscriptionNumber,
 		'SubscriptionNumber was undefined in response from Zuora',


### PR DESCRIPTION
## What does this change?

Allows contributions to be created dynamically so that they can be used in the integration tests (contributionToSupporterPlusIntegration.test.ts for now) instead of having to manually create the contributions.