### PR TITLE
Change paper+ rate plan names to paperPlus

### DIFF
--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -449,37 +449,72 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Everyday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Everyday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Friday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			EverydayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Monday: z.object({
-						id: z.string(),
-					}),
-					Saturday: z.object({
-						id: z.string(),
-					}),
-					Sunday: z.object({
-						id: z.string(),
-					}),
-					Thursday: z.object({
-						id: z.string(),
-					}),
-					Tuesday: z.object({
-						id: z.string(),
-					}),
-					Wednesday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Saturday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -490,19 +525,36 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Saturday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Saturday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Saturday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SaturdayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
 					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Sixday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -528,34 +580,66 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Sixday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Sixday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Friday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SixdayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Monday: z.object({
-						id: z.string(),
-					}),
-					Saturday: z.object({
-						id: z.string(),
-					}),
-					Thursday: z.object({
-						id: z.string(),
-					}),
-					Tuesday: z.object({
-						id: z.string(),
-					}),
-					Wednesday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Sunday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -566,19 +650,36 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Sunday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Sunday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Sunday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SundayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Weekend: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -592,22 +693,42 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Weekend+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Weekend+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Saturday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			WeekendPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Sunday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 		}),
 	}),
 	NationalDelivery: z.object({
@@ -642,37 +763,72 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Everyday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Everyday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Friday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			EverydayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Monday: z.object({
-						id: z.string(),
-					}),
-					Saturday: z.object({
-						id: z.string(),
-					}),
-					Sunday: z.object({
-						id: z.string(),
-					}),
-					Thursday: z.object({
-						id: z.string(),
-					}),
-					Tuesday: z.object({
-						id: z.string(),
-					}),
-					Wednesday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Sixday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -698,34 +854,66 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Sixday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Sixday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Friday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SixdayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Monday: z.object({
-						id: z.string(),
-					}),
-					Saturday: z.object({
-						id: z.string(),
-					}),
-					Thursday: z.object({
-						id: z.string(),
-					}),
-					Tuesday: z.object({
-						id: z.string(),
-					}),
-					Wednesday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Weekend: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -739,22 +927,42 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Weekend+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Weekend+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Saturday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			WeekendPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Sunday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 		}),
 	}),
 	NewspaperVoucher: z.object({
@@ -789,37 +997,72 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Everyday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Everyday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Friday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			EverydayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Monday: z.object({
-						id: z.string(),
-					}),
-					Saturday: z.object({
-						id: z.string(),
-					}),
-					Sunday: z.object({
-						id: z.string(),
-					}),
-					Thursday: z.object({
-						id: z.string(),
-					}),
-					Tuesday: z.object({
-						id: z.string(),
-					}),
-					Wednesday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Saturday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -830,19 +1073,36 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Saturday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Saturday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Saturday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SaturdayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
 					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Sixday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -868,34 +1128,66 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Sixday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Sixday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Friday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SixdayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Monday: z.object({
-						id: z.string(),
-					}),
-					Saturday: z.object({
-						id: z.string(),
-					}),
-					Thursday: z.object({
-						id: z.string(),
-					}),
-					Tuesday: z.object({
-						id: z.string(),
-					}),
-					Wednesday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Sunday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -906,19 +1198,36 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Sunday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Sunday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Sunday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SundayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Weekend: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -932,22 +1241,42 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Weekend+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Weekend+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Saturday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			WeekendPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Sunday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 		}),
 	}),
 	OneTimeContribution: z.object({
@@ -1090,37 +1419,72 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Everyday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Everyday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Friday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			EverydayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Monday: z.object({
-						id: z.string(),
-					}),
-					Saturday: z.object({
-						id: z.string(),
-					}),
-					Sunday: z.object({
-						id: z.string(),
-					}),
-					Thursday: z.object({
-						id: z.string(),
-					}),
-					Tuesday: z.object({
-						id: z.string(),
-					}),
-					Wednesday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Saturday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -1131,19 +1495,36 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Saturday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Saturday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Saturday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SaturdayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
 					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Sixday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -1169,34 +1550,66 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Sixday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Sixday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Friday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SixdayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Friday: z.object({
+							id: z.string(),
+						}),
+						Monday: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Thursday: z.object({
+							id: z.string(),
+						}),
+						Tuesday: z.object({
+							id: z.string(),
+						}),
+						Wednesday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Monday: z.object({
-						id: z.string(),
-					}),
-					Saturday: z.object({
-						id: z.string(),
-					}),
-					Thursday: z.object({
-						id: z.string(),
-					}),
-					Tuesday: z.object({
-						id: z.string(),
-					}),
-					Wednesday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Sunday: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -1207,19 +1620,36 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Sunday+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Sunday+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Sunday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			SundayPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 			Weekend: z.object({
 				billingPeriod: z.literal('Month'),
 				charges: z.object({
@@ -1233,22 +1663,42 @@ export const productCatalogSchema = z.object({
 				id: z.string(),
 				pricing: z.object({ GBP: z.number() }),
 			}),
-			'Weekend+': z.object({
-				billingPeriod: z.literal('Month'),
-				charges: z.object({
-					DigitalPack: z.object({
-						id: z.string(),
+			'Weekend+': z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Saturday: z.object({
-						id: z.string(),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
+			WeekendPlus: z
+				.object({
+					billingPeriod: z.literal('Month'),
+					charges: z.object({
+						DigitalPack: z.object({
+							id: z.string(),
+						}),
+						Saturday: z.object({
+							id: z.string(),
+						}),
+						Sunday: z.object({
+							id: z.string(),
+						}),
 					}),
-					Sunday: z.object({
-						id: z.string(),
-					}),
-				}),
-				id: z.string(),
-				pricing: z.object({ GBP: z.number() }),
-			}),
+					id: z.string(),
+					pricing: z.object({ GBP: z.number() }),
+				})
+				.optional(),
 		}),
 	}),
 	SupporterMembership: z.object({

--- a/modules/product-catalog/src/zuoraToProductNameMappings.ts
+++ b/modules/product-catalog/src/zuoraToProductNameMappings.ts
@@ -93,11 +93,11 @@ const zuoraCatalogToProductRatePlanKey: Record<string, string> = {
 	Weekend: 'Weekend',
 	Sixday: 'Sixday',
 	// Paper+ rate plans
-	'Everyday+': 'Everyday+',
-	'Saturday+': 'Saturday+',
-	'Sunday+': 'Sunday+',
-	'Weekend+': 'Weekend+',
-	'Sixday+': 'Sixday+',
+	'Everyday+': 'EverydayPlus',
+	'Saturday+': 'SaturdayPlus',
+	'Sunday+': 'SundayPlus',
+	'Weekend+': 'WeekendPlus',
+	'Sixday+': 'SixdayPlus',
 	'Guardian Ad-Lite Monthly': 'Monthly',
 	// Membership rate plans
 	'Supporter - monthly': 'V1DeprecatedMonthly',


### PR DESCRIPTION

## What does this change?

We are going to start selling paper plus digital plans again, however the current naming of the rate plans in the product catalog (Weekend+, Everyday+ etc.) causes a problem when trying to purchase one of those plans through the checkout because + is a special character in URLs.

This means that we either have to URL encode the rate plan name in the checkout ratePlan query parameter, eg. https://support.thegulocal.com/uk/checkout?product=NationalDelivery&ratePlan=Weekend%2b or rename the plans in the catalog and we have decided that renaming is a better approach.

I have left the old rate plan names in the schema and marked them as `.optional()`. The new plans are also optional so that there will be no schema validation issues caused by race conditions. Once this PR has deployed successfully and the product catalog API contains the new plans, the old ones can be removed as well as the optional attribute.

