### PR TITLE
Make address validation errors from New Product API more specific 

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/digipack/DigipackAddressValidator.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/digipack/DigipackAddressValidator.scala
@@ -20,7 +20,7 @@ object DigipackAddressValidator {
       validatedAddress1 <- validateNotEmpty("address1", address.address1)
       validatedCity <- validateNotEmpty("city", address.city)
       validatedPostcode <- validateNotEmpty("postcode", address.postcode)
-      validatedCountry <- address.country getOrFailWith "bill to country must be populated"
+      validatedCountry <- address.country getOrFailWith "Billing country must be populated in Zuora"
     } yield ValidatedAddress(
       validatedAddress1,
       address.address2,
@@ -35,8 +35,8 @@ object DigipackAddressValidator {
       fieldName: String,
       maybeAddressField: Option[Field],
   ): ValidationResult[Field] = for {
-    addressField <- maybeAddressField getOrFailWith (s"bill to $fieldName must be populated")
-    _ <- !addressField.value.trim.isEmpty orFailWith s"bill to $fieldName must be populated"
+    addressField <- maybeAddressField getOrFailWith (s"Billing $fieldName must be populated in Zuora")
+    _ <- !addressField.value.trim.isEmpty orFailWith s"Billing $fieldName must be populated in Zuora"
   } yield addressField
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidator.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidator.scala
@@ -46,10 +46,10 @@ object GuardianWeeklyAddressValidator {
 
   def validateBillingAddress(billToAddress: BillToAddress): ValidationResult[Unit] = {
     for {
-      _ <- billToAddress.address1 getOrFailWith ("bill to address1 must be populated")
-      _ <- billToAddress.city getOrFailWith ("bill to city must be populated")
-      _ <- billToAddress.postcode getOrFailWith ("bill to postcode must be populated")
-      _ <- billToAddress.country getOrFailWith ("bill to country must be populated")
+      _ <- billToAddress.address1 getOrFailWith ("Billing address must be populated in Zuora")
+      _ <- billToAddress.city getOrFailWith ("Billing address city must be populated in Zuora")
+      _ <- billToAddress.postcode getOrFailWith ("Billing address postcode must be populated in Zuora")
+      _ <- billToAddress.country getOrFailWith ("Billing address country must be populated in Zuora")
     } yield (())
   }
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/paper/PaperAddressValidator.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/paper/PaperAddressValidator.scala
@@ -22,7 +22,7 @@ object PaperAddressValidator {
   }
 
   private def validatePostCodeForHomeDelivery(postcode: Option[Postcode]): ValidationResult[Postcode] = for {
-    deliveryPostcode <- postcode getOrFailWith ("delivery postcode is required")
+    deliveryPostcode <- postcode getOrFailWith ("Delivery postcode is missing in Zuora, check mailing address")
     _ <- isWithinM25(
       deliveryPostcode,
     ) orFailWith (s"Invalid postcode ${deliveryPostcode.value}: postcode must be within M25")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/digipack/DigipackAddressValidatorTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/digipack/DigipackAddressValidatorTest.scala
@@ -38,7 +38,7 @@ class DigipackAddressValidatorTest extends AnyFlatSpec with Matchers {
     DigipackAddressValidator(noOptionalFieldsAddress) shouldBe Passed(validatedNoOptionalFieldsAddress)
   }
 
-  def failedResponse(fieldName: String) = Failed(s"bill to $fieldName must be populated")
+  def failedResponse(fieldName: String) = Failed(s"Billing $fieldName must be populated in Zuora")
 
   it should "fail if address1 is missing" in {
     DigipackAddressValidator(testAddress.copy(address1 = None)) shouldBe failedResponse("address1")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidatorTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidatorTest.scala
@@ -72,11 +72,11 @@ class GuardianWeeklyAddressValidatorTest extends AnyFlatSpec with Matchers {
     GuardianWeeklyDomesticAddressValidator(
       invalidBillingAddress,
       testDomesticSoldToAddress,
-    ) shouldBe Failed(s"bill to address1 must be populated")
+    ) shouldBe Failed(s"Delivery address must be populated in Zuora")
     GuardianWeeklyROWAddressValidator(
       invalidBillingAddress,
       testROWSoldToAddress,
-    ) shouldBe Failed(s"bill to address1 must be populated")
+    ) shouldBe Failed(s"Delivery address must be populated in Zuora")
   }
 
   it should "fail if bill address city is empty" in {
@@ -84,11 +84,11 @@ class GuardianWeeklyAddressValidatorTest extends AnyFlatSpec with Matchers {
     GuardianWeeklyDomesticAddressValidator(
       invalidBillingAddress,
       testDomesticSoldToAddress,
-    ) shouldBe Failed(s"bill to city must be populated")
+    ) shouldBe Failed(s"Billing address city must be populated in Zuora")
     GuardianWeeklyROWAddressValidator(
       invalidBillingAddress,
       testROWSoldToAddress,
-    ) shouldBe Failed(s"bill to city must be populated")
+    ) shouldBe Failed(s"Billing address city must be populated in Zuora")
   }
 
   it should "fail if bill address postcode is empty" in {
@@ -96,11 +96,11 @@ class GuardianWeeklyAddressValidatorTest extends AnyFlatSpec with Matchers {
     GuardianWeeklyDomesticAddressValidator(
       invalidBillingAddress,
       testDomesticSoldToAddress,
-    ) shouldBe Failed(s"bill to postcode must be populated")
+    ) shouldBe Failed(s"Billing address postcode must be populated in Zuora")
     GuardianWeeklyROWAddressValidator(
       invalidBillingAddress,
       testROWSoldToAddress,
-    ) shouldBe Failed(s"bill to postcode must be populated")
+    ) shouldBe Failed(s"Billing address postcode must be populated in Zuora")
   }
 
   it should "fail if bill address country is empty" in {
@@ -108,10 +108,10 @@ class GuardianWeeklyAddressValidatorTest extends AnyFlatSpec with Matchers {
     GuardianWeeklyDomesticAddressValidator(
       invalidBillingAddress,
       testDomesticSoldToAddress,
-    ) shouldBe Failed(s"bill to country must be populated")
+    ) shouldBe Failed(s"Billing address country must be populated in Zuora")
     GuardianWeeklyROWAddressValidator(
       invalidBillingAddress,
       testROWSoldToAddress,
-    ) shouldBe Failed(s"bill to country must be populated")
+    ) shouldBe Failed(s"Billing address country must be populated in Zuora")
   }
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidatorTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAddressValidatorTest.scala
@@ -72,11 +72,11 @@ class GuardianWeeklyAddressValidatorTest extends AnyFlatSpec with Matchers {
     GuardianWeeklyDomesticAddressValidator(
       invalidBillingAddress,
       testDomesticSoldToAddress,
-    ) shouldBe Failed(s"Delivery address must be populated in Zuora")
+    ) shouldBe Failed(s"Billing address must be populated in Zuora")
     GuardianWeeklyROWAddressValidator(
       invalidBillingAddress,
       testROWSoldToAddress,
-    ) shouldBe Failed(s"Delivery address must be populated in Zuora")
+    ) shouldBe Failed(s"Billing address must be populated in Zuora")
   }
 
   it should "fail if bill address city is empty" in {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/voucher/PaperAddressValidatorTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/voucher/PaperAddressValidatorTest.scala
@@ -36,7 +36,7 @@ class PaperAddressValidatorTest extends AnyFlatSpec with Matchers {
 
   it should "fail if postcode is not provided for home delivery plan" in {
     val noPostCodeAddress = testAddress.copy(postcode = None)
-    PaperAddressValidator(HomeDeliveryWeekendPlus, noPostCodeAddress) shouldBe Failed("delivery postcode is required")
+    PaperAddressValidator(HomeDeliveryWeekendPlus, noPostCodeAddress) shouldBe Failed("Delivery postcode is missing in Zuora, check mailing address")
   }
 
   it should "fail if postcode is not within the m25 for home delivery plan" in {


### PR DESCRIPTION
For the old acquisition tool used by CSRs in Salesforce, the address displayed is from Salesforce - but the address that is validated is actually from the Zuora Customer Account. This can lead to confusion if they are different, which in theory should be rare but in practice can happen if a customer is acquiring a mix of print and digital subscriptions via the online checkout.

The errors that are shown do indicate that the address validation is based on Zuora, not Salesforce, so CSRs do not know what they should do to fix this:

<img width="1485" alt="Screenshot 2025-06-09 at 16 25 58" src="https://github.com/user-attachments/assets/a70cd895-aa1f-4c85-85bf-f18868b9c3b9" />
_Address appears populated and correct_

<img width="795" alt="Screenshot 2025-06-09 at 16 26 44" src="https://github.com/user-attachments/assets/844c9d6a-1365-4c0e-9778-66bed70de253" />
_But CSR is shown error indicating address is not populated when they try to acquire a new print subscription_

## What does this change?
Updates the errors returned to Salesforce when the address is not populated to indicate more clearly that it is missing from Zuora (not Salesforce). Hopefully this provides more of a clue about what's going wrong.

<img width="1167" alt="Screenshot 2025-06-09 at 17 00 39" src="https://github.com/user-attachments/assets/b99d9c01-cb53-4fe7-9aae-0f870c99df3c" />


> [!NOTE]
> We are working on a new acquisition tool for CSRs that will mean this problem won't exist because CSRs will always be using a new Customer Account. 

## How to test
Find a contact with a populated address in Salesforce, with a Billing Account where the address is NOT populated. This can be setup by acquiring a new Print subscription (which populates the billing/delivery addresses in Zuora and Salesforce) then acquiring a new Digital-only subscription to the same contact (which does not collect a full billing/delivery address, and does not populate in Zuora).

Verify that you can use the acquisition function in Salesforce for Guardian Weekly, Newspaper Print and Digital Packs.
