### PR TITLE
fix: correct api field is Comment - not Comments

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -89,7 +89,7 @@ object InvoicingApiRefund {
         {
             "AdjustmentDate": "2022-09-29",
             "Amount": 30,
-            "Comments": "e6282ccd-d06a-49bd-ad2e-9c362e912232",
+            "Comment": "e6282ccd-d06a-49bd-ad2e-9c362e912232",
             "InvoiceId": "8ad0877b8373493d018389a5f5301259",
             "Type": "Credit",
             "SourceType": "InvoiceDetail",

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/InvoiceItemAdjustment.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/InvoiceItemAdjustment.scala
@@ -78,7 +78,7 @@ object InvoiceItemAdjustment {
       SourceId: String, // The invoice item id
       Type: String = "Charge",
       SourceType: String,
-      Comments: String = "Created by the product-move-api refund process to balance a cancelled invoice",
+      Comment: String = "Created by the product-move-api refund process to balance a cancelled invoice",
   )
 
   case class InvoiceItemAdjustmentResult(Success: Boolean, Id: String)

--- a/modules/zuora/src/invoice.ts
+++ b/modules/zuora/src/invoice.ts
@@ -37,7 +37,7 @@ export const creditInvoice = async (
 	invoiceId: string,
 	invoiceItemId: string,
 	amount: number,
-	comments?: string,
+	comment?: string,
 ): Promise<InvoiceItemAdjustmentResult> => {
 	console.log(`Adjusting invoice ${invoiceId} by ${amount}`);
 	return await zuoraClient.post(
@@ -49,7 +49,7 @@ export const creditInvoice = async (
 			SourceId: invoiceItemId,
 			SourceType: 'InvoiceDetail',
 			Type: 'Credit',
-			Comments: comments ?? 'Created by support-service-lambdas',
+			Comment: comment ?? 'Created by support-service-lambdas',
 		}),
 		invoiceItemAdjustmentResultSchema,
 	);


### PR DESCRIPTION
## What does this change?

For the API call Create an invoice item adjustment, correct api field is Comment - not Comments.

Worth noting that the Zuora docs are incoherent & incorrect too.

https://developer.zuora.com/v1-api-reference/older-api/operation/Object_POSTInvoiceItemAdjustment/

Example invoice item adjustment where comment is null: https://www.zuora.com/apps/InvoiceItemAdjustment.do?method=view&id=8a12926d966ad25f0196a2e9f267692f

<img width="515" alt="Screenshot 2025-05-06 at 15 29 51" src="https://github.com/user-attachments/assets/2e3338db-d3ae-43eb-b291-3982acbafaf5" />
<img width="792" alt="Screenshot 2025-05-06 at 15 30 01" src="https://github.com/user-attachments/assets/2caae18f-3d03-41c0-8b29-e758e7a9a5b8" />
