### PR TITLE
product switch confirmation email currency clarity

### DIFF
--- a/modules/internationalisation/src/currency.ts
+++ b/modules/internationalisation/src/currency.ts
@@ -17,10 +17,10 @@ export const isSupportedCurrency = (
 const currencyToGlyphMapping: { [C in Currency]: string } = {
 	GBP: '£',
 	EUR: '€',
-	AUD: '$',
-	USD: '$',
-	CAD: '$',
-	NZD: '$',
+	AUD: 'AU$',
+	USD: 'US$',
+	CAD: 'CA$',
+	NZD: 'NZ$',
 };
 
 export const getCurrencyGlyph = (currency: Currency) =>


### PR DESCRIPTION
In the product switch confirmation email we were representing all types of dollars with the same symbol.

This PR changes it to match the acquisition emails, where we prefix the dollar sign accordingly:

```
	{% if {{api_trigger_properties.${currency}}} == 'USD' %}
	{% assign currency = 'US$' %}
	{% elsif {{api_trigger_properties.${currency}}} == 'EUR' %}
	{% assign currency = '€' %}
	{% elsif {{api_trigger_properties.${currency}}} == 'GBP' %}
	{% assign currency = '£' %}
	{% elsif {{api_trigger_properties.${currency}}} == 'CAD' %}
	{% assign currency = 'CA$' %}
	{% elsif {{api_trigger_properties.${currency}}} == 'NZD' %}
	{% assign currency = 'NZ$' %}
	{% elsif {{api_trigger_properties.${currency}}} == 'AUD' %}
	{% assign currency = 'AU$' %}
```