### PR TITLE
add alarms for the product move switch tracking lambda

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -263,6 +263,74 @@ Resources:
           Value: SAM
       Architectures:
         - arm64
+
+
+  SalesforceTrackingLambdaErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn:
+      - SalesforceTrackingLambda
+    Properties:
+      AlarmActions:
+        - Fn::Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
+      AlarmName:
+        Fn::Sub: ${Stage} Salesforce tracking of a product switch has failed
+      AlarmDescription: Impact - tracking of product switches is not going to salesforce/bigquery/braze
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value:
+            Fn::Sub: product-switch-salesforce-tracking-${Stage}
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags:
+        - Key: DiagnosticLinks
+          Value:
+            Fn::Sub: lambda:product-switch-salesforce-tracking-${Stage}
+
+  NoSalesforceTrackingAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn:
+      - SalesforceTrackingLambda
+    Properties:
+      AlarmActions:
+        - Fn::Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
+      AlarmName:
+        Fn::Sub: ${Stage} No Salesforce tracking of a product switch has been queued recently
+      AlarmDescription: Impact - tracking of product switches is not going to salesforce/bigquery/braze
+      Metrics:
+        - Id: e1
+          Expression: "FILL(m1,0)"
+          Label: TrackingEvents
+        - Id: m1
+          Label: Metric1
+          MetricStat:
+            Metric:
+              MetricName: Invocations
+              Namespace: AWS/Lambda
+              Dimensions:
+                - Name: FunctionName
+                  Value:
+                    Fn::Sub: product-switch-salesforce-tracking-${Stage}
+            Period: 3600
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 0
+      EvaluationPeriods: 1
+      TreatMissingData: breaching
+      Tags:
+        - Key: DiagnosticLinks
+          Value:
+            Fn::Sub: lambda:product-switch-salesforce-tracking-${Stage}
+
   ProductMoveApiGateway:
     Type: AWS::ApiGateway::RestApi
     Properties:

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceHandler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceHandler.scala
@@ -20,7 +20,7 @@ class SalesforceHandler extends RequestHandler[SQSEvent, Unit] {
         salesforceRecordInput <- record.getBody
           .fromJson[SalesforceRecordInput]
           .left
-          .map(msg => new RuntimeException("failed to deserialise input: " + msg))
+          .map(msg => new RuntimeException(s"failed to deserialise input ${record.getBody}: " + msg))
         _ = context.getLogger.log(s"Processing salesforceRecordInput with body: ${record.getBody}")
         _ <- runZio(salesforceRecordInput, context)
       } yield ()


### PR DESCRIPTION
We have not had tracking of product switches in salesforce since June last year.

We didn't notice because there were no alarms, and JSON serialisation errors didn't make the lambda Error

Traffic to the lambda was very low until december, (fixed in https://github.com/guardian/support-service-lambdas/pull/2602 ) and after that point it was throwing JSON deserialisation errors on every request. (Fixed in https://github.com/guardian/support-service-lambdas/pull/2829 )

This PR
1. adds both a low traffic alarm and an errors alarm
2. changes the lambda so it will attempt to execute all records in the queue, and Error if any one of them doesn't work.  This does mean that if there are multiple records, some records might be retried even if they have worked, however I can see that the BatchSize is set to 1 anyway.

Thresholds are arbitrary and can be tweaked later if needed.

Tested in AWS console and it shows that the alarms will be created:

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/549fb00c-a6df-4249-8b26-ac9c0aef50b0" />

and

<img width="1569" alt="image" src="https://github.com/user-attachments/assets/7ed63f88-9412-466c-ace9-4d9d988d7525" />


Tested in CODE
one valid JSON and one invalid worked correctly:
<img width="229" alt="image" src="https://github.com/user-attachments/assets/99e0765c-4f45-4788-8ba8-db2737873ced" />
