### PR TITLE
Remove `similar-guardian-products` soft opt-in for Live App IAPs

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -19,6 +19,7 @@ object Handler extends LazyLogging {
   val readyToProcessAcquisitionStatus = "Ready to process acquisition"
   val readyToProcessCancellationStatus = "Ready to process cancellation"
   val readyProcessSwitchStatus = "Ready to process switch"
+  val similarGuardianProducts = "similar_guardian_products"
 
   def main(args: Array[String]): Unit = {
     handleRequest()
@@ -119,6 +120,7 @@ object Handler extends LazyLogging {
       toRemove = oldProductSoftOptIns.diff(currentProductSoftOptIns).map(ConsentsObject(_, false))
       toAdd = newProductSoftOptIns
         .filter(option => !oldProductSoftOptIns.contains(option) && !allOtherProductSoftOptIns.contains(option))
+        .filterNot(_ == similarGuardianProducts)
         .map(ConsentsObject(_, true))
 
       consentsBody = (toRemove ++ toAdd).asJson.toString()

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -1,15 +1,7 @@
 package com.gu.soft_opt_in_consent_setter
 
-import com.gu.soft_opt_in_consent_setter.models.{
-  ConsentsMapping,
-  EnhancedSub,
-  SFAssociatedSubResponse,
-  SFSubRecord,
-  SFSubRecordUpdate,
-  SFSubRecordUpdateRequest,
-  SoftOptInConfig,
-  SoftOptInError,
-}
+import com.gu.soft_opt_in_consent_setter.models.ConsentsMapping.similarGuardianProducts
+import com.gu.soft_opt_in_consent_setter.models.{ConsentsMapping, EnhancedSub, SFAssociatedSubResponse, SFSubRecord, SFSubRecordUpdate, SFSubRecordUpdateRequest, SoftOptInConfig, SoftOptInError}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -19,7 +11,6 @@ object Handler extends LazyLogging {
   val readyToProcessAcquisitionStatus = "Ready to process acquisition"
   val readyToProcessCancellationStatus = "Ready to process cancellation"
   val readyProcessSwitchStatus = "Ready to process switch"
-  val similarGuardianProducts = "similar_guardian_products"
 
   def main(args: Array[String]): Unit = {
     handleRequest()

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IAPMessageProcessor.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IAPMessageProcessor.scala
@@ -132,6 +132,7 @@ object IAPMessageProcessor extends StrictLogging {
       toRemove = oldProductSoftOptIns.diff(currentProductSoftOptIns).map(ConsentsObject(_, false))
       toAdd = newProductSoftOptIns
         .filter(option => !oldProductSoftOptIns.contains(option) && !allOtherProductSoftOptIns.contains(option))
+        .filterNot(_ == similarGuardianProducts)
         .map(ConsentsObject(_, true))
       consentsBody = (toRemove ++ toAdd).asJson.toString()
     } yield consentsBody

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala
@@ -108,7 +108,6 @@ object ConsentsMapping {
     ),
     "InAppPurchase" -> Set(
       yourSupportOnboarding,
-      similarGuardianProducts,
       supporterNewsletter,
     ),
     "FeastInAppPurchase" -> Set(

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -213,24 +213,6 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |]""".stripMargin)
   }
 
-  "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
-    Handler.buildProductSwitchConsents(
-      "Guardian Weekly",
-      "newspaper",
-      Set("newspaper", "InAppPurchase"),
-      calculator,
-    ) shouldBe Right("""[
-        |  {
-        |    "id" : "guardian_weekly_newsletter",
-        |    "consented" : false
-        |  },
-        |  {
-        |    "id" : "subscriber_preview",
-        |    "consented" : true
-        |  }
-        |]""".stripMargin)
-  }
-
   "buildProductSwitchConsents - HandlerIAP" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
     IAPMessageProcessor.buildProductSwitchConsents(
       "Guardian Weekly",

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculatorTests.scala
@@ -167,10 +167,6 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
         |    "consented" : false
         |  },
         |  {
-        |    "id" : "similar_guardian_products",
-        |    "consented" : true
-        |  },
-        |  {
         |    "id" : "subscriber_preview",
         |    "consented" : true
         |  },
@@ -200,6 +196,24 @@ class ConsentsCalculatorTests extends AnyFlatSpec with should.Matchers with Eith
       "Guardian Weekly",
       "newspaper",
       Set("newspaper", "Contributor"),
+      calculator,
+    ) shouldBe Right("""[
+        |  {
+        |    "id" : "guardian_weekly_newsletter",
+        |    "consented" : false
+        |  },
+        |  {
+        |    "id" : "subscriber_preview",
+        |    "consented" : true
+        |  }
+        |]""".stripMargin)
+  }
+
+  "buildProductSwitchConsents" should "return the correct consents when switching from a Guardian Weekly to a Newspaper subscription whilst also owning a Mobile Subscription (IAP)" in {
+    Handler.buildProductSwitchConsents(
+      "Guardian Weekly",
+      "newspaper",
+      Set("newspaper", "InAppPurchase"),
       calculator,
     ) shouldBe Right("""[
         |  {


### PR DESCRIPTION
### What does this PR do?
This PR updates the soft opt-in `ConsentsMapping` to prevent Live App IAPs being opted-in to `similar-guardian-products`. 

### Why are we doing this?
We are removing `similar_guardian_products` but keeping `your_support_onboarding`, so we only need to update the consents mapping here [support-service-lambdas/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala at main · guardian/support-service-lambdas](https://github.com/guardian/support-service-lambdas/blob/main/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/ConsentsMapping.scala)

https://docs.google.com/document/d/19RvjreFZezqe_sgXp496y4Ha5W58TAtiggQVxKPSOEk/edit?tab=t.0Connect your Google account

We need to make a change to how we capture Soft Opt-in on the Feast app. We currently capture Similar Guardian Products at the point of sign-in. However we also capture it at the point of IAP purchase. We need to remove this consent capture at the point of IAP purchase and only rely on the sign-in journey to capture SGP consent.

We will need to sync up with the Feast team so they can adapt the copy on the Thank You screen post purchase to reflect the consent mechanism change.