### PR TITLE
fix soft opt in setter to use actual print product instead of whole printOptions object

### DIFF
--- a/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
+++ b/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
@@ -789,12 +789,12 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
             "InputTransformer": {
               "InputPathsMap": {
                 "detail-identityId": "$.detail.identityId",
-                "detail-printOptions": "$.detail.printOptions",
+                "detail-printOptions-product": "$.detail.printOptions.product",
                 "detail-product": "$.detail.product",
                 "detail-similarProductsConsent": "$.detail.similarProductsConsent",
                 "detail-zuoraSubscriptionNumber": "$.detail.zuoraSubscriptionNumber",
               },
-              "InputTemplate": "{"subscriptionId":<detail-zuoraSubscriptionNumber>,"identityId":<detail-identityId>,"eventType":"Acquisition","productName":<detail-product>,"printOptions":<detail-printOptions>,"previousProductName":null,"userConsentsOverrides":{"similarGuardianProducts":<detail-similarProductsConsent>}}",
+              "InputTemplate": "{"subscriptionId":<detail-zuoraSubscriptionNumber>,"identityId":<detail-identityId>,"eventType":"Acquisition","productName":<detail-product>,"printProduct":<detail-printOptions-product>,"previousProductName":null,"userConsentsOverrides":{"similarGuardianProducts":<detail-similarProductsConsent>}}",
             },
           },
         ],

--- a/cdk/lib/soft-opt-in-consent-setter.ts
+++ b/cdk/lib/soft-opt-in-consent-setter.ts
@@ -431,8 +431,8 @@ export class SoftOptInConsentSetter extends GuStack {
 						identityId: aws_events.EventField.fromPath('$.detail.identityId'),
 						eventType: 'Acquisition',
 						productName: aws_events.EventField.fromPath('$.detail.product'),
-						printOptions: aws_events.EventField.fromPath(
-							'$.detail.printOptions',
+						printProduct: aws_events.EventField.fromPath(
+							'$.detail.printOptions.product',
 						),
 						previousProductName: null,
 						userConsentsOverrides: {

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -42,7 +42,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       identityId: String,
       eventType: EventType,
       productName: String,
-      printOptions: Option[String],
+      printProduct: Option[String],
       previousProductName: Option[String],
       userConsentsOverrides: Option[UserConsentsOverrides],
   )
@@ -150,7 +150,7 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       sendConsentsReq: (String, String) => Either[SoftOptInError, Unit],
       consentsCalculator: ConsentsCalculator,
   ): Either[SoftOptInError, Unit] = {
-    val mappingProductName = ConsentsMapping.productMappings(message.productName, message.printOptions)
+    val mappingProductName = ConsentsMapping.productMappings(message.productName, message.printProduct)
     for {
       consentKeys <- consentsCalculator.getSoftOptInsByProduct(mappingProductName)
       implicitConsents = consentKeys.map(_ -> true).toMap

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -10,16 +10,16 @@ object ConsentsMapping {
   /*
   This function is needed because when events come from the acquisition event bus, they have an ophan style product name.
    */
-  def productMappings(productName: String, printOptions: Option[String]): String = {
+  def productMappings(productName: String, printProduct: Option[String]): String = {
     // the values on the left come from https://github.com/guardian/support-frontend/blob/beef97734c1ca1549bc1cb5f1ea5b4501d24fc46/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala#L97
     productName match {
       case "RECURRING_CONTRIBUTION" => "Contribution"
       case "SUPPORTER_PLUS" => "Supporter Plus"
       case "TIER_THREE" => "Tier Three"
       case "DIGITAL_SUBSCRIPTION" => "Digital Pack"
-      case "PRINT_SUBSCRIPTION" if printOptions.exists(List("HOME_DELIVERY_SUNDAY", "VOUCHER_SUNDAY").contains) => "Newspaper - Observer only" // don't set any consents for observer only
-      case "PRINT_SUBSCRIPTION" if !printOptions.contains("GUARDIAN_WEEKLY") => "newspaper"
-      case "PRINT_SUBSCRIPTION" if printOptions.contains("GUARDIAN_WEEKLY") => "Guardian Weekly"
+      case "PRINT_SUBSCRIPTION" if printProduct.exists(List("HOME_DELIVERY_SUNDAY", "VOUCHER_SUNDAY").contains) => "Newspaper - Observer only" // don't set any consents for observer only
+      case "PRINT_SUBSCRIPTION" if !printProduct.contains("GUARDIAN_WEEKLY") => "newspaper"
+      case "PRINT_SUBSCRIPTION" if printProduct.contains("GUARDIAN_WEEKLY") => "Guardian Weekly"
       case "GUARDIAN_AD_LITE" => "Guardian Ad-Lite"
       case other => other
     }

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/HandlerTests.scala
@@ -58,7 +58,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
-      printOptions = None,
+      printProduct = None,
       previousProductName = Some("Contributor"),
       eventType = Switch,
       subscriptionId = "A-S12345678",
@@ -100,7 +100,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
-      printOptions = None,
+      printProduct = None,
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",
@@ -142,7 +142,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
-      printOptions = None,
+      printProduct = None,
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -190,7 +190,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
-      printOptions = None,
+      printProduct = None,
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -240,7 +240,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Supporter Plus",
-      printOptions = None,
+      printProduct = None,
       previousProductName = None,
       eventType = Cancellation,
       subscriptionId = "A-S12345678",
@@ -285,7 +285,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Tier Three",
-      printOptions = None,
+      printProduct = None,
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",
@@ -329,7 +329,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Tier Three",
-      printOptions = None,
+      printProduct = None,
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",
@@ -373,7 +373,7 @@ class HandlerTests extends AnyFunSuite with Matchers with MockFactory {
     val testMessageBody = MessageBody(
       identityId = "someIdentityId",
       productName = "Tier Three",
-      printOptions = None,
+      printProduct = None,
       previousProductName = None,
       eventType = Acquisition,
       subscriptionId = "A-S12345678",

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/JsonCodecSpec.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com.gu.soft_opt_in_consent_setter/JsonCodecSpec.scala
@@ -1,15 +1,17 @@
 package com.gu.soft_opt_in_consent_setter
 
-import com.gu.soft_opt_in_consent_setter.models.{SFSubRecordResponse}
+import com.gu.soft_opt_in_consent_setter.HandlerIAP.{Acquisition, Cancellation, MessageBody, UserConsentsOverrides}
+import com.gu.soft_opt_in_consent_setter.models.SFSubRecordResponse
 import com.gu.soft_opt_in_consent_setter.testData.SFSubscriptionTestData.{subRecord2, subRecord3}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 import io.circe.generic.auto._
 import io.circe.parser.decode
+import org.scalatest.Inside
 
 import scala.io.Source
 
-class JsonCodecSpec extends AnyFlatSpec with should.Matchers {
+class JsonCodecSpec extends AnyFlatSpec with should.Matchers with Inside {
   it should "JSON Decoding: decodes SF_Subscription__c correctly" in {
     val json = Source.fromResource("sfSubRecords.json").mkString
 
@@ -25,4 +27,58 @@ class JsonCodecSpec extends AnyFlatSpec with should.Matchers {
 
     record shouldBe Right(MobileSubscriptions(List(MobileSubscription(false, "InAppPurchase"))))
   }
+
+  "queue decoder" should "handle a guardian weekly with no overrides" in {
+    val testData =
+      """{
+        |    "subscriptionId": "A-S000",
+        |    "identityId": "1234",
+        |    "eventType": "Acquisition",
+        |    "productName": "PRINT_SUBSCRIPTION",
+        |    "printProduct": "GUARDIAN_WEEKLY",
+        |    "previousProductName": null,
+        |    "userConsentsOverrides": {
+        |        "similarGuardianProducts": null
+        |    }
+        |}""".stripMargin
+    val expected = MessageBody(
+      subscriptionId = "A-S000",
+      identityId = "1234",
+      eventType = Acquisition,
+      productName = "PRINT_SUBSCRIPTION",
+      printProduct = Some("GUARDIAN_WEEKLY"),
+      previousProductName = None,
+      userConsentsOverrides = Some(UserConsentsOverrides(None)),
+    )
+    inside(decode[MessageBody](testData)) {
+      case Right(actual) => actual should be(expected)
+    }
+  }
+
+  it should "handle a non print product" in {
+    val testData =
+      """{
+        |    "subscriptionId": "A-S000",
+        |    "identityId": "1234",
+        |    "eventType": "Acquisition",
+        |    "productName": "SUPPORTER_PLUS",
+        |    "previousProductName": null,
+        |    "userConsentsOverrides": {
+        |        "similarGuardianProducts": true
+        |    }
+        |}""".stripMargin
+    val expected = MessageBody(
+      subscriptionId = "A-S000",
+      identityId = "1234",
+      eventType = Acquisition,
+      productName = "SUPPORTER_PLUS",
+      printProduct = None,
+      previousProductName = None,
+      userConsentsOverrides = Some(UserConsentsOverrides(Some(true))),
+    )
+    inside(decode[MessageBody](testData)) {
+      case Right(actual) => actual should be(expected)
+    }
+  }
+
 }


### PR DESCRIPTION
We noticed a lot of alarms where guardian weekly could not be set consents.  
The error was this (also logged on HandlerIAP$:52)
```
com.gu.soft_opt_in_consent_setter.models.SoftOptInError: Unknown error when decoding JSON to MessageBody with body: 
{
    "subscriptionId": "A-S11111111",
    "identityId": "22222222",
    "eventType": "Acquisition",
    "productName": "PRINT_SUBSCRIPTION",
    "printOptions": {
        "product": "GUARDIAN_WEEKLY",
        "deliveryCountry": "GB"
    },
    "previousProductName": null,
    "userConsentsOverrides": {
        "similarGuardianProducts": null
    }
}

	at com.gu.soft_opt_in_consent_setter.HandlerIAP$.$anonfun$handleRequest$1(HandlerIAP.scala:69)
	at scala.collection.immutable.List.map(List.scala:247)
	at com.gu.soft_opt_in_consent_setter.HandlerIAP$.handleRequest(HandlerIAP.scala:60)
	at com.gu.soft_opt_in_consent_setter.HandlerIAP.handleRequest(HandlerIAP.scala)
```
The issue is that the printProducts value is an object [1], whereas we thought it was a string.

This PR changes it so that the actual product is extracted, and renamed the property to reflect that.

[1] https://github.com/guardian/support-frontend/blob/main/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala#L168-L181
