### PR TITLE
Negative invoices processor - save results to s3

### DIFF
--- a/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
+++ b/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
@@ -10,6 +10,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -21,6 +22,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "Bucket83908E77": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketName": "negative-invoices-processor-code",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
     "applycredittoaccountbalancelambda254CBA80": {
       "DependsOn": [
         "applycredittoaccountbalancelambdaServiceRoleDefaultPolicy322F837F",
@@ -1045,7 +1072,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Credit applied successfully?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","Next":"Save results to S3","ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Credit applied successfully?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -1089,7 +1116,18 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}}}}}",
+              "","Payload.$":"$"}}}}},"Save results to S3":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "saveresultslambda2CAFC532",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}}}}",
             ],
           ],
         },
@@ -1143,6 +1181,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                       {
                         "Fn::GetAtt": [
                           "getinvoiceslambdaBD92FECC",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "saveresultslambda2CAFC532",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "saveresultslambda2CAFC532",
                           "Arn",
                         ],
                       },
@@ -1473,6 +1537,250 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "saveresultslambda2CAFC532": {
+      "DependsOn": [
+        "saveresultslambdaServiceRoleDefaultPolicyC690A6F5",
+        "saveresultslambdaServiceRoleDD59B626",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "S3_BUCKET": {
+              "Ref": "Bucket83908E77",
+            },
+            "STACK": "support",
+            "STAGE": "CODE",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-save-results-CODE",
+        "Handler": "saveResults.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "saveresultslambdaServiceRoleDD59B626",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "saveresultslambdaServiceRoleDD59B626": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "saveresultslambdaServiceRoleDefaultPolicyC690A6F5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "saveresultslambdaServiceRoleDefaultPolicyC690A6F5",
+        "Roles": [
+          {
+            "Ref": "saveresultslambdaServiceRoleDD59B626",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
   },
 }
 `;
@@ -1482,6 +1790,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
+      "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
@@ -1498,6 +1807,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
     },
   },
   "Resources": {
+    "Bucket83908E77": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketName": "negative-invoices-processor-prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
     "applycredittoaccountbalancelambda254CBA80": {
       "DependsOn": [
         "applycredittoaccountbalancelambdaServiceRoleDefaultPolicy322F837F",
@@ -2522,7 +2857,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","End":true,"ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Credit applied successfully?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"Invoice processor map":{"Type":"Map","ResultPath":"$.processedInvoices","Next":"Save results to S3","ItemsPath":"$.invoices","MaxConcurrency":1,"Iterator":{"StartAt":"Apply credit to account balance","States":{"Apply credit to account balance":{"Next":"Credit applied successfully?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2566,7 +2901,18 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}}}}}",
+              "","Payload.$":"$"}}}}},"Save results to S3":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "saveresultslambda2CAFC532",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}}}}",
             ],
           ],
         },
@@ -2655,6 +3001,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                       {
                         "Fn::GetAtt": [
                           "getinvoiceslambdaBD92FECC",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "saveresultslambda2CAFC532",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "saveresultslambda2CAFC532",
                           "Arn",
                         ],
                       },
@@ -2945,6 +3317,250 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
         "Roles": [
           {
             "Ref": "querylambdaroleC6C8A94B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "saveresultslambda2CAFC532": {
+      "DependsOn": [
+        "saveresultslambdaServiceRoleDefaultPolicyC690A6F5",
+        "saveresultslambdaServiceRoleDD59B626",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "S3_BUCKET": {
+              "Ref": "Bucket83908E77",
+            },
+            "STACK": "support",
+            "STAGE": "PROD",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-save-results-PROD",
+        "Handler": "saveResults.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "saveresultslambdaServiceRoleDD59B626",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "saveresultslambdaServiceRoleDD59B626": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "saveresultslambdaServiceRoleDefaultPolicyC690A6F5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "saveresultslambdaServiceRoleDefaultPolicyC690A6F5",
+        "Roles": [
+          {
+            "Ref": "saveresultslambdaServiceRoleDD59B626",
           },
         ],
       },

--- a/handlers/negative-invoices-processor/riff-raff.yaml
+++ b/handlers/negative-invoices-processor/riff-raff.yaml
@@ -25,4 +25,5 @@ deployments:
         - negative-invoices-processor-get-payment-methods-
         - negative-invoices-processor-apply-credit-to-account-balance-
         - negative-invoices-processor-do-credit-balance-refund-
+        - negative-invoices-processor-save-results-
     dependencies: [negative-invoices-processor-cloudformation]

--- a/handlers/negative-invoices-processor/src/handlers/saveResults.ts
+++ b/handlers/negative-invoices-processor/src/handlers/saveResults.ts
@@ -50,6 +50,6 @@ export const handler = async (event: SaveResultsInput) => {
 
 function generateFilePath(): string {
 	const executionDateTime = new Date().toISOString();
-	const [date, time] = executionDateTime.split('T');
-	return `${date}/${(time ?? '00:00:00.000').replace('Z', '')}.json`; //e.g. 2025-10-01/12:56:12.111.json
+	const date = executionDateTime.split('T')[0];
+	return `${date}/${executionDateTime}.json`; //e.g. 2025-10-01/2025-10-01T12:56:12.111Z.json
 }

--- a/handlers/negative-invoices-processor/src/handlers/saveResults.ts
+++ b/handlers/negative-invoices-processor/src/handlers/saveResults.ts
@@ -44,7 +44,7 @@ export const handler = async (event: SaveResultsInput) => {
 		return {
 			...event,
 			s3UploadAttemptStatus: 'error',
-			errorDetail:
+			error:
 				error instanceof Error ? error.message : JSON.stringify(error, null, 2),
 		};
 	}

--- a/handlers/negative-invoices-processor/src/handlers/saveResults.ts
+++ b/handlers/negative-invoices-processor/src/handlers/saveResults.ts
@@ -23,8 +23,8 @@ export const handler = async (event: SaveResultsInput) => {
 		);
 
 		const executionDateTime = new Date().toISOString();
-
-		const filePath = executionDateTime;
+		const [date, time] = executionDateTime.split('T');
+		const filePath = `${date}/${(time ?? '00:00:00.000').replace('Z', '')}`;
 
 		const s3UploadAttempt = await uploadFileToS3({
 			bucketName,

--- a/handlers/negative-invoices-processor/src/handlers/saveResults.ts
+++ b/handlers/negative-invoices-processor/src/handlers/saveResults.ts
@@ -1,0 +1,53 @@
+import { uploadFileToS3 } from '@modules/aws/s3';
+import { getIfDefined } from '@modules/nullAndUndefined';
+import { z } from 'zod';
+import { InvoiceSchema, ProcessedInvoiceSchema } from '../types';
+
+export const saveResultsInputSchema = z.object({
+	invoicesCount: z.number(),
+	invoices: z.array(InvoiceSchema),
+	processedInvoices: z.array(ProcessedInvoiceSchema),
+});
+export type SaveResultsInput = z.infer<typeof saveResultsInputSchema>;
+
+export const handler = async (event: SaveResultsInput) => {
+	try {
+		const parsedEventResult = saveResultsInputSchema.safeParse(event);
+		if (!parsedEventResult.success) {
+			throw new Error('Invalid event data');
+		}
+		const parsedEvent = parsedEventResult.data;
+		const bucketName = getIfDefined<string>(
+			process.env.S3_BUCKET,
+			'S3_BUCKET environment variable not set',
+		);
+
+		const discountExpiresOnDate = '2025-06-24';
+
+		const executionDateTime = new Date().toISOString();
+
+		const filePath = `${discountExpiresOnDate}/${executionDateTime}`;
+
+		const s3UploadAttempt = await uploadFileToS3({
+			bucketName,
+			filePath,
+			content: JSON.stringify(parsedEvent, null, 2),
+		});
+
+		if (s3UploadAttempt.$metadata.httpStatusCode !== 200) {
+			throw new Error('Failed to upload to S3');
+		}
+		return {
+			...parsedEvent,
+			s3UploadAttemptStatus: 'success',
+			filePath,
+		};
+	} catch (error) {
+		return {
+			...event,
+			s3UploadAttemptStatus: 'error',
+			errorDetail:
+				error instanceof Error ? error.message : JSON.stringify(error, null, 2),
+		};
+	}
+};

--- a/handlers/negative-invoices-processor/src/handlers/saveResults.ts
+++ b/handlers/negative-invoices-processor/src/handlers/saveResults.ts
@@ -22,16 +22,14 @@ export const handler = async (event: SaveResultsInput) => {
 			'S3_BUCKET environment variable not set',
 		);
 
-		const executionDateTime = new Date().toISOString();
-		const [date, time] = executionDateTime.split('T');
-		const filePath = `${date}/${(time ?? '00:00:00.000').replace('Z', '')}`;
+		const filePath = generateFilePath();
 
 		const s3UploadAttempt = await uploadFileToS3({
 			bucketName,
 			filePath,
 			content: JSON.stringify(parsedEvent, null, 2),
 		});
-		console.log('S3 upload attempt:', s3UploadAttempt);
+
 		if (s3UploadAttempt.$metadata.httpStatusCode !== 200) {
 			throw new Error('Failed to upload to S3');
 		}
@@ -49,3 +47,9 @@ export const handler = async (event: SaveResultsInput) => {
 		};
 	}
 };
+
+function generateFilePath(): string {
+	const executionDateTime = new Date().toISOString();
+	const [date, time] = executionDateTime.split('T');
+	return `${date}/${(time ?? '00:00:00.000').replace('Z', '')}.json`; //e.g. 2025-10-01/12:56:12.111.json
+}

--- a/handlers/negative-invoices-processor/src/handlers/saveResults.ts
+++ b/handlers/negative-invoices-processor/src/handlers/saveResults.ts
@@ -22,18 +22,16 @@ export const handler = async (event: SaveResultsInput) => {
 			'S3_BUCKET environment variable not set',
 		);
 
-		const discountExpiresOnDate = '2025-06-24';
-
 		const executionDateTime = new Date().toISOString();
 
-		const filePath = `${discountExpiresOnDate}/${executionDateTime}`;
+		const filePath = executionDateTime;
 
 		const s3UploadAttempt = await uploadFileToS3({
 			bucketName,
 			filePath,
 			content: JSON.stringify(parsedEvent, null, 2),
 		});
-
+		console.log('S3 upload attempt:', s3UploadAttempt);
 		if (s3UploadAttempt.$metadata.httpStatusCode !== 200) {
 			throw new Error('Failed to upload to S3');
 		}

--- a/handlers/negative-invoices-processor/src/types.ts
+++ b/handlers/negative-invoices-processor/src/types.ts
@@ -11,3 +11,28 @@ export const InvoiceSchema = z
 export type InvoiceRecord = z.infer<typeof InvoiceSchema>;
 
 export const InvoiceRecordsArraySchema = z.array(InvoiceSchema);
+
+export const PaymentMethodSchema = z.object({
+	id: z.string(),
+	status: z.string(),
+	type: z.string(),
+	isDefault: z.boolean(),
+});
+
+export const ApplyCreditToAccountBalanceAttemptSchema = z.object({
+	Success: z.boolean(),
+});
+
+export const RefundAttemptSchema = z.object({
+	Success: z.boolean(),
+	paymentMethod: PaymentMethodSchema.optional(),
+});
+
+export const ProcessedInvoiceSchema = InvoiceSchema.extend({
+	hasActiveSub: z.boolean().optional(),
+	applyCreditToAccountBalanceAttempt: ApplyCreditToAccountBalanceAttemptSchema,
+	hasActivePaymentMethod: z.boolean().optional(),
+	activePaymentMethods: z.array(PaymentMethodSchema).optional(),
+	refundAttempt: RefundAttemptSchema.optional(),
+	errorDetail: z.string().optional(),
+});

--- a/handlers/negative-invoices-processor/test/handlers/data/CODEDataMockQueryResponse.ts
+++ b/handlers/negative-invoices-processor/test/handlers/data/CODEDataMockQueryResponse.ts
@@ -2,9 +2,9 @@
 export const CODEDataMockQueryResponse = [
 	{
 		//actual records from the Zuora dev sandbox. Update as needed.
-		accountId: '8ad09fc283d5e5030183d6c0ad002031',
-		invoiceId: '8ad085298634dd38018639f5fcae2247',
-		invoiceNumber: 'INV00303506',
+		accountId: '8ad08aef83d5d6330183d6b24bd46138',
+		invoiceId: '8ad085298634dd3801863a16a1cd3024',
+		invoiceNumber: 'INV00316069',
 		invoiceBalance: -30.0,
 	},
 	{


### PR DESCRIPTION
## What does this change?
- Add a lambda to save state machine payload to S3 upon completion of processing invoices, for logging and troubleshooting

<img width="783" alt="Screenshot 2025-06-26 at 09 21 27" src="https://github.com/user-attachments/assets/53f29f84-b961-4032-96d1-67da6e233d43" />

_Example contents_
```
{
  "invoicesCount": 2,
  "invoices": [
    {
      "invoiceId": "8ad085298634dd38018639f5fcae2247",
      "accountId": "8ad09fc283d5e5030183d6c0ad002031",
      "invoiceNumber": "INV00303506",
      "invoiceBalance": -30
    },
    {
      "invoiceId": "1c91a0ad795f6bcc017966151113650d",
      "accountId": "3c93a0ff5bec3ec3015c0ca913e7415b",
      "invoiceNumber": "XXX",
      "invoiceBalance": -2
    }
  ],
  "processedInvoices": [
    {
      "invoiceId": "8ad085298634dd38018639f5fcae2247",
      "accountId": "8ad09fc283d5e5030183d6c0ad002031",
      "invoiceNumber": "INV00303506",
      "invoiceBalance": -30,
      "applyCreditToAccountBalanceAttempt": {
        "Success": false
      },
      "errorDetail": "Bad Request"
    },
    {
      "invoiceId": "1c91a0ad795f6bcc017966151113650d",
      "accountId": "3c93a0ff5bec3ec3015c0ca913e7415b",
      "invoiceNumber": "XXX",
      "invoiceBalance": -2,
      "applyCreditToAccountBalanceAttempt": {
        "Success": false
      },
      "errorDetail": "Bad Request"
    }
  ]
}
```
## How to test
- execute the state machine and verify the file gets saved to S3:
<img width="931" alt="Screenshot 2025-06-26 at 09 20 01" src="https://github.com/user-attachments/assets/b8d96bd6-0e50-4c58-83ac-6d2202b2d086" />
