### PR TITLE
Negative invoices processor - apply credit to balance as first action

### DIFF
--- a/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
+++ b/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
@@ -9,6 +9,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -255,241 +256,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "checkforactivepaymentmethodlambdaA80DA53A": {
-      "DependsOn": [
-        "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF",
-        "checkforactivepaymentmethodlambdaServiceRole57C29B81",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "negative-invoices-processor",
-            "STACK": "support",
-            "STAGE": "CODE",
-            "Stage": "CODE",
-          },
-        },
-        "FunctionName": "negative-invoices-processor-check-for-active-payment-method-CODE",
-        "Handler": "checkForActivePaymentMethod.handler",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-        },
-        "MemorySize": 512,
-        "Role": {
-          "Fn::GetAtt": [
-            "checkforactivepaymentmethodlambdaServiceRole57C29B81",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "checkforactivepaymentmethodlambdaServiceRole57C29B81": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "secretsmanager:GetSecretValue",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/support/negative-invoices-processor",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/support/negative-invoices-processor/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF",
-        "Roles": [
-          {
-            "Ref": "checkforactivepaymentmethodlambdaServiceRole57C29B81",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "checkforactivesublambdaB4F70D0E": {
       "DependsOn": [
         "checkforactivesublambdaServiceRoleDefaultPolicy8B3E106B",
@@ -725,6 +491,241 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "docreditbalancerefundlambda2AAB1C48": {
+      "DependsOn": [
+        "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9",
+        "docreditbalancerefundlambdaServiceRoleE63DB3B7",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "STACK": "support",
+            "STAGE": "CODE",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-do-credit-balance-refund-CODE",
+        "Handler": "doCreditBalanceRefund.handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "docreditbalancerefundlambdaServiceRoleE63DB3B7",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9",
+        "Roles": [
+          {
+            "Ref": "docreditbalancerefundlambdaServiceRoleE63DB3B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "docreditbalancerefundlambdaServiceRoleE63DB3B7": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "getinvoiceslambdaBD92FECC": {
       "DependsOn": [
         "querylambdaroleDefaultPolicy929B9FB7",
@@ -787,6 +788,241 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
+    "getpaymentmethodslambda870A5F3C": {
+      "DependsOn": [
+        "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4",
+        "getpaymentmethodslambdaServiceRoleCC0EA259",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "STACK": "support",
+            "STAGE": "CODE",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-get-payment-methods-CODE",
+        "Handler": "getPaymentMethods.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "getpaymentmethodslambdaServiceRoleCC0EA259",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "getpaymentmethodslambdaServiceRoleCC0EA259": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4",
+        "Roles": [
+          {
+            "Ref": "getpaymentmethodslambdaServiceRoleCC0EA259",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "negativeinvoicesprocessorstatemachineCODE3A72431E": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -809,7 +1045,18 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Check for Active Sub","States":{"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Check for Active Sub","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "applycredittoaccountbalancelambda254CBA80",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -820,25 +1067,25 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":true,"Next":"Apply credit to account balance"}],"Default":"Check for Active Payment Method"},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Get Payment Methods"}],"Default":"End"},"End":{"Type":"Pass","End":true},"Get Payment Methods":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
               ":states:::lambda:invoke","Parameters":{"FunctionName":"",
               {
                 "Fn::GetAtt": [
-                  "checkforactivepaymentmethodlambdaA80DA53A",
+                  "getpaymentmethodslambda870A5F3C",
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Apply credit to account balance"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"Apply credit to account balance":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Do credit balance refund"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"Do credit balance refund":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
               ":states:::lambda:invoke","Parameters":{"FunctionName":"",
               {
                 "Fn::GetAtt": [
-                  "applycredittoaccountbalancelambda254CBA80",
+                  "docreditbalancerefundlambda2AAB1C48",
                   "Arn",
                 ],
               },
@@ -911,6 +1158,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
+                    "applycredittoaccountbalancelambda254CBA80",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "applycredittoaccountbalancelambda254CBA80",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
                     "checkforactivesublambdaB4F70D0E",
                     "Arn",
                   ],
@@ -937,7 +1210,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "checkforactivepaymentmethodlambdaA80DA53A",
+                    "getpaymentmethodslambda870A5F3C",
                     "Arn",
                   ],
                 },
@@ -947,7 +1220,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "checkforactivepaymentmethodlambdaA80DA53A",
+                          "getpaymentmethodslambda870A5F3C",
                           "Arn",
                         ],
                       },
@@ -963,7 +1236,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "applycredittoaccountbalancelambda254CBA80",
+                    "docreditbalancerefundlambda2AAB1C48",
                     "Arn",
                   ],
                 },
@@ -973,7 +1246,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "applycredittoaccountbalancelambda254CBA80",
+                          "docreditbalancerefundlambda2AAB1C48",
                           "Arn",
                         ],
                       },
@@ -1209,6 +1482,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
+      "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
@@ -1459,241 +1733,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "checkforactivepaymentmethodlambdaA80DA53A": {
-      "DependsOn": [
-        "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF",
-        "checkforactivepaymentmethodlambdaServiceRole57C29B81",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "negative-invoices-processor",
-            "STACK": "support",
-            "STAGE": "PROD",
-            "Stage": "PROD",
-          },
-        },
-        "FunctionName": "negative-invoices-processor-check-for-active-payment-method-PROD",
-        "Handler": "checkForActivePaymentMethod.handler",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-        },
-        "MemorySize": 512,
-        "Role": {
-          "Fn::GetAtt": [
-            "checkforactivepaymentmethodlambdaServiceRole57C29B81",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "checkforactivepaymentmethodlambdaServiceRole57C29B81": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "secretsmanager:GetSecretValue",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/negative-invoices-processor",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/negative-invoices-processor/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF",
-        "Roles": [
-          {
-            "Ref": "checkforactivepaymentmethodlambdaServiceRole57C29B81",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "checkforactivesublambdaB4F70D0E": {
       "DependsOn": [
         "checkforactivesublambdaServiceRoleDefaultPolicy8B3E106B",
@@ -1929,6 +1968,241 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "docreditbalancerefundlambda2AAB1C48": {
+      "DependsOn": [
+        "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9",
+        "docreditbalancerefundlambdaServiceRoleE63DB3B7",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "STACK": "support",
+            "STAGE": "PROD",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-do-credit-balance-refund-PROD",
+        "Handler": "doCreditBalanceRefund.handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "docreditbalancerefundlambdaServiceRoleE63DB3B7",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9",
+        "Roles": [
+          {
+            "Ref": "docreditbalancerefundlambdaServiceRoleE63DB3B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "docreditbalancerefundlambdaServiceRoleE63DB3B7": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "getinvoiceslambdaBD92FECC": {
       "DependsOn": [
         "querylambdaroleDefaultPolicy929B9FB7",
@@ -1991,6 +2265,241 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
+    "getpaymentmethodslambda870A5F3C": {
+      "DependsOn": [
+        "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4",
+        "getpaymentmethodslambdaServiceRoleCC0EA259",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "STACK": "support",
+            "STAGE": "PROD",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-get-payment-methods-PROD",
+        "Handler": "getPaymentMethods.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "getpaymentmethodslambdaServiceRoleCC0EA259",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "getpaymentmethodslambdaServiceRoleCC0EA259": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4",
+        "Roles": [
+          {
+            "Ref": "getpaymentmethodslambdaServiceRoleCC0EA259",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "negativeinvoicesprocessorstatemachinePROD17CC3EA7": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -2013,7 +2522,18 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Check for Active Sub","States":{"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Check for Active Sub","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "applycredittoaccountbalancelambda254CBA80",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2024,25 +2544,25 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":true,"Next":"Apply credit to account balance"}],"Default":"Check for Active Payment Method"},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Get Payment Methods"}],"Default":"End"},"End":{"Type":"Pass","End":true},"Get Payment Methods":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
               ":states:::lambda:invoke","Parameters":{"FunctionName":"",
               {
                 "Fn::GetAtt": [
-                  "checkforactivepaymentmethodlambdaA80DA53A",
+                  "getpaymentmethodslambda870A5F3C",
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Apply credit to account balance"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"Apply credit to account balance":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Do credit balance refund"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"Do credit balance refund":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
               ":states:::lambda:invoke","Parameters":{"FunctionName":"",
               {
                 "Fn::GetAtt": [
-                  "applycredittoaccountbalancelambda254CBA80",
+                  "docreditbalancerefundlambda2AAB1C48",
                   "Arn",
                 ],
               },
@@ -2150,6 +2670,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
+                    "applycredittoaccountbalancelambda254CBA80",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "applycredittoaccountbalancelambda254CBA80",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
                     "checkforactivesublambdaB4F70D0E",
                     "Arn",
                   ],
@@ -2176,7 +2722,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "checkforactivepaymentmethodlambdaA80DA53A",
+                    "getpaymentmethodslambda870A5F3C",
                     "Arn",
                   ],
                 },
@@ -2186,7 +2732,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "checkforactivepaymentmethodlambdaA80DA53A",
+                          "getpaymentmethodslambda870A5F3C",
                           "Arn",
                         ],
                       },
@@ -2202,7 +2748,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "applycredittoaccountbalancelambda254CBA80",
+                    "docreditbalancerefundlambda2AAB1C48",
                     "Arn",
                   ],
                 },
@@ -2212,7 +2758,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "applycredittoaccountbalancelambda254CBA80",
+                          "docreditbalancerefundlambda2AAB1C48",
                           "Arn",
                         ],
                       },

--- a/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
+++ b/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
@@ -9,7 +9,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
-      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -256,6 +255,241 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
+    "checkforactivepaymentmethodlambdaA80DA53A": {
+      "DependsOn": [
+        "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF",
+        "checkforactivepaymentmethodlambdaServiceRole57C29B81",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "STACK": "support",
+            "STAGE": "CODE",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-check-for-active-payment-method-CODE",
+        "Handler": "checkForActivePaymentMethod.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "checkforactivepaymentmethodlambdaServiceRole57C29B81",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "checkforactivepaymentmethodlambdaServiceRole57C29B81": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF",
+        "Roles": [
+          {
+            "Ref": "checkforactivepaymentmethodlambdaServiceRole57C29B81",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "checkforactivesublambdaB4F70D0E": {
       "DependsOn": [
         "checkforactivesublambdaServiceRoleDefaultPolicy8B3E106B",
@@ -491,241 +725,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "docreditbalancerefundlambda2AAB1C48": {
-      "DependsOn": [
-        "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9",
-        "docreditbalancerefundlambdaServiceRoleE63DB3B7",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "negative-invoices-processor",
-            "STACK": "support",
-            "STAGE": "CODE",
-            "Stage": "CODE",
-          },
-        },
-        "FunctionName": "negative-invoices-processor-do-credit-balance-refund-CODE",
-        "Handler": "doCreditBalanceRefund.handler",
-        "LoggingConfig": {
-          "LogFormat": "JSON",
-        },
-        "MemorySize": 512,
-        "Role": {
-          "Fn::GetAtt": [
-            "docreditbalancerefundlambdaServiceRoleE63DB3B7",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "secretsmanager:GetSecretValue",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/support/negative-invoices-processor",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/support/negative-invoices-processor/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9",
-        "Roles": [
-          {
-            "Ref": "docreditbalancerefundlambdaServiceRoleE63DB3B7",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "docreditbalancerefundlambdaServiceRoleE63DB3B7": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "getinvoiceslambdaBD92FECC": {
       "DependsOn": [
         "querylambdaroleDefaultPolicy929B9FB7",
@@ -788,241 +787,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "getpaymentmethodslambda870A5F3C": {
-      "DependsOn": [
-        "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4",
-        "getpaymentmethodslambdaServiceRoleCC0EA259",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "negative-invoices-processor",
-            "STACK": "support",
-            "STAGE": "CODE",
-            "Stage": "CODE",
-          },
-        },
-        "FunctionName": "negative-invoices-processor-get-payment-methods-CODE",
-        "Handler": "getPaymentMethods.handler",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-        },
-        "MemorySize": 512,
-        "Role": {
-          "Fn::GetAtt": [
-            "getpaymentmethodslambdaServiceRoleCC0EA259",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "getpaymentmethodslambdaServiceRoleCC0EA259": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "secretsmanager:GetSecretValue",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/support/negative-invoices-processor",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/support/negative-invoices-processor/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4",
-        "Roles": [
-          {
-            "Ref": "getpaymentmethodslambdaServiceRoleCC0EA259",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "negativeinvoicesprocessorstatemachineCODE3A72431E": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -1056,7 +820,18 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Apply credit to account balance"}],"Default":"check for valid email lambda will go here"},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "checkforactivepaymentmethodlambdaA80DA53A",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End"},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -1067,29 +842,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Get Payment Methods"}],"Default":"End"},"End":{"Type":"Pass","End":true},"Get Payment Methods":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
-              {
-                "Fn::GetAtt": [
-                  "getpaymentmethodslambda870A5F3C",
-                  "Arn",
-                ],
-              },
-              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Do credit balance refund"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"Do credit balance refund":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
-              {
-                "Fn::GetAtt": [
-                  "docreditbalancerefundlambda2AAB1C48",
-                  "Arn",
-                ],
-              },
-              "","Payload.$":"$"}}}}}}}",
+              "","Payload.$":"$"}},"End":{"Type":"Pass","End":true},"check for valid email lambda will go here":{"Type":"Pass","End":true}}}}}}",
             ],
           ],
         },
@@ -1184,6 +937,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
+                    "checkforactivepaymentmethodlambdaA80DA53A",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "checkforactivepaymentmethodlambdaA80DA53A",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
                     "checkforactivesublambdaB4F70D0E",
                     "Arn",
                   ],
@@ -1195,58 +974,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                       {
                         "Fn::GetAtt": [
                           "checkforactivesublambdaB4F70D0E",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "getpaymentmethodslambda870A5F3C",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "getpaymentmethodslambda870A5F3C",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "docreditbalancerefundlambda2AAB1C48",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "docreditbalancerefundlambda2AAB1C48",
                           "Arn",
                         ],
                       },
@@ -1482,7 +1209,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
@@ -1733,6 +1459,241 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Role",
     },
+    "checkforactivepaymentmethodlambdaA80DA53A": {
+      "DependsOn": [
+        "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF",
+        "checkforactivepaymentmethodlambdaServiceRole57C29B81",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "STACK": "support",
+            "STAGE": "PROD",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-check-for-active-payment-method-PROD",
+        "Handler": "checkForActivePaymentMethod.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "checkforactivepaymentmethodlambdaServiceRole57C29B81",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "checkforactivepaymentmethodlambdaServiceRole57C29B81": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "checkforactivepaymentmethodlambdaServiceRoleDefaultPolicyBCD9A5EF",
+        "Roles": [
+          {
+            "Ref": "checkforactivepaymentmethodlambdaServiceRole57C29B81",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "checkforactivesublambdaB4F70D0E": {
       "DependsOn": [
         "checkforactivesublambdaServiceRoleDefaultPolicy8B3E106B",
@@ -1968,241 +1929,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "docreditbalancerefundlambda2AAB1C48": {
-      "DependsOn": [
-        "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9",
-        "docreditbalancerefundlambdaServiceRoleE63DB3B7",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "negative-invoices-processor",
-            "STACK": "support",
-            "STAGE": "PROD",
-            "Stage": "PROD",
-          },
-        },
-        "FunctionName": "negative-invoices-processor-do-credit-balance-refund-PROD",
-        "Handler": "doCreditBalanceRefund.handler",
-        "LoggingConfig": {
-          "LogFormat": "JSON",
-        },
-        "MemorySize": 512,
-        "Role": {
-          "Fn::GetAtt": [
-            "docreditbalancerefundlambdaServiceRoleE63DB3B7",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "secretsmanager:GetSecretValue",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/negative-invoices-processor",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/negative-invoices-processor/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "docreditbalancerefundlambdaServiceRoleDefaultPolicy1367E5E9",
-        "Roles": [
-          {
-            "Ref": "docreditbalancerefundlambdaServiceRoleE63DB3B7",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "docreditbalancerefundlambdaServiceRoleE63DB3B7": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "getinvoiceslambdaBD92FECC": {
       "DependsOn": [
         "querylambdaroleDefaultPolicy929B9FB7",
@@ -2265,241 +1991,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "getpaymentmethodslambda870A5F3C": {
-      "DependsOn": [
-        "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4",
-        "getpaymentmethodslambdaServiceRoleCC0EA259",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "negative-invoices-processor",
-            "STACK": "support",
-            "STAGE": "PROD",
-            "Stage": "PROD",
-          },
-        },
-        "FunctionName": "negative-invoices-processor-get-payment-methods-PROD",
-        "Handler": "getPaymentMethods.handler",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-        },
-        "MemorySize": 512,
-        "Role": {
-          "Fn::GetAtt": [
-            "getpaymentmethodslambdaServiceRoleCC0EA259",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "getpaymentmethodslambdaServiceRoleCC0EA259": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "negative-invoices-processor",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "secretsmanager:GetSecretValue",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/negative-invoices-processor",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/negative-invoices-processor/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "getpaymentmethodslambdaServiceRoleDefaultPolicy61DF09D4",
-        "Roles": [
-          {
-            "Ref": "getpaymentmethodslambdaServiceRoleCC0EA259",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "negativeinvoicesprocessorstatemachinePROD17CC3EA7": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -2533,7 +2024,18 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Apply credit to account balance"}],"Default":"check for valid email lambda will go here"},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "checkforactivepaymentmethodlambdaA80DA53A",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End"},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2544,29 +2046,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Get Payment Methods"}],"Default":"End"},"End":{"Type":"Pass","End":true},"Get Payment Methods":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
-              {
-                "Fn::GetAtt": [
-                  "getpaymentmethodslambda870A5F3C",
-                  "Arn",
-                ],
-              },
-              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Do credit balance refund"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"Do credit balance refund":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
-              {
-                "Fn::GetAtt": [
-                  "docreditbalancerefundlambda2AAB1C48",
-                  "Arn",
-                ],
-              },
-              "","Payload.$":"$"}}}}}}}",
+              "","Payload.$":"$"}},"End":{"Type":"Pass","End":true},"check for valid email lambda will go here":{"Type":"Pass","End":true}}}}}}",
             ],
           ],
         },
@@ -2696,6 +2176,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
+                    "checkforactivepaymentmethodlambdaA80DA53A",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "checkforactivepaymentmethodlambdaA80DA53A",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
                     "checkforactivesublambdaB4F70D0E",
                     "Arn",
                   ],
@@ -2707,58 +2213,6 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                       {
                         "Fn::GetAtt": [
                           "checkforactivesublambdaB4F70D0E",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "getpaymentmethodslambda870A5F3C",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "getpaymentmethodslambda870A5F3C",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "docreditbalancerefundlambda2AAB1C48",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "docreditbalancerefundlambda2AAB1C48",
                           "Arn",
                         ],
                       },

--- a/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
+++ b/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
@@ -820,7 +820,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Check for Active Sub"}]},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Check for Active Sub"}],"Default":"End 1"},"End 1":{"Type":"Pass","End":true},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -831,7 +831,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}]},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End 2"},"End 2":{"Type":"Pass","End":true},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2024,7 +2024,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Check for Active Sub"}]},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Check for Active Sub"}],"Default":"End 1"},"End 1":{"Type":"Pass","End":true},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2035,7 +2035,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}]},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End 2"},"End 2":{"Type":"Pass","End":true},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
+++ b/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
@@ -820,18 +820,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Apply credit to account balance"}],"Default":"check for valid email lambda will go here"},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
-              {
-                "Fn::GetAtt": [
-                  "checkforactivepaymentmethodlambdaA80DA53A",
-                  "Arn",
-                ],
-              },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End"},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -842,7 +831,18 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"End":{"Type":"Pass","End":true},"check for valid email lambda will go here":{"Type":"Pass","End":true}}}}}}",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End"},"End":{"Type":"Pass","End":true},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "checkforactivepaymentmethodlambdaA80DA53A",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"do refund lambda will go here"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"do refund lambda will go here":{"Type":"Pass","End":true}}}}}}",
             ],
           ],
         },
