### PR TITLE
don't use salesforce query to set SOI consents on acquisition

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -183,7 +183,7 @@ object Handler extends LazyLogging {
       if (consents.nonEmpty) {
         sendConsentsReq(
           identityId,
-          consentsCalculator.buildConsentsBody(consents, state = false),
+          consentsCalculator.buildConsentsBody(consents.map(_ -> false).toMap),
         )
       } else {
         Right(())

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -40,7 +40,7 @@ object Handler extends LazyLogging {
       consentsCalculator = new ConsentsCalculator(ConsentsMapping.consentsMapping)
 
       acqSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyToProcessAcquisitionStatus))
-      _ <- processAcquiredSubs(acqSubs, identityConnector.sendConsentsReq, sfConnector.updateSubs, consentsCalculator)
+      _ <- markAcquiredSubsProcessed(acqSubs, sfConnector.updateSubs)
 
       cancelledSubs = allSubs.records.filter(_.Soft_Opt_in_Status__c.equals(readyToProcessCancellationStatus))
       cancelledSubsIdentityIds = cancelledSubs.map(sub => sub.Buyer__r.IdentityID__c)
@@ -76,32 +76,21 @@ object Handler extends LazyLogging {
       })
   }
 
-  def processAcquiredSubs(
+  def markAcquiredSubsProcessed(
       acquiredSubs: Seq[SFSubRecord],
-      sendConsentsReq: (String, String) => Either[SoftOptInError, Unit],
       updateSubs: String => Either[SoftOptInError, Unit],
-      consentsCalculator: ConsentsCalculator,
   ): Either[SoftOptInError, Unit] = {
     Metrics.put(event = "acquisitions_to_process", acquiredSubs.size)
 
     val recordsToUpdate = acquiredSubs
       .map(sub => {
-        val updateResult =
-          for {
-            consents <- consentsCalculator.getSoftOptInsByProduct(sub.Product__c)
-            consentsBody = consentsCalculator.buildConsentsBody(consents, state = true)
-            _ = logger.info(
-              s"Sending consents request - sub ${sub.Name}, Identity id ${sub.Buyer__r.IdentityID__c}, product ${sub.Product__c} with body $consentsBody",
-            )
-            _ <- sendConsentsReq(sub.Buyer__r.IdentityID__c, consentsBody)
-          } yield ()
-
-        logErrors(updateResult)
-
-        SFSubRecordUpdate(
+        // as cleanup, we could stop salesforce making these available in the first place
+        logger.info(
+          s"acquisition consents are set via event bus/queue, marking as processed: ${sub.Name} on ${sub.Buyer__r.IdentityID__c}",
+        )
+        SFSubRecordUpdate.successfulUpdate(
           sub,
           "Acquisition",
-          updateResult,
         )
       })
 


### PR DESCRIPTION
As part of switching over to triggering acquisition consents via the queue for zuora products https://github.com/guardian/support-service-lambdas/pull/2776 , we need to disable the old salesforce based consent mechanism.

This PR is a simple way by making acquisiton consent setting a no-op.

In the longer term we can make it not appear in the SF query, but this means we can quickly reenable it if there is an issue by reverting this PR.

This PR should be merged once we are happy that the queue based consent is coming through alright.  Until that happens, there will be a race condition where both lambdas will write the consents, but this lambda will usually come in last, making it safer.