### PR TITLE
add new fields to product switch confirmation email for next payment

### DIFF
--- a/handlers/product-switch-api/src/productSwitchEmail.ts
+++ b/handlers/product-switch-api/src/productSwitchEmail.ts
@@ -6,29 +6,20 @@ import { getCurrencyGlyph } from '@modules/internationalisation/currency';
 import dayjs from 'dayjs';
 import type { SwitchInformation } from './switchInformation';
 
-export const buildEmailMessage = ({
-	dateOfFirstPayment,
-	emailAddress,
-	firstName,
-	lastName,
-	currency,
-	productPrice,
-	firstPaymentAmount,
-	billingPeriod,
-	subscriptionNumber,
-	identityId,
-}: {
-	dateOfFirstPayment: dayjs.Dayjs;
-	emailAddress: string;
-	firstName: string;
-	lastName: string;
-	currency: Currency;
-	productPrice: number;
-	firstPaymentAmount: number;
-	billingPeriod: BillingPeriod;
-	subscriptionNumber: string;
-	identityId: string;
-}) => {
+type Payment = { date: dayjs.Dayjs; amount: number };
+
+export const buildEmailMessage = (
+	payments: { first: Payment; next: Payment },
+	emailAddress: string,
+	firstName: string,
+	lastName: string,
+	currency: Currency,
+	productPrice: number,
+	billingPeriod: BillingPeriod,
+	subscriptionNumber: string,
+	identityId: string,
+) => {
+	const { first, next } = payments;
 	return {
 		To: {
 			Address: emailAddress,
@@ -38,8 +29,10 @@ export const buildEmailMessage = ({
 					last_name: lastName,
 					currency: getCurrencyGlyph(currency),
 					price: productPrice.toFixed(2),
-					first_payment_amount: firstPaymentAmount.toFixed(2),
-					date_of_first_payment: dateOfFirstPayment.format('DD MMMM YYYY'),
+					first_payment_amount: first.amount.toFixed(2),
+					date_of_first_payment: first.date.format('DD MMMM YYYY'),
+					next_payment_amount: next.amount.toFixed(2),
+					date_of_next_payment: next.date.format('DD MMMM YYYY'),
 					payment_frequency: `${billingPeriod}ly`,
 					subscription_id: subscriptionNumber,
 				},
@@ -60,18 +53,35 @@ export const sendThankYouEmail = async (
 	const { subscriptionNumber, currency, billingPeriod } =
 		switchInformation.subscription;
 
-	const emailMessage: EmailMessageWithUserId = buildEmailMessage({
-		dateOfFirstPayment: dayjs(),
-		emailAddress: emailAddress,
-		firstName: firstName,
-		lastName: lastName,
-		currency: currency,
-		productPrice: switchInformation.actualTotalPrice,
-		firstPaymentAmount: firstPaymentAmount,
-		billingPeriod: billingPeriod,
-		subscriptionNumber: subscriptionNumber,
-		identityId: identityId,
-	});
+	const billingPeriodMonths: number =
+		switchInformation.subscription.billingPeriod == 'Month'
+			? 1
+			: switchInformation.subscription.billingPeriod == 'Annual'
+				? 12
+				: switchInformation.subscription.billingPeriod == 'Quarter'
+					? 3
+					: 1;
+
+	const emailMessage: EmailMessageWithUserId = buildEmailMessage(
+		{
+			first: {
+				date: dayjs(),
+				amount: firstPaymentAmount,
+			},
+			next: {
+				date: dayjs().add(billingPeriodMonths, 'month'),
+				amount: switchInformation.actualTotalPrice,
+			},
+		},
+		emailAddress,
+		firstName,
+		lastName,
+		currency,
+		switchInformation.actualTotalPrice,
+		billingPeriod,
+		subscriptionNumber,
+		identityId,
+	);
 
 	return await sendEmail(switchInformation.stage, emailMessage);
 };

--- a/handlers/product-switch-api/src/productSwitchEmail.ts
+++ b/handlers/product-switch-api/src/productSwitchEmail.ts
@@ -53,14 +53,11 @@ export const sendThankYouEmail = async (
 	const { subscriptionNumber, currency, billingPeriod } =
 		switchInformation.subscription;
 
-	const billingPeriodMonths: number =
-		switchInformation.subscription.billingPeriod == 'Month'
-			? 1
-			: switchInformation.subscription.billingPeriod == 'Annual'
-				? 12
-				: switchInformation.subscription.billingPeriod == 'Quarter'
-					? 3
-					: 1;
+	const billingPeriodMonths: number = {
+		Month: 1,
+		Quarter: 3,
+		Annual: 12,
+	}[switchInformation.subscription.billingPeriod];
 
 	const emailMessage: EmailMessageWithUserId = buildEmailMessage(
 		{

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -297,18 +297,26 @@ test('handleMissingRefundAmount() called on a date that is not the charge-throug
 test('Email message body is correct', () => {
 	const emailAddress = 'test@thegulocal.com';
 	const dateOfFirstPayment = dayjs('2024-04-16');
-	const emailMessage: EmailMessageWithUserId = buildEmailMessage({
-		dateOfFirstPayment: dateOfFirstPayment,
-		emailAddress: emailAddress,
-		firstName: 'test',
-		lastName: 'user',
-		currency: 'GBP',
-		productPrice: 10,
-		firstPaymentAmount: 5.6,
-		billingPeriod: 'Month',
-		subscriptionNumber: 'A-S123456',
-		identityId: '123456789',
-	});
+	const emailMessage: EmailMessageWithUserId = buildEmailMessage(
+		{
+			first: {
+				date: dateOfFirstPayment,
+				amount: 5.6,
+			},
+			next: {
+				date: dateOfFirstPayment.add(12, 'month'),
+				amount: 10,
+			},
+		},
+		emailAddress,
+		'test',
+		'user',
+		'GBP',
+		10,
+		'Month',
+		'A-S123456',
+		'123456789',
+	);
 
 	const expectedOutput = {
 		To: {
@@ -321,6 +329,8 @@ test('Email message body is correct', () => {
 					price: '10.00',
 					first_payment_amount: '5.60',
 					date_of_first_payment: '16 April 2024',
+					next_payment_amount: '10.00',
+					date_of_next_payment: '16 April 2025',
 					payment_frequency: 'Monthly',
 					subscription_id: 'A-S123456',
 				},


### PR DESCRIPTION
We noticed that the switch confirmation email mentions the date and amount of the immediate payment, and the ongoing amount, but it doesn't mention the exact date of the next payment.

This PR adds two new fields to the email
next_payment_amount
date_of_next_payment

After this is shipped, the email template can be updated in braze to use it.

Before: 
<img width="624" alt="image" src="https://github.com/user-attachments/assets/aa8e0114-1600-49b0-8766-b75f2c4c1b5c" />

After (tested in CODE)
```
{
    "To": {
        "Address": "aaa.aaa+aaaa@guardian.co.uk",
        "ContactAttributes": {
            "SubscriberAttributes": {
                "first_name": "aaaa",
                "last_name": "aaaaaa",
                "currency": "£",
                "price": "60.00",
                "first_payment_amount": "10.00",
                "date_of_first_payment": "19 May 2025",
                "next_payment_amount": "60.00",
                "date_of_next_payment": "19 May 2026",
                "payment_frequency": "Annually",
                "subscription_id": "A-S001234"
            }
        }
    },
    "DataExtensionName": "SV_RCtoSP_Switch",
    "IdentityUserId": "1234"
}
```