### PR TITLE
make sure Lazy only initialises once even when mapped

### DIFF
--- a/modules/lazy.test.ts
+++ b/modules/lazy.test.ts
@@ -28,13 +28,14 @@ test('it should handle failed promises', async () => {
 
 test('it should only call the function when its used even if its mapped', async () => {
 	let log = 0;
-	const sut = new Lazy<string>(() => {
+	const original = new Lazy<string>(() => {
 		log++;
 		return Promise.resolve('hi');
-	}, 'testing').then((value) => value);
+	}, 'testing');
+	const mapped = original.then((value) => value);
 	expect(log).toEqual(0);
-	expect(await sut.get()).toEqual('hi');
+	expect(await original.get()).toEqual('hi');
 	expect(log).toEqual(1);
-	expect(await sut.get()).toEqual('hi');
+	expect(await mapped.get()).toEqual('hi');
 	expect(log).toEqual(1);
 });

--- a/modules/lazy.ts
+++ b/modules/lazy.ts
@@ -13,6 +13,6 @@ export class Lazy<T> {
 	}
 
 	public then<B>(f: (t: T) => B): Lazy<B> {
-		return new Lazy(() => this.getValue().then(f), this.message);
+		return new Lazy(() => this.get().then(f), this.message);
 	}
 }


### PR DESCRIPTION
discount api alarm was going off sometimes due to it taking nearly 30 seconds to execute, due to a zuora slowdown. (billing preview taking 10-18 seconds to complete)

When investigating, I noticed that the billing preview call was being made twice, unnecessarily.

I found that due to a bug in the lazy class, it was initialising it twice.

This PR fixes lazy to only initialise once, even when it's mapped.