### PR TITLE
For PayPal payments use paypalTransactionId for the payment ID field in Salesforce

### DIFF
--- a/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/handlers/CreateSalesforceSingleContributionRecordHandler.scala
+++ b/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/handlers/CreateSalesforceSingleContributionRecordHandler.scala
@@ -19,6 +19,7 @@ case class PaymentApiMessageDetail(
     postalCode: Option[String],
     state: Option[String],
     email: String,
+    paypalTransactionId: Option[String],
 )
 
 case class PaymentApiMessage(

--- a/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/services/Salesforce.scala
+++ b/handlers/single-contribution-salesforce-writes/src/main/scala/com/gu/singleContributionSalesforceWrites/services/Salesforce.scala
@@ -19,7 +19,7 @@ case class CreateSingleContributionRecordRequestData(
     Email__c: String,
     Identity_ID__c: Option[String],
     Payment_Date__c: String,
-    Payment_ID__c: String,
+    Payment_ID__c: Option[String],
     Payment_Provider__c: String,
     Payment_Status__c: String,
     Postal_Code__c: Option[String],
@@ -62,6 +62,11 @@ object Salesforce extends Logging {
   private def getContribution(
       messageBodyDetail: PaymentApiMessageDetail,
   ): CreateSingleContributionRecordRequestData = {
+    val paymentId = messageBodyDetail.paymentProvider match {
+      case "PAYPAL" => messageBodyDetail.paypalTransactionId
+      case _ => Some(messageBodyDetail.paymentId)
+    }
+
     CreateSingleContributionRecordRequestData(
       Amount__c = messageBodyDetail.amount,
       Country_Code__c = messageBodyDetail.country,
@@ -70,7 +75,7 @@ object Salesforce extends Logging {
       Email__c = messageBodyDetail.email,
       Identity_ID__c = messageBodyDetail.identityId,
       Payment_Date__c = messageBodyDetail.eventTimeStamp,
-      Payment_ID__c = messageBodyDetail.paymentId,
+      Payment_ID__c = paymentId,
       Payment_Provider__c = messageBodyDetail.paymentProvider,
       Payment_Status__c = "Paid",
       Postal_Code__c = messageBodyDetail.postalCode,


### PR DESCRIPTION
## What does this change?

For PayPal payments use `paypalTransactionId` from the event payload for the payment ID field in Salesforce. This new field is an identifier which CSRs can use to find a transaction in PayPal. Previously we used the paymentId from the event payload but found that CSRs could not use this to find information in PayPal.

See also guardian/support-frontend#7073.

## How to test

Test manually by deploying this branch to CODE and making single contributions using PayPal and another payment method. The PayPal payment should use the new transaction ID field for populating the payment ID in Salesforce. The other payment method should continue to use the existing paymentID field from the event payload.

Payment ID field in Salesforce Sandbox:

<img width="378" alt="Screenshot 2025-06-19 at 10 02 42" src="https://github.com/user-attachments/assets/d1a18b9c-048c-429e-80c6-caccd066a3e2" />

Using this to search the PayPal sandbox returns the expected record:

<img width="824" alt="Screenshot 2025-06-19 at 10 03 19" src="https://github.com/user-attachments/assets/13778d3c-4db1-411a-8b2d-3dba5461952b" />


## How can we measure success?

CSRs should find it easier to find transactions in PayPal using the information available in Salesforce.