### PR TITLE
fix: update bucket lifecycle rules to specify a rule for each prefix

### DIFF
--- a/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
+++ b/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
@@ -32,10 +32,17 @@ exports[`The ObserverDataExport stack matches the snapshot 1`] = `
           "Rules": [
             {
               "ExpirationInDays": 28,
+              "Prefix": "Observer_newsletter_eligible/",
               "Status": "Enabled",
             },
             {
-              "Prefix": "Public_keys/",
+              "ExpirationInDays": 28,
+              "Prefix": "Observer_newsletter_subscribers/",
+              "Status": "Enabled",
+            },
+            {
+              "ExpirationInDays": 28,
+              "Prefix": "Observer_newspaper_subscribers/",
               "Status": "Enabled",
             },
           ],
@@ -1733,10 +1740,17 @@ exports[`The ObserverDataExport stack matches the snapshot 2`] = `
           "Rules": [
             {
               "ExpirationInDays": 28,
+              "Prefix": "Observer_newsletter_eligible/",
               "Status": "Enabled",
             },
             {
-              "Prefix": "Public_keys/",
+              "ExpirationInDays": 28,
+              "Prefix": "Observer_newsletter_subscribers/",
+              "Status": "Enabled",
+            },
+            {
+              "ExpirationInDays": 28,
+              "Prefix": "Observer_newspaper_subscribers/",
               "Status": "Enabled",
             },
           ],

--- a/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
+++ b/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
@@ -34,6 +34,10 @@ exports[`The ObserverDataExport stack matches the snapshot 1`] = `
               "ExpirationInDays": 28,
               "Status": "Enabled",
             },
+            {
+              "Prefix": "Public_keys/",
+              "Status": "Enabled",
+            },
           ],
         },
         "Tags": [
@@ -1729,6 +1733,10 @@ exports[`The ObserverDataExport stack matches the snapshot 2`] = `
           "Rules": [
             {
               "ExpirationInDays": 28,
+              "Status": "Enabled",
+            },
+            {
+              "Prefix": "Public_keys/",
               "Status": "Enabled",
             },
           ],

--- a/cdk/lib/observer-data-export.ts
+++ b/cdk/lib/observer-data-export.ts
@@ -34,7 +34,10 @@ export class ObserverDataExport extends GuStack {
 
 		const sharedBucket = new Bucket(this, 'Bucket', {
 			bucketName: `${app}-${this.stage.toLowerCase()}`,
-			lifecycleRules: [{ expiration: Duration.days(28) }],
+			lifecycleRules: [
+				{ expiration: Duration.days(28) },
+				{ prefix: 'Public_keys/' }, // No expiration
+			],
 		});
 
 		const md5FingerprintsBucket = new Bucket(this, 'Md5FingerprintsBucket', {

--- a/cdk/lib/observer-data-export.ts
+++ b/cdk/lib/observer-data-export.ts
@@ -35,9 +35,13 @@ export class ObserverDataExport extends GuStack {
 		const sharedBucket = new Bucket(this, 'Bucket', {
 			bucketName: `${app}-${this.stage.toLowerCase()}`,
 			lifecycleRules: [
-				{ expiration: Duration.days(28) },
-				{ prefix: 'Public_keys/' }, // No expiration
-			],
+				'Observer_newsletter_eligible/',
+				'Observer_newsletter_subscribers/',
+				'Observer_newspaper_subscribers/',
+			].map((prefix) => ({
+				expiration: Duration.days(28),
+				prefix,
+			})),
 		});
 
 		const md5FingerprintsBucket = new Bucket(this, 'Md5FingerprintsBucket', {


### PR DESCRIPTION
## What does this change?

The observer-data-export S3 bucket has currently a retention period of 28 days. However, it also contains Unifida's public key which should not expire (`s3://observer-data-export-prod/Public_keys/unifida_public_rsa_key.pem`).

Therefore, this PR updates the S3 bucket lifecycle rules to specify which folders should have a retention of 28 days, rather than including the whole bucket.