@@ -937,7 +937,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "checkforactivepaymentmethodlambdaA80DA53A",
+                    "checkforactivesublambdaB4F70D0E",
                     "Arn",
                   ],
                 },
@@ -947,7 +947,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "checkforactivepaymentmethodlambdaA80DA53A",
+                          "checkforactivesublambdaB4F70D0E",
                           "Arn",
                         ],
                       },
@@ -963,7 +963,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "checkforactivesublambdaB4F70D0E",
+                    "checkforactivepaymentmethodlambdaA80DA53A",
                     "Arn",
                   ],
                 },
@@ -973,7 +973,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "checkforactivesublambdaB4F70D0E",
+                          "checkforactivepaymentmethodlambdaA80DA53A",
                           "Arn",
                         ],
                       },
@@ -2024,18 +2024,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"Apply credit to account balance"}],"Default":"check for valid email lambda will go here"},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
-              {
-                "Fn::GetAtt": [
-                  "checkforactivepaymentmethodlambdaA80DA53A",
-                  "Arn",
-                ],
-              },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End"},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2046,7 +2035,18 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"End":{"Type":"Pass","End":true},"check for valid email lambda will go here":{"Type":"Pass","End":true}}}}}}",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End"},"End":{"Type":"Pass","End":true},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "checkforactivepaymentmethodlambdaA80DA53A",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"do refund lambda will go here"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"do refund lambda will go here":{"Type":"Pass","End":true}}}}}}",
             ],
           ],
         },
