### PR TITLE
add DiagnosticLinks tag to most CDKed alarms

### DIFF
--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -578,9 +578,7 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
             "STAGE": "CODE",
           },
         },
-        "FunctionName": {
-          "Ref": "alarmshandlerlambda383D2BAA",
-        },
+        "FunctionName": "alarms-handler-scheduled-CODE",
         "Handler": "indexScheduled.handler",
         "LoggingConfig": {
           "LogFormat": "Text",
@@ -1655,9 +1653,7 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
             "STAGE": "PROD",
           },
         },
-        "FunctionName": {
-          "Ref": "alarmshandlerlambda383D2BAA",
-        },
+        "FunctionName": "alarms-handler-scheduled-PROD",
         "Handler": "indexScheduled.handler",
         "LoggingConfig": {
           "LogFormat": "Text",

--- a/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
+++ b/cdk/lib/__snapshots__/alarms-handler.test.ts.snap
@@ -8,6 +8,7 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuStringParameter",
       "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -21,6 +22,10 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "alarmshandlerbackupemailaddress": {
+      "Description": "Alarm email address to use if the alarms handler itself fails",
+      "Type": "String",
     },
     "alarmshandlermobileaccountrolearn": {
       "Description": "ARN of role in the mobile account which allows cloudwatch:ListTagsForResource",
@@ -59,7 +64,7 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
                 ":",
                 {
                   "Fn::GetAtt": [
-                    "alarmshandlertopic003C974E",
+                    "alarmshandleremailtopic52F6F612",
                     "TopicName",
                   ],
                 },
@@ -128,6 +133,42 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "alarmshandleremailtopic52F6F612": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TopicName": "alarms-handler-email-topic-CODE",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "alarmshandleremailtopicTokenSubscription191C59777": {
+      "Properties": {
+        "Endpoint": {
+          "Ref": "alarmshandlerbackupemailaddress",
+        },
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "alarmshandleremailtopic52F6F612",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
     },
     "alarmshandlerlambda383D2BAA": {
       "DependsOn": [
@@ -537,7 +578,9 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
             "STAGE": "CODE",
           },
         },
-        "FunctionName": "alarms-handler-scheduled-CODE",
+        "FunctionName": {
+          "Ref": "alarmshandlerlambda383D2BAA",
+        },
         "Handler": "indexScheduled.handler",
         "LoggingConfig": {
           "LogFormat": "Text",
@@ -592,7 +635,13 @@ exports[`The alarms-handler stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":alarms-handler-topic-CODE",
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "alarmshandleremailtopic52F6F612",
+                    "TopicName",
+                  ],
+                },
               ],
             ],
           },
@@ -1036,6 +1085,7 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
       "GuStringParameter",
       "GuStringParameter",
       "GuStringParameter",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuAlarm",
@@ -1049,6 +1099,10 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "alarmshandlerbackupemailaddress": {
+      "Description": "Alarm email address to use if the alarms handler itself fails",
+      "Type": "String",
     },
     "alarmshandlermobileaccountrolearn": {
       "Description": "ARN of role in the mobile account which allows cloudwatch:ListTagsForResource",
@@ -1087,7 +1141,7 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
                 ":",
                 {
                   "Fn::GetAtt": [
-                    "alarmshandlertopic003C974E",
+                    "alarmshandleremailtopic52F6F612",
                     "TopicName",
                   ],
                 },
@@ -1156,6 +1210,42 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "alarmshandleremailtopic52F6F612": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "TopicName": "alarms-handler-email-topic-PROD",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "alarmshandleremailtopicTokenSubscription191C59777": {
+      "Properties": {
+        "Endpoint": {
+          "Ref": "alarmshandlerbackupemailaddress",
+        },
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "alarmshandleremailtopic52F6F612",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
     },
     "alarmshandlerlambda383D2BAA": {
       "DependsOn": [
@@ -1565,7 +1655,9 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
             "STAGE": "PROD",
           },
         },
-        "FunctionName": "alarms-handler-scheduled-PROD",
+        "FunctionName": {
+          "Ref": "alarmshandlerlambda383D2BAA",
+        },
         "Handler": "indexScheduled.handler",
         "LoggingConfig": {
           "LogFormat": "Text",
@@ -1620,7 +1712,13 @@ exports[`The alarms-handler stack matches the snapshot 2`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":alarms-handler-topic-PROD",
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "alarmshandleremailtopic52F6F612",
+                    "TopicName",
+                  ],
+                },
               ],
             ],
           },

--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -6,7 +6,6 @@ exports[`The Discount API stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuApiLambda",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -62,7 +61,7 @@ exports[`The Discount API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":alarms-handler-topic-PROD",
+                ":alarms-handler-topic-CODE",
               ],
             ],
           },
@@ -82,6 +81,20 @@ exports[`The Discount API stack matches the snapshot 1`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "discountapilambda972ABED6",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -995,7 +1008,6 @@ exports[`The Discount API stack matches the snapshot 2`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuApiLambda",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1071,6 +1083,20 @@ exports[`The Discount API stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "discountapilambda972ABED6",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
@@ -73,8 +73,24 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
     },
     "alarm05E1DB6A1": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -122,6 +138,20 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "getexpiringdiscountslambda573EEC70",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -145,8 +175,24 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
     },
     "alarm11F7E5553": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -194,6 +240,20 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "filterrecordslambdaFF1D2725",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -217,8 +277,24 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
     },
     "alarm2999D08C3": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -265,6 +341,20 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "alarmonfailureslambda88ECE430",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -2711,6 +2801,22 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
               ],
             ],
           },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
         ],
         "AlarmDescription": "Something went wrong when executing the Discount Expiry Notifier. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -2742,6 +2848,20 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "getexpiringdiscountslambda573EEC70",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -2767,6 +2887,22 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -2814,6 +2950,20 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "filterrecordslambdaFF1D2725",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -2839,6 +2989,22 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -2885,6 +3051,20 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "alarmonfailureslambda88ECE430",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-expiry-notifier.test.ts.snap
@@ -91,22 +91,6 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Something went wrong when executing the Discount Expiry Notifier. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -193,22 +177,6 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Something went wrong when executing the Discount Expiry Notifier. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -279,22 +247,6 @@ exports[`The discount-expiry-notifier stack matches the snapshot 1`] = `
       "Properties": {
         "ActionsEnabled": false,
         "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
           {
             "Fn::Join": [
               "",
@@ -2801,22 +2753,6 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Something went wrong when executing the Discount Expiry Notifier. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -2903,22 +2839,6 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Something went wrong when executing the Discount Expiry Notifier. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -2989,22 +2909,6 @@ exports[`The discount-expiry-notifier stack matches the snapshot 2`] = `
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
           {
             "Fn::Join": [
               "",

--- a/cdk/lib/__snapshots__/generate-product-catalog.test.ts.snap
+++ b/cdk/lib/__snapshots__/generate-product-catalog.test.ts.snap
@@ -590,7 +590,6 @@ exports[`The generate product catalog stack matches the snapshot 2`] = `
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuCname",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -864,6 +863,20 @@ def sort_filter_rules(json_obj):
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "generateproductcataloglambda1E6192C7",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/metric-push-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/metric-push-api.test.ts.snap
@@ -8,7 +8,6 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
       "GuApiLambda",
       "GuPutCloudwatchMetricsPolicy",
       "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -83,6 +82,20 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "metricpushapilambda0761BDD0",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -898,7 +911,6 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
       "GuApiLambda",
       "GuPutCloudwatchMetricsPolicy",
       "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -973,6 +985,20 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "metricpushapilambda0761BDD0",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/new-product-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/new-product-api.test.ts.snap
@@ -93,6 +93,10 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
                   {
                     "Ref": "addsubscriptionA4705116",
                   },
+                  ",lambda:",
+                  {
+                    "Ref": "productcatalog39C6E2D1",
+                  },
                 ],
               ],
             },
@@ -1579,6 +1583,10 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
                   "lambda:",
                   {
                     "Ref": "addsubscriptionA4705116",
+                  },
+                  ",lambda:",
+                  {
+                    "Ref": "productcatalog39C6E2D1",
                   },
                 ],
               ],

--- a/cdk/lib/__snapshots__/new-product-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/new-product-api.test.ts.snap
@@ -8,8 +8,6 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
-      "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -65,7 +63,7 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":alarms-handler-topic-PROD",
+                ":alarms-handler-topic-CODE",
               ],
             ],
           },
@@ -85,6 +83,20 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
         "Period": 900,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "addsubscriptionA4705116",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -122,7 +134,7 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":alarms-handler-topic-PROD",
+                ":alarms-handler-topic-CODE",
               ],
             ],
           },
@@ -142,6 +154,24 @@ exports[`The NewProductApi stack matches the snapshot 1`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "addsubscriptionA4705116",
+                  },
+                  ",lambda:",
+                  {
+                    "Ref": "productcatalog39C6E2D1",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1465,8 +1495,6 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
-      "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1543,6 +1571,20 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "addsubscriptionA4705116",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1599,6 +1641,24 @@ exports[`The NewProductApi stack matches the snapshot 2`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "addsubscriptionA4705116",
+                  },
+                  ",lambda:",
+                  {
+                    "Ref": "productcatalog39C6E2D1",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
+++ b/cdk/lib/__snapshots__/observer-data-export.test.ts.snap
@@ -7,8 +7,6 @@ exports[`The ObserverDataExport stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
-      "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1548,7 +1546,7 @@ def sort_filter_rules(json_obj):
     },
     "encryptanduploadobserverdataCODElambdaalarmA1B7D79A": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
           {
             "Fn::Join": [
@@ -1606,6 +1604,20 @@ def sort_filter_rules(json_obj):
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "EncryptAndUploadObserverDataLambda5BD6CD5A",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1708,7 +1720,7 @@ def sort_filter_rules(json_obj):
     },
     "salesforceobserverdatatransferCODEflowalarmDEC9DDC2": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
           {
             "Fn::Join": [
@@ -1755,6 +1767,20 @@ def sort_filter_rules(json_obj):
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "EncryptAndUploadObserverDataLambda5BD6CD5A",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1787,8 +1813,6 @@ exports[`The ObserverDataExport stack matches the snapshot 2`] = `
       "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
-      "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -3387,6 +3411,20 @@ def sort_filter_rules(json_obj):
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "EncryptAndUploadObserverDataLambda5BD6CD5A",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -3534,6 +3572,20 @@ def sort_filter_rules(json_obj):
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "EncryptAndUploadObserverDataLambda5BD6CD5A",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
+++ b/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
@@ -7,7 +7,6 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuApiGateway5xxPercentageAlarm",
-      "GuAlarm",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -84,6 +83,20 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "pressreaderentitlementslambda849A2923",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1033,7 +1046,6 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuApiGateway5xxPercentageAlarm",
-      "GuAlarm",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -1110,6 +1122,20 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "pressreaderentitlementslambda849A2923",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/product-switch-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/product-switch-api.test.ts.snap
@@ -971,8 +971,6 @@ exports[`The Product switch api stack matches the snapshot 2`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuApiLambda",
-      "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1048,6 +1046,20 @@ exports[`The Product switch api stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "productswitchapilambdaDA3EBA76",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1179,6 +1191,20 @@ exports[`The Product switch api stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "productswitchapilambdaDA3EBA76",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
+++ b/cdk/lib/__snapshots__/single-contribution-salesforce-writes.test.ts.snap
@@ -6,7 +6,6 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -133,6 +132,20 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 1`] =
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "singlecontributionsalesforcewriteslambda1B9830FE",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -566,7 +579,6 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -693,6 +705,20 @@ exports[`The SingleContributionSalesforceWrites stack matches the snapshot 2`] =
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "singlecontributionsalesforcewriteslambda1B9830FE",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-webhook-endpoints.test.ts.snap
@@ -21,8 +21,6 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
       "GuApiGateway5xxPercentageAlarm",
-      "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -101,7 +99,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":conversion-dev",
+                ":alarms-handler-topic-CODE",
               ],
             ],
           },
@@ -121,6 +119,24 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "paymentintentissuescdklambdaD549B87A",
+                  },
+                  ",lambda:",
+                  {
+                    "Ref": "customerupdatedcdklambda94E6ED36",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -158,7 +174,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":conversion-dev",
+                ":alarms-handler-topic-CODE",
               ],
             ],
           },
@@ -178,6 +194,24 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 1`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "paymentintentissuescdklambdaD549B87A",
+                  },
+                  ",lambda:",
+                  {
+                    "Ref": "customerupdatedcdklambda94E6ED36",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1473,8 +1507,6 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
       "GuApiGateway5xxPercentageAlarm",
-      "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1553,7 +1585,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":conversion-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1573,6 +1605,24 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "paymentintentissuescdklambdaD549B87A",
+                  },
+                  ",lambda:",
+                  {
+                    "Ref": "customerupdatedcdklambda94E6ED36",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1610,7 +1660,7 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":conversion-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1630,6 +1680,24 @@ exports[`The StripeWebhookEndpoints stack matches the snapshot 2`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "paymentintentissuescdklambdaD549B87A",
+                  },
+                  ",lambda:",
+                  {
+                    "Ref": "customerupdatedcdklambda94E6ED36",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/update-supporter-plus-amount.test.ts.snap
+++ b/cdk/lib/__snapshots__/update-supporter-plus-amount.test.ts.snap
@@ -955,7 +955,6 @@ exports[`The Update supporter plus amount stack matches the snapshot 2`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuApiLambda",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1031,6 +1030,20 @@ exports[`The Update supporter plus amount stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "updatesupporterplusamountlambda0DA9A4CB",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/write-off-unpaid-invoices.test.ts.snap
+++ b/cdk/lib/__snapshots__/write-off-unpaid-invoices.test.ts.snap
@@ -897,6 +897,22 @@ exports[`The WriteOffUnpaidInvoices stack matches the snapshot 1`] = `
               ],
             ],
           },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
         ],
         "AlarmDescription": "The scheduled job that writes off unpaid invoices has failed. Login to the AWS console and debug the last execution.",
         "AlarmName": "CODE: WriteOffUnpaidInvoicesStepFunctionExecutionFailure",
@@ -915,6 +931,20 @@ exports[`The WriteOffUnpaidInvoices stack matches the snapshot 1`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "WriteOffInvoicesLambdaED9D09A3",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1837,6 +1867,22 @@ exports[`The WriteOffUnpaidInvoices stack matches the snapshot 2`] = `
               ],
             ],
           },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
         ],
         "AlarmDescription": "The scheduled job that writes off unpaid invoices has failed. Login to the AWS console and debug the last execution.",
         "AlarmName": "PROD: WriteOffUnpaidInvoicesStepFunctionExecutionFailure",
@@ -1855,6 +1901,20 @@ exports[`The WriteOffUnpaidInvoices stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "WriteOffInvoicesLambdaED9D09A3",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/write-off-unpaid-invoices.test.ts.snap
+++ b/cdk/lib/__snapshots__/write-off-unpaid-invoices.test.ts.snap
@@ -897,22 +897,6 @@ exports[`The WriteOffUnpaidInvoices stack matches the snapshot 1`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "The scheduled job that writes off unpaid invoices has failed. Login to the AWS console and debug the last execution.",
         "AlarmName": "CODE: WriteOffUnpaidInvoicesStepFunctionExecutionFailure",
@@ -1851,22 +1835,6 @@ exports[`The WriteOffUnpaidInvoices stack matches the snapshot 2`] = `
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
           {
             "Fn::Join": [
               "",

--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -60,22 +60,6 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Something went wrong when executing the zuora <-> salesforce link remover. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -162,22 +146,6 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Something went wrong when executing the zuora <-> salesforce link remover. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -248,22 +216,6 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
       "Properties": {
         "ActionsEnabled": false,
         "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
           {
             "Fn::Join": [
               "",
@@ -1511,22 +1463,6 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Something went wrong when executing the zuora <-> salesforce link remover. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -1613,22 +1549,6 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
               ],
             ],
           },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
         ],
         "AlarmDescription": "Something went wrong when executing the zuora <-> salesforce link remover. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -1699,22 +1619,6 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
           {
             "Fn::Join": [
               "",

--- a/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
+++ b/cdk/lib/__snapshots__/zuora-salesforce-link-remover.test.ts.snap
@@ -42,8 +42,24 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
     },
     "alarm05E1DB6A1": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -91,6 +107,20 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "getbillingaccountslambdaEDDA46BF",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -114,8 +144,24 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
     },
     "alarm11F7E5553": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -163,6 +209,20 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "updatezuorabillingaccountlambda6EF8BCFE",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -186,8 +246,24 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
     },
     "alarm2999D08C3": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -234,6 +310,20 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 1`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "updatesfbillingaccountslambda98285844",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1421,6 +1511,22 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
               ],
             ],
           },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
         ],
         "AlarmDescription": "Something went wrong when executing the zuora <-> salesforce link remover. See Cloudwatch logs for more information on the error.",
         "AlarmName": {
@@ -1452,6 +1558,20 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "getbillingaccountslambdaEDDA46BF",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1477,6 +1597,22 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -1524,6 +1660,20 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "updatezuorabillingaccountlambda6EF8BCFE",
+                  },
+                ],
+              ],
+            },
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1549,6 +1699,22 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
           {
             "Fn::Join": [
               "",
@@ -1595,6 +1761,20 @@ exports[`The zuora-salesforce-link-remover stack matches the snapshot 2`] = `
         "Period": 60,
         "Statistic": "Sum",
         "Tags": [
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "updatesfbillingaccountslambda98285844",
+                  },
+                ],
+              ],
+            },
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/alarms-handler.ts
+++ b/cdk/lib/alarms-handler.ts
@@ -180,7 +180,7 @@ export class AlarmsHandler extends GuStack {
 				runtime: nodeVersion,
 				timeout: Duration.seconds(15),
 				handler: 'indexScheduled.handler',
-				functionName: triggeredLambda.functionName,
+				functionName: `${app}-scheduled-${this.stage}`,
 				loggingFormat: LoggingFormat.TEXT,
 				environment: {
 					APP: app,

--- a/cdk/lib/batch-email-sender.ts
+++ b/cdk/lib/batch-email-sender.ts
@@ -1,5 +1,4 @@
 import { GuApiGatewayWithLambdaByPath } from '@guardian/cdk';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
@@ -17,6 +16,7 @@ import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 
 export interface BatchEmailSenderProps extends GuStackProps {
 	certificateId: string;
@@ -29,9 +29,7 @@ export class BatchEmailSender extends GuStack {
 		super(scope, id, props);
 
 		// ---- Miscellaneous constants ---- //
-		const isProd = this.stage === 'PROD';
 		const app = 'batch-email-sender';
-		const alarmTopic = 'alarms-handler-topic-PROD';
 
 		// ---- API-triggered lambda functions ---- //
 		const batchEmailSenderLambda = new GuLambdaFunction(
@@ -96,14 +94,13 @@ export class BatchEmailSender extends GuStack {
 		});
 
 		// ---- Alarms ---- //
-		new GuAlarm(this, 'FailedEmailApiAlarm', {
+		new SrLambdaAlarm(this, 'FailedEmailApiAlarm', {
 			app,
 			alarmName: `URGENT 9-5 - ${this.stage}: Failed to send email triggered by Salesforce - 5XXError (CDK)`,
 			alarmDescription: `API responded with 5xx to Salesforce meaning some emails failed to send. Logs at /aws/lambda/batch-email-sender-${this.stage} repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/`,
 			evaluationPeriods: 1,
 			threshold: 1,
-			actionsEnabled: isProd,
-			snsTopicName: alarmTopic,
+			lambdaFunctionNames: batchEmailSenderLambda.functionName,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: '5XXError',
@@ -116,14 +113,13 @@ export class BatchEmailSender extends GuStack {
 			}),
 		});
 
-		new GuAlarm(this, 'FailedEmailLambdaAlarm', {
+		new SrLambdaAlarm(this, 'FailedEmailLambdaAlarm', {
 			app,
 			alarmName: `URGENT 9-5 - ${this.stage}: Failed to send email triggered by Salesforce - Lambda crash (CDK)`,
 			alarmDescription: `Lambda crashed unexpectedely meaning email message sent from Salesforce to the Service Layer could not be processed. Logs at /aws/lambda/batch-email-sender-${this.stage} repo at https://github.com/guardian/support-service-lambdas/blob/main/handlers/batch-email-sender/`,
 			evaluationPeriods: 1,
 			threshold: 1,
-			actionsEnabled: isProd,
-			snsTopicName: alarmTopic,
+			lambdaFunctionNames: batchEmailSenderLambda.functionName,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: 'Errors',

--- a/cdk/lib/cdk/sr-lambda-alarm.ts
+++ b/cdk/lib/cdk/sr-lambda-alarm.ts
@@ -1,0 +1,32 @@
+import type { GuAlarmProps } from '@guardian/cdk/lib/constructs/cloudwatch';
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { Tags } from 'aws-cdk-lib';
+
+interface SRLambdaAlarmProps
+	extends Omit<GuAlarmProps, 'snsTopicName' | 'actionsEnabled'> {
+	lambdaFunctionNames: string | string[];
+	actionsEnabled?: boolean; // defaults to PROD only
+}
+
+/**
+ * Creates an alarm which is triggered whenever the percentage of requests with a 5xx response code exceeds
+ * the specified threshold.
+ */
+export class SrLambdaAlarm extends GuAlarm {
+	constructor(scope: GuStack, id: string, props: SRLambdaAlarmProps) {
+		super(scope, id, {
+			...props,
+			snsTopicName: `alarms-handler-topic-${scope.stage}`,
+			actionsEnabled: props.actionsEnabled ?? scope.stage == 'PROD',
+		});
+		const lambdaFunctionNames =
+			typeof props.lambdaFunctionNames === 'string'
+				? [props.lambdaFunctionNames]
+				: props.lambdaFunctionNames;
+		const diagnosticLinksValue = lambdaFunctionNames
+			.map((lambdaFunctionName) => `lambda:${lambdaFunctionName}`)
+			.join(',');
+		Tags.of(this).add('DiagnosticLinks', diagnosticLinksValue);
+	}
+}

--- a/cdk/lib/cdk/sr-lambda-alarm.ts
+++ b/cdk/lib/cdk/sr-lambda-alarm.ts
@@ -9,10 +9,6 @@ interface SRLambdaAlarmProps
 	actionsEnabled?: boolean; // defaults to PROD only
 }
 
-/**
- * Creates an alarm which is triggered whenever the percentage of requests with a 5xx response code exceeds
- * the specified threshold.
- */
 export class SrLambdaAlarm extends GuAlarm {
 	constructor(scope: GuStack, id: string, props: SRLambdaAlarmProps) {
 		super(scope, id, {

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -1,5 +1,4 @@
 import { GuApiLambda } from '@guardian/cdk';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
@@ -13,6 +12,7 @@ import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat } from 'aws-cdk-lib/aws-lambda';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { nodeVersion } from './node-version';
 
 export interface DiscountApiProps extends GuStackProps {
@@ -138,7 +138,7 @@ export class DiscountApi extends GuStack {
 		const alarmDescription = (description: string) =>
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
-		new GuAlarm(this, 'ApiGateway5XXAlarmCDK', {
+		new SrLambdaAlarm(this, 'ApiGateway5XXAlarmCDK', {
 			app,
 			alarmName: alarmName('Discount-api 5XX response'),
 			alarmDescription: alarmDescription(
@@ -146,8 +146,7 @@ export class DiscountApi extends GuStack {
 			),
 			evaluationPeriods: 1,
 			threshold: 1,
-			snsTopicName: 'alarms-handler-topic-PROD',
-			actionsEnabled: this.stage === 'PROD',
+			lambdaFunctionNames: lambda.functionName,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: '5XXError',

--- a/cdk/lib/discount-expiry-notifier.ts
+++ b/cdk/lib/discount-expiry-notifier.ts
@@ -3,12 +3,7 @@ import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import { aws_cloudwatch, Duration } from 'aws-cdk-lib';
-import {
-	Alarm,
-	Metric,
-	Stats,
-	TreatMissingData,
-} from 'aws-cdk-lib/aws-cloudwatch';
+import { Metric, Stats, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
@@ -29,6 +24,7 @@ import {
 	StateMachine,
 } from 'aws-cdk-lib/aws-stepfunctions';
 import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { nodeVersion } from './node-version';
 
 export class DiscountExpiryNotifier extends GuStack {
@@ -387,13 +383,13 @@ export class DiscountExpiryNotifier extends GuStack {
 		];
 
 		lambdaFunctionsToAlarmOn.forEach((lambdaFunction, index) => {
-			const alarm = new Alarm(this, `alarm-${index}`, {
+			const alarm = new SrLambdaAlarm(this, `alarm-${index}`, {
 				alarmName: `Discount Expiry Notifier - ${lambdaFunction.functionName} - something went wrong - ${this.stage}`,
 				alarmDescription:
 					'Something went wrong when executing the Discount Expiry Notifier. See Cloudwatch logs for more information on the error.',
 				datapointsToAlarm: 1,
 				evaluationPeriods: 1,
-				actionsEnabled: true,
+				lambdaFunctionNames: lambdaFunction.functionName,
 				comparisonOperator:
 					aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
 				metric: new Metric({
@@ -407,6 +403,7 @@ export class DiscountExpiryNotifier extends GuStack {
 				}),
 				threshold: 0,
 				treatMissingData: TreatMissingData.MISSING,
+				app: appName,
 			});
 			alarm.addAlarmAction(new SnsAction(topic));
 		});

--- a/cdk/lib/discount-expiry-notifier.ts
+++ b/cdk/lib/discount-expiry-notifier.ts
@@ -4,7 +4,6 @@ import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import { aws_cloudwatch, Duration } from 'aws-cdk-lib';
 import { Metric, Stats, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
-import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
 import {
@@ -16,7 +15,6 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { Architecture, LoggingFormat } from 'aws-cdk-lib/aws-lambda';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { Topic } from 'aws-cdk-lib/aws-sns';
 import {
 	DefinitionBody,
 	JsonPath,
@@ -370,12 +368,6 @@ export class DiscountExpiryNotifier extends GuStack {
 			enabled: true,
 		});
 
-		const topic = Topic.fromTopicArn(
-			this,
-			'Topic',
-			`arn:aws:sns:${this.region}:${this.account}:alarms-handler-topic-${this.stage}`,
-		);
-
 		const lambdaFunctionsToAlarmOn = [
 			getExpiringDiscountsLambda,
 			filterRecordsLambda,
@@ -383,7 +375,7 @@ export class DiscountExpiryNotifier extends GuStack {
 		];
 
 		lambdaFunctionsToAlarmOn.forEach((lambdaFunction, index) => {
-			const alarm = new SrLambdaAlarm(this, `alarm-${index}`, {
+			new SrLambdaAlarm(this, `alarm-${index}`, {
 				alarmName: `Discount Expiry Notifier - ${lambdaFunction.functionName} - something went wrong - ${this.stage}`,
 				alarmDescription:
 					'Something went wrong when executing the Discount Expiry Notifier. See Cloudwatch logs for more information on the error.',
@@ -405,7 +397,6 @@ export class DiscountExpiryNotifier extends GuStack {
 				treatMissingData: TreatMissingData.MISSING,
 				app: appName,
 			});
-			alarm.addAlarmAction(new SnsAction(topic));
 		});
 	}
 }

--- a/cdk/lib/generate-product-catalog.ts
+++ b/cdk/lib/generate-product-catalog.ts
@@ -1,4 +1,3 @@
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
@@ -10,6 +9,7 @@ import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat } from 'aws-cdk-lib/aws-lambda';
 import { Bucket, EventType } from 'aws-cdk-lib/aws-s3';
 import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { nodeVersion } from './node-version';
 
 export interface GenerateProductCatalogProps extends GuStackProps {
@@ -96,14 +96,13 @@ export class GenerateProductCatalog extends GuStack {
 		});
 
 		if (this.stage === 'PROD') {
-			new GuAlarm(this, `FailedProductCatalogLambdaAlarm`, {
+			new SrLambdaAlarm(this, `FailedProductCatalogLambdaAlarm`, {
 				app,
 				alarmName: `The ${app} Lambda has failed`,
 				alarmDescription:
 					'This means the product catalog may not be up to date in S3. This lambda runs on a regular schedule so action will only be necessary if the alarm is triggered continuously',
 				evaluationPeriods: 1,
 				threshold: 1,
-				snsTopicName: `alarms-handler-topic-${this.stage}`,
 				comparisonOperator:
 					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				metric: new Metric({
@@ -115,6 +114,7 @@ export class GenerateProductCatalog extends GuStack {
 						FunctionName: lambda.functionName,
 					},
 				}),
+				lambdaFunctionNames: lambda.functionName,
 			});
 		}
 	}

--- a/cdk/lib/metric-push-api.ts
+++ b/cdk/lib/metric-push-api.ts
@@ -12,6 +12,7 @@ import {
 } from 'aws-cdk-lib/aws-cloudwatch';
 import { LoggingFormat } from 'aws-cdk-lib/aws-lambda';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { nodeVersion } from './node-version';
 
 export class MetricPushApi extends GuStack {
@@ -83,13 +84,12 @@ export class MetricPushApi extends GuStack {
 		dnsRecord.overrideLogicalId('MetricPushDNSRecord');
 
 		// Alarms
-		new GuAlarm(this, '5xxApiAlarm', {
+		new SrLambdaAlarm(this, '5xxApiAlarm', {
 			app,
 			alarmName: `URGENT 9-5 - ${this.stage} ${nameWithStage} API Gateway is returning 5XX errors`,
 			threshold: 2,
 			evaluationPeriods: 1,
-			snsTopicName: `alarms-handler-topic-${this.stage}`,
-			actionsEnabled: this.stage === 'PROD',
+			lambdaFunctionNames: lambda.functionName,
 			treatMissingData: TreatMissingData.NOT_BREACHING,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
 			metric: new Metric({

--- a/cdk/lib/new-product-api.ts
+++ b/cdk/lib/new-product-api.ts
@@ -1,5 +1,4 @@
 import { GuApiGatewayWithLambdaByPath } from '@guardian/cdk';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
@@ -17,6 +16,7 @@ import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 
 export interface NewProductApiProps extends GuStackProps {
 	domainName: string;
@@ -32,7 +32,6 @@ export class NewProductApi extends GuStack {
 		super(scope, id, props);
 
 		// ---- Miscellaneous constants ---- //
-		const isProd = this.stage === 'PROD';
 		const app = 'new-product-api';
 		const runtime = Runtime.JAVA_21;
 		const fileName = 'new-product-api.jar';
@@ -50,7 +49,6 @@ export class NewProductApi extends GuStack {
 			timeout,
 			environment,
 		};
-		const alarmTopic = 'alarms-handler-topic-PROD';
 
 		// ---- API-triggered lambda functions ---- //
 		const addSubscriptionLambda = new GuLambdaFunction(
@@ -97,14 +95,13 @@ export class NewProductApi extends GuStack {
 		});
 
 		// ---- Alarms ---- //
-		new GuAlarm(this, 'ApiGateway4XXAlarm', {
+		new SrLambdaAlarm(this, 'ApiGateway4XXAlarm', {
 			app,
 			alarmName: `new-product-api-${this.stage} API gateway 4XX response`,
 			alarmDescription: 'New Product API received an invalid request',
 			evaluationPeriods: 1,
 			threshold: 6,
-			actionsEnabled: isProd,
-			snsTopicName: alarmTopic,
+			lambdaFunctionNames: addSubscriptionLambda.functionName,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: '4XXError',
@@ -117,14 +114,16 @@ export class NewProductApi extends GuStack {
 			}),
 		});
 
-		new GuAlarm(this, 'ApiGateway5XXAlarm', {
+		new SrLambdaAlarm(this, 'ApiGateway5XXAlarm', {
 			app,
 			alarmName: `new-product-api-${this.stage} 5XX error`,
 			alarmDescription: `new-product-api-${this.stage} exceeded 1% 5XX error rate`,
 			evaluationPeriods: 1,
 			threshold: 1,
-			actionsEnabled: isProd,
-			snsTopicName: alarmTopic,
+			lambdaFunctionNames: [
+				addSubscriptionLambda.functionName,
+				productCatalogLambda.functionName,
+			],
 			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
 			metric: new Metric({
 				metricName: '5XXError',

--- a/cdk/lib/new-product-api.ts
+++ b/cdk/lib/new-product-api.ts
@@ -101,7 +101,10 @@ export class NewProductApi extends GuStack {
 			alarmDescription: 'New Product API received an invalid request',
 			evaluationPeriods: 1,
 			threshold: 6,
-			lambdaFunctionNames: addSubscriptionLambda.functionName,
+			lambdaFunctionNames: [
+				addSubscriptionLambda.functionName,
+				productCatalogLambda.functionName,
+			],
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: '4XXError',

--- a/cdk/lib/observer-data-export.ts
+++ b/cdk/lib/observer-data-export.ts
@@ -1,4 +1,3 @@
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
 import {
@@ -23,6 +22,7 @@ import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Bucket, EventType } from 'aws-cdk-lib/aws-s3';
 import { SqsDestination } from 'aws-cdk-lib/aws-s3-notifications';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { nodeVersion } from './node-version';
 
 export class ObserverDataExport extends GuStack {
@@ -212,12 +212,11 @@ export class ObserverDataExport extends GuStack {
 			new SqsDestination(queue),
 		);
 
-		new GuAlarm(
+		new SrLambdaAlarm(
 			this,
 			`encrypt-and-upload-observer-data-${this.stage}-lambda-alarm`,
 			{
 				app,
-				snsTopicName: `alarms-handler-topic-${this.stage}`,
 				alarmName: `${this.stage}: Failed to encrypt & upload Observer-only data to S3 bucket shared with Unifida (Tortoise's dev team)`,
 				alarmDescription: `Fix: check logs for lambda ${lambda.functionName} and redrive event from dead letter queue ${deadLetterQueue.queueName}.`,
 				metric: deadLetterQueue
@@ -228,13 +227,12 @@ export class ObserverDataExport extends GuStack {
 				threshold: 0,
 				evaluationPeriods: 1,
 				datapointsToAlarm: 1,
-				actionsEnabled: true,
+				lambdaFunctionNames: lambda.functionName,
 			},
 		);
 
-		new GuAlarm(this, `${flow.flowName}-flow-alarm`, {
+		new SrLambdaAlarm(this, `${flow.flowName}-flow-alarm`, {
 			app,
-			snsTopicName: `alarms-handler-topic-${this.stage}`,
 			alarmName: `${this.stage}: Failed to transfer Observer-only data from Salesforce to AWS (via AppFlow)`,
 			alarmDescription: `Debug: view "Run history" in the dashboard for flow ${flow.flowName}. Manual fix: upload today's unencrypted CSV file anywhere inside the ${salesforceObserverDataTransferBucket.bucketName} bucket.`,
 			metric: new Metric({
@@ -251,7 +249,7 @@ export class ObserverDataExport extends GuStack {
 			threshold: 0,
 			evaluationPeriods: 1,
 			datapointsToAlarm: 1,
-			actionsEnabled: true,
+			lambdaFunctionNames: lambda.functionName,
 		});
 	}
 }

--- a/cdk/lib/press-reader-entitlements.ts
+++ b/cdk/lib/press-reader-entitlements.ts
@@ -1,5 +1,4 @@
 import { GuApiLambda } from '@guardian/cdk';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
@@ -14,6 +13,7 @@ import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat } from 'aws-cdk-lib/aws-lambda';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { nodeVersion } from './node-version';
 
 export interface PressReaderEntitlementsProps extends GuStackProps {
@@ -105,7 +105,7 @@ export class PressReaderEntitlements extends GuStack {
 		const alarmDescription = (description: string) =>
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
-		new GuAlarm(this, 'ApiGateway4XXAlarmCDK', {
+		new SrLambdaAlarm(this, 'ApiGateway4XXAlarmCDK', {
 			app,
 			alarmName: alarmName('API gateway 4XX response'),
 			alarmDescription: alarmDescription(
@@ -113,8 +113,7 @@ export class PressReaderEntitlements extends GuStack {
 			),
 			evaluationPeriods: 1,
 			threshold: 10,
-			snsTopicName: `alarms-handler-topic-${this.stage}`,
-			actionsEnabled: this.stage === 'PROD',
+			lambdaFunctionNames: lambda.functionName,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: '4XXError',

--- a/cdk/lib/product-switch-api.ts
+++ b/cdk/lib/product-switch-api.ts
@@ -1,5 +1,4 @@
 import { GuApiLambda } from '@guardian/cdk';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
@@ -13,6 +12,7 @@ import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat } from 'aws-cdk-lib/aws-lambda';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { nodeVersion } from './node-version';
 
 export interface ProductSwitchApiProps extends GuStackProps {
@@ -166,9 +166,7 @@ export class ProductSwitchApi extends GuStack {
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
 		if (this.stage === 'PROD') {
-			const snsTopicName = 'alarms-handler-topic-PROD';
-
-			new GuAlarm(this, 'ApiGateway5XXAlarmCDK', {
+			new SrLambdaAlarm(this, 'ApiGateway5XXAlarmCDK', {
 				app,
 				alarmName: alarmName('API gateway 5XX response'),
 				alarmDescription: alarmDescription(
@@ -176,7 +174,6 @@ export class ProductSwitchApi extends GuStack {
 				),
 				evaluationPeriods: 1,
 				threshold: 1,
-				snsTopicName,
 				comparisonOperator:
 					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				metric: new Metric({
@@ -188,14 +185,14 @@ export class ProductSwitchApi extends GuStack {
 						ApiName: nameWithStage,
 					},
 				}),
+				lambdaFunctionNames: lambda.functionName,
 			});
-			new GuAlarm(this, 'ProductSwitchFailureAlarm', {
+			new SrLambdaAlarm(this, 'ProductSwitchFailureAlarm', {
 				app,
 				alarmName: alarmName('An error occurred in the Product Switch lambda'),
 				alarmDescription: alarmDescription(
 					'Product switch lambda failed, please check the logs to diagnose the issue.',
 				),
-				snsTopicName,
 				comparisonOperator:
 					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				metric: new Metric({
@@ -209,6 +206,7 @@ export class ProductSwitchApi extends GuStack {
 				}),
 				threshold: 1,
 				evaluationPeriods: 1,
+				lambdaFunctionNames: lambda.functionName,
 			});
 		}
 	}

--- a/cdk/lib/single-contribution-salesforce-writes.ts
+++ b/cdk/lib/single-contribution-salesforce-writes.ts
@@ -1,4 +1,3 @@
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
@@ -10,6 +9,7 @@ import { Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 
 export const APP_NAME = 'single-contribution-salesforce-writes';
 
@@ -91,9 +91,8 @@ export class SingleContributionSalesforceWrites extends GuStack {
 
 		lambda.addToRolePolicy(getSecretValuePolicyStatement);
 
-		new GuAlarm(this, `${APP_NAME}-alarm`, {
+		new SrLambdaAlarm(this, `${APP_NAME}-alarm`, {
 			app: APP_NAME,
-			snsTopicName: `alarms-handler-topic-${this.stage}`,
 			alarmName: `${this.stage}: Failed to sync single contribution to Salesforce`,
 			alarmDescription: `Impact: A Single Contribution record has not been added to Salesforce. Fix: check logs for lambda ${lambda.functionName} and redrive from dead letter queue or, if Salesforce is preventing record creation due to a data quality issue, fix and add record manually to Salesforce`,
 			metric: deadLetterQueue
@@ -102,7 +101,7 @@ export class SingleContributionSalesforceWrites extends GuStack {
 			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
 			threshold: 0,
 			evaluationPeriods: 24,
-			actionsEnabled: this.stage === 'PROD',
+			lambdaFunctionNames: lambda.functionName,
 		});
 	}
 }

--- a/cdk/lib/stripe-webhook-endpoints.ts
+++ b/cdk/lib/stripe-webhook-endpoints.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { GuApiGatewayWithLambdaByPath } from '@guardian/cdk';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
@@ -12,6 +11,7 @@ import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 
 export interface StripeWebhookEndpointsProps extends GuStackProps {
 	stack: string;
@@ -114,7 +114,7 @@ export class StripeWebhookEndpoints extends GuStack {
 		const alarmDescription = (description: string) =>
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
-		new GuAlarm(this, 'ApiGateway4XXAlarmCDK', {
+		new SrLambdaAlarm(this, 'ApiGateway4XXAlarmCDK', {
 			app,
 			alarmName: alarmName('API gateway 4XX response'),
 			alarmDescription: alarmDescription(
@@ -122,8 +122,10 @@ export class StripeWebhookEndpoints extends GuStack {
 			),
 			evaluationPeriods: 1,
 			threshold: 1,
-			snsTopicName: 'conversion-dev',
-			actionsEnabled: this.stage === 'PROD',
+			lambdaFunctionNames: [
+				paymentIntentIssuesLambda.functionName,
+				customerUpdatedLambda.functionName,
+			],
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: '4XXError',
@@ -136,14 +138,16 @@ export class StripeWebhookEndpoints extends GuStack {
 			}),
 		});
 
-		new GuAlarm(this, 'ApiGateway5XXAlarmCDK', {
+		new SrLambdaAlarm(this, 'ApiGateway5XXAlarmCDK', {
 			app,
 			alarmName: alarmName('API gateway 5XX error'),
 			alarmDescription: `stripe-webhook-endpoints-${this.stage} exceeded 1% 5XX error rate`,
 			evaluationPeriods: 1,
 			threshold: 1,
-			actionsEnabled: this.stage === 'PROD',
-			snsTopicName: 'conversion-dev',
+			lambdaFunctionNames: [
+				paymentIntentIssuesLambda.functionName,
+				customerUpdatedLambda.functionName,
+			],
 			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
 			metric: new Metric({
 				metricName: '5XXError',

--- a/cdk/lib/update-supporter-plus-amount.ts
+++ b/cdk/lib/update-supporter-plus-amount.ts
@@ -1,5 +1,4 @@
 import { GuApiLambda } from '@guardian/cdk';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
@@ -13,6 +12,7 @@ import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat } from 'aws-cdk-lib/aws-lambda';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { nodeVersion } from './node-version';
 
 export interface UpdateSupporterPlusAmountProps extends GuStackProps {
@@ -95,7 +95,7 @@ export class UpdateSupporterPlusAmount extends GuStack {
 			`Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
 		if (this.stage === 'PROD') {
-			new GuAlarm(this, 'ApiGateway5XXAlarm', {
+			new SrLambdaAlarm(this, 'ApiGateway5XXAlarm', {
 				app,
 				alarmName: alarmName(
 					'Update supporter plus amount - API gateway 5XX response',
@@ -106,7 +106,6 @@ export class UpdateSupporterPlusAmount extends GuStack {
 				),
 				evaluationPeriods: 1,
 				threshold: 1,
-				snsTopicName: 'alarms-handler-topic-PROD',
 				comparisonOperator:
 					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				metric: new Metric({
@@ -118,6 +117,7 @@ export class UpdateSupporterPlusAmount extends GuStack {
 						ApiName: nameWithStage,
 					},
 				}),
+				lambdaFunctionNames: lambda.functionName,
 			});
 		}
 

--- a/cdk/lib/zuora-salesforce-link-remover.ts
+++ b/cdk/lib/zuora-salesforce-link-remover.ts
@@ -4,12 +4,10 @@ import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import { aws_cloudwatch, Duration } from 'aws-cdk-lib';
 import { Metric, Stats, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
-import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Architecture, LoggingFormat } from 'aws-cdk-lib/aws-lambda';
-import { Topic } from 'aws-cdk-lib/aws-sns';
 import {
 	Choice,
 	Condition,
@@ -198,12 +196,6 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 			enabled: true,
 		});
 
-		const topic = Topic.fromTopicArn(
-			this,
-			'Topic',
-			`arn:aws:sns:${this.region}:${this.account}:alarms-handler-topic-${this.stage}`,
-		);
-
 		const lambdaFunctions = [
 			getSalesforceBillingAccountsLambda,
 			updateZuoraBillingAccountLambda,
@@ -211,7 +203,7 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 		];
 
 		lambdaFunctions.forEach((lambdaFunction, index) => {
-			const alarm = new SrLambdaAlarm(this, `alarm-${index}`, {
+			new SrLambdaAlarm(this, `alarm-${index}`, {
 				app: appName,
 				alarmName: `Zuora <-> Salesforce link remover - ${lambdaFunction.functionName} - something went wrong - ${this.stage}`,
 				alarmDescription:
@@ -233,7 +225,6 @@ export class ZuoraSalesforceLinkRemover extends GuStack {
 				threshold: 0,
 				treatMissingData: TreatMissingData.MISSING,
 			});
-			alarm.addAlarmAction(new SnsAction(topic));
 		});
 	}
 }


### PR DESCRIPTION
## Note: when deploying to PROD, we need to manually add the alarmshandlerbackupemailaddress to alarms-handler stack.

following on from cdk update https://github.com/guardian/support-service-lambdas/pull/2660
and DiagnosticLinks in alarms handler https://github.com/guardian/support-service-lambdas/pull/2641

This PR adds a new SrLambdaAlarm construct ( cdk/lib/cdk/sr-lambda-alarm.ts ) and uses it where possible in our stacks.

I've also make some other tweaks so the alarms are enabled only in PROD by default, and they use the appropriate alarms handler topic.  This reduces duplication in our stacks.

I also noticed that alarms-handler alarms went to alarms-handler-topic.  This means if alarms handler broke, it would be silently looping.  I've added provision for those alarms to be emailed to us as I wasn't sure what best to do.

It has not been added everywhere (yet) - some places we use CfnAlarm rather than GuAlarm, which is apparently a low level construct.  And also places we use GuLambda's monitoringConfig rather than a separate alarm.  This can be resolved in future.

Also in future this may be exportable to support-frontend repo if it's useful there.