### PR TITLE
Fix zod version in package.json

### DIFF
--- a/handlers/discount-expiry-notifier/package.json
+++ b/handlers/discount-expiry-notifier/package.json
@@ -22,6 +22,6 @@
 		"aws-sdk": "^2.1692.0",
 		"dayjs": "^1.11.13",
 		"google-auth-library": "^9.15.0",
-		"zod": "catalog:"
+		"zod": "^3.23.8"
 	}
 }


### PR DESCRIPTION
## What does this change?
I noticed the zod version is not standard for specifying a package version, so updated to most recent version.