### PR TITLE
Add National Delivery Paper+ plans to the product catalog

### DIFF
--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -350,6 +350,87 @@ export const productCatalogSchema = z.object({
 		billingSystem: z.literal('zuora'),
 		active: z.boolean(),
 		ratePlans: z.object({
+			'Everyday+': z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+					}),
+					billingPeriod: z.literal('Month'),
+				})
+				.optional(),
+			'Weekend+': z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+					}),
+					billingPeriod: z.literal('Month'),
+				})
+				.optional(),
+			'Sixday+': z
+				.object({
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+					}),
+					billingPeriod: z.literal('Month'),
+				})
+				.optional(),
 			Sixday: z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We want to switch to selling Paper+ rate plans (ones that give digital access and have a digital pack charge) rather than the regular paper only plans. These already exist for all products except National Delivery which was developed after the original Paper+ was taken off sale.

The new plans have now been added to Zuora, this PR adds them into the product catalog API and schema. I have marked them as optional in the schema in this PR so that it can be deployed safely. Once the API has deployed and is including the new plans in the response, the optional attribute can be removed.