@@ -2176,7 +2176,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "checkforactivepaymentmethodlambdaA80DA53A",
+                    "checkforactivesublambdaB4F70D0E",
                     "Arn",
                   ],
                 },
@@ -2186,7 +2186,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "checkforactivepaymentmethodlambdaA80DA53A",
+                          "checkforactivesublambdaB4F70D0E",
                           "Arn",
                         ],
                       },
@@ -2202,7 +2202,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "checkforactivesublambdaB4F70D0E",
+                    "checkforactivepaymentmethodlambdaA80DA53A",
                     "Arn",
                   ],
                 },
@@ -2212,7 +2212,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "checkforactivesublambdaB4F70D0E",
+                          "checkforactivepaymentmethodlambdaA80DA53A",
                           "Arn",
                         ],
                       },

--- a/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
+++ b/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
@@ -831,7 +831,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End"},"End":{"Type":"Pass","End":true},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}]},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Has active sub?"}]},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2035,7 +2035,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}],"Default":"End"},"End":{"Type":"Pass","End":true},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}]},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Has active sub?"}]},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
+++ b/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
@@ -809,7 +809,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Check for Active Sub","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Credit applied successfully?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -820,7 +820,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Check for Active Sub"}]},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -831,7 +831,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}]},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Has active sub?"}]},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}]},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -842,7 +842,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"do refund lambda will go here"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"do refund lambda will go here":{"Type":"Pass","End":true}}}}}}",
+              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"do refund lambda will go here"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"do refund lambda will go here":{"Type":"Pass","End":true}}},"MaxConcurrency":1}}}",
             ],
           ],
         },
