### PR TITLE
fix product-switch-api tests and make them run in the CI

### DIFF
--- a/handlers/product-switch-api/package.json
+++ b/handlers/product-switch-api/package.json
@@ -6,7 +6,7 @@
     "type-check": "tsc --noEmit",
     "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm build && cd target && zip -qr product-switch-api.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr product-switch-api.zip ./*.js",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   },

--- a/handlers/product-switch-api/src/index.ts
+++ b/handlers/product-switch-api/src/index.ts
@@ -6,6 +6,7 @@ import type {
 	APIGatewayProxyResult,
 	Handler,
 } from 'aws-lambda';
+import dayjs from 'dayjs';
 import { contributionToSupporterPlusEndpoint } from './productSwitchEndpoint';
 import { parseUrlPath } from './urlParsing';
 
@@ -35,6 +36,7 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 				event.headers,
 				requestBody,
 				parsedUrlPath.subscriptionNumber,
+				dayjs(),
 			);
 		} else {
 			return {

--- a/handlers/product-switch-api/src/productSwitchEndpoint.ts
+++ b/handlers/product-switch-api/src/productSwitchEndpoint.ts
@@ -1,10 +1,16 @@
+import { Lazy } from '@modules/lazy';
 import { prettyPrint } from '@modules/prettyPrint';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import type { Stage } from '@modules/stage';
+import {
+	billingPreviewToSimpleInvoiceItems,
+	getBillingPreview,
+} from '@modules/zuora/billingPreview';
 import { getAccount } from '@modules/zuora/getAccount';
 import { getSubscription } from '@modules/zuora/getSubscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type { APIGatewayProxyEventHeaders } from 'aws-lambda';
+import type dayjs from 'dayjs';
 import { preview, switchToSupporterPlus } from './contributionToSupporterPlus';
 import { productSwitchRequestSchema } from './schemas';
 import { getSwitchInformationWithOwnerCheck } from './switchInformation';
@@ -14,6 +20,7 @@ export const contributionToSupporterPlusEndpoint = async (
 	headers: APIGatewayProxyEventHeaders,
 	body: string,
 	subscriptionNumber: string,
+	today: dayjs.Dayjs,
 ) => {
 	const identityId = headers['x-identity-id'];
 	const zuoraClient = await ZuoraClient.create(stage);
@@ -27,6 +34,17 @@ export const contributionToSupporterPlusEndpoint = async (
 
 	const account = await getAccount(zuoraClient, subscription.accountNumber);
 
+	// don't get the billing preview until we know the subscription is not cancelled
+	const lazyBillingPreview = new Lazy(
+		() =>
+			getBillingPreview(
+				zuoraClient,
+				today.add(13, 'months'),
+				subscription.accountNumber,
+			),
+		'get billing preview for the subscription',
+	).then(billingPreviewToSimpleInvoiceItems);
+
 	const switchInformation = await getSwitchInformationWithOwnerCheck(
 		stage,
 		input,
@@ -34,7 +52,8 @@ export const contributionToSupporterPlusEndpoint = async (
 		account,
 		productCatalog,
 		identityId,
-		zuoraClient,
+		lazyBillingPreview,
+		today,
 	);
 
 	const response = input.preview

--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -2,11 +2,12 @@ import type { BillingPeriod } from '@modules/billingPeriod';
 import { ValidationError } from '@modules/errors';
 import type { Currency } from '@modules/internationalisation/currency';
 import { isSupportedCurrency } from '@modules/internationalisation/currency';
+import type { Lazy } from '@modules/lazy';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { prettyPrint } from '@modules/prettyPrint';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
-import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import type { SimpleInvoiceItem } from '@modules/zuora/billingPreview';
 import type {
 	RatePlan,
 	ZuoraAccount,
@@ -136,8 +137,8 @@ export const getSwitchInformationWithOwnerCheck = async (
 	account: ZuoraAccount,
 	productCatalog: ProductCatalog,
 	identityIdFromRequest: string | undefined,
-	zuroaClient: ZuoraClient,
-	today: Dayjs = dayjs(),
+	lazyBillingPreview: Lazy<SimpleInvoiceItem[]>,
+	today: Dayjs,
 ): Promise<SwitchInformation> => {
 	console.log(
 		`Checking subscription ${subscription.subscriptionNumber} is owned by the currently logged in user`,
@@ -183,10 +184,9 @@ export const getSwitchInformationWithOwnerCheck = async (
 		catalogInformation.supporterPlus.price,
 		billingPeriod,
 		subscription.status,
-		subscription.accountNumber,
 		account.metrics.totalInvoiceBalance,
 		stage,
-		zuroaClient,
+		lazyBillingPreview,
 	);
 
 	const actualBasePrice =

--- a/handlers/product-switch-api/test/supporterRatePlanItem.test.ts
+++ b/handlers/product-switch-api/test/supporterRatePlanItem.test.ts
@@ -71,9 +71,5 @@ test('supporterRatePlanItemFromSwitchInformation works with a contribution eleme
 		productRatePlanName: 'Supporter Plus V2 - Monthly',
 		termEndDate: zuoraDateFormat(dayjs().add(1, 'year')),
 		contractEffectiveDate: zuoraDateFormat(dayjs()),
-		contributionAmount: {
-			amount: 10,
-			currency: 'GBP',
-		},
 	});
 });


### PR DESCRIPTION
Richard and I noticed that we are not running the product-switch-api tests in the CI, and several tests have been broken recently.

This PR makes them run in CI again, and also fixes the failing tests.

I checked the other package.jsons and it looks like the test command is there everywhere else.  Looking back in the history for this file, it was never there.  It must have been a typo or oversight.