### PR TITLE
Remove `similar-guardian-products` soft opt-in for Feast IAPs

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -109,7 +109,6 @@ object ConsentsMapping {
     ),
     "FeastInAppPurchase" -> Set(
       yourSupportOnboarding,
-      similarGuardianProducts,
     ),
     "Guardian Ad-Lite" -> Set(
       yourSupportOnboarding,


### PR DESCRIPTION
This PR updates the soft opt-in `ConsentsMapping` to prevent Feast IAPs being opted-in to `similar-guardian-products`. 

[See this Trello card for more info.](https://trello.com/c/CjWVzPx2/753-remove-soft-opt-in-for-the-feast-purchase-flow)