### PR TITLE
Add SQS queue and API Gateway for mParticle callbacks

### DIFF
--- a/cdk/lib/__snapshots__/mparticle-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/mparticle-api.test.ts.snap
@@ -6,8 +6,38 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuApiGatewayWithLambdaByPath",
+      "GuApiGateway5xxPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "RestApiEndpoint0551178A": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "RestApiDeploymentStageprod3855DE66",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
   },
   "Parameters": {
     "DistributionBucketName": {
@@ -17,6 +47,438 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "ApiGatewayHigh5xxPercentageAlarmExampleapigatewayinstance0B776A32": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "example-api-gateway-instance exceeded 1% error rate",
+        "AlarmName": "High 5XX error percentage from example-api-gateway-instance (ApiGateway) in CODE",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for example-api-gateway-instance",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "membership-CODE-example-api-gateway-instance",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "membership-CODE-example-api-gateway-instance",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MparticleApiCallbackDeadLetterQueue39444883": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 864000,
+        "QueueName": "mparticle-api-callback-dead-letter-queue-CODE",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "MparticleCallbackQueue769EFD7C": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "mparticle-callback-queue-CODE",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "MparticleApiCallbackDeadLetterQueue39444883",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 3,
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VisibilityTimeout": 3000,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RestApi0C43BF4B": {
+      "Properties": {
+        "Name": "membership-CODE-example-api-gateway-instance",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiAccount7C83CF5A": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC5037648e86c6c588fcd7d6d036b55ec7d65": {
+      "DependsOn": [
+        "RestApidatasubjectrequestsrequestIdcallbackPOST2BF76B7C",
+        "RestApidatasubjectrequestsrequestIdcallback3E3A4143",
+        "RestApidatasubjectrequestsrequestId1EC01CA2",
+        "RestApidatasubjectrequests6F9B1B02",
+      ],
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageprod3855DE66": {
+      "DependsOn": [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "RestApiDeployment180EC5037648e86c6c588fcd7d6d036b55ec7d65",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApidatasubjectrequests6F9B1B02": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "data-subject-requests",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApidatasubjectrequestsrequestId1EC01CA2": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApidatasubjectrequests6F9B1B02",
+        },
+        "PathPart": "{requestId}",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApidatasubjectrequestsrequestIdcallback3E3A4143": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApidatasubjectrequestsrequestId1EC01CA2",
+        },
+        "PathPart": "callback",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApidatasubjectrequestsrequestIdcallbackPOST2BF76B7C": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "mparticleapilambdaD503F5B2",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApidatasubjectrequestsrequestIdcallback3E3A4143",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApidatasubjectrequestsrequestIdcallbackPOSTApiPermissionTestmparticleapiCODERestApi21B2EC7DPOSTdatasubjectrequestsrequestIdcallbackC8C3F328": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "mparticleapilambdaD503F5B2",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/POST/data-subject-requests/*/callback",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApidatasubjectrequestsrequestIdcallbackPOSTApiPermissionmparticleapiCODERestApi21B2EC7DPOSTdatasubjectrequestsrequestIdcallback1F28B3F3": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "mparticleapilambdaD503F5B2",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/POST/data-subject-requests/*/callback",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "mparticleapicloudwatchpolicy1B6A7573": {
       "Properties": {
         "PolicyDocument": {
@@ -256,8 +718,38 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuApiGatewayWithLambdaByPath",
+      "GuApiGateway5xxPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "RestApiEndpoint0551178A": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "RestApiDeploymentStageprod3855DE66",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
   },
   "Parameters": {
     "DistributionBucketName": {
@@ -267,6 +759,438 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
     },
   },
   "Resources": {
+    "ApiGatewayHigh5xxPercentageAlarmExampleapigatewayinstance0B776A32": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "example-api-gateway-instance exceeded 1% error rate",
+        "AlarmName": "High 5XX error percentage from example-api-gateway-instance (ApiGateway) in PROD",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for example-api-gateway-instance",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "membership-PROD-example-api-gateway-instance",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "membership-PROD-example-api-gateway-instance",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MparticleApiCallbackDeadLetterQueue39444883": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 864000,
+        "QueueName": "mparticle-api-callback-dead-letter-queue-PROD",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "MparticleCallbackQueue769EFD7C": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "mparticle-callback-queue-PROD",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "MparticleApiCallbackDeadLetterQueue39444883",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 3,
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VisibilityTimeout": 3000,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RestApi0C43BF4B": {
+      "Properties": {
+        "Name": "membership-PROD-example-api-gateway-instance",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiAccount7C83CF5A": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50314d038cb4e966fdfb4c20b8d896025e0": {
+      "DependsOn": [
+        "RestApidatasubjectrequestsrequestIdcallbackPOST2BF76B7C",
+        "RestApidatasubjectrequestsrequestIdcallback3E3A4143",
+        "RestApidatasubjectrequestsrequestId1EC01CA2",
+        "RestApidatasubjectrequests6F9B1B02",
+      ],
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageprod3855DE66": {
+      "DependsOn": [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "RestApiDeployment180EC50314d038cb4e966fdfb4c20b8d896025e0",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "membership",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApidatasubjectrequests6F9B1B02": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "data-subject-requests",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApidatasubjectrequestsrequestId1EC01CA2": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApidatasubjectrequests6F9B1B02",
+        },
+        "PathPart": "{requestId}",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApidatasubjectrequestsrequestIdcallback3E3A4143": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApidatasubjectrequestsrequestId1EC01CA2",
+        },
+        "PathPart": "callback",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApidatasubjectrequestsrequestIdcallbackPOST2BF76B7C": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "mparticleapilambdaD503F5B2",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApidatasubjectrequestsrequestIdcallback3E3A4143",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApidatasubjectrequestsrequestIdcallbackPOSTApiPermissionTestmparticleapiPRODRestApi381B330APOSTdatasubjectrequestsrequestIdcallback7E07506F": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "mparticleapilambdaD503F5B2",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/POST/data-subject-requests/*/callback",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApidatasubjectrequestsrequestIdcallbackPOSTApiPermissionmparticleapiPRODRestApi381B330APOSTdatasubjectrequestsrequestIdcallback82222DDA": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "mparticleapilambdaD503F5B2",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/POST/data-subject-requests/*/callback",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "mparticleapicloudwatchpolicy1B6A7573": {
       "Properties": {
         "PolicyDocument": {

--- a/cdk/lib/__snapshots__/mparticle-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/mparticle-api.test.ts.snap
@@ -47,7 +47,7 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "ApiGatewayHigh5xxPercentageAlarmExampleapigatewayinstance0B776A32": {
+    "ApiGatewayHigh5xxPercentageAlarmMparticleapi50549F1E": {
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -68,15 +68,15 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "example-api-gateway-instance exceeded 1% error rate",
-        "AlarmName": "High 5XX error percentage from example-api-gateway-instance (ApiGateway) in CODE",
+        "AlarmDescription": "mparticle-api exceeded 1% error rate",
+        "AlarmName": "High 5XX error percentage from mparticle-api (ApiGateway) in CODE",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
           {
             "Expression": "100*m1/m2",
             "Id": "expr_1",
-            "Label": "% of 5XX responses served for example-api-gateway-instance",
+            "Label": "% of 5XX responses served for mparticle-api",
           },
           {
             "Id": "m1",
@@ -85,7 +85,7 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
                 "Dimensions": [
                   {
                     "Name": "ApiName",
-                    "Value": "membership-CODE-example-api-gateway-instance",
+                    "Value": "membership-CODE-mparticle-api",
                   },
                 ],
                 "MetricName": "5XXError",
@@ -103,7 +103,7 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
                 "Dimensions": [
                   {
                     "Name": "ApiName",
-                    "Value": "membership-CODE-example-api-gateway-instance",
+                    "Value": "membership-CODE-mparticle-api",
                   },
                 ],
                 "MetricName": "Count",
@@ -185,7 +185,7 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
     },
     "RestApi0C43BF4B": {
       "Properties": {
-        "Name": "membership-CODE-example-api-gateway-instance",
+        "Name": "membership-CODE-mparticle-api",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -274,7 +274,7 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5037648e86c6c588fcd7d6d036b55ec7d65": {
+    "RestApiDeployment180EC5036c821d4f4e0e40d947572b1ff5f7f643": {
       "DependsOn": [
         "RestApidatasubjectrequestsrequestIdcallbackPOST2BF76B7C",
         "RestApidatasubjectrequestsrequestIdcallback3E3A4143",
@@ -295,7 +295,7 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5037648e86c6c588fcd7d6d036b55ec7d65",
+          "Ref": "RestApiDeployment180EC5036c821d4f4e0e40d947572b1ff5f7f643",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -759,7 +759,7 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
     },
   },
   "Resources": {
-    "ApiGatewayHigh5xxPercentageAlarmExampleapigatewayinstance0B776A32": {
+    "ApiGatewayHigh5xxPercentageAlarmMparticleapi50549F1E": {
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -780,15 +780,15 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
             ],
           },
         ],
-        "AlarmDescription": "example-api-gateway-instance exceeded 1% error rate",
-        "AlarmName": "High 5XX error percentage from example-api-gateway-instance (ApiGateway) in PROD",
+        "AlarmDescription": "mparticle-api exceeded 1% error rate",
+        "AlarmName": "High 5XX error percentage from mparticle-api (ApiGateway) in PROD",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
           {
             "Expression": "100*m1/m2",
             "Id": "expr_1",
-            "Label": "% of 5XX responses served for example-api-gateway-instance",
+            "Label": "% of 5XX responses served for mparticle-api",
           },
           {
             "Id": "m1",
@@ -797,7 +797,7 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
                 "Dimensions": [
                   {
                     "Name": "ApiName",
-                    "Value": "membership-PROD-example-api-gateway-instance",
+                    "Value": "membership-PROD-mparticle-api",
                   },
                 ],
                 "MetricName": "5XXError",
@@ -815,7 +815,7 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
                 "Dimensions": [
                   {
                     "Name": "ApiName",
-                    "Value": "membership-PROD-example-api-gateway-instance",
+                    "Value": "membership-PROD-mparticle-api",
                   },
                 ],
                 "MetricName": "Count",
@@ -897,7 +897,7 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
     },
     "RestApi0C43BF4B": {
       "Properties": {
-        "Name": "membership-PROD-example-api-gateway-instance",
+        "Name": "membership-PROD-mparticle-api",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -986,7 +986,7 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50314d038cb4e966fdfb4c20b8d896025e0": {
+    "RestApiDeployment180EC50345abd92429a59a7a83941d3e0ce20b53": {
       "DependsOn": [
         "RestApidatasubjectrequestsrequestIdcallbackPOST2BF76B7C",
         "RestApidatasubjectrequestsrequestIdcallback3E3A4143",
@@ -1007,7 +1007,7 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50314d038cb4e966fdfb4c20b8d896025e0",
+          "Ref": "RestApiDeployment180EC50345abd92429a59a7a83941d3e0ce20b53",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",

--- a/cdk/lib/mparticle-api.ts
+++ b/cdk/lib/mparticle-api.ts
@@ -1,10 +1,10 @@
+import {GuApiGatewayWithLambdaByPath} from '@guardian/cdk';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
-import {GuApiGatewayWithLambdaByPath} from '@guardian/cdk';
-import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { type App, Duration } from 'aws-cdk-lib';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { nodeVersion } from './node-version';
 
 
@@ -30,7 +30,7 @@ export class MParticleApi extends GuStack {
 		});
 
 		// API Gateway
-		const mparticleCallbackApiGatway = new GuApiGatewayWithLambdaByPath(this, {
+		new GuApiGatewayWithLambdaByPath(this, {
 			app: "example-api-gateway-instance",
 			targets: [
 				{
@@ -57,7 +57,7 @@ export class MParticleApi extends GuStack {
 			},
 		);
 
-		const mparticleCallbackQueue = new Queue(this, 'MparticleCallbackQueue', {
+		new Queue(this, 'MparticleCallbackQueue', {
 			queueName: `mparticle-callback-queue-${this.stage}`,
 			visibilityTimeout: Duration.seconds(3000),
 			deadLetterQueue: {

--- a/cdk/lib/mparticle-api.ts
+++ b/cdk/lib/mparticle-api.ts
@@ -1,4 +1,4 @@
-import {GuApiGatewayWithLambdaByPath} from '@guardian/cdk';
+import { GuApiGatewayWithLambdaByPath } from '@guardian/cdk';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
@@ -6,7 +6,6 @@ import { type App, Duration } from 'aws-cdk-lib';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { nodeVersion } from './node-version';
-
 
 export class MParticleApi extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -34,17 +33,18 @@ export class MParticleApi extends GuStack {
 			app: app,
 			targets: [
 				{
-			path: "/data-subject-requests/{requestId}/callback",
-			httpMethod: "POST",
-			lambda: lambda,
-				}
+					path: '/data-subject-requests/{requestId}/callback',
+					httpMethod: 'POST',
+					lambda: lambda,
+				},
 			],
-		// Create an alarm
-		monitoringConfiguration: {
-			snsTopicName: `alarms-handler-topic-${this.stage}`,
-			http5xxAlarm: {
-				tolerated5xxPercentage: 1,
-				}}
+			// Create an alarm
+			monitoringConfiguration: {
+				snsTopicName: `alarms-handler-topic-${this.stage}`,
+				http5xxAlarm: {
+					tolerated5xxPercentage: 1,
+				},
+			},
 		});
 
 		// SQS Queue

--- a/cdk/lib/mparticle-api.ts
+++ b/cdk/lib/mparticle-api.ts
@@ -31,7 +31,7 @@ export class MParticleApi extends GuStack {
 
 		// API Gateway
 		new GuApiGatewayWithLambdaByPath(this, {
-			app: "example-api-gateway-instance",
+			app: app,
 			targets: [
 				{
 			path: "/data-subject-requests/{requestId}/callback",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds SQS queue infrastructure and API Gateway endpoint for handling mParticle callback processing.

- **SQS Queue**: Added main callback queue with dead letter queue for failed message handling
- **API Gateway**: Added endpoint for data subject request callbacks (`/data-subject-requests/{requestId}/callback`)
- **Infrastructure**: Queue configured with 3 retry attempts before moving to DLQ
- **Monitoring**: Includes CloudWatch alarms for API Gateway 5xx errors

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- Updated CDK snapshots to include new infrastructure and passed tests
- Fixed linting tests

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
