### PR TITLE
send date only to salesforce tracking queue

### DIFF
--- a/handlers/product-switch-api/src/salesforceTracking.ts
+++ b/handlers/product-switch-api/src/salesforceTracking.ts
@@ -10,18 +10,18 @@ export type SalesforceTrackingInput = {
 	previousProductName: string;
 	previousRatePlanName: string;
 	newRatePlanName: string;
-	requestedDate: Date;
-	effectiveDate: Date;
+	requestedDate: string;
+	effectiveDate: string;
 	paidAmount: number;
 	csrUserId?: string;
 	caseId?: string;
 };
-export const sendSalesforceTracking = async (
-	paidAmount: number,
+
+export function createSQSMessageBody(
 	switchInformation: SwitchInformation,
-) => {
-	const queueName = `product-switch-salesforce-tracking-${switchInformation.stage}`;
-	const client = new SQSClient(awsConfig);
+	paidAmount: number,
+	now: Date,
+) {
 	const {
 		subscriptionNumber,
 		previousProductName,
@@ -37,20 +37,35 @@ export const sendSalesforceTracking = async (
 		previousProductName: previousProductName,
 		previousRatePlanName: previousRatePlanName,
 		newRatePlanName: 'Supporter Plus',
-		requestedDate: new Date(),
-		effectiveDate: new Date(),
+		requestedDate: now.toISOString().substring(0, 10),
+		effectiveDate: now.toISOString().substring(0, 10),
 		paidAmount,
 		csrUserId: csrUserId,
 		caseId: caseId,
 	};
+	return JSON.stringify(salesforceTrackingInput);
+}
+
+export const sendSalesforceTracking = async (
+	paidAmount: number,
+	switchInformation: SwitchInformation,
+) => {
+	const messageBody = createSQSMessageBody(
+		switchInformation,
+		paidAmount,
+		new Date(),
+	);
+
+	const client = new SQSClient(awsConfig);
+	const queueName = `product-switch-salesforce-tracking-${switchInformation.stage}`;
 	console.log(
 		`Sending Salesforce tracking message ${prettyPrint(
-			salesforceTrackingInput,
+			JSON.parse(messageBody),
 		)} to queue ${queueName}`,
 	);
 	const command = new SendMessageCommand({
 		QueueUrl: queueName,
-		MessageBody: JSON.stringify(salesforceTrackingInput),
+		MessageBody: messageBody,
 	});
 
 	const response = await client.send(command);

--- a/handlers/product-switch-api/test/salesforceTracking.test.ts
+++ b/handlers/product-switch-api/test/salesforceTracking.test.ts
@@ -1,0 +1,63 @@
+import { createSQSMessageBody } from '../src/salesforceTracking';
+import type { SwitchInformation } from '../src/switchInformation';
+
+test('salesforce tracking data is serialised to the queue correctly', () => {
+	const testData: SwitchInformation = {
+		stage: 'CODE',
+		input: {
+			price: 45.5,
+			preview: false,
+			// csrUserId: undefined,
+			// caseId: undefined,
+		},
+		startNewTerm: false,
+		contributionAmount: 10.5,
+		account: {
+			id: '',
+			identityId: '',
+			emailAddress: '',
+			firstName: '',
+			lastName: '',
+			defaultPaymentMethodId: '',
+		},
+		subscription: {
+			accountNumber: '',
+			subscriptionNumber: 'A-S0123',
+			previousProductName: 'Contributor',
+			previousRatePlanName: 'Monthly Contribution',
+			previousAmount: 20,
+			currency: 'GBP',
+			billingPeriod: 'Month',
+		},
+		catalog: {
+			supporterPlus: {
+				price: 0,
+				productRatePlanId: '',
+				subscriptionChargeId: '',
+				contributionChargeId: '',
+			},
+			contribution: {
+				productRatePlanId: '',
+				chargeId: '',
+			},
+		},
+	};
+	const expected = {
+		subscriptionName: 'A-S0123',
+		previousAmount: 20,
+		newAmount: 45.5,
+		previousProductName: 'Contributor',
+		previousRatePlanName: 'Monthly Contribution',
+		newRatePlanName: 'Supporter Plus',
+		requestedDate: '2025-05-12',
+		effectiveDate: '2025-05-12',
+		paidAmount: 15.81,
+	};
+	const MAY = 4;
+	const actual = createSQSMessageBody(
+		testData,
+		15.81,
+		new Date(2025, MAY, 12, 2, 2, 2, 2),
+	);
+	expect(JSON.parse(actual)).toEqual(expected);
+});

--- a/modules/prettyPrint.ts
+++ b/modules/prettyPrint.ts
@@ -1,3 +1,3 @@
-export const prettyPrint = (object: object) => {
+export const prettyPrint = (object: any) => {
 	return JSON.stringify(object, null, 2);
 };


### PR DESCRIPTION
Last july some product switches were moved over to the product-switch-api which was a clean TS rewrite.

Unfortunately we missed that the events weren't ending up in salesforce, culminating in a fix in late december to the permissions of the switch lambda so it could write to SQS. https://github.com/guardian/support-service-lambdas/pull/2602

However after that, we again failed to check it was working, and since then it's been constantly failing with 
```
Error '.requestedDate(2025-05-13T13:00:50.183Z is not a valid ISO-8601 format, illegal local date at index 10)' when decoding JSON to SalesforceRecordInput with body: 
```
https://865473395570-3z35t5l4.eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fproduct-switch-salesforce-tracking-PROD/log-events$3Fstart$3D-1800000

This is because the JS date format is a complete offsetdatetime, however the lambda that reads is requires it to only be a localdate, with no time or timezone appended.

This PR fixes that and also adds a test.

Tested in CODE which produced this data, which was then ingested successfully by lambda 
product-switch-salesforce-tracking-CODE and passed to salesforce DEV
```
{
    "subscriptionName": "A-S00985326",
    "previousAmount": 8,
    "newAmount": 12,
    "previousProductName": "Contributor",
    "previousRatePlanName": "Monthly Contribution",
    "newRatePlanName": "Supporter Plus",
    "requestedDate": "2025-05-14",
    "effectiveDate": "2025-05-14",
    "paidAmount": 4
}
```


TODO in a later PR, make sure there's an alarm on that queue product-switch-salesforce-tracking-PROD