@@ -2013,7 +2013,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Check for Active Sub","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Credit applied successfully?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2024,7 +2024,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Check for Active Sub"}]},"Check for Active Sub":{"Next":"Has active sub?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2035,7 +2035,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}]},"Credit applied successfully?":{"Type":"Choice","Choices":[{"Variable":"$.applyCreditToAccountBalanceAttempt.Success","BooleanEquals":true,"Next":"Has active sub?"}]},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Has active sub?":{"Type":"Choice","Choices":[{"Variable":"$.hasActiveSub","BooleanEquals":false,"Next":"Check for Active Payment Method"}]},"Check for Active Payment Method":{"Next":"Has active payment method?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2046,7 +2046,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"do refund lambda will go here"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"do refund lambda will go here":{"Type":"Pass","End":true}}}}}}",
+              "","Payload.$":"$"}},"Has active payment method?":{"Type":"Choice","Choices":[{"Variable":"$.hasActivePaymentMethod","BooleanEquals":true,"Next":"do refund lambda will go here"}],"Default":"check for valid email lambda will go here"},"check for valid email lambda will go here":{"Type":"Pass","End":true},"do refund lambda will go here":{"Type":"Pass","End":true}}},"MaxConcurrency":1}}}",
             ],
           ],
         },

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -237,13 +237,13 @@ export class NegativeInvoicesProcessor extends GuStack {
 				'$.applyCreditToAccountBalanceAttempt.Success',
 				true,
 			),
