### PR TITLE
Refactor submitDataSubjectRequest to remove lambdaDomainUrl parameter…

### DIFF
--- a/handlers/mparticle-api/src/apis/data-subject-requests.ts
+++ b/handlers/mparticle-api/src/apis/data-subject-requests.ts
@@ -77,10 +77,9 @@ async function requestDataSubjectApi<T>(url: string, options: {
  * The OpenDSR Request takes a JSON request body and requires a Content-Type: application/json header.
  * https://docs.mparticle.com/developers/apis/dsr-api/v3/#submit-a-data-subject-request-dsr
  * @param {DataSubjectRequestForm} form - The form containing the data subject request details.
- * @param {string} lambdaDomainUrl - Current running lambda domain url
  * @returns https://docs.mparticle.com/developers/apis/dsr-api/v3/#example-success-response-body
  */
-export const submitDataSubjectRequest = async (form: DataSubjectRequestForm, lambdaDomainUrl: string): Promise<DataSubjectRequestSubmission> => {
+export const submitDataSubjectRequest = async (form: DataSubjectRequestForm): Promise<DataSubjectRequestSubmission> => {
     const response = await requestDataSubjectApi<{
         expected_completion_time: Date;
         received_time: Date;
@@ -103,7 +102,10 @@ export const submitDataSubjectRequest = async (form: DataSubjectRequestForm, lam
             },
             api_version: "3.0",
             status_callback_urls: [
-                `${lambdaDomainUrl}/data-subject-requests/${form.requestId}/callback`
+                `${getSecretValue(
+                    `/mparticle-api/${stageFromEnvironment()}/api-gateway-url`,
+                    'MPARTICLE_API_GATEWAY_URL'
+                )}/data-subject-requests/${form.requestId}/callback`
             ],
             group_id: form.userId, // Let's group by User Unique Id to group all requests related to that user (max 150 requests per group)
         }

--- a/handlers/mparticle-api/src/index.ts
+++ b/handlers/mparticle-api/src/index.ts
@@ -55,15 +55,9 @@ const router = new Router([
                 console.warn("It was not possible to set the User Attribute to remove user from audiences or from event forwarding during the waiting period.", error)
             }
 
-            // Request for Erasure
-            const domain = event.headers['host'] ?? 'code.dev-theguardian.com'; // e.g., "abc123.lambda-url.region.on.aws" or API Gateway domain
-            const protocol = event.headers['x-forwarded-proto'] ?? 'https';
-            const lambdaDomainUrl = `${protocol}://${domain}`;
-            const requestForErasureResult = await submitDataSubjectRequest(parsed.body, lambdaDomainUrl)
-
             return {
                 statusCode: 201,
-                body: JSON.stringify(requestForErasureResult),
+                body: JSON.stringify(await submitDataSubjectRequest(parsed.body)),
             };
         }),
         parser: {


### PR DESCRIPTION
This pull request simplifies the handling of API gateway URLs in the `mparticle-api` service by removing the concept of generating the lambda domain URL based on the request and replacing it with a secret-based approach. 

### Simplification of API Gateway URL Handling:

* [`handlers/mparticle-api/src/apis/data-subject-requests.ts`](diffhunk://#diff-576d76677bb1f209c474d33ac5b8abe5d0924e3ff5547e3dc046a5a8e7efd118L80-R82): Removed the `lambdaDomainUrl` parameter from the `submitDataSubjectRequest` function. The callback URL is now constructed using a secret value retrieved from the environment instead of relying on the dynamic lambda domain URL. [[1]](diffhunk://#diff-576d76677bb1f209c474d33ac5b8abe5d0924e3ff5547e3dc046a5a8e7efd118L80-R82) [[2]](diffhunk://#diff-576d76677bb1f209c474d33ac5b8abe5d0924e3ff5547e3dc046a5a8e7efd118L106-R108)

### Code Cleanup:

* [`handlers/mparticle-api/src/index.ts`](diffhunk://#diff-5337205cb740a327a40dd884da9e0ebb8b16e47175c40ba890d8e477436e8501L58-R60): Removed the logic for dynamically constructing the `lambdaDomainUrl` from request headers and simplified the call to `submitDataSubjectRequest` by eliminating the `lambdaDomainUrl` argument.