### PR TITLE
return generic error string on 500 response for the switch-api endpoint

### DIFF
--- a/handlers/product-switch-api/src/index.ts
+++ b/handlers/product-switch-api/src/index.ts
@@ -54,7 +54,7 @@ const routeRequest = async (event: APIGatewayProxyEvent) => {
 			};
 		} else {
 			return {
-				body: JSON.stringify(error),
+				body: 'An error occurred, check the logs for details',
 				statusCode: 500,
 			};
 		}


### PR DESCRIPTION
## What does this change?

Stop returning the entire error object back to the client if the switch api throws a 500 error, instead return a generic error message string. This is to avoid leaking any sensitive information.