### PR TITLE
connect soft opt in setter to the event bus for payment api

### DIFF
--- a/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
+++ b/cdk/lib/__snapshots__/soft-opt-in-consent-setter.test.ts.snap
@@ -748,6 +748,42 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "PaymentApiSoftOptInToSQSRule769CA5B4": {
+      "Properties": {
+        "Description": "Send all events received via payment-api onto soft opt-in SQS queue",
+        "EventBusName": "acquisitions-bus-CODE",
+        "EventPattern": {
+          "region": [
+            "eu-west-1",
+          ],
+          "source": [
+            "payment-api.1",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "SoftOptInsQueue",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "InputTransformer": {
+              "InputPathsMap": {
+                "detail-contributionId": "$.detail.contributionId",
+                "detail-identityId": "$.detail.identityId",
+                "detail-product": "$.detail.product",
+                "detail-similarProductsConsent": "$.detail.similarProductsConsent",
+              },
+              "InputTemplate": "{"subscriptionId":<detail-contributionId>,"identityId":<detail-identityId>,"eventType":"Acquisition","productName":<detail-product>,"previousProductName":null,"userConsentsOverrides":{"similarGuardianProducts":<detail-similarProductsConsent>}}",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "SQSTrigger": {
       "Properties": {
         "BatchSize": 1,
@@ -1030,6 +1066,33 @@ exports[`The SoftOptInConsentSetter stack matches the snapshot 1`] = `
                   "aws:SourceArn": {
                     "Fn::GetAtt": [
                       "SoftOptInToSQSRuleA7A6FB25",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SoftOptInsQueue",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "PaymentApiSoftOptInToSQSRule769CA5B4",
                       "Arn",
                     ],
                   },

--- a/cdk/lib/soft-opt-in-consent-setter.ts
+++ b/cdk/lib/soft-opt-in-consent-setter.ts
@@ -444,5 +444,33 @@ export class SoftOptInConsentSetter extends GuStack {
 				}),
 			],
 		});
+
+		new Rule(this, 'PaymentApiSoftOptInToSQSRule', {
+			description:
+				'Send all events received via payment-api onto soft opt-in SQS queue',
+			eventBus: acquisitionsEventBus,
+			eventPattern: {
+				region: ['eu-west-1'],
+				source: ['payment-api.1'],
+			},
+			targets: [
+				new SqsQueue(softOptInsQueue, {
+					message: aws_events.RuleTargetInput.fromObject({
+						subscriptionId: aws_events.EventField.fromPath(
+							'$.detail.contributionId',
+						),
+						identityId: aws_events.EventField.fromPath('$.detail.identityId'),
+						eventType: 'Acquisition',
+						productName: aws_events.EventField.fromPath('$.detail.product'),
+						previousProductName: null,
+						userConsentsOverrides: {
+							similarGuardianProducts: aws_events.EventField.fromPath(
+								'$.detail.similarProductsConsent',
+							),
+						},
+					}),
+				}),
+			],
+		});
 	}
 }

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -7,20 +7,24 @@ object ConsentsMapping {
   val subscriberPreview = "subscriber_preview"
   val guardianWeeklyNewsletter = "guardian_weekly_newsletter"
 
+  private val singleAndRecurringContribution = "Contribution"
+
   /*
-  This function is needed because when events come from the acquisition event bus, they have an ophan style product name.
+    This function is needed because when events come from the acquisition event bus, they have an ophan style product name.
    */
   def productMappings(productName: String, printProduct: Option[String]): String = {
     // the values on the left come from https://github.com/guardian/support-frontend/blob/beef97734c1ca1549bc1cb5f1ea5b4501d24fc46/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala#L97
     productName match {
-      case "RECURRING_CONTRIBUTION" => "Contribution"
+      case "RECURRING_CONTRIBUTION" => singleAndRecurringContribution
       case "SUPPORTER_PLUS" => "Supporter Plus"
       case "TIER_THREE" => "Tier Three"
       case "DIGITAL_SUBSCRIPTION" => "Digital Pack"
-      case "PRINT_SUBSCRIPTION" if printProduct.exists(List("HOME_DELIVERY_SUNDAY", "VOUCHER_SUNDAY").contains) => "Newspaper - Observer only" // don't set any consents for observer only
+      case "PRINT_SUBSCRIPTION" if printProduct.exists(List("HOME_DELIVERY_SUNDAY", "VOUCHER_SUNDAY").contains) =>
+        "Newspaper - Observer only" // don't set any consents for observer only
       case "PRINT_SUBSCRIPTION" if !printProduct.contains("GUARDIAN_WEEKLY") => "newspaper"
       case "PRINT_SUBSCRIPTION" if printProduct.contains("GUARDIAN_WEEKLY") => "Guardian Weekly"
       case "GUARDIAN_AD_LITE" => "Guardian Ad-Lite"
+      case "CONTRIBUTION" /* single */ => singleAndRecurringContribution
       case other => other
     }
   }
@@ -36,17 +40,17 @@ object ConsentsMapping {
       similarGuardianProducts,
       supporterNewsletter,
     ),
-    "Contribution" -> Set(
+    singleAndRecurringContribution -> Set(
       yourSupportOnboarding,
       similarGuardianProducts,
       supporterNewsletter,
     ),
-    "Recurring Contribution" -> Set(
+    "Recurring Contribution" -> Set( // unused I think
       yourSupportOnboarding,
       similarGuardianProducts,
       supporterNewsletter,
     ),
-    "Contributor" -> Set(
+    "Contributor" -> Set( // unused I think
       yourSupportOnboarding,
       similarGuardianProducts,
       supporterNewsletter,


### PR DESCRIPTION
At the moment, payment api writes consents to the queue and ophan data to the bus.

This is out of step with how support-workers acquisitions happen as the SOI rule reads directly from the bus.

This PR adds a rule so that payment API events will also come from the bus.

After this PR it needs to be changed in support-frontend repo so payment api will no longer send directly to the queue.