### PR TITLE
Rename Paper+ rate plans to PaperPlus to avoid problems with url encoding

### DIFF
--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -644,73 +644,83 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.NewspaperVoucher.billingPeriods)
 					.optional(),
 			}),
-			EverydayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Monday: z.object({ id: z.string() }),
-					Tuesday: z.object({ id: z.string() }),
-					Wednesday: z.object({ id: z.string() }),
-					Thursday: z.object({ id: z.string() }),
-					Friday: z.object({ id: z.string() }),
-					Saturday: z.object({ id: z.string() }),
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.NewspaperVoucher.billingPeriods)
-					.optional(),
-			}),
-			SixdayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Monday: z.object({ id: z.string() }),
-					Tuesday: z.object({ id: z.string() }),
-					Wednesday: z.object({ id: z.string() }),
-					Thursday: z.object({ id: z.string() }),
-					Friday: z.object({ id: z.string() }),
-					Saturday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.NewspaperVoucher.billingPeriods)
-					.optional(),
-			}),
-			WeekendPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Saturday: z.object({ id: z.string() }),
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.NewspaperVoucher.billingPeriods)
-					.optional(),
-			}),
-			SaturdayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Saturday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.NewspaperVoucher.billingPeriods)
-					.optional(),
-			}),
-			SundayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.NewspaperVoucher.billingPeriods)
-					.optional(),
-			}),
+			EverydayPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Monday: z.object({ id: z.string() }),
+						Tuesday: z.object({ id: z.string() }),
+						Wednesday: z.object({ id: z.string() }),
+						Thursday: z.object({ id: z.string() }),
+						Friday: z.object({ id: z.string() }),
+						Saturday: z.object({ id: z.string() }),
+						Sunday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.NewspaperVoucher.billingPeriods)
+						.optional(),
+				})
+				.optional(),
+			SixdayPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Monday: z.object({ id: z.string() }),
+						Tuesday: z.object({ id: z.string() }),
+						Wednesday: z.object({ id: z.string() }),
+						Thursday: z.object({ id: z.string() }),
+						Friday: z.object({ id: z.string() }),
+						Saturday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.NewspaperVoucher.billingPeriods)
+						.optional(),
+				})
+				.optional(),
+			WeekendPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Saturday: z.object({ id: z.string() }),
+						Sunday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.NewspaperVoucher.billingPeriods)
+						.optional(),
+				})
+				.optional(),
+			SaturdayPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Saturday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.NewspaperVoucher.billingPeriods)
+						.optional(),
+				})
+				.optional(),
+			SundayPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Sunday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.NewspaperVoucher.billingPeriods)
+						.optional(),
+				})
+				.optional(),
 		}),
 	}),
 	SupporterPlus: z.object({

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -334,7 +334,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.HomeDelivery.billingPeriods)
 					.optional(),
 			}),
-			'Everyday+': z.object({
+			EverydayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -351,7 +351,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.HomeDelivery.billingPeriods)
 					.optional(),
 			}),
-			'Sixday+': z.object({
+			SixdayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -367,7 +367,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.HomeDelivery.billingPeriods)
 					.optional(),
 			}),
-			'Weekend+': z.object({
+			WeekendPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -379,7 +379,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.HomeDelivery.billingPeriods)
 					.optional(),
 			}),
-			'Saturday+': z.object({
+			SaturdayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -390,7 +390,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.HomeDelivery.billingPeriods)
 					.optional(),
 			}),
-			'Sunday+': z.object({
+			SundayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -513,7 +513,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.SubscriptionCard.billingPeriods)
 					.optional(),
 			}),
-			'Everyday+': z.object({
+			EverydayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -530,7 +530,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.SubscriptionCard.billingPeriods)
 					.optional(),
 			}),
-			'Sixday+': z.object({
+			SixdayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -546,7 +546,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.SubscriptionCard.billingPeriods)
 					.optional(),
 			}),
-			'Weekend+': z.object({
+			WeekendPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -558,7 +558,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.SubscriptionCard.billingPeriods)
 					.optional(),
 			}),
-			'Saturday+': z.object({
+			SaturdayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -569,7 +569,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.SubscriptionCard.billingPeriods)
 					.optional(),
 			}),
-			'Sunday+': z.object({
+			SundayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -644,7 +644,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.NewspaperVoucher.billingPeriods)
 					.optional(),
 			}),
-			'Everyday+': z.object({
+			EverydayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -661,7 +661,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.NewspaperVoucher.billingPeriods)
 					.optional(),
 			}),
-			'Sixday+': z.object({
+			SixdayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -677,7 +677,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.NewspaperVoucher.billingPeriods)
 					.optional(),
 			}),
-			'Weekend+': z.object({
+			WeekendPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -689,7 +689,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.NewspaperVoucher.billingPeriods)
 					.optional(),
 			}),
-			'Saturday+': z.object({
+			SaturdayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({
@@ -700,7 +700,7 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.NewspaperVoucher.billingPeriods)
 					.optional(),
 			}),
-			'Sunday+': z.object({
+			SundayPlus: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 				charges: z.object({

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -275,133 +275,143 @@ export const productCatalogSchema = z.object({
 	HomeDelivery: z.object({
 		billingSystem: z.literal('zuora'),
 		active: z.boolean(),
-		ratePlans: z.object({
-			Everyday: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Monday: z.object({ id: z.string() }),
-					Tuesday: z.object({ id: z.string() }),
-					Wednesday: z.object({ id: z.string() }),
-					Thursday: z.object({ id: z.string() }),
-					Friday: z.object({ id: z.string() }),
-					Saturday: z.object({ id: z.string() }),
-					Sunday: z.object({ id: z.string() }),
+		ratePlans: z
+			.object({
+				Everyday: z.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Monday: z.object({ id: z.string() }),
+						Tuesday: z.object({ id: z.string() }),
+						Wednesday: z.object({ id: z.string() }),
+						Thursday: z.object({ id: z.string() }),
+						Friday: z.object({ id: z.string() }),
+						Saturday: z.object({ id: z.string() }),
+						Sunday: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.HomeDelivery.billingPeriods)
+						.optional(),
 				}),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-			Sixday: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Monday: z.object({ id: z.string() }),
-					Tuesday: z.object({ id: z.string() }),
-					Wednesday: z.object({ id: z.string() }),
-					Thursday: z.object({ id: z.string() }),
-					Friday: z.object({ id: z.string() }),
-					Saturday: z.object({ id: z.string() }),
+				Sixday: z.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Monday: z.object({ id: z.string() }),
+						Tuesday: z.object({ id: z.string() }),
+						Wednesday: z.object({ id: z.string() }),
+						Thursday: z.object({ id: z.string() }),
+						Friday: z.object({ id: z.string() }),
+						Saturday: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.HomeDelivery.billingPeriods)
+						.optional(),
 				}),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-			Weekend: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Saturday: z.object({ id: z.string() }),
-					Sunday: z.object({ id: z.string() }),
+				Weekend: z.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Saturday: z.object({ id: z.string() }),
+						Sunday: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.HomeDelivery.billingPeriods)
+						.optional(),
 				}),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-			Saturday: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({ Saturday: z.object({ id: z.string() }) }),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-			Sunday: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({ Sunday: z.object({ id: z.string() }) }),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-			EverydayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Monday: z.object({ id: z.string() }),
-					Tuesday: z.object({ id: z.string() }),
-					Wednesday: z.object({ id: z.string() }),
-					Thursday: z.object({ id: z.string() }),
-					Friday: z.object({ id: z.string() }),
-					Saturday: z.object({ id: z.string() }),
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
+				Saturday: z.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({ Saturday: z.object({ id: z.string() }) }),
+					billingPeriod: z
+						.enum(typeObject.HomeDelivery.billingPeriods)
+						.optional(),
 				}),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-			SixdayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Monday: z.object({ id: z.string() }),
-					Tuesday: z.object({ id: z.string() }),
-					Wednesday: z.object({ id: z.string() }),
-					Thursday: z.object({ id: z.string() }),
-					Friday: z.object({ id: z.string() }),
-					Saturday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
+				Sunday: z.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({ Sunday: z.object({ id: z.string() }) }),
+					billingPeriod: z
+						.enum(typeObject.HomeDelivery.billingPeriods)
+						.optional(),
 				}),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
+				EverydayPlus: z
+					.object({
+						id: z.string(),
+						pricing: z.object({ GBP: z.number() }),
+						charges: z.object({
+							Monday: z.object({ id: z.string() }),
+							Tuesday: z.object({ id: z.string() }),
+							Wednesday: z.object({ id: z.string() }),
+							Thursday: z.object({ id: z.string() }),
+							Friday: z.object({ id: z.string() }),
+							Saturday: z.object({ id: z.string() }),
+							Sunday: z.object({ id: z.string() }),
+							DigitalPack: z.object({ id: z.string() }),
+						}),
+						billingPeriod: z
+							.enum(typeObject.HomeDelivery.billingPeriods)
+							.optional(),
+					})
 					.optional(),
-			}),
-			WeekendPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Saturday: z.object({ id: z.string() }),
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
+				SixdayPlus: z
+					.object({
+						id: z.string(),
+						pricing: z.object({ GBP: z.number() }),
+						charges: z.object({
+							Monday: z.object({ id: z.string() }),
+							Tuesday: z.object({ id: z.string() }),
+							Wednesday: z.object({ id: z.string() }),
+							Thursday: z.object({ id: z.string() }),
+							Friday: z.object({ id: z.string() }),
+							Saturday: z.object({ id: z.string() }),
+							DigitalPack: z.object({ id: z.string() }),
+						}),
+						billingPeriod: z
+							.enum(typeObject.HomeDelivery.billingPeriods)
+							.optional(),
+					})
+					.optional(),
+				WeekendPlus: z
+					.object({
+						id: z.string(),
+						pricing: z.object({ GBP: z.number() }),
+						charges: z.object({
+							Saturday: z.object({ id: z.string() }),
+							Sunday: z.object({ id: z.string() }),
+							DigitalPack: z.object({ id: z.string() }),
+						}),
+						billingPeriod: z
+							.enum(typeObject.HomeDelivery.billingPeriods)
+							.optional(),
+					})
+					.optional(),
+				SaturdayPlus: z
+					.object({
+						id: z.string(),
+						pricing: z.object({ GBP: z.number() }),
+						charges: z.object({
+							Saturday: z.object({ id: z.string() }),
+							DigitalPack: z.object({ id: z.string() }),
+						}),
+						billingPeriod: z
+							.enum(typeObject.HomeDelivery.billingPeriods)
+							.optional(),
+					})
+					.optional(),
+				SundayPlus: z.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Sunday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.HomeDelivery.billingPeriods)
+						.optional(),
 				}),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-			SaturdayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Saturday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-			SundayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.HomeDelivery.billingPeriods)
-					.optional(),
-			}),
-		}),
+			})
+			.optional(),
 	}),
 	NationalDelivery: z.object({
 		billingSystem: z.literal('zuora'),
@@ -513,73 +523,83 @@ export const productCatalogSchema = z.object({
 					.enum(typeObject.SubscriptionCard.billingPeriods)
 					.optional(),
 			}),
-			EverydayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Monday: z.object({ id: z.string() }),
-					Tuesday: z.object({ id: z.string() }),
-					Wednesday: z.object({ id: z.string() }),
-					Thursday: z.object({ id: z.string() }),
-					Friday: z.object({ id: z.string() }),
-					Saturday: z.object({ id: z.string() }),
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.SubscriptionCard.billingPeriods)
-					.optional(),
-			}),
-			SixdayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Monday: z.object({ id: z.string() }),
-					Tuesday: z.object({ id: z.string() }),
-					Wednesday: z.object({ id: z.string() }),
-					Thursday: z.object({ id: z.string() }),
-					Friday: z.object({ id: z.string() }),
-					Saturday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.SubscriptionCard.billingPeriods)
-					.optional(),
-			}),
-			WeekendPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Saturday: z.object({ id: z.string() }),
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.SubscriptionCard.billingPeriods)
-					.optional(),
-			}),
-			SaturdayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Saturday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.SubscriptionCard.billingPeriods)
-					.optional(),
-			}),
-			SundayPlus: z.object({
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-				charges: z.object({
-					Sunday: z.object({ id: z.string() }),
-					DigitalPack: z.object({ id: z.string() }),
-				}),
-				billingPeriod: z
-					.enum(typeObject.SubscriptionCard.billingPeriods)
-					.optional(),
-			}),
+			EverydayPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Monday: z.object({ id: z.string() }),
+						Tuesday: z.object({ id: z.string() }),
+						Wednesday: z.object({ id: z.string() }),
+						Thursday: z.object({ id: z.string() }),
+						Friday: z.object({ id: z.string() }),
+						Saturday: z.object({ id: z.string() }),
+						Sunday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.SubscriptionCard.billingPeriods)
+						.optional(),
+				})
+				.optional(),
+			SixdayPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Monday: z.object({ id: z.string() }),
+						Tuesday: z.object({ id: z.string() }),
+						Wednesday: z.object({ id: z.string() }),
+						Thursday: z.object({ id: z.string() }),
+						Friday: z.object({ id: z.string() }),
+						Saturday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.SubscriptionCard.billingPeriods)
+						.optional(),
+				})
+				.optional(),
+			WeekendPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Saturday: z.object({ id: z.string() }),
+						Sunday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.SubscriptionCard.billingPeriods)
+						.optional(),
+				})
+				.optional(),
+			SaturdayPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Saturday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.SubscriptionCard.billingPeriods)
+						.optional(),
+				})
+				.optional(),
+			SundayPlus: z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Sunday: z.object({ id: z.string() }),
+						DigitalPack: z.object({ id: z.string() }),
+					}),
+					billingPeriod: z
+						.enum(typeObject.SubscriptionCard.billingPeriods)
+						.optional(),
+				})
+				.optional(),
 		}),
 	}),
 	NewspaperVoucher: z.object({

--- a/modules/product-catalog/src/typeObject.ts
+++ b/modules/product-catalog/src/typeObject.ts
@@ -57,7 +57,7 @@ export const activeTypeObject = {
 		},
 	},
 	DigitalSubscription: {
-		billingPeriods: ['Quarter', 'Month', 'Annual'],
+		billingPeriods: ['Month', 'Annual'],
 		productRatePlans: {
 			Monthly: {
 				Subscription: {},
@@ -161,14 +161,6 @@ export const activeTypeObject = {
 	SubscriptionCard: {
 		billingPeriods: ['Month'],
 		productRatePlans: {
-			Sixday: {
-				Friday: {},
-				Monday: {},
-				Tuesday: {},
-				Thursday: {},
-				Wednesday: {},
-				Saturday: {},
-			},
 			Everyday: {
 				Monday: {},
 				Tuesday: {},
@@ -182,13 +174,21 @@ export const activeTypeObject = {
 				Saturday: {},
 				Sunday: {},
 			},
+			Sixday: {
+				Friday: {},
+				Monday: {},
+				Tuesday: {},
+				Thursday: {},
+				Wednesday: {},
+				Saturday: {},
+			},
 			Sunday: {
 				Sunday: {},
 			},
 			Saturday: {
 				Saturday: {},
 			},
-			'Everyday+': {
+			EverydayPlus: {
 				DigitalPack: {},
 				Saturday: {},
 				Tuesday: {},
@@ -198,7 +198,7 @@ export const activeTypeObject = {
 				Sunday: {},
 				Friday: {},
 			},
-			'Sixday+': {
+			SixdayPlus: {
 				DigitalPack: {},
 				Thursday: {},
 				Wednesday: {},
@@ -207,16 +207,16 @@ export const activeTypeObject = {
 				Monday: {},
 				Tuesday: {},
 			},
-			'Sunday+': {
+			SundayPlus: {
 				DigitalPack: {},
 				Sunday: {},
 			},
-			'Weekend+': {
+			WeekendPlus: {
 				DigitalPack: {},
 				Saturday: {},
 				Sunday: {},
 			},
-			'Saturday+': {
+			SaturdayPlus: {
 				DigitalPack: {},
 				Saturday: {},
 			},
@@ -245,9 +245,6 @@ export const activeTypeObject = {
 				Tuesday: {},
 				Saturday: {},
 			},
-			Sunday: {
-				Sunday: {},
-			},
 			Sixday: {
 				Wednesday: {},
 				Friday: {},
@@ -260,10 +257,13 @@ export const activeTypeObject = {
 				Sunday: {},
 				Saturday: {},
 			},
+			Sunday: {
+				Sunday: {},
+			},
 			Saturday: {
 				Saturday: {},
 			},
-			'Everyday+': {
+			EverydayPlus: {
 				DigitalPack: {},
 				Wednesday: {},
 				Friday: {},
@@ -273,12 +273,12 @@ export const activeTypeObject = {
 				Tuesday: {},
 				Saturday: {},
 			},
-			'Weekend+': {
+			WeekendPlus: {
 				DigitalPack: {},
 				Sunday: {},
 				Saturday: {},
 			},
-			'Sixday+': {
+			SixdayPlus: {
 				DigitalPack: {},
 				Wednesday: {},
 				Friday: {},
@@ -287,11 +287,11 @@ export const activeTypeObject = {
 				Tuesday: {},
 				Saturday: {},
 			},
-			'Sunday+': {
+			SundayPlus: {
 				DigitalPack: {},
 				Sunday: {},
 			},
-			'Saturday+': {
+			SaturdayPlus: {
 				DigitalPack: {},
 				Saturday: {},
 			},
@@ -387,7 +387,7 @@ export const inactiveTypeObject = {
 				Wednesday: {},
 				Sunday: {},
 			},
-			'Everyday+': {
+			EverydayPlus: {
 				DigitalPack: {},
 				Saturday: {},
 				Tuesday: {},
@@ -405,7 +405,7 @@ export const inactiveTypeObject = {
 				Wednesday: {},
 				Saturday: {},
 			},
-			'Sixday+': {
+			SixdayPlus: {
 				DigitalPack: {},
 				Thursday: {},
 				Wednesday: {},
@@ -418,7 +418,7 @@ export const inactiveTypeObject = {
 				Saturday: {},
 				Sunday: {},
 			},
-			'Weekend+': {
+			WeekendPlus: {
 				DigitalPack: {},
 				Saturday: {},
 				Sunday: {},
@@ -426,14 +426,14 @@ export const inactiveTypeObject = {
 			Sunday: {
 				Sunday: {},
 			},
-			'Sunday+': {
+			SundayPlus: {
 				DigitalPack: {},
 				Sunday: {},
 			},
 			Saturday: {
 				Saturday: {},
 			},
-			'Saturday+': {
+			SaturdayPlus: {
 				DigitalPack: {},
 				Saturday: {},
 			},

--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -93,11 +93,11 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	Weekend: 'Weekend',
 	Sixday: 'Sixday',
 	// Paper+ rate plans
-	'Everyday+': 'Everyday+',
-	'Saturday+': 'Saturday+',
-	'Sunday+': 'Sunday+',
-	'Weekend+': 'Weekend+',
-	'Sixday+': 'Sixday+',
+	'Everyday+': 'EverydayPlus',
+	'Saturday+': 'SaturdayPlus',
+	'Sunday+': 'SundayPlus',
+	'Weekend+': 'WeekendPlus',
+	'Sixday+': 'SixdayPlus',
 	'Guardian Ad-Lite Monthly': 'Monthly',
 	// Membership rate plans
 	'Supporter - monthly': 'V1DeprecatedMonthly',

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -475,7 +475,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 83.99,
         },
       },
-      "Everyday+": {
+      "EverydayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -520,7 +520,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 20.99,
         },
       },
-      "Saturday+": {
+      "SaturdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -562,7 +562,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 73.99,
         },
       },
-      "Sixday+": {
+      "SixdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -604,7 +604,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 20.99,
         },
       },
-      "Sunday+": {
+      "SundayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -634,7 +634,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 33.99,
         },
       },
-      "Weekend+": {
+      "WeekendPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -766,7 +766,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 69.99,
         },
       },
-      "Everyday+": {
+      "EverydayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -811,7 +811,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 15.99,
         },
       },
-      "Saturday+": {
+      "SaturdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -853,7 +853,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 61.99,
         },
       },
-      "Sixday+": {
+      "SixdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -898,7 +898,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 15.99,
         },
       },
-      "Sunday+": {
+      "SundayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -928,7 +928,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 26.99,
         },
       },
-      "Weekend+": {
+      "WeekendPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -1106,7 +1106,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 69.99,
         },
       },
-      "Everyday+": {
+      "EverydayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -1151,7 +1151,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 15.99,
         },
       },
-      "Saturday+": {
+      "SaturdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -1193,7 +1193,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 61.99,
         },
       },
-      "Sixday+": {
+      "SixdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -1238,7 +1238,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 15.99,
         },
       },
-      "Sunday+": {
+      "SundayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -1268,7 +1268,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
           "GBP": 26.99,
         },
       },
-      "Weekend+": {
+      "WeekendPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -1830,7 +1830,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Everyday+": {
+        "EverydayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -1843,7 +1843,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
         "Saturday": {
           "Saturday": {},
         },
-        "Saturday+": {
+        "SaturdayPlus": {
           "DigitalPack": {},
           "Saturday": {},
         },
@@ -1855,7 +1855,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Sixday+": {
+        "SixdayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -1867,7 +1867,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
         "Sunday": {
           "Sunday": {},
         },
-        "Sunday+": {
+        "SundayPlus": {
           "DigitalPack": {},
           "Sunday": {},
         },
@@ -1875,7 +1875,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Saturday": {},
           "Sunday": {},
         },
-        "Weekend+": {
+        "WeekendPlus": {
           "DigitalPack": {},
           "Saturday": {},
           "Sunday": {},
@@ -1934,7 +1934,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Everyday+": {
+        "EverydayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -1947,7 +1947,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
         "Saturday": {
           "Saturday": {},
         },
-        "Saturday+": {
+        "SaturdayPlus": {
           "DigitalPack": {},
           "Saturday": {},
         },
@@ -1959,7 +1959,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Sixday+": {
+        "SixdayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -1972,7 +1972,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
         "Sunday": {
           "Sunday": {},
         },
-        "Sunday+": {
+        "SundayPlus": {
           "DigitalPack": {},
           "Sunday": {},
         },
@@ -1980,7 +1980,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Saturday": {},
           "Sunday": {},
         },
-        "Weekend+": {
+        "WeekendPlus": {
           "DigitalPack": {},
           "Saturday": {},
           "Sunday": {},
@@ -2133,7 +2133,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Everyday+": {
+        "EverydayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -2146,7 +2146,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
         "Saturday": {
           "Saturday": {},
         },
-        "Saturday+": {
+        "SaturdayPlus": {
           "DigitalPack": {},
           "Saturday": {},
         },
@@ -2158,7 +2158,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Sixday+": {
+        "SixdayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -2171,7 +2171,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
         "Sunday": {
           "Sunday": {},
         },
-        "Sunday+": {
+        "SundayPlus": {
           "DigitalPack": {},
           "Sunday": {},
         },
@@ -2179,7 +2179,7 @@ exports[`code Generated product catalog types match snapshot 1`] = `
           "Saturday": {},
           "Sunday": {},
         },
-        "Weekend+": {
+        "WeekendPlus": {
           "DigitalPack": {},
           "Saturday": {},
           "Sunday": {},
@@ -2745,7 +2745,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 83.99,
         },
       },
-      "Everyday+": {
+      "EverydayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -2790,7 +2790,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 20.99,
         },
       },
-      "Saturday+": {
+      "SaturdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -2832,7 +2832,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 73.99,
         },
       },
-      "Sixday+": {
+      "SixdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -2874,7 +2874,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 20.99,
         },
       },
-      "Sunday+": {
+      "SundayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -2904,7 +2904,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 33.99,
         },
       },
-      "Weekend+": {
+      "WeekendPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3036,7 +3036,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 69.99,
         },
       },
-      "Everyday+": {
+      "EverydayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3081,7 +3081,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 15.99,
         },
       },
-      "Saturday+": {
+      "SaturdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3123,7 +3123,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 61.99,
         },
       },
-      "Sixday+": {
+      "SixdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3165,7 +3165,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 15.99,
         },
       },
-      "Sunday+": {
+      "SundayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3195,7 +3195,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 26.99,
         },
       },
-      "Weekend+": {
+      "WeekendPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3373,7 +3373,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 69.99,
         },
       },
-      "Everyday+": {
+      "EverydayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3418,7 +3418,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 15.99,
         },
       },
-      "Saturday+": {
+      "SaturdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3460,7 +3460,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 61.99,
         },
       },
-      "Sixday+": {
+      "SixdayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3502,7 +3502,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 15.99,
         },
       },
-      "Sunday+": {
+      "SundayPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -3532,7 +3532,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
           "GBP": 26.99,
         },
       },
-      "Weekend+": {
+      "WeekendPlus": {
         "billingPeriod": "Month",
         "charges": {
           "DigitalPack": {
@@ -4014,7 +4014,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Everyday+": {
+        "EverydayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -4027,7 +4027,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
         "Saturday": {
           "Saturday": {},
         },
-        "Saturday+": {
+        "SaturdayPlus": {
           "DigitalPack": {},
           "Saturday": {},
         },
@@ -4039,7 +4039,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Sixday+": {
+        "SixdayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -4051,7 +4051,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
         "Sunday": {
           "Sunday": {},
         },
-        "Sunday+": {
+        "SundayPlus": {
           "DigitalPack": {},
           "Sunday": {},
         },
@@ -4059,7 +4059,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Saturday": {},
           "Sunday": {},
         },
-        "Weekend+": {
+        "WeekendPlus": {
           "DigitalPack": {},
           "Saturday": {},
           "Sunday": {},
@@ -4118,7 +4118,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Everyday+": {
+        "EverydayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -4131,7 +4131,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
         "Saturday": {
           "Saturday": {},
         },
-        "Saturday+": {
+        "SaturdayPlus": {
           "DigitalPack": {},
           "Saturday": {},
         },
@@ -4143,7 +4143,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Sixday+": {
+        "SixdayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -4155,7 +4155,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
         "Sunday": {
           "Sunday": {},
         },
-        "Sunday+": {
+        "SundayPlus": {
           "DigitalPack": {},
           "Sunday": {},
         },
@@ -4163,7 +4163,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Saturday": {},
           "Sunday": {},
         },
-        "Weekend+": {
+        "WeekendPlus": {
           "DigitalPack": {},
           "Saturday": {},
           "Sunday": {},
@@ -4301,7 +4301,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Everyday+": {
+        "EverydayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -4314,7 +4314,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
         "Saturday": {
           "Saturday": {},
         },
-        "Saturday+": {
+        "SaturdayPlus": {
           "DigitalPack": {},
           "Saturday": {},
         },
@@ -4326,7 +4326,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Tuesday": {},
           "Wednesday": {},
         },
-        "Sixday+": {
+        "SixdayPlus": {
           "DigitalPack": {},
           "Friday": {},
           "Monday": {},
@@ -4338,7 +4338,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
         "Sunday": {
           "Sunday": {},
         },
-        "Sunday+": {
+        "SundayPlus": {
           "DigitalPack": {},
           "Sunday": {},
         },
@@ -4346,7 +4346,7 @@ exports[`prod Generated product catalog types match snapshot 1`] = `
           "Saturday": {},
           "Sunday": {},
         },
-        "Weekend+": {
+        "WeekendPlus": {
           "DigitalPack": {},
           "Saturday": {},
           "Sunday": {},


### PR DESCRIPTION
## What does this change?
We are going to start selling paper plus digital plans again, however the current naming of the rate plans in the product catalog (Weekend+, Everyday+ etc.) causes a problem when trying to purchase one of those plans through the checkout because + is a special character in URLs. 

This means that we either have to URL encode the rate plan name in the checkout ratePlan query parameter, eg. https://support.thegulocal.com/uk/checkout?product=NationalDelivery&ratePlan=Weekend%2b or rename the plans in the catalog and we have decided that renaming is a better approach.

# Notes
- Various lambdas use the schema defined in the product-catalog module when loading the product catalog
