### PR TITLE
always chain exceptions in SOI setter

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/AwsCredentialsBuilder.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/AwsCredentialsBuilder.scala
@@ -27,7 +27,7 @@ object AwsCredentialsBuilder extends LazyLogging {
       case Success(credentialsProvider) => Right(credentialsProvider)
       case Failure(e) =>
         logger.error("Failed to build AWS credentials", e)
-        Left(SoftOptInError("Failed to build AWS credentials"))
+        Left(SoftOptInError("Failed to build AWS credentials", e))
     }
   }
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/DynamoConnector.scala
@@ -59,7 +59,7 @@ object DynamoConnector extends LazyLogging {
         case Success(dynamoDbClient) => Right(new DynamoConnector(dynamoDbClient))
         case Failure(e) =>
           logger.error("Failed to build DynamoDB client", e)
-          Left(SoftOptInError("Failed to build DynamoDB client"))
+          Left(SoftOptInError("Failed to build DynamoDB client", e))
       }
     }
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -62,11 +62,12 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
           case Left(pf: ParsingFailure) =>
             val exception = SoftOptInError(
               s"Error '${pf.message}' when decoding JSON to MessageBody with cause :${pf.getCause} with body: ${message.getBody}",
+              pf,
             )
             handleError(exception)
-          case Left(_) =>
+          case Left(ex) =>
             val exception =
-              SoftOptInError(s"Unknown error when decoding JSON to MessageBody with body: ${message.getBody}")
+              SoftOptInError(s"Unknown error when decoding JSON to MessageBody with body: ${message.getBody}", ex)
             handleError(exception)
           case Right(result) =>
             logger.info(s"Decoded message body: $result")

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IdentityConnector.scala
@@ -29,7 +29,7 @@ class IdentityConnector(config: IdentityConfig) {
       errorDesc: String = "",
   ): Either[SoftOptInError, Unit] = {
     response.left
-      .map(i => SoftOptInError(s"IdentityConnector: Identity request failed: $i"))
+      .map(i => SoftOptInError(s"IdentityConnector: Identity request failed: $i", i))
       .flatMap { response =>
         if (response.isSuccess)
           Right(())

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
@@ -18,7 +18,7 @@ class MpapiConnector(config: MpapiConfig) {
       errorDesc: String = "Decode error",
   ): Either[SoftOptInError, T] = {
     response.left
-      .map(error => SoftOptInError(s"MpapiConnector: Mobile purchases API (MPAPI) query request failed: $error"))
+      .map(error => SoftOptInError(s"MpapiConnector: Mobile purchases API (MPAPI) query request failed: $error", error))
       .flatMap { result =>
         decode[T](result.body).left.map(decodeError =>
           SoftOptInError(s"MpapiConnector: $errorDesc:$decodeError. String to decode ${result.body}"),

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
@@ -79,7 +79,7 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
       errorDesc: String = "Decode error",
   ): Either[SoftOptInError, T] = {
     response.left
-      .map(error => SoftOptInError(s"SalesforceConnector: Salesforce query request failed: $error"))
+      .map(error => SoftOptInError(s"SalesforceConnector: Salesforce query request failed: $error", error))
       .flatMap { result =>
         decode[T](result.body).left.map(decodeError =>
           SoftOptInError(s"SalesforceConnector: $errorDesc:$decodeError. String to decode ${result.body}"),
@@ -92,7 +92,7 @@ class SalesforceConnector(sfAuthDetails: SalesforceAuth, sfApiVersion: String) e
       putMetric: (String, Double) => Unit,
   ): Either[SoftOptInError, Unit] = {
     response.left
-      .map(i => SoftOptInError(s"SalesforceConnector: Salesforce composite request failed: $i"))
+      .map(i => SoftOptInError(s"SalesforceConnector: Salesforce composite request failed: $i", i))
       .flatMap { result =>
         decode[List[SFResponse]](result.body) match {
           case Right(compositeResponse) =>
@@ -146,7 +146,7 @@ object SalesforceConnector {
 
   def handleAuthResp(response: Either[Throwable, HttpResponse[String]]): Either[SoftOptInError, SalesforceAuth] = {
     response.left
-      .map(i => SoftOptInError(s"SalesforceConnector: Salesforce authentication failed: $i"))
+      .map(i => SoftOptInError(s"SalesforceConnector: Salesforce authentication failed: $i", i))
       .flatMap { result =>
         decode[SalesforceAuth](result.body).left
           .map(i =>

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/SoftOptInError.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/SoftOptInError.scala
@@ -1,3 +1,7 @@
 package com.gu.soft_opt_in_consent_setter.models
 
-case class SoftOptInError(message: String) extends Exception(message)
+case class SoftOptInError(message: String, cause: Throwable) extends Exception(message, cause)
+
+object SoftOptInError {
+  def apply(message: String) = new SoftOptInError(message, null)
+}


### PR DESCRIPTION
We had an incident in SOI setter where the exception information was missing for the root cause from the logs.

This PR adds root cause information to all exceptions where present.

It should surface something like this:
`DecodingFailure at .printOptions: Got value '{"product":"GUARDIAN_WEEKLY","deliveryCountry":"GB"}' with wrong type, expecting string`