### PR TITLE
Revert Changes On Product Move API from Supporter Membership to Recurring Subscription

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/ToRecurringContribution.scala
@@ -77,7 +77,7 @@ class ToRecurringContributionImpl(
 
       updateRequestBody <- getRatePlans(
         billingPeriod,
-        price,
+        previousAmount,
         subscription.ratePlans,
         activeRatePlanCharge.chargedThroughDate.get,
       ).map { case (addRatePlan, removeRatePlan) =>


### PR DESCRIPTION
## What does this change?

This change reverts the major change done in [this](https://github.com/guardian/support-service-lambdas/pull/2810) pull request. After a new evaluation it was found that the price is changing but the subscription type is not. So we will revert this until we understand what is happening.

Why could the user be staying on the Supporter Membership?
If the price is incorrect or does not match the expected value for the target product (e.g., an annual recurring subscription), the migration logic might fail silently or reject the migration request. This would leave the user on their current product (supporter membership).