### PR TITLE
wrap invoiceid and accountid in a value class

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/RecurringContributionToSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/move/switchtype/RecurringContributionToSupporterPlus.scala
@@ -11,6 +11,7 @@ import com.gu.productmove.salesforce.Salesforce.SalesforceRecordInput
 import com.gu.productmove.zuora.*
 import com.gu.productmove.zuora.GetAccount.GetAccountResponse
 import com.gu.productmove.zuora.GetSubscription.{GetSubscriptionResponse, RatePlanCharge}
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.model.SubscriptionName
 import com.gu.supporterdata.model.SupporterRatePlanItem
 import zio.*
@@ -312,7 +313,7 @@ class RecurringContributionToSupporterPlusImpl(
       currency: Currency,
       currentRatePlanId: String,
       price: BigDecimal,
-  ): Task[String] = {
+  ): Task[InvoiceId] = {
     for {
       updateRequestBody <- getRatePlans.getRatePlans(billingPeriod, currency, currentRatePlanId, price).map {
         case (addRatePlan, removeRatePlan) =>
@@ -343,7 +344,7 @@ class RecurringContributionToSupporterPlusImpl(
       currency: Currency,
       currentRatePlanId: String,
       price: BigDecimal,
-  ): Task[String] = {
+  ): Task[InvoiceId] = {
     // To start a new term for this subscription we reduce the the current term length so that it ends today in
     // the update subscription request, and then renew the sub using a separate request
     val newTermLength = getNewTermLengthInDays(today, termStartDate)
@@ -378,7 +379,7 @@ class RecurringContributionToSupporterPlusImpl(
      This function is used to adjust the invoice item for the supporter plus subscription charge
    */
   private def adjustNonCollectedInvoice(
-      invoiceId: String,
+      invoiceId: InvoiceId,
       supporterPlusRatePlanIds: SupporterPlusRatePlanIds,
       subscriptionName: SubscriptionName,
       balanceToAdjust: BigDecimal,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/CreatePayment.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/CreatePayment.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.Currency
 import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError, PreviewResult}
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.model.{SubscriptionId, SubscriptionName}
 import com.gu.productmove.zuora.rest.ZuoraGet
 import com.gu.productmove.zuora.rest.ZuoraRestBody.{ZuoraSuccessCheck, ZuoraSuccessLowercase}
@@ -24,8 +25,8 @@ import java.time.temporal.ChronoUnit
 
 trait CreatePayment {
   def create(
-      accountId: String,
-      invoiceId: String,
+      accountId: ZuoraAccountId,
+      invoiceId: InvoiceId,
       paymentMethodId: String,
       amount: BigDecimal,
       today: LocalDate,
@@ -38,8 +39,8 @@ object CreatePaymentLive {
 
 private class CreatePaymentLive(zuoraGet: ZuoraGet) extends CreatePayment {
   override def create(
-      accountId: String,
-      invoiceId: String,
+      accountId: ZuoraAccountId,
+      invoiceId: InvoiceId,
       paymentMethodId: String,
       amount: BigDecimal,
       today: LocalDate,
@@ -68,8 +69,8 @@ private class CreatePaymentLive(zuoraGet: ZuoraGet) extends CreatePayment {
 
 object CreatePayment {
   def create(
-      accountId: String,
-      invoiceId: String,
+      accountId: ZuoraAccountId,
+      invoiceId: InvoiceId,
       paymentMethodId: String,
       amount: BigDecimal,
       today: LocalDate,
@@ -77,8 +78,8 @@ object CreatePayment {
     ZIO.serviceWithZIO[CreatePayment](_.create(accountId, invoiceId, paymentMethodId, amount, today))
 }
 case class CreatePaymentRequest(
-    AccountId: String,
-    InvoiceId: String,
+    AccountId: ZuoraAccountId,
+    InvoiceId: InvoiceId,
     PaymentMethodId: String,
     Amount: BigDecimal,
     AppliedInvoiceAmount: BigDecimal,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetAccount.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetAccount.scala
@@ -60,7 +60,7 @@ object GetAccount {
   )
 
   case class BasicInfo(
-      id: String,
+      id: ZuoraAccountId,
       defaultPaymentMethod: DefaultPaymentMethod,
       IdentityId__c: Option[IdentityId],
       sfContactId__c: String,
@@ -87,7 +87,7 @@ object GetAccount {
     given JsonDecoder[BasicInfo] = DeriveJsonDecoder.gen[BasicInfoWire].map {
       case BasicInfoWire(id, defaultPaymentMethod, identityId, sfContactId__c, balance, currency) =>
         BasicInfo(
-          id = id,
+          id = ZuoraAccountId(id),
           defaultPaymentMethod = defaultPaymentMethod,
           IdentityId__c = identityId.filter(_ != "").map(IdentityId.apply),
           sfContactId__c = sfContactId__c,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetInvoice.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetInvoice.scala
@@ -5,6 +5,7 @@ import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.ErrorResponse
 import com.gu.productmove.zuora.GetInvoice.GetInvoiceResponse
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.rest.ZuoraRestBody.ZuoraSuccessCheck.None
 import com.gu.productmove.zuora.rest.{ZuoraGet, ZuoraRestBody}
 import sttp.capabilities.zio.ZioStreams
@@ -26,7 +27,7 @@ object GetInvoiceLive {
 }
 
 private class GetInvoiceLive(zuoraGet: ZuoraGet) extends GetInvoice {
-  override def get(invoiceId: String): Task[GetInvoiceResponse] =
+  override def get(invoiceId: InvoiceId): Task[GetInvoiceResponse] =
     zuoraGet.get[GetInvoiceResponse](
       uri"invoices/$invoiceId",
       ZuoraRestBody.ZuoraSuccessCheck.None,
@@ -34,7 +35,7 @@ private class GetInvoiceLive(zuoraGet: ZuoraGet) extends GetInvoice {
 }
 
 trait GetInvoice {
-  def get(invoiceId: String): Task[GetInvoiceResponse]
+  def get(invoiceId: InvoiceId): Task[GetInvoiceResponse]
 }
 
 object GetInvoice {
@@ -43,6 +44,6 @@ object GetInvoice {
 
   given JsonDecoder[GetInvoiceResponse] = DeriveJsonDecoder.gen[GetInvoiceResponse]
 
-  def get(invoiceId: String): RIO[GetInvoice, GetInvoiceResponse] =
+  def get(invoiceId: InvoiceId): RIO[GetInvoice, GetInvoiceResponse] =
     ZIO.serviceWithZIO[GetInvoice](_.get(invoiceId))
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetInvoice.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetInvoice.scala
@@ -29,7 +29,7 @@ object GetInvoiceLive {
 private class GetInvoiceLive(zuoraGet: ZuoraGet) extends GetInvoice {
   override def get(invoiceId: InvoiceId): Task[GetInvoiceResponse] =
     zuoraGet.get[GetInvoiceResponse](
-      uri"invoices/$invoiceId",
+      uri"invoices/${invoiceId.id}",
       ZuoraRestBody.ZuoraSuccessCheck.None,
     )
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetInvoiceItems.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/GetInvoiceItems.scala
@@ -4,7 +4,8 @@ import com.gu.newproduct.api.productcatalog.{Annual, BillingPeriod, Monthly}
 import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.ErrorResponse
-import com.gu.productmove.zuora.GetInvoiceItems.{GetInvoiceItemsResponse}
+import com.gu.productmove.zuora.GetInvoiceItems.GetInvoiceItemsResponse
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.rest.ZuoraRestBody.ZuoraSuccessCheck.None
 import com.gu.productmove.zuora.rest.{ZuoraGet, ZuoraRestBody}
 import sttp.capabilities.zio.ZioStreams
@@ -26,7 +27,7 @@ object GetInvoiceItemsLive {
 }
 
 private class GetInvoiceItemsLive(zuoraGet: ZuoraGet) extends GetInvoiceItems {
-  override def get(invoiceId: String): Task[GetInvoiceItemsResponse] =
+  override def get(invoiceId: InvoiceId): Task[GetInvoiceItemsResponse] =
     zuoraGet.get[GetInvoiceItemsResponse](
       uri"invoices/$invoiceId/items",
       ZuoraRestBody.ZuoraSuccessCheck.None,
@@ -34,7 +35,7 @@ private class GetInvoiceItemsLive(zuoraGet: ZuoraGet) extends GetInvoiceItems {
 }
 
 trait GetInvoiceItems {
-  def get(invoiceId: String): Task[GetInvoiceItemsResponse]
+  def get(invoiceId: InvoiceId): Task[GetInvoiceItemsResponse]
 }
 
 object GetInvoiceItems {
@@ -45,6 +46,6 @@ object GetInvoiceItems {
   given JsonDecoder[InvoiceItem] = DeriveJsonDecoder.gen[InvoiceItem]
   given JsonDecoder[GetInvoiceItemsResponse] = DeriveJsonDecoder.gen[GetInvoiceItemsResponse]
 
-  def get(invoiceId: String): RIO[GetInvoiceItems, GetInvoiceItemsResponse] =
+  def get(invoiceId: InvoiceId): RIO[GetInvoiceItems, GetInvoiceItemsResponse] =
     ZIO.serviceWithZIO[GetInvoiceItems](_.get(invoiceId))
 }

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/InvoiceItemAdjustment.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/InvoiceItemAdjustment.scala
@@ -5,6 +5,7 @@ import com.gu.productmove.AwsS3
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.ErrorResponse
 import com.gu.productmove.zuora.InvoiceItemAdjustment.*
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.rest.ZuoraRestBody.ZuoraSuccessCheck.None
 import com.gu.productmove.zuora.rest.{ZuoraGet, ZuoraRestBody}
 import sttp.capabilities.zio.ZioStreams
@@ -27,7 +28,7 @@ object InvoiceItemAdjustmentLive {
 
 private class InvoiceItemAdjustmentLive(zuoraGet: ZuoraGet) extends InvoiceItemAdjustment {
   override def update(
-      invoiceId: String,
+      invoiceId: InvoiceId,
       amount: BigDecimal,
       invoiceItemId: String,
       adjustmentType: String,
@@ -57,7 +58,7 @@ private class InvoiceItemAdjustmentLive(zuoraGet: ZuoraGet) extends InvoiceItemA
 
 trait InvoiceItemAdjustment {
   def update(
-      invoiceId: String,
+      invoiceId: InvoiceId,
       amount: BigDecimal,
       invoiceItemId: String,
       adjustmentType: String,
@@ -74,7 +75,7 @@ object InvoiceItemAdjustment {
   case class PostBody(
       AdjustmentDate: LocalDate,
       Amount: BigDecimal,
-      InvoiceId: String,
+      InvoiceId: InvoiceId,
       SourceId: String, // The invoice item id
       Type: String = "Charge",
       SourceType: String,
@@ -93,7 +94,7 @@ object InvoiceItemAdjustment {
   given JsonEncoder[InvoiceItemAdjustmentsWriteRequest] = DeriveJsonEncoder.gen[InvoiceItemAdjustmentsWriteRequest]
 
   def update(
-      invoiceId: String,
+      invoiceId: InvoiceId,
       amount: BigDecimal,
       invoiceItemId: String,
       adjustmentType: String,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/Subscribe.scala
@@ -68,6 +68,10 @@ case class ChargeOverrides(
 given JsonEncoder[ChargeOverrides] = DeriveJsonEncoder.gen[ChargeOverrides]
 
 case class ZuoraAccountId(value: String) extends AnyVal
+object ZuoraAccountId {
+  given JsonCodec[ZuoraAccountId] = JsonCodec.string.transform(ZuoraAccountId.apply, _.value)
+}
+
 case class CaseId(value: String) extends AnyVal
 case class AcquisitionSource(value: String) extends AnyVal
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/SubscriptionUpdate.scala
@@ -1,5 +1,6 @@
 package com.gu.productmove.zuora
 
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.model.SubscriptionName
 import com.gu.productmove.zuora.rest.ZuoraGet
 import sttp.client3.*
@@ -85,7 +86,7 @@ case class RemoveRatePlan(
 case class SubscriptionUpdateResponse(
     subscriptionId: String,
     totalDeltaMrr: BigDecimal,
-    invoiceId: Option[String],
+    invoiceId: Option[InvoiceId],
     paidAmount: Option[BigDecimal],
 ) derives JsonDecoder
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/TermRenewal.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/TermRenewal.scala
@@ -1,5 +1,6 @@
 package com.gu.productmove.zuora
 
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.model.SubscriptionName
 import com.gu.productmove.zuora.rest.ZuoraGet
 import com.gu.productmove.zuora.rest.ZuoraRestBody.ZuoraSuccessCheck
@@ -59,4 +60,4 @@ case class RenewalRequest(
     collect: Option[Boolean],
     runBilling: Boolean,
 ) derives JsonEncoder
-case class RenewalResponse(success: Option[Boolean], invoiceId: Option[String]) derives JsonDecoder
+case class RenewalResponse(success: Option[Boolean], invoiceId: Option[InvoiceId]) derives JsonDecoder

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/model/InvoiceId.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/model/InvoiceId.scala
@@ -1,0 +1,9 @@
+package com.gu.productmove.zuora.model
+
+import zio.json.{JsonCodec, JsonDecoder}
+
+case class InvoiceId(id: String)
+
+object InvoiceId {
+  given JsonCodec[InvoiceId] = JsonCodec.string.transform(InvoiceId.apply, _.id)
+}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -84,6 +84,7 @@ import com.gu.productmove.endpoint.move.switchtype.{
   ToRecurringContribution,
   ToRecurringContributionImpl,
 }
+import com.gu.productmove.zuora.model.InvoiceId
 import zio.*
 import zio.test.*
 import zio.test.Assertion.*
@@ -112,7 +113,7 @@ object HandlerSpec extends ZIOSpecDefault {
     val subscriptionUpdateStubs = Map(subscriptionUpdateInputsShouldBe -> subscriptionUpdateResponse)
     val termRenewalInputsShouldBe: SubscriptionName =
       SubscriptionName("subscription_name")
-    val termRenewalResponse = RenewalResponse(Some(true), Some("invoiceId"))
+    val termRenewalResponse = RenewalResponse(Some(true), Some(InvoiceId("invoiceId")))
     val termRenewalStubs = Map(termRenewalInputsShouldBe -> termRenewalResponse)
     val getAccountStubs = Map(AccountNumber("accountNumber") -> getAccountResponse)
     val getAccountStubs2 = Map(AccountNumber("accountNumber") -> getAccountResponse2)

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -22,6 +22,7 @@ import com.gu.productmove.zuora.Fixtures.{
 }
 import com.gu.productmove.zuora.GetInvoice.GetInvoiceResponse
 import com.gu.productmove.zuora.GetInvoiceItems.{GetInvoiceItemsResponse, InvoiceItem}
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.{EmailMessage, EmailPayload, IdentityId, RCtoSPEmailPayloadProductSwitchAttributes}
 import com.gu.supporterdata.model.SupporterRatePlanItem
 import com.gu.util.config.Stage
@@ -239,7 +240,7 @@ val getSubscriptionResponseNoChargedThroughDate = GetSubscriptionResponse(
 //-----------------------------------------------------
 val getAccountResponse = GetAccountResponse(
   BasicInfo(
-    "id",
+    ZuoraAccountId("id"),
     DefaultPaymentMethod("paymentMethodId", Some(LocalDate.of(2030, 12, 1))),
     someIdentityId,
     "sfContactId",
@@ -252,7 +253,7 @@ val getAccountResponse = GetAccountResponse(
 
 val getAccountResponse2 = GetAccountResponse(
   BasicInfo(
-    "id",
+    ZuoraAccountId("id"),
     DefaultPaymentMethod("paymentMethodId", Some(LocalDate.of(2030, 12, 1))),
     None,
     "sfContactId",
@@ -265,7 +266,7 @@ val getAccountResponse2 = GetAccountResponse(
 
 val directDebitGetAccountResponse = GetAccountResponse(
   BasicInfo(
-    "id",
+    ZuoraAccountId("id"),
     DefaultPaymentMethod("paymentMethodId", None),
     None,
     "sfContactId",
@@ -487,19 +488,39 @@ val salesforceRecordInput4 = SalesforceRecordInput(
 // Stubs for SubscriptionUpdate service
 //-----------------------------------------------------
 val subscriptionUpdateResponse =
-  SubscriptionUpdateResponse("8ad0823f841cf4e601841e61f7b57mkd", 28, Some("89ad8casd9c0asdcaj89sdc98as"), Some(20))
+  SubscriptionUpdateResponse(
+    "8ad0823f841cf4e601841e61f7b57mkd",
+    28,
+    Some(InvoiceId("89ad8casd9c0asdcaj89sdc98as")),
+    Some(20),
+  )
 val subscriptionUpdateResponse2 =
-  SubscriptionUpdateResponse("8ad0823f841cf4e601841e61f7b57osi", -4, Some("80a23d9sdf9a89fs8cjjk2"), Some(10))
+  SubscriptionUpdateResponse(
+    "8ad0823f841cf4e601841e61f7b57osi",
+    -4,
+    Some(InvoiceId("80a23d9sdf9a89fs8cjjk2")),
+    Some(10),
+  )
 val subscriptionUpdateResponse3 =
-  SubscriptionUpdateResponse("8ad0823f841cf4e601841e61f7b57jsd", 28, Some("89ad8casd9c0asdcaj89sdc98as"), None)
+  SubscriptionUpdateResponse(
+    "8ad0823f841cf4e601841e61f7b57jsd",
+    28,
+    Some(InvoiceId("89ad8casd9c0asdcaj89sdc98as")),
+    None,
+  )
 val subscriptionUpdateResponse4 = SubscriptionUpdateResponse(
   "8ad0823f841cf4e601841e61f6d070b8",
   BigDecimal(25),
-  Some("8ad0823f841cf4e601841e61f7b570e8"),
+  Some(InvoiceId("8ad0823f841cf4e601841e61f7b570e8")),
   Some(25),
 )
 val subscriptionUpdateResponse5 =
-  SubscriptionUpdateResponse("8ad08ccf844271800184528017044b36", -4, Some("8ad08ccf844271800184528017b24b4b"), None)
+  SubscriptionUpdateResponse(
+    "8ad08ccf844271800184528017044b36",
+    -4,
+    Some(InvoiceId("8ad08ccf844271800184528017b24b4b")),
+    None,
+  )
 
 val timeLocalDate = LocalDate.of(2022, 5, 10)
 val timeLocalDate2 = LocalDate.of(2023, 2, 6)

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointStepsSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointStepsSpec.scala
@@ -76,7 +76,14 @@ object SubscriptionCancelEndpointStepsSpec extends ZIOSpecDefault {
         if (subscriptionNumber.value == expectedAccountNumber)
           ZIO.succeed(
             GetAccountResponse(
-              BasicInfo("", DefaultPaymentMethod("", None), identityIdToReturn.map(IdentityId.apply), "", 0, GBP),
+              BasicInfo(
+                ZuoraAccountId(""),
+                DefaultPaymentMethod("", None),
+                identityIdToReturn.map(IdentityId.apply),
+                "",
+                0,
+                GBP,
+              ),
               null,
               null,
             ),

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/endpoint/move/ProductMoveEndpointSpec.scala
@@ -20,6 +20,7 @@ import com.gu.productmove.zuora.{
   InvoiceItemAdjustment,
   SubscriptionUpdate,
   TermRenewal,
+  ZuoraAccountId,
   ZuoraProductCatalogue,
 }
 import zio.{Task, UIO, URIO, ZIO}
@@ -81,7 +82,14 @@ object ProductMoveEndpointSpec extends ZIOSpecDefault {
         if (subscriptionNumber.value == expectedAccountNumber)
           ZIO.succeed(
             GetAccountResponse(
-              BasicInfo("", DefaultPaymentMethod("", None), identityIdToReturn.map(IdentityId.apply), "", 0, GBP),
+              BasicInfo(
+                ZuoraAccountId(""),
+                DefaultPaymentMethod("", None),
+                identityIdToReturn.map(IdentityId.apply),
+                "",
+                0,
+                GBP,
+              ),
               null,
               null,
             ),

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/CreatePaymentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/CreatePaymentSpec.scala
@@ -1,9 +1,10 @@
 package com.gu.productmove.zuora
 
 import com.gu.productmove.*
+import com.gu.productmove.endpoint.move.ProductMoveEndpoint
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.ExpectedInput
-import com.gu.productmove.endpoint.move.{ProductMoveEndpoint}
 import com.gu.productmove.endpoint.move.switchtype.RecurringContributionToSupporterPlus
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.model.SubscriptionName
 import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGetLive}
 import zio.*
@@ -20,8 +21,8 @@ object CreatePaymentSpec extends ZIOSpecDefault {
         for {
           _ <- CreatePayment
             .create(
-              accountId = "8ad09be48bae944c018baf50186850a5",
-              invoiceId = "8ad087d28bb86b72018bb9e90bad101d",
+              accountId = ZuoraAccountId("8ad09be48bae944c018baf50186850a5"),
+              invoiceId = InvoiceId("8ad087d28bb86b72018bb9e90bad101d"),
               paymentMethodId = "8ad09be48bae944c018baf50189950aa",
               amount = 45.270000000,
               today = LocalDate.now(),

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundAmountSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/GetRefundAmountSpec.scala
@@ -23,7 +23,7 @@ object GetRefundAmountSpec extends ZIOSpecDefault {
               ZuoraGetLive.layer,
             )
         } yield {
-          assert(invoicesForRefund.negativeInvoiceId)(equalTo("8ad0934e86a19cca0186a817d551251e")) &&
+          assert(invoicesForRefund.negativeInvoiceId.id)(equalTo("8ad0934e86a19cca0186a817d551251e")) &&
           assert(invoicesForRefund.refundAmount)(equalTo(12.14))
         }
       },
@@ -45,7 +45,7 @@ object GetRefundAmountSpec extends ZIOSpecDefault {
               ZuoraGetLive.layer,
             )
         } yield {
-          assert(invoicesForRefund.negativeInvoiceId)(equalTo("8ad08dc989e27bbe0189e40e61110aba")) &&
+          assert(invoicesForRefund.negativeInvoiceId.id)(equalTo("8ad08dc989e27bbe0189e40e61110aba")) &&
           assert(invoicesForRefund.refundAmount)(equalTo(10))
         }
       },
@@ -59,7 +59,7 @@ object GetRefundAmountSpec extends ZIOSpecDefault {
               ZuoraGetLive.layer,
             )
         } yield {
-          assert(invoicesForRefund.negativeInvoiceId)(equalTo("8ad09b2186b5fdb50186b708669f2114")) &&
+          assert(invoicesForRefund.negativeInvoiceId.id)(equalTo("8ad09b2186b5fdb50186b708669f2114")) &&
           assert(invoicesForRefund.refundAmount)(equalTo(20))
         }
       },

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/InvoiceItemAdjustmentSpec.scala
@@ -8,6 +8,7 @@ import com.gu.productmove.invoicingapi.InvoicingApiRefundLive
 import com.gu.productmove.refund.*
 import com.gu.productmove.zuora.GetSubscription
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.Subscribe.*
 import com.gu.productmove.zuora.rest.{ZuoraClientLive, ZuoraGetLive}
 import com.gu.productmove.*
@@ -28,7 +29,7 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
           _ <- TestClock.setTime(LocalDateTime.now.toInstant(ZoneOffset.UTC))
           _ <- InvoiceItemAdjustment
             .update(
-              invoiceId = "8ad09b2186bfd8100186c73164d82886",
+              invoiceId = InvoiceId("8ad09b2186bfd8100186c73164d82886"),
               amount = 11.43,
               invoiceItemId = "8ad09b2186bfd8100186c73164e92887",
               "Charge",
@@ -52,14 +53,14 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
               ChargeDate = "2023-08-09T17:01:56.000+01:00",
               ChargeAmount = -120,
               TaxDetails = None,
-              InvoiceId = "8ad08dc989d472290189db08883a0961",
+              InvoiceId = InvoiceId("8ad08dc989d472290189db08883a0961"),
             ),
             InvoiceItemWithTaxDetails(
               Id = "8ad08dc989d472290189db0888460963",
               ChargeDate = "2023-08-09T17:01:56.000+01:00",
               ChargeAmount = 0,
               TaxDetails = None,
-              InvoiceId = "8ad08dc989d472290189db08883a0961",
+              InvoiceId = InvoiceId("8ad08dc989d472290189db08883a0961"),
             ),
           ),
         )
@@ -74,14 +75,14 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
               ChargeDate = "2023-08-15T00:27:52.000+01:00",
               ChargeAmount = -33,
               TaxDetails = None,
-              InvoiceId = "8a12843289e577d00189f660965f56bc",
+              InvoiceId = InvoiceId("8a12843289e577d00189f660965f56bc"),
             ),
             InvoiceItemWithTaxDetails(
               Id = "8a12843289e577d00189f660966d56be",
               ChargeDate = "2023-08-15T00:27:52.000+01:00",
               ChargeAmount = -15.45,
               TaxDetails = None,
-              InvoiceId = "8a12843289e577d00189f660965f56bc",
+              InvoiceId = InvoiceId("8a12843289e577d00189f660965f56bc"),
             ),
           ),
         )
@@ -96,14 +97,14 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             ChargeAmount = 0,
             TaxDetails = None,
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
           ),
           // Subscription charge
           InvoiceItemWithTaxDetails(
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             TaxDetails = Some(TaxDetails(-0.91, "8a12867e90766628019084f204fa5338")),
             Id = "8a12867e90766628019084f204fa5335",
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
             ChargeAmount = -9.09,
           ),
           // The discount
@@ -112,7 +113,7 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             AppliedToInvoiceItemId = Some("8a12867e90766628019084f204fa5335"),
             TaxDetails = Some(TaxDetails(0.45, "8a12867e90766628019084f204fa5339")),
             Id = "8a12867e90766628019084f204fa5336",
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
             ChargeAmount = 4.55,
           ),
         )
@@ -132,14 +133,14 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             ChargeAmount = -10,
             TaxDetails = None,
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
           ),
           // Subscription charge
           InvoiceItemWithTaxDetails(
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             TaxDetails = Some(TaxDetails(-0.91, "8a12867e90766628019084f204fa5338")),
             Id = "8a12867e90766628019084f204fa5335",
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
             ChargeAmount = -9.09,
           ),
           // The discount
@@ -148,7 +149,7 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             AppliedToInvoiceItemId = Some("8a12867e90766628019084f204fa5335"),
             TaxDetails = Some(TaxDetails(0.45, "8a12867e90766628019084f204fa5339")),
             Id = "8a12867e90766628019084f204fa5336",
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
             ChargeAmount = 4.55,
           ),
         )
@@ -168,14 +169,14 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             ChargeAmount = -10,
             TaxDetails = None,
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
           ),
           // Subscription charge
           InvoiceItemWithTaxDetails(
             ChargeDate = "2024-07-05T23:09:31.000+01:00",
             TaxDetails = None,
             Id = "8a12867e90766628019084f204fa5335",
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
             ChargeAmount = -15,
           ),
           // The discount
@@ -184,7 +185,7 @@ object InvoiceItemAdjustmentSpec extends ZIOSpecDefault {
             AppliedToInvoiceItemId = Some("8a12867e90766628019084f204fa5335"),
             TaxDetails = None,
             Id = "8a12867e90766628019084f204fa5336",
-            InvoiceId = "8a12867e90766628019084f204f15333",
+            InvoiceId = InvoiceId("8a12867e90766628019084f204f15333"),
             ChargeAmount = 5,
           ),
         )

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/JsonCodecSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/JsonCodecSpec.scala
@@ -65,7 +65,7 @@ class JsonCodecSpec extends AnyFlatSpec {
   it should "JSON Decoding: null fields should convert to type None" in {
     val json = Source.fromResource("AccountBasicInfo2.json").mkString
     val expectedBasicInfo = BasicInfo(
-      "2c92a0ff58bjkleb0158ff0351370sdf",
+      ZuoraAccountId("2c92a0ff58bjkleb0158ff0351370sdf"),
       DefaultPaymentMethod("2c92a0fd590128e4015902ad34001c1f", None),
       None,
       "0030J00001tCDhGAMKL",
@@ -81,7 +81,7 @@ class JsonCodecSpec extends AnyFlatSpec {
   it should "JSON Decoding: empty strings should convert to type None" in {
     val json = Source.fromResource("AccountBasicInfo.json").mkString
     val expectedBasicInfo = BasicInfo(
-      "2c92a0ff58bjkleb0158ff0351370sdf",
+      ZuoraAccountId("2c92a0ff58bjkleb0158ff0351370sdf"),
       DefaultPaymentMethod("2c92a0fd590128e4015902ad34001c1f", None),
       None,
       "0030J00001tCDhGAMKL",

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockCreatePayment.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockCreatePayment.scala
@@ -3,6 +3,7 @@ package com.gu.productmove.zuora
 import com.gu.productmove.GuStageLive.Stage
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError}
 import com.gu.productmove.zuora.GetInvoice.GetInvoiceResponse
+import com.gu.productmove.zuora.model.InvoiceId
 import zio.*
 
 import java.time.LocalDate
@@ -16,13 +17,13 @@ class MockCreatePayment(
   def requests = mutableStore.reverse
 
   override def create(
-      accountId: String,
-      invoiceId: String,
+      accountId: ZuoraAccountId,
+      invoiceId: InvoiceId,
       paymentMethodId: String,
       amount: BigDecimal,
       today: LocalDate,
   ): Task[CreatePaymentResponse] = {
-    mutableStore = invoiceId :: mutableStore
+    mutableStore = invoiceId.id :: mutableStore
     ZIO.succeed(response)
   }
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoice.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoice.scala
@@ -2,6 +2,7 @@ package com.gu.productmove.zuora
 
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError}
 import com.gu.productmove.zuora.GetInvoice.GetInvoiceResponse
+import com.gu.productmove.zuora.model.InvoiceId
 import zio.*
 
 class MockGetInvoice(
@@ -12,10 +13,10 @@ class MockGetInvoice(
 
   def requests = mutableStore.reverse
 
-  override def get(invoiceId: String): Task[GetInvoiceResponse] = {
-    mutableStore = invoiceId :: mutableStore
+  override def get(invoiceId: InvoiceId): Task[GetInvoiceResponse] = {
+    mutableStore = invoiceId.id :: mutableStore
 
-    response.get(invoiceId) match {
+    response.get(invoiceId.id) match {
       case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
       case None => ZIO.fail(new Throwable(s"mock: success = false: getinvoice " + invoiceId))
     }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoiceItems.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockGetInvoiceItems.scala
@@ -3,6 +3,7 @@ package com.gu.productmove.zuora
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError}
 import com.gu.productmove.zuora.GetAccount.PaymentMethodResponse
 import com.gu.productmove.zuora.GetInvoiceItems.GetInvoiceItemsResponse
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.model.AccountNumber
 import zio.*
 
@@ -14,10 +15,10 @@ class MockGetInvoiceItems(
 
   def requests = mutableStore.reverse
 
-  override def get(invoiceId: String): Task[GetInvoiceItemsResponse] = {
-    mutableStore = invoiceId :: mutableStore
+  override def get(invoiceId: InvoiceId): Task[GetInvoiceItemsResponse] = {
+    mutableStore = invoiceId.id :: mutableStore
 
-    response.get(invoiceId) match {
+    response.get(invoiceId.id) match {
       case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
       case None => ZIO.fail(new Throwable(s"mock: success = false: getInvoiceItems: " + invoiceId))
     }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockInvoiceItemAdjustment.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockInvoiceItemAdjustment.scala
@@ -4,6 +4,7 @@ import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse,
 import com.gu.productmove.zuora.GetAccount.PaymentMethodResponse
 import com.gu.productmove.zuora.GetInvoiceItems.GetInvoiceItemsResponse
 import com.gu.productmove.zuora.InvoiceItemAdjustment.InvoiceItemAdjustmentResult
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.model.AccountNumber
 import zio.*
 
@@ -16,16 +17,16 @@ class MockInvoiceItemAdjustment(
   def requests = mutableStore.reverse
 
   override def update(
-      invoiceId: String,
+      invoiceId: InvoiceId,
       amount: BigDecimal,
       invoiceItemId: String,
       adjustmentType: String,
       sourceType: String,
   ): Task[InvoiceItemAdjustmentResult] = {
-    val params = (invoiceId, amount, invoiceItemId, adjustmentType)
+    val params = (invoiceId.id, amount, invoiceItemId, adjustmentType)
     mutableStore = params :: mutableStore
 
-    response.get(invoiceId, amount, invoiceItemId, adjustmentType) match {
+    response.get(invoiceId.id, amount, invoiceItemId, adjustmentType) match {
       case Some(stubbedResponse) => ZIO.succeed(stubbedResponse.head)
       case None => ZIO.fail(new Throwable(s"mock: success = false invoiceItemAdjustment: " + params))
     }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockTermRenewal.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockTermRenewal.scala
@@ -5,6 +5,7 @@ import com.gu.newproduct.api.productcatalog.BillingPeriod
 import com.gu.productmove.GuStageLive
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError, PreviewResult}
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
+import com.gu.productmove.zuora.model.InvoiceId
 import com.gu.productmove.zuora.{GetSubscription, SubscriptionUpdatePreviewResponse}
 import com.gu.productmove.zuora.model.SubscriptionName
 import zio.json.JsonDecoder
@@ -30,7 +31,7 @@ class MockTermRenewal(
     ZIO.succeed(
       RenewalResponse(
         success = Some(true),
-        invoiceId = Some("invoiceId"),
+        invoiceId = Some(InvoiceId("invoiceId")),
       ),
     )
   }


### PR DESCRIPTION
The main PR I was doing was getting too big, so this is a pre-refactoring for https://github.com/guardian/support-service-lambdas/pull/2826

The changes are to wrap the account id and invoice id in a unique type, so that the compiler can keep track of them when refactoring etc.