### PR TITLE
make consent setter understand and map event bus style queue messages

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -19,7 +19,6 @@ object ConsentsMapping {
       case "PRINT_SUBSCRIPTION" if !printOptions.contains("GUARDIAN_WEEKLY") => "newspaper"
       case "PRINT_SUBSCRIPTION" if printOptions.contains("GUARDIAN_WEEKLY") => "Guardian Weekly"
       case "GUARDIAN_AD_LITE" => "Guardian Ad-Lite"
-      case s"Newspaper - $_" => "newspaper"
       case other => other
     }
   }
@@ -46,6 +45,26 @@ object ConsentsMapping {
       supporterNewsletter,
     ),
     "newspaper" -> Set(
+      yourSupportOnboarding,
+      subscriberPreview,
+      supporterNewsletter,
+    ),
+    "Newspaper - Home Delivery" -> Set(
+      yourSupportOnboarding,
+      subscriberPreview,
+      supporterNewsletter,
+    ),
+    "Newspaper - Voucher Book" -> Set(
+      yourSupportOnboarding,
+      subscriberPreview,
+      supporterNewsletter,
+    ),
+    "Newspaper - Digital Voucher" -> Set(
+      yourSupportOnboarding,
+      subscriberPreview,
+      supporterNewsletter,
+    ),
+    "Newspaper - National Delivery" -> Set(
       yourSupportOnboarding,
       subscriberPreview,
       supporterNewsletter,

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -6,6 +6,24 @@ object ConsentsMapping {
   val subscriberPreview = "subscriber_preview"
   val guardianWeeklyNewsletter = "guardian_weekly_newsletter"
 
+  /*
+  This function is needed because when events come from the acquisition event bus, they have an ophan style product name.
+   */
+  def productMappings(productName: String, printOptions: Option[String]): String = {
+    // the values on the left come from https://github.com/guardian/support-frontend/blob/beef97734c1ca1549bc1cb5f1ea5b4501d24fc46/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala#L97
+    productName match {
+      case "RECURRING_CONTRIBUTION" => "Contribution"
+      case "SUPPORTER_PLUS" => "Supporter Plus"
+      case "TIER_THREE" => "Tier Three"
+      case "DIGITAL_SUBSCRIPTION" => "Digital Pack"
+      case "PRINT_SUBSCRIPTION" if !printOptions.contains("GUARDIAN_WEEKLY") => "newspaper"
+      case "PRINT_SUBSCRIPTION" if printOptions.contains("GUARDIAN_WEEKLY") => "Guardian Weekly"
+      case "GUARDIAN_AD_LITE" => "Guardian Ad-Lite"
+      case s"Newspaper - $_" => "newspaper"
+      case other => other
+    }
+  }
+
   val consentsMapping: Map[String, Set[String]] = Map(
     "Membership" -> Set(
       yourSupportOnboarding,
@@ -32,21 +50,6 @@ object ConsentsMapping {
       subscriberPreview,
       supporterNewsletter,
     ),
-    "Newspaper - Home Delivery" -> Set(
-      yourSupportOnboarding,
-      subscriberPreview,
-      supporterNewsletter,
-    ),
-    "Newspaper - Voucher Book" -> Set(
-      yourSupportOnboarding,
-      subscriberPreview,
-      supporterNewsletter,
-    ),
-    "Newspaper - Digital Voucher" -> Set(
-      yourSupportOnboarding,
-      subscriberPreview,
-      supporterNewsletter,
-    ),
     "Guardian Weekly" -> Set(
       yourSupportOnboarding,
       guardianWeeklyNewsletter,
@@ -67,11 +70,6 @@ object ConsentsMapping {
     "InAppPurchase" -> Set(
       yourSupportOnboarding,
       supporterNewsletter,
-    ),
-    "Newspaper - National Delivery" -> Set(
-      yourSupportOnboarding,
-      supporterNewsletter,
-      subscriberPreview,
     ),
     "FeastInAppPurchase" -> Set(
       yourSupportOnboarding,

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsMappingTest.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsMappingTest.scala
@@ -6,19 +6,19 @@ import org.scalatest.matchers.should.Matchers
 
 class ConsentsMappingTest extends AnyFlatSpec with Matchers {
 
-  "productMappings" should "map ophan style name to the zuora style name" in {
+  "productMappings" should "map ophan style supporter plus to its zuora charge producttype__c" in {
     val actual = productMappings("SUPPORTER_PLUS", None)
     actual should be("Supporter Plus")
     consentsMapping.contains(actual) should be(true)
   }
 
-  it should "map ophan style newspaper to the newspaper value" in {
+  it should "map ophan style newspaper to the generic 'newspaper' value" in {
     val actual = productMappings("PRINT_SUBSCRIPTION", Some("HOME_DELIVERY_SATURDAY_PLUS"))
     actual should be("newspaper")
     consentsMapping.contains(actual) should be(true)
   }
 
-  it should "map ophan style guardian weekly to the right value" in {
+  it should "map ophan style guardian weekly to its zuora charge producttype__c" in {
     val actual = productMappings("PRINT_SUBSCRIPTION", Some("GUARDIAN_WEEKLY"))
     actual should be("Guardian Weekly")
     consentsMapping.contains(actual) should be(true)

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsMappingTest.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsMappingTest.scala
@@ -12,12 +12,6 @@ class ConsentsMappingTest extends AnyFlatSpec with Matchers {
     consentsMapping.contains(actual) should be(true)
   }
 
-  it should "map any kind of zuora style newspaper to the newspaper value" in {
-    val actual = productMappings("Newspaper - Home Delivery", None)
-    actual should be("newspaper")
-    consentsMapping.contains(actual) should be(true)
-  }
-
   it should "map ophan style newspaper to the newspaper value" in {
     val actual = productMappings("PRINT_SUBSCRIPTION", Some("HOME_DELIVERY_SATURDAY_PLUS"))
     actual should be("newspaper")

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsMappingTest.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/ConsentsMappingTest.scala
@@ -1,0 +1,33 @@
+package com.gu.soft_opt_in_consent_setter
+
+import com.gu.soft_opt_in_consent_setter.models.ConsentsMapping._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConsentsMappingTest extends AnyFlatSpec with Matchers {
+
+  "productMappings" should "map ophan style name to the zuora style name" in {
+    val actual = productMappings("SUPPORTER_PLUS", None)
+    actual should be("Supporter Plus")
+    consentsMapping.contains(actual) should be(true)
+  }
+
+  it should "map any kind of zuora style newspaper to the newspaper value" in {
+    val actual = productMappings("Newspaper - Home Delivery", None)
+    actual should be("newspaper")
+    consentsMapping.contains(actual) should be(true)
+  }
+
+  it should "map ophan style newspaper to the newspaper value" in {
+    val actual = productMappings("PRINT_SUBSCRIPTION", Some("HOME_DELIVERY_SATURDAY_PLUS"))
+    actual should be("newspaper")
+    consentsMapping.contains(actual) should be(true)
+  }
+
+  it should "map ophan style guardian weekly to the right value" in {
+    val actual = productMappings("PRINT_SUBSCRIPTION", Some("GUARDIAN_WEEKLY"))
+    actual should be("Guardian Weekly")
+    consentsMapping.contains(actual) should be(true)
+  }
+
+}

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -58,6 +58,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
+      printOptions = None,
       previousProductName = Some("Contributor"),
       eventType = Switch,
       subscriptionId = "A-S12345678",
@@ -95,6 +96,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
+      printOptions = None,
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",
@@ -136,6 +138,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
+      printOptions = None,
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -183,6 +186,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
+      printOptions = None,
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -232,6 +236,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
+      printOptions = None,
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -272,6 +277,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Tier Three",
+      printOptions = None,
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",
@@ -315,6 +321,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Tier Three",
+      printOptions = None,
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",
@@ -358,6 +365,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Tier Three",
+      printOptions = None,
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",


### PR DESCRIPTION
This is a PR on top of related PR https://github.com/guardian/support-service-lambdas/pull/2801

To support soft opt in + explicit consent at the same time, we need to trigger soft opt in from the event bus rather than from the SF query.

We have noticed that the product name is represented as a more capitalised version in the event bus https://github.com/guardian/support-frontend/blob/beef97734c1ca1549bc1cb5f1ea5b4501d24fc46/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala#L99-L117
and also some of the necessary information is in a separate field `printOptions` to distinguish GW and newspaper.
https://github.com/guardian/support-frontend/blob/beef97734c1ca1549bc1cb5f1ea5b4501d24fc46/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala#L147-L193

We can't change the names in the mappings, as cancellation and switching are going to continue to be handled via the SF query.


After some back and forth, this PR makes the existing consent setter queue contain the extra information if it comes from the event bus, and have a mapping from old to new format in the file.