### PR TITLE
update to scala 3.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val scala2Settings = Seq(
 )
 
 val scala3Settings = Seq(
-  scalaVersion := "3.3.4",
+  scalaVersion := "3.7.0",
   version := "0.0.1",
   organization := "com.gu",
   scalacOptions ++= Seq(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Dynamo.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Dynamo.scala
@@ -1,7 +1,7 @@
 package com.gu.productmove
 
 import com.gu.productmove.GuStageLive.Stage
-import com.gu.supporterdata.model.Stage.{PROD, CODE}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 import com.gu.supporterdata.model.SupporterRatePlanItem
 import com.gu.supporterdata.services.SupporterDataDynamoService
 
@@ -9,6 +9,8 @@ import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 import zio.*
 import zio.json.*
+
+import scala.concurrent.ExecutionContext
 
 trait Dynamo {
   def writeItem(item: SupporterRatePlanItem): Task[Unit]
@@ -38,7 +40,7 @@ object DynamoLive {
           override def writeItem(item: SupporterRatePlanItem): Task[Unit] =
             ZIO
               .fromFuture {
-                dynamoService.writeItem(item)
+                dynamoService.writeItem(item)(using _)
               }
               .mapError { ex =>
                 new Throwable(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Handler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Handler.scala
@@ -82,7 +82,7 @@ object HandlerManualTests {
   // for testing
   def runTest(method: String, path: String, testInput: Option[String]): Unit = {
     val inputValue = makeTestRequest(method, path, testInput)
-    val inputJson = inputValue.asJson(deriveEncoder).spaces2
+    val inputJson = inputValue.asJson(using deriveEncoder).spaces2
     runStringTest(inputJson)
   }
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Secrets.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Secrets.scala
@@ -110,7 +110,7 @@ class SecretsLive(secretsClient: SecretsManagerClient, stage: Stage) extends Sec
 
 object SecretsLive {
 
-  val layer: ZLayer[AwsCredentialsProvider with Stage, Throwable, Secrets] =
+  val layer: ZLayer[AwsCredentialsProvider & Stage, Throwable, Secrets] =
     ZLayer.scoped {
       for {
         creds <- ZIO.service[AwsCredentialsProvider]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/SttpClientLive.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/SttpClientLive.scala
@@ -24,7 +24,7 @@ object SttpClientLive {
       ),
     )
 
-  def impl: Task[SttpBackend[Task, ZioStreams with capabilities.WebSockets]] =
+  def impl: Task[SttpBackend[Task, ZioStreams & capabilities.WebSockets]] =
     HttpClientZioBackend()
       .map(underlying =>
         LoggingBackend(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/available/AvailableProductMovesEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/available/AvailableProductMovesEndpoint.scala
@@ -129,7 +129,7 @@ object AvailableProductMovesEndpoint {
 
   private[productmove] def runWithEnvironment(
       subscriptionName: SubscriptionName,
-  ): RIO[GetSubscription with GetCatalogue with GetAccount with Stage, OutputBody] = {
+  ): RIO[GetSubscription & GetCatalogue & GetAccount & Stage, OutputBody] = {
     val output = for {
       stage <- ZIO.service[Stage]
       monthlyContributionRatePlanId =

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/updateamount/UpdateSupporterPlusAmountSteps.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/updateamount/UpdateSupporterPlusAmountSteps.scala
@@ -20,11 +20,11 @@ import zio.{IO, RIO, Task, ZIO}
 object UpdateSupporterPlusAmountSteps {
 
   private[updateamount] def subscriptionUpdateAmount(subscriptionName: SubscriptionName, postData: ExpectedInput): RIO[
-    GetSubscription with GetAccount with SubscriptionUpdate with SQS with Stage,
+    GetSubscription & GetAccount & SubscriptionUpdate & SQS & Stage,
     OutputBody,
   ] = {
     val maybeResult: ZIO[
-      SQS with SubscriptionUpdate with Stage with GetAccount with GetSubscription,
+      SQS & SubscriptionUpdate & Stage & GetAccount & GetSubscription,
       OutputBody | Throwable,
       Success,
     ] = for {

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/invoicingapi/InvoicingApiRefund.scala
@@ -25,7 +25,7 @@ object InvoicingApiRefundLive {
     given JsonDecoder[InvoicingApiConfig] = DeriveJsonDecoder.gen[InvoicingApiConfig]
   }
 
-  val layer: RLayer[SttpBackend[Task, Any] with AwsS3 with Secrets, InvoicingApiRefundLive] =
+  val layer: RLayer[SttpBackend[Task, Any] & AwsS3 & Secrets, InvoicingApiRefundLive] =
     ZLayer {
       for {
         secrets <- ZIO.service[Secrets]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
@@ -26,14 +26,8 @@ object RefundInput {
 
 object RefundSupporterPlus {
   def applyRefund(refundInput: RefundInput): ZIO[
-    InvoicingApiRefund
-      with CreditBalanceAdjustment
-      with Stage
-      with SttpBackend[Task, Any]
-      with AwsS3
-      with GetRefundInvoiceDetails
-      with GetInvoice
-      with InvoiceItemAdjustment,
+    InvoicingApiRefund & CreditBalanceAdjustment & Stage & SttpBackend[Task, Any] & AwsS3 & GetRefundInvoiceDetails &
+      GetInvoice & InvoiceItemAdjustment,
     Throwable | TransactionError,
     Unit,
   ] = {
@@ -52,7 +46,7 @@ object RefundSupporterPlus {
 
   private def ensureThatNegativeInvoiceBalanceIsZero(
       refundInvoiceDetails: RefundInvoiceDetails,
-  ): ZIO[GetInvoice with InvoiceItemAdjustment, Throwable | TransactionError, Unit] = for {
+  ): ZIO[GetInvoice & InvoiceItemAdjustment, Throwable | TransactionError, Unit] = for {
     // unfortunately we can't get an invoice balance from the invoice items, it needs another request
     negativeInvoice <- GetInvoice.get(
       refundInvoiceDetails.negativeInvoiceId,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/Salesforce.scala
@@ -28,7 +28,7 @@ object Salesforce {
 
   def createSfRecord(
       salesforceRecordInput: SalesforceRecordInput,
-  ): RIO[CreateRecord with GetSfSubscription, Unit] = {
+  ): RIO[CreateRecord & GetSfSubscription, Unit] = {
     import salesforceRecordInput.*
 
     for {

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceClient.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/salesforce/SalesforceClient.scala
@@ -41,7 +41,7 @@ trait SalesforceClient {
 
 object SalesforceClientLive {
 
-  val layer: RLayer[SttpBackend[Task, Any] with Secrets, SalesforceClient] =
+  val layer: RLayer[SttpBackend[Task, Any] & Secrets, SalesforceClient] =
     ZLayer.fromZIO(
       for {
         secrets <- ZIO.service[Secrets]

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetCatalogue.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetCatalogue.scala
@@ -18,7 +18,7 @@ import zio.{IO, RIO, Task, URLayer, ZIO, ZLayer}
 import java.time.LocalDate
 
 object GetCatalogueLive {
-  val layer: URLayer[AwsS3 with Stage, GetCatalogue] = ZLayer.fromFunction(GetCatalogueLive(_, _))
+  val layer: URLayer[AwsS3 & Stage, GetCatalogue] = ZLayer.fromFunction(GetCatalogueLive(_, _))
 }
 
 class GetCatalogueLive(awsS3: AwsS3, stage: Stage) extends GetCatalogue {

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetRefundInvoiceDetails.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetRefundInvoiceDetails.scala
@@ -123,7 +123,7 @@ private class GetRefundInvoiceDetailsLive(zuoraGet: ZuoraGet) extends GetRefundI
   }
   private def getInvoicesSortedByDate(items: List[InvoiceItem]): Map[String, List[InvoiceItem]] = {
     val invoices: Map[String, List[InvoiceItem]] = items.groupBy(_.InvoiceId)
-    ListMap(invoices.toSeq.sortWith(getDate(_) > getDate(_)): _*)
+    ListMap(invoices.toSeq.sortWith(getDate(_) > getDate(_))*)
   }
   private def getDate(i: (String, List[InvoiceItem])) =
     i._2.headOption.map(_.chargeDateAsDateTime).getOrElse(LocalDateTime.MIN)

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
@@ -47,7 +47,7 @@ object Subscribe {
   def create(
       zuoraAccountId: String,
       targetProductId: String,
-  ): RIO[Subscribe with Stage, CreateSubscriptionResponse] =
+  ): RIO[Subscribe & Stage, CreateSubscriptionResponse] =
     ZIO.serviceWithZIO[Subscribe](_.create(zuoraAccountId, targetProductId))
 }
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraClient.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/rest/ZuoraClient.scala
@@ -22,7 +22,7 @@ object ZuoraClientLive {
     given JsonDecoder[ZuoraRestConfig] = DeriveJsonDecoder.gen[ZuoraRestConfig]
   }
 
-  val layer: ZLayer[SttpBackend[Task, Any] with Secrets, Throwable, ZuoraClient] =
+  val layer: ZLayer[SttpBackend[Task, Any] & Secrets, Throwable, ZuoraClient] =
     ZLayer {
       for {
         secrets <- ZIO.service[Secrets]

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/salesforce/CreateRecordSpec.scala
@@ -24,7 +24,7 @@ import zio.*
 import java.time.*
 
 object CreateRecordSpec extends ZIOSpecDefault {
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("Create Salesforce Record")(
       test("Run locally") {
         /*

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/CreatePaymentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/CreatePaymentSpec.scala
@@ -14,7 +14,7 @@ import java.time.*
 
 object CreatePaymentSpec extends ZIOSpecDefault {
 
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("Create Payment")(
       test("Test creating a payment locally") {
         for {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/CreditBalanceAdjustmentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/CreditBalanceAdjustmentSpec.scala
@@ -10,7 +10,7 @@ import zio.test.Assertion.equalTo
 import zio.test.{Spec, TestAspect, TestEnvironment, ZIOSpecDefault, assert}
 
 object CreditBalanceAdjustmentSpec extends ZIOSpecDefault {
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("Credit balance adjustment")(
       test("Run CreditBalanceAdjustment increase locally") {
         val amount = 27.86

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundAmountSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundAmountSpec.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable
 
 object GetRefundAmountSpec extends ZIOSpecDefault {
 
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("GetSwitchInvoice")(
       test("finds the right amount for a switched sub") {
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundInvoiceDetailsLiveSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundInvoiceDetailsLiveSpec.scala
@@ -18,7 +18,7 @@ import scala.collection.mutable
 import scala.collection.mutable.Stack
 
 object GetRefundInvoiceDetailsLiveSpec extends ZIOSpecDefault {
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("GetInvoiceItemsForSubscriptionLive")(
       test("finds taxation details for a subscription") {
         for {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
@@ -21,7 +21,7 @@ import zio.json.JsonDecoder
 import java.time.*
 
 object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("InvoiceItemAdjustment")(
       test("Run InvoiceItemAdjustment locally") {
         for {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/RefundSupporterPlusSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/RefundSupporterPlusSpec.scala
@@ -19,7 +19,7 @@ import zio.test.Assertion.*
 import zio.test.*
 
 object RefundSupporterPlusSpec extends ZIOSpecDefault {
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("RefundSupporterPlus")(
       test("Run refund lambda locally") {
         /*

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscribeSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscribeSpec.scala
@@ -17,7 +17,7 @@ import java.time.*
 object SubscribeSpec extends ZIOSpecDefault {
   private val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 16, 10, 2), ZoneOffset.ofHours(0))
 
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("subscribe layer")(test("createRequest function: JSON request body is created and encoded correctly") {
       val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 10, 10, 2), ZoneOffset.ofHours(0)).toInstant
       val expectedSubscribeRequest = SubscribeRequest(

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/SubscriptionUpdateSpec.scala
@@ -39,7 +39,7 @@ import scala.None
 
 object SubscriptionUpdateSpec extends ZIOSpecDefault {
 
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("subscription update service")(
       test("SwitchProductUpdateRequest is correct for input (CODE)") {
         val timeLocalDate = LocalDate.of(2022, 5, 10)

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ZuoraGetSerialisationSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ZuoraGetSerialisationSpec.scala
@@ -15,7 +15,7 @@ import sttp.client3.testing.SttpBackendStub
 import java.time.LocalDate
 
 object ZuoraGetSerialisationSpec extends ZIOSpecDefault {
-  override def spec: Spec[TestEnvironment with Scope, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("ZuoraGetSerialisation")(
       test("can deserialise a list") {
         for {


### PR DESCRIPTION
updated to 3.7.0 and recompiled with `-rewrite -source 3.7-migration` to squash all the warnings that can be auto fixed since 3.3
https://www.scala-lang.org/news/3.7.0/#:~:text=Scala%203.7%20provides%20an%20automated%20migration%20path%20for%20existing%20codebases%20through%20the%20compiler%20flags%20%2Drewrite%20%2Dsource%3A3.7%2Dmigration

https://github.com/guardian/recommendations/blob/main/scala.md#:~:text=latest%20for%20production%20code.