-			hasActiveSubChoice,
+			checkForActiveSubLambdaTask.next(hasActiveSubChoice),
 		);
 		// .otherwise(new Pass(this, 'End1'));
-		invoiceProcessorMap.iterator(
-			applyCreditToAccountBalanceLambdaTask
-				.next(checkForActiveSubLambdaTask)
-				.next(hasActiveSubChoice),
+		invoiceProcessorMap.itemProcessor(
+			applyCreditToAccountBalanceLambdaTask.next(
+				CreditAppliedSuccessfullyChoice,
+			),
 		);
 
 		const definitionBody = DefinitionBody.fromChainable(

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -219,7 +219,7 @@ export class NegativeInvoicesProcessor extends GuStack {
 		)
 			.when(
 				Condition.booleanEquals('$.hasActivePaymentMethod', true),
-				doCreditBalanceRefundLambdaTask,
+				new Pass(this, 'do refund lambda will go here'),
 			)
 			.otherwise(new Pass(this, 'check for valid email lambda will go here'));
 

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -219,14 +219,16 @@ export class NegativeInvoicesProcessor extends GuStack {
 		)
 			.when(
 				Condition.booleanEquals('$.hasActivePaymentMethod', true),
-				new Pass(this, 'do refund lambda will go here'),
+				applyCreditToAccountBalanceLambdaTask,
 			)
 			.otherwise(new Pass(this, 'check for valid email lambda will go here'));
 
 		const hasActiveSubChoice = new Choice(this, 'Has active sub?')
 			.when(
 				Condition.booleanEquals('$.hasActiveSub', false),
-				getPaymentMethodsLambdaTask.next(hasActivePaymentMethodChoice),
+				checkForActivePaymentMethodLambdaTask.next(
+					hasActivePaymentMethodChoice,
+				),
 			)
 			.otherwise(new Pass(this, 'End'));
 

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -109,18 +109,18 @@ export class NegativeInvoicesProcessor extends GuStack {
 			},
 		);
 
-		const getPaymentMethodsLambda = new GuLambdaFunction(
+		const checkForActivePaymentMethodLambda = new GuLambdaFunction(
 			this,
-			'get-payment-methods-lambda',
+			'check-for-active-payment-method-lambda',
 			{
 				app: appName,
-				functionName: `${appName}-get-payment-methods-${this.stage}`,
+				functionName: `${appName}-check-for-active-payment-method-${this.stage}`,
 				loggingFormat: LoggingFormat.TEXT,
 				runtime: nodeVersion,
 				environment: {
 					Stage: this.stage,
 				},
-				handler: 'getPaymentMethods.handler',
+				handler: 'checkForActivePaymentMethod.handler',
 				fileName: `${appName}.zip`,
 				architecture: Architecture.ARM_64,
 				initialPolicy: [

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -225,14 +225,10 @@ export class NegativeInvoicesProcessor extends GuStack {
 
 		const hasActiveSubChoice = new Choice(this, 'Has active sub?')
 			.when(
-				Condition.booleanEquals('$.hasActiveSub', true),
-				applyCreditToAccountBalanceLambdaTask,
+				Condition.booleanEquals('$.hasActiveSub', false),
+				getPaymentMethodsLambdaTask.next(hasActivePaymentMethodChoice),
 			)
-			.otherwise(
-				checkForActivePaymentMethodLambdaTask.next(
-					hasActivePaymentMethodChoice,
-				),
-			);
+			.otherwise(new Pass(this, 'End'));
 
 		invoiceProcessorMap.iterator(
 			applyCreditToAccountBalanceLambdaTask

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -235,7 +235,9 @@ export class NegativeInvoicesProcessor extends GuStack {
 			);
 
 		invoiceProcessorMap.iterator(
-			checkForActiveSubLambdaTask.next(hasActiveSubChoice),
+			applyCreditToAccountBalanceLambdaTask
+				.next(checkForActiveSubLambdaTask)
+				.next(hasActiveSubChoice),
 		);
 
 		const definitionBody = DefinitionBody.fromChainable(

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -219,7 +219,7 @@ export class NegativeInvoicesProcessor extends GuStack {
 		)
 			.when(
 				Condition.booleanEquals('$.hasActivePaymentMethod', true),
-				applyCreditToAccountBalanceLambdaTask,
+				doCreditBalanceRefundLambdaTask,
 			)
 			.otherwise(new Pass(this, 'check for valid email lambda will go here'));
 

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -109,18 +109,18 @@ export class NegativeInvoicesProcessor extends GuStack {
 			},
 		);
 
-		const checkForActivePaymentMethodLambda = new GuLambdaFunction(
+		const getPaymentMethodsLambda = new GuLambdaFunction(
 			this,
-			'check-for-active-payment-method-lambda',
+			'get-payment-methods-lambda',
 			{
 				app: appName,
-				functionName: `${appName}-check-for-active-payment-method-${this.stage}`,
+				functionName: `${appName}-get-payment-methods-${this.stage}`,
 				loggingFormat: LoggingFormat.TEXT,
 				runtime: nodeVersion,
 				environment: {
 					Stage: this.stage,
 				},
-				handler: 'checkForActivePaymentMethod.handler',
+				handler: 'getPaymentMethods.handler',
 				fileName: `${appName}.zip`,
 				architecture: Architecture.ARM_64,
 				initialPolicy: [
@@ -159,6 +159,30 @@ export class NegativeInvoicesProcessor extends GuStack {
 			},
 		);
 
+		const doCreditBalanceRefundLambda = new GuLambdaFunction(
+			this,
+			'do-credit-balance-refund-lambda',
+			{
+				app: appName,
+				functionName: `${appName}-do-credit-balance-refund-${this.stage}`,
+				runtime: nodeVersion,
+				environment: {
+					Stage: this.stage,
+				},
+				handler: 'doCreditBalanceRefund.handler',
+				fileName: `${appName}.zip`,
+				architecture: Architecture.ARM_64,
+				initialPolicy: [
+					new PolicyStatement({
+						actions: ['secretsmanager:GetSecretValue'],
+						resources: [
+							`arn:aws:secretsmanager:${this.region}:${this.account}:secret:${this.stage}/Zuora-OAuth/SupportServiceLambdas-*`,
+						],
+					}),
+				],
+			},
+		);
+
 		const getInvoicesLambdaTask = new LambdaInvoke(this, 'Get invoices', {
 			lambdaFunction: getInvoicesLambda,
 			outputPath: '$.Payload',
@@ -181,11 +205,11 @@ export class NegativeInvoicesProcessor extends GuStack {
 			maxAttempts: 2, // Retry only once (1 initial attempt + 1 retry)
 		});
 
-		const checkForActivePaymentMethodLambdaTask = new LambdaInvoke(
+		const getPaymentMethodsLambdaTask = new LambdaInvoke(
 			this,
-			'Check for Active Payment Method',
+			'Get Payment Methods',
 			{
-				lambdaFunction: checkForActivePaymentMethodLambda,
+				lambdaFunction: getPaymentMethodsLambda,
 				outputPath: '$.Payload',
 			},
 		).addRetry({
@@ -207,6 +231,19 @@ export class NegativeInvoicesProcessor extends GuStack {
 			maxAttempts: 2, // Retry only once (1 initial attempt + 1 retry)
 		});
 
+		const doCreditBalanceRefundLambdaTask = new LambdaInvoke(
+			this,
+			'Do credit balance refund',
+			{
+				lambdaFunction: doCreditBalanceRefundLambda,
+				outputPath: '$.Payload',
+			},
+		).addRetry({
+			errors: ['States.ALL'],
+			interval: Duration.seconds(10),
+			maxAttempts: 2, // Retry only once (1 initial attempt + 1 retry)
+		});
+
 		const invoiceProcessorMap = new Map(this, 'Invoice processor map', {
 			maxConcurrency: 1,
 			itemsPath: JsonPath.stringAt('$.invoices'),
@@ -219,23 +256,21 @@ export class NegativeInvoicesProcessor extends GuStack {
 		)
 			.when(
 				Condition.booleanEquals('$.hasActivePaymentMethod', true),
-				applyCreditToAccountBalanceLambdaTask,
+				doCreditBalanceRefundLambdaTask,
 			)
 			.otherwise(new Pass(this, 'check for valid email lambda will go here'));
 
 		const hasActiveSubChoice = new Choice(this, 'Has active sub?')
 			.when(
-				Condition.booleanEquals('$.hasActiveSub', true),
-				applyCreditToAccountBalanceLambdaTask,
+				Condition.booleanEquals('$.hasActiveSub', false),
+				getPaymentMethodsLambdaTask.next(hasActivePaymentMethodChoice),
 			)
-			.otherwise(
-				checkForActivePaymentMethodLambdaTask.next(
-					hasActivePaymentMethodChoice,
-				),
-			);
+			.otherwise(new Pass(this, 'End'));
 
 		invoiceProcessorMap.iterator(
-			checkForActiveSubLambdaTask.next(hasActiveSubChoice),
+			applyCreditToAccountBalanceLambdaTask
+				.next(checkForActiveSubLambdaTask)
+				.next(hasActiveSubChoice),
 		);
 
 		const definitionBody = DefinitionBody.fromChainable(

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -223,15 +223,23 @@ export class NegativeInvoicesProcessor extends GuStack {
 			)
 			.otherwise(new Pass(this, 'check for valid email lambda will go here'));
 
-		const hasActiveSubChoice = new Choice(this, 'Has active sub?')
-			.when(
-				Condition.booleanEquals('$.hasActiveSub', false),
-				checkForActivePaymentMethodLambdaTask.next(
-					hasActivePaymentMethodChoice,
-				),
-			)
-			.otherwise(new Pass(this, 'End'));
+		const hasActiveSubChoice = new Choice(this, 'Has active sub?').when(
+			Condition.booleanEquals('$.hasActiveSub', false),
+			checkForActivePaymentMethodLambdaTask.next(hasActivePaymentMethodChoice),
+		);
+		// .otherwise(new Pass(this, 'End'));
 
+		const CreditAppliedSuccessfullyChoice = new Choice(
+			this,
+			'Credit applied successfully?',
+		).when(
+			Condition.booleanEquals(
+				'$.applyCreditToAccountBalanceAttempt.Success',
+				true,
+			),
+			hasActiveSubChoice,
+		);
+		// .otherwise(new Pass(this, 'End1'));
 		invoiceProcessorMap.iterator(
 			applyCreditToAccountBalanceLambdaTask
 				.next(checkForActiveSubLambdaTask)

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -219,7 +219,7 @@ export class NegativeInvoicesProcessor extends GuStack {
 		)
 			.when(
 				Condition.booleanEquals('$.hasActivePaymentMethod', true),
-				applyCreditToAccountBalanceLambdaTask,
+				new Pass(this, 'do refund lambda will go here'),
 			)
 			.otherwise(new Pass(this, 'check for valid email lambda will go here'));
 

--- a/cdk/lib/negative-invoices-processor.ts
+++ b/cdk/lib/negative-invoices-processor.ts
@@ -223,23 +223,28 @@ export class NegativeInvoicesProcessor extends GuStack {
 			)
 			.otherwise(new Pass(this, 'check for valid email lambda will go here'));
 
-		const hasActiveSubChoice = new Choice(this, 'Has active sub?').when(
-			Condition.booleanEquals('$.hasActiveSub', false),
-			checkForActivePaymentMethodLambdaTask.next(hasActivePaymentMethodChoice),
-		);
-		// .otherwise(new Pass(this, 'End'));
+		const hasActiveSubChoice = new Choice(this, 'Has active sub?')
+			.when(
+				Condition.booleanEquals('$.hasActiveSub', false),
+				checkForActivePaymentMethodLambdaTask.next(
+					hasActivePaymentMethodChoice,
+				),
+			)
+			.otherwise(new Pass(this, 'End 2'));
 
 		const CreditAppliedSuccessfullyChoice = new Choice(
 			this,
 			'Credit applied successfully?',
-		).when(
-			Condition.booleanEquals(
-				'$.applyCreditToAccountBalanceAttempt.Success',
-				true,
-			),
-			checkForActiveSubLambdaTask.next(hasActiveSubChoice),
-		);
-		// .otherwise(new Pass(this, 'End1'));
+		)
+			.when(
+				Condition.booleanEquals(
+					'$.applyCreditToAccountBalanceAttempt.Success',
+					true,
+				),
+				checkForActiveSubLambdaTask.next(hasActiveSubChoice),
+			)
+			.otherwise(new Pass(this, 'End 1'));
+
 		invoiceProcessorMap.itemProcessor(
 			applyCreditToAccountBalanceLambdaTask.next(
 				CreditAppliedSuccessfullyChoice,

--- a/handlers/negative-invoices-processor/src/handlers/applyCreditToAccountBalance.ts
+++ b/handlers/negative-invoices-processor/src/handlers/applyCreditToAccountBalance.ts
@@ -1,24 +1,16 @@
 import { stageFromEnvironment } from '@modules/stage';
 import { applyCreditToAccountBalance } from '@modules/zuora/applyCreditToAccountBalance';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { z } from 'zod';
-
-export const ApplyCreditToAccountBalanceInputSchema = z.object({
-	invoiceId: z.string(),
-	accountId: z.string(),
-	invoiceNumber: z.string(),
-	invoiceBalance: z.number(),
-	hasActiveSub: z.boolean(),
-	hasActivePaymentMethod: z.boolean().optional(),
-});
+import type { z } from 'zod';
+import { BigQueryRecordSchema } from '../types';
 
 export type ApplyCreditToAccountBalanceInput = z.infer<
-	typeof ApplyCreditToAccountBalanceInputSchema
+	typeof BigQueryRecordSchema
 >;
 
 export const handler = async (event: ApplyCreditToAccountBalanceInput) => {
 	try {
-		const parsedEvent = ApplyCreditToAccountBalanceInputSchema.parse(event);
+		const parsedEvent = BigQueryRecordSchema.parse(event);
 		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
 		const body = JSON.stringify({
 			Amount: Math.abs(parsedEvent.invoiceBalance), //must be a positive value

--- a/handlers/negative-invoices-processor/src/handlers/applyCreditToAccountBalance.ts
+++ b/handlers/negative-invoices-processor/src/handlers/applyCreditToAccountBalance.ts
@@ -27,6 +27,7 @@ export const handler = async (event: ApplyCreditToAccountBalanceInput) => {
 	} catch (error) {
 		return {
 			...event,
+			attempt,
 			applyCreditToAccountBalanceStatus: 'Error',
 			errorDetail:
 				error instanceof Error ? error.message : JSON.stringify(error, null, 2),

--- a/handlers/negative-invoices-processor/src/handlers/applyCreditToAccountBalance.ts
+++ b/handlers/negative-invoices-processor/src/handlers/applyCreditToAccountBalance.ts
@@ -18,7 +18,8 @@ export const handler = async (event: ApplyCreditToAccountBalanceInput) => {
 			Type: 'Increase',
 		});
 
-		const applyCreditToAccountBalanceAttempt = await applyCreditToAccountBalance(zuoraClient, body);
+		const applyCreditToAccountBalanceAttempt =
+			await applyCreditToAccountBalance(zuoraClient, body);
 
 		return {
 			...parsedEvent,
@@ -27,9 +28,9 @@ export const handler = async (event: ApplyCreditToAccountBalanceInput) => {
 	} catch (error) {
 		return {
 			...event,
-			applyCreditToAccountBalanceAttempt:{
+			applyCreditToAccountBalanceAttempt: {
 				Success: false,
-			}
+			},
 			errorDetail:
 				error instanceof Error ? error.message : JSON.stringify(error, null, 2),
 		};

--- a/handlers/negative-invoices-processor/src/handlers/applyCreditToAccountBalance.ts
+++ b/handlers/negative-invoices-processor/src/handlers/applyCreditToAccountBalance.ts
@@ -18,17 +18,18 @@ export const handler = async (event: ApplyCreditToAccountBalanceInput) => {
 			Type: 'Increase',
 		});
 
-		const attempt = await applyCreditToAccountBalance(zuoraClient, body);
+		const applyCreditToAccountBalanceAttempt = await applyCreditToAccountBalance(zuoraClient, body);
 
 		return {
 			...parsedEvent,
-			attempt,
+			applyCreditToAccountBalanceAttempt,
 		};
 	} catch (error) {
 		return {
 			...event,
-			attempt,
-			applyCreditToAccountBalanceStatus: 'Error',
+			applyCreditToAccountBalanceAttempt:{
+				Success: false,
+			}
 			errorDetail:
 				error instanceof Error ? error.message : JSON.stringify(error, null, 2),
 		};

--- a/handlers/negative-invoices-processor/src/handlers/checkForActiveSub.ts
+++ b/handlers/negative-invoices-processor/src/handlers/checkForActiveSub.ts
@@ -2,13 +2,21 @@ import { stageFromEnvironment } from '@modules/stage';
 import { doQuery } from '@modules/zuora/query';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { z } from 'zod';
-import { BigQueryRecordSchema } from '../types';
 
-export type CheckForActiveSubInput = z.infer<typeof BigQueryRecordSchema>;
+export const CheckForActiveSubSchema = z.object({
+	invoiceId: z.string(),
+	accountId: z.string(),
+	invoiceNumber: z.string(),
+	invoiceBalance: z.number(),
+	applyCreditToAccountBalanceAttempt: z.object({
+		Success: z.boolean(),
+	}),
+});
+export type CheckForActiveSubInput = z.infer<typeof CheckForActiveSubSchema>;
 
 export const handler = async (event: CheckForActiveSubInput) => {
 	try {
-		const parsedEvent = BigQueryRecordSchema.parse(event);
+		const parsedEvent = CheckForActiveSubSchema.parse(event);
 		const zuoraClient = await ZuoraClient.create(stageFromEnvironment());
 		const hasActiveSub = await hasActiveSubscription(
 			zuoraClient,


### PR DESCRIPTION
## What does this change?
Alter the order of execution by shifting the 'Apply credit to Account Balance' lambda to the first action that takes place within the invoice processing map, because:

- we are always going to want to do this action
- it will simplify the infrastructure so that we don't have to create 2 instances of the lambda task in cdk
- avoids duplication in cdk

_Before_
<img width="781" alt="Screenshot 2025-06-19 at 15 32 52" src="https://github.com/user-attachments/assets/38936f6c-7388-46e9-b7cf-567db338b8f0" />

_After_
<img width="783" alt="Screenshot 2025-06-19 at 15 40 30" src="https://github.com/user-attachments/assets/9884dd62-14cc-40b2-b323-f5b28293ceed" />

## How to test
- run the state machine for an account and verify the account balance is credited