### PR TITLE
Fixed price change + Added price validation when switching to recurring contribution

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
@@ -1,10 +1,10 @@
 package com.gu.productmove.endpoint.move.switchtype
 
+import com.gu.i18n.Currency
 import com.gu.newproduct.api.productcatalog.ZuoraIds.zuoraIdsForStage
 import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
 import com.gu.productmove.*
 import com.gu.productmove.GuStageLive.Stage
-import com.gu.productmove.endpoint.available.Currency
 import com.gu.productmove.endpoint.move.ProductMoveEndpoint.SwitchType
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.*
 import com.gu.productmove.endpoint.move.stringFor
@@ -212,11 +212,11 @@ class ToRecurringContributionImpl(
       price: BigDecimal,
   ): Task[Unit] = {
     val expectedPrices = Map(
-      "GBP" -> Map("month" -> 7, "year" -> 75),
-      "USD" -> Map("month" -> 9.99, "year" -> 120),
-      "EUR" -> Map("month" -> 9.99, "year" -> 95),
-      "AUD" -> Map("month" -> 14.99, "year" -> 160),
-      "CAD" -> Map("month" -> 12.99, "year" -> 120),
+      Currency.GBP -> Map("month" -> 7, "year" -> 75),
+      Currency.USD -> Map("month" -> 9.99, "year" -> 120),
+      Currency.EUR -> Map("month" -> 9.99, "year" -> 95),
+      Currency.AUD -> Map("month" -> 14.99, "year" -> 160),
+      Currency.CAD -> Map("month" -> 12.99, "year" -> 120),
     )
 
     val periodKey = billingPeriod match {
@@ -225,14 +225,14 @@ class ToRecurringContributionImpl(
       case _ => throw new IllegalArgumentException(s"Unsupported billing period: $billingPeriod")
     }
 
-    expectedPrices.get(currency.symbol) match {
+    expectedPrices.get(currency) match {
       case Some(prices) if prices.get(periodKey).contains(price.toDouble) =>
         ZIO.unit
       case _ =>
         ZIO.fail(
           new Throwable(
-            s"Invalid price $price for currency ${currency.symbol} and billing period $billingPeriod. Expected: ${expectedPrices
-                .get(currency.symbol)
+            s"Invalid price $price for currency ${currency.iso} and billing period $billingPeriod. Expected: ${expectedPrices
+                .get(currency)
                 .flatMap(_.get(periodKey))}",
           ),
         )

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
@@ -1,10 +1,10 @@
 package com.gu.productmove.endpoint.move.switchtype
 
-import com.gu.i18n.Currency
 import com.gu.newproduct.api.productcatalog.ZuoraIds.zuoraIdsForStage
 import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
 import com.gu.productmove.*
 import com.gu.productmove.GuStageLive.Stage
+import com.gu.productmove.endpoint.available.Currency
 import com.gu.productmove.endpoint.move.ProductMoveEndpoint.SwitchType
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.*
 import com.gu.productmove.endpoint.move.stringFor

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
@@ -1,5 +1,6 @@
 package com.gu.productmove.endpoint.move.switchtype
 
+import com.gu.i18n.Currency
 import com.gu.newproduct.api.productcatalog.ZuoraIds.zuoraIdsForStage
 import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
 import com.gu.productmove.*

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
@@ -73,7 +73,7 @@ class ToRecurringContributionImpl(
         .orElseFail(new Throwable(s"billingPeriod is null for rate plan charge $activeRatePlanCharge"))
 
       // Make sure that price is valid and acceptable
-      _ <- validatePrice(currency, billingPeriod, price)
+      _ <- validateOldMembershipPrice(currency, billingPeriod, price)
 
       updateRequestBody <- getRatePlans(
         billingPeriod,
@@ -206,17 +206,17 @@ class ToRecurringContributionImpl(
     if ratePlanCharge.chargedThroughDate.isDefined
   } yield (ratePlan, ratePlanCharge)).headOption
 
-  private def validatePrice(
+  private def validateOldMembershipPrice(
       currency: Currency,
       billingPeriod: BillingPeriod,
       price: BigDecimal,
   ): Task[Unit] = {
     val expectedPrices = Map(
-      "GBP" -> Map("month" -> 7, "year" -> 75),
-      "USD" -> Map("month" -> 9.99, "year" -> 120),
-      "EUR" -> Map("month" -> 9.99, "year" -> 95),
-      "AUD" -> Map("month" -> 14.99, "year" -> 160),
-      "CAD" -> Map("month" -> 12.99, "year" -> 120),
+      "GBP" -> Map("month" -> 5, "year" -> 49),
+      "USD" -> Map("month" -> 6.99, "year" -> 69),
+      "EUR" -> Map("month" -> 4.99, "year" -> 49),
+      "AUD" -> Map("month" -> 10, "year" -> 100),
+      "CAD" -> Map("month" -> 6.99, "year" -> 69),
     )
 
     val periodKey = billingPeriod match {

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
@@ -212,11 +212,11 @@ class ToRecurringContributionImpl(
       price: BigDecimal,
   ): Task[Unit] = {
     val expectedPrices = Map(
-      Currency.GBP -> Map("month" -> 7, "year" -> 75),
-      Currency.USD -> Map("month" -> 9.99, "year" -> 120),
-      Currency.EUR -> Map("month" -> 9.99, "year" -> 95),
-      Currency.AUD -> Map("month" -> 14.99, "year" -> 160),
-      Currency.CAD -> Map("month" -> 12.99, "year" -> 120),
+      "GBP" -> Map("month" -> 7, "year" -> 75),
+      "USD" -> Map("month" -> 9.99, "year" -> 120),
+      "EUR" -> Map("month" -> 9.99, "year" -> 95),
+      "AUD" -> Map("month" -> 14.99, "year" -> 160),
+      "CAD" -> Map("month" -> 12.99, "year" -> 120),
     )
 
     val periodKey = billingPeriod match {
@@ -225,17 +225,20 @@ class ToRecurringContributionImpl(
       case _ => throw new IllegalArgumentException(s"Unsupported billing period: $billingPeriod")
     }
 
-    expectedPrices.get(currency) match {
+    val currencyCode = currency.iso
+
+    expectedPrices.get(currencyCode) match {
       case Some(prices) if prices.get(periodKey).contains(price.toDouble) =>
         ZIO.unit
       case _ =>
         ZIO.fail(
           new Throwable(
-            s"Invalid price $price for currency ${currency.iso} and billing period $billingPeriod. Expected: ${expectedPrices
-                .get(currency)
+            s"Invalid price $price for currency $currencyCode and billing period $billingPeriod. Expected: ${expectedPrices
+                .get(currencyCode)
                 .flatMap(_.get(periodKey))}",
           ),
         )
     }
   }
+
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds price validation to the product move API when switching to a recurring contribution. Previously, we were accepting any price input from the frontend when processing this switch. Now, we:

1. Added a new validateOldMembershipPrice method that checks if the provided price matches the expected price for the given currency and billing period
2. Fixed an issue where we were using the previousAmount instead of the new price when creating rate plans (link [here](https://trello.com/c/4dqTTGKs/288-severity-2-medium-bug-report-74-system-impacted-manage-my-account-mma-product-switch-payment-amount-not-reflected-in-mma)).
3. The validation ensures prices match our expected values for different currency and billing period combinations

The main benefits are:

- Prevents potential security issues by validating prices server-side
- Ensures price consistency between frontend and backend
- Makes the backend the source of truth for valid prices

Some context:

- **Somewhere in 2023 there was a Membership Price Rise.**
- **Users that still have the "Supporter Membership" subscription are allowed (we offer them) to move their product to a Recurring Subscription keeping the current price (old price, before 2023).**

Compare old and new prices.

Determine if a user is eligible for a "save" journey (e.g., offering discounts or alternative plans to retain the user).

Display the correct pricing based on the user's subscription status (e.g., whether they are on the old or new pricing).

## How to test

1. Try switching a subscription to a recurring contribution with valid prices:

- GBP: £5/month or £49/year
- USD: $6.99/month or $69/year
- EUR: €4.99/month or €49/year
- AUD: $10/month or $100/year
- CAD: $6.99/month or $69/year

2. Try switching with an invalid price (should fail with appropriate error message):

- Example: GBP £8/month (not in valid price list)
- Example: USD $10/month (not in valid price list)


3. Verify error messages are clear and helpful

## How can we measure success?

1. No failed switches due to price mismatches between frontend and backend
2. Reduction in support tickets related to price inconsistencies
3. Successful blocking of any attempts to use invalid prices
4. No performance degradation in the switching process

## Have we considered potential risks?

- **Limited flexibility**: By hardcoding accepted prices, we'll need to update both frontend and backend if prices change. This is an acceptable tradeoff given the temporary nature of this feature.
- **Error handling**: We need to ensure errors are appropriately surfaced to users with clear messages about what went wrong.
- **Future maintenance**: The hardcoded price table will need to be kept in sync with any price changes, but as known, this is a transitional solution until all users are migrated.
- **Performance impact**: The validation adds minimal overhead and doesn't require any API calls, so performance impact should be negligible.

## Images

N/A - This is a backend change with no UI modifications.

## Accessibility

N/A - This change doesn't affect the UI or accessibility features.
