### PR TITLE
change no product switch alarm to 8 hours

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -302,7 +302,7 @@ Resources:
       AlarmActions:
         - Fn::Sub: arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
       AlarmName:
-        Fn::Sub: ${Stage} No Salesforce tracking of a product switch has been queued for 4 hours
+        Fn::Sub: ${Stage} No Salesforce tracking of a product switch has been queued for 8 hours
       AlarmDescription: Impact - tracking of product switches may not be going to salesforce/bigquery/braze
       Metrics:
         - Id: e1
@@ -318,7 +318,7 @@ Resources:
                 - Name: FunctionName
                   Value:
                     Fn::Sub: product-switch-salesforce-tracking-${Stage}
-            Period: 14400
+            Period: 28800
             Stat: Sum
             Unit: Count
           ReturnData: false


### PR DESCRIPTION
We have had a few false alarms from this new alarm.  Originally it was tweaked to 4 hours: https://github.com/guardian/support-service-lambdas/pull/2832 (original pr https://github.com/guardian/support-service-lambdas/pull/2830 )

This changes the period from 4 to 8 hours, to reduce that.

This means that it will take longer than a working day to notice if it has been broken, but given it was broken for most of a year without being fixed, that won't be an issue.