### PR TITLE
extract order trigger dates duplication

### DIFF
--- a/handlers/product-switch-api/src/contributionToSupporterPlus.ts
+++ b/handlers/product-switch-api/src/contributionToSupporterPlus.ts
@@ -6,6 +6,7 @@ import type {
 	OrderAction,
 	PreviewOrderRequest,
 } from '@modules/zuora/orders';
+import { singleTriggerDate } from '@modules/zuora/orders';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type {
 	RatePlan,
@@ -245,20 +246,7 @@ const buildAddDiscountOrderAction = (
 	return [
 		{
 			type: 'AddProduct',
-			triggerDates: [
-				{
-					name: 'ContractEffective',
-					triggerDate: zuoraDateFormat(orderDate),
-				},
-				{
-					name: 'ServiceActivation',
-					triggerDate: zuoraDateFormat(orderDate),
-				},
-				{
-					name: 'CustomerAcceptance',
-					triggerDate: zuoraDateFormat(orderDate),
-				},
-			],
+			triggerDates: singleTriggerDate(orderDate),
 			addProduct: {
 				productRatePlanId: discount.productRatePlanId,
 			},
@@ -273,20 +261,7 @@ const buildChangePlanOrderAction = (
 ): ChangePlanOrderAction => {
 	return {
 		type: 'ChangePlan',
-		triggerDates: [
-			{
-				name: 'ContractEffective',
-				triggerDate: zuoraDateFormat(orderDate),
-			},
-			{
-				name: 'ServiceActivation',
-				triggerDate: zuoraDateFormat(orderDate),
-			},
-			{
-				name: 'CustomerAcceptance',
-				triggerDate: zuoraDateFormat(orderDate),
-			},
-		],
+		triggerDates: singleTriggerDate(orderDate),
 		changePlan: {
 			productRatePlanId: catalog.contribution.productRatePlanId,
 			subType: 'Upgrade',
@@ -352,20 +327,7 @@ export const buildSwitchRequestBody = (
 		? [
 				{
 					type: 'TermsAndConditions',
-					triggerDates: [
-						{
-							name: 'ContractEffective',
-							triggerDate: zuoraDateFormat(orderDate),
-						},
-						{
-							name: 'ServiceActivation',
-							triggerDate: zuoraDateFormat(orderDate),
-						},
-						{
-							name: 'CustomerAcceptance',
-							triggerDate: zuoraDateFormat(orderDate),
-						},
-					],
+					triggerDates: singleTriggerDate(orderDate),
 					termsAndConditions: {
 						lastTerm: {
 							termType: 'TERMED',
@@ -375,20 +337,7 @@ export const buildSwitchRequestBody = (
 				},
 				{
 					type: 'RenewSubscription',
-					triggerDates: [
-						{
-							name: 'ContractEffective',
-							triggerDate: zuoraDateFormat(orderDate),
-						},
-						{
-							name: 'ServiceActivation',
-							triggerDate: zuoraDateFormat(orderDate),
-						},
-						{
-							name: 'CustomerAcceptance',
-							triggerDate: zuoraDateFormat(orderDate),
-						},
-					],
+					triggerDates: singleTriggerDate(orderDate),
 					renewSubscription: {},
 				},
 			]

--- a/handlers/update-supporter-plus-amount/src/zuoraApi.ts
+++ b/handlers/update-supporter-plus-amount/src/zuoraApi.ts
@@ -1,5 +1,6 @@
 import { zuoraDateFormat } from '@modules/zuora/common';
 import type { OrderRequest } from '@modules/zuora/orders';
+import { singleTriggerDate } from '@modules/zuora/orders';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type { ZuoraSuccessResponse } from '@modules/zuora/zuoraSchemas';
 import { zuoraSuccessResponseSchema } from '@modules/zuora/zuoraSchemas';
@@ -76,20 +77,7 @@ export const buildNewTermRequestBody = (
 				orderActions: [
 					{
 						type: 'TermsAndConditions',
-						triggerDates: [
-							{
-								name: 'ContractEffective',
-								triggerDate: zuoraDateFormat(newTermStartDate),
-							},
-							{
-								name: 'ServiceActivation',
-								triggerDate: zuoraDateFormat(newTermStartDate),
-							},
-							{
-								name: 'CustomerAcceptance',
-								triggerDate: zuoraDateFormat(newTermStartDate),
-							},
-						],
+						triggerDates: singleTriggerDate(newTermStartDate),
 						termsAndConditions: {
 							lastTerm: {
 								termType: 'TERMED',
@@ -99,20 +87,7 @@ export const buildNewTermRequestBody = (
 					},
 					{
 						type: 'RenewSubscription',
-						triggerDates: [
-							{
-								name: 'ContractEffective',
-								triggerDate: zuoraDateFormat(newTermStartDate),
-							},
-							{
-								name: 'ServiceActivation',
-								triggerDate: zuoraDateFormat(newTermStartDate),
-							},
-							{
-								name: 'CustomerAcceptance',
-								triggerDate: zuoraDateFormat(newTermStartDate),
-							},
-						],
+						triggerDates: singleTriggerDate(newTermStartDate),
 						renewSubscription: {},
 					},
 				],
@@ -146,20 +121,7 @@ export const buildUpdateAmountRequestBody = ({
 				orderActions: [
 					{
 						type: 'UpdateProduct',
-						triggerDates: [
-							{
-								name: 'ContractEffective',
-								triggerDate: zuoraDateFormat(applyFromDate),
-							},
-							{
-								name: 'ServiceActivation',
-								triggerDate: zuoraDateFormat(applyFromDate),
-							},
-							{
-								name: 'CustomerAcceptance',
-								triggerDate: zuoraDateFormat(applyFromDate),
-							},
-						],
+						triggerDates: singleTriggerDate(applyFromDate),
 						updateProduct: {
 							ratePlanId,
 							chargeUpdates: [

--- a/modules/zuora/src/orders.ts
+++ b/modules/zuora/src/orders.ts
@@ -1,3 +1,6 @@
+import type { Dayjs } from 'dayjs';
+import { zuoraDateFormat } from '@modules/zuora/common';
+
 export type ProcessingOptions = {
 	runBilling: boolean;
 	collectPayment: boolean;
@@ -14,22 +17,24 @@ export type OrderActionType =
 	| 'UpdateProduct'
 	| 'AddProduct';
 
+export type TriggerDates = [
+	{
+		name: 'ContractEffective';
+		triggerDate: string;
+	},
+	{
+		name: 'ServiceActivation';
+		triggerDate: string;
+	},
+	{
+		name: 'CustomerAcceptance';
+		triggerDate: string;
+	},
+];
+
 type BaseOrderAction = {
 	type: OrderActionType;
-	triggerDates: [
-		{
-			name: 'ContractEffective';
-			triggerDate: string;
-		},
-		{
-			name: 'ServiceActivation';
-			triggerDate: string;
-		},
-		{
-			name: 'CustomerAcceptance';
-			triggerDate: string;
-		},
-	];
+	triggerDates: TriggerDates;
 };
 export type ChangePlanOrderAction = BaseOrderAction & {
 	type: 'ChangePlan';
@@ -109,3 +114,20 @@ export type PreviewOrderRequest = OrderRequest & {
 export type CreateOrderRequest = OrderRequest & {
 	processingOptions: ProcessingOptions;
 };
+
+export function singleTriggerDate(applyFromDate: Dayjs): TriggerDates {
+	return [
+		{
+			name: 'ContractEffective',
+			triggerDate: zuoraDateFormat(applyFromDate),
+		},
+		{
+			name: 'ServiceActivation',
+			triggerDate: zuoraDateFormat(applyFromDate),
+		},
+		{
+			name: 'CustomerAcceptance',
+			triggerDate: zuoraDateFormat(applyFromDate),
+		},
+	];
+}


### PR DESCRIPTION
I noticed that we keep repeating the same trigger block, and the formatting rules make it take a huge amount of space.

This PR extracts the trigger dates into a shared function.

This makes it much more readable of the logic we are actually interested in