### PR TITLE
Increase lambda memory to recommended amounts

### DIFF
--- a/cdk/lib/__snapshots__/generate-product-catalog.test.ts.snap
+++ b/cdk/lib/__snapshots__/generate-product-catalog.test.ts.snap
@@ -310,7 +310,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         },
         "FunctionName": "generate-product-catalog-CODE",
         "Handler": "index.handler",
-        "MemorySize": 1024,
+        "MemorySize": 1232,
         "Role": {
           "Fn::GetAtt": [
             "generateproductcataloglambdaServiceRole5FF40E84",
@@ -922,7 +922,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         },
         "FunctionName": "generate-product-catalog-PROD",
         "Handler": "index.handler",
-        "MemorySize": 1024,
+        "MemorySize": 1232,
         "Role": {
           "Fn::GetAtt": [
             "generateproductcataloglambdaServiceRole5FF40E84",

--- a/cdk/lib/generate-product-catalog.ts
+++ b/cdk/lib/generate-product-catalog.ts
@@ -37,7 +37,7 @@ export class GenerateProductCatalog extends GuStack {
 			fileName: `${app}.zip`,
 			handler: 'index.handler',
 			runtime: nodeVersion,
-			memorySize: 1024,
+			memorySize: 1232,
 			timeout: Duration.seconds(300),
 			environment: commonEnvironmentVariables,
 			app: app,

--- a/handlers/digital-voucher-suspension-processor/cfn.yaml
+++ b/handlers/digital-voucher-suspension-processor/cfn.yaml
@@ -83,7 +83,7 @@ Resources:
         Suspends fulfilment of digital voucher subscriptions.
         Source: https://github.com/guardian/support-service-lambdas/tree/main/handlers/digital-voucher-suspension-processor.
       Runtime: java21
-      MemorySize: 1536
+      MemorySize: 1792
       Timeout: 900
       CodeUri:
         Bucket: support-service-lambdas-dist

--- a/handlers/holiday-stop-processor/cfn.yaml
+++ b/handlers/holiday-stop-processor/cfn.yaml
@@ -83,7 +83,7 @@ Resources:
           Stage: !Ref Stage
       Role:
         !GetAtt HolidayStopProcessorRole.Arn
-      MemorySize: 1024
+      MemorySize: 1232
       Runtime: java21
       Timeout: 900
       Architectures:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
AWS Trusted Advisor has a report on lambdas which are under-provisioned for memory size: https://us-east-1.console.aws.amazon.com/trustedadvisor/home?region=eu-west-1#/category/performance

This PR makes the updates recommended in that report