### PR TITLE
User benefits api shouldn't return expired products

### DIFF
--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -13,6 +13,7 @@ import {
 	productBenefitMapping,
 } from '@modules/product-benefits/productBenefit';
 import type { ProductBenefit } from '@modules/product-benefits/schemas';
+import dayjs from 'dayjs';
 
 export const getUserProducts = async (
 	stage: Stage,
@@ -35,6 +36,7 @@ export const getValidUserProducts = (
 	supporterProductDataItems: SupporterRatePlanItem[],
 ): ProductKey[] =>
 	supporterProductDataItems
+		.filter((item) => dayjs(item.termEndDate) >= dayjs())
 		.flatMap((item) => {
 			const product = productCatalogHelper.findProductDetails(
 				item.productRatePlanId,

--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -36,7 +36,7 @@ export const getValidUserProducts = (
 	supporterProductDataItems: SupporterRatePlanItem[],
 ): ProductKey[] =>
 	supporterProductDataItems
-		.filter((item) => dayjs(item.termEndDate) >= dayjs())
+		.filter((item) => dayjs(item.termEndDate) >= dayjs().startOf('day'))
 		.flatMap((item) => {
 			const product = productCatalogHelper.findProductDetails(
 				item.productRatePlanId,

--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -7,13 +7,13 @@ import type {
 import type { Stage } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import { getSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
+import dayjs from 'dayjs';
 import {
 	allProductBenefits,
 	itemIsValidForProduct,
 	productBenefitMapping,
 } from '@modules/product-benefits/productBenefit';
 import type { ProductBenefit } from '@modules/product-benefits/schemas';
-import dayjs from 'dayjs';
 
 export const getUserProducts = async (
 	stage: Stage,

--- a/modules/product-benefits/test/getUserBenefits.test.ts
+++ b/modules/product-benefits/test/getUserBenefits.test.ts
@@ -43,12 +43,14 @@ describe('getUserProductsFromSupporterProductDataItems', () => {
 					subscriptionName: '123',
 					productRatePlanId: '2c92c0f94c510a0d014c569ba8eb45f7',
 					productRatePlanName: 'Non Founder Supporter - monthly',
-					contractEffectiveDate: zuoraDateFormat(dayjs()),
-					termEndDate: zuoraDateFormat(dayjs()),
+					contractEffectiveDate: zuoraDateFormat(
+						dayjs().subtract(1, 'month').startOf('day'),
+					),
+					termEndDate: zuoraDateFormat(dayjs().startOf('day')),
 					identityId: '123',
 				},
-			]),
-		).toEqual([]);
+			]).length,
+		).toEqual(1);
 	});
 
 	test('returns single contribution when there is a single contribution less than 3 months old', () => {

--- a/modules/product-benefits/test/getUserBenefits.test.ts
+++ b/modules/product-benefits/test/getUserBenefits.test.ts
@@ -21,6 +21,36 @@ describe('getUserProductsFromSupporterProductDataItems', () => {
 		expect(getValidUserProducts(codeCatalogHelper, [])).toEqual([]);
 	});
 
+	test('does not return expired products', () => {
+		expect(
+			getValidUserProducts(codeCatalogHelper, [
+				{
+					subscriptionName: '123',
+					productRatePlanId: '2c92c0f94c510a0d014c569ba8eb45f7',
+					productRatePlanName: 'Non Founder Supporter - monthly',
+					contractEffectiveDate: '2017-01-19',
+					termEndDate: '2017-02-19',
+					identityId: '123',
+				},
+			]),
+		).toEqual([]);
+	});
+
+	test('does return products which expire today', () => {
+		expect(
+			getValidUserProducts(codeCatalogHelper, [
+				{
+					subscriptionName: '123',
+					productRatePlanId: '2c92c0f94c510a0d014c569ba8eb45f7',
+					productRatePlanName: 'Non Founder Supporter - monthly',
+					contractEffectiveDate: zuoraDateFormat(dayjs()),
+					termEndDate: zuoraDateFormat(dayjs()),
+					identityId: '123',
+				},
+			]),
+		).toEqual([]);
+	});
+
 	test('returns single contribution when there is a single contribution less than 3 months old', () => {
 		expect(
 			getValidUserProducts(codeCatalogHelper, [


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
I've noticed that the user-benefits API is returning benefits associated with subscriptions which have expired. 

This shouldn't be too much of a problem because DynamoDB _should_ automatically delete any expired subscriptions when their TTL is up, but I have found at least one subscription where this is not the case [See this query](https://eu-west-1.console.aws.amazon.com/dynamodbv2/home?region=eu-west-1#item-explorer?maximize=true&operation=QUERY&pk=11464179&table=SupporterProductData-PROD)

This PR updates the application logic to explicitly filter out subscriptions which have expired.