### PR TITLE
use semi-auto json in SOI setter

### DIFF
--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculator.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/ConsentsCalculator.scala
@@ -1,12 +1,16 @@
 package com.gu.soft_opt_in_consent_setter
 
 import com.gu.soft_opt_in_consent_setter.models.SoftOptInError
-import io.circe.generic.auto._
+import io.circe.Encoder
+import io.circe.generic.semiauto._
 import io.circe.syntax.EncoderOps
 
 class ConsentsCalculator(consentsMappings: Map[String, Set[String]]) {
 
   case class ConsentsObject(id: String, consented: Boolean)
+  object ConsentsObject {
+    implicit val encoder: Encoder[ConsentsObject] = deriveEncoder[ConsentsObject]
+  }
 
   def getSoftOptInsByProduct(productName: String): Either[SoftOptInError, Set[String]] = {
     consentsMappings

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/Handler.scala
@@ -1,9 +1,18 @@
 package com.gu.soft_opt_in_consent_setter
 
 import com.gu.soft_opt_in_consent_setter.models.ConsentsMapping.similarGuardianProducts
-import com.gu.soft_opt_in_consent_setter.models.{ConsentsMapping, EnhancedSub, SFAssociatedSubResponse, SFSubRecord, SFSubRecordUpdate, SFSubRecordUpdateRequest, SoftOptInConfig, SoftOptInError}
+import com.gu.soft_opt_in_consent_setter.models.{
+  ConsentsMapping,
+  EnhancedSub,
+  SFAssociatedSubResponse,
+  SFSubRecord,
+  SFSubRecordUpdate,
+  SFSubRecordUpdateRequest,
+  SoftOptInConfig,
+  SoftOptInError,
+}
 import com.typesafe.scalalogging.LazyLogging
-import io.circe.generic.auto._
+import io.circe.generic.semiauto._
 import io.circe.syntax._
 
 object Handler extends LazyLogging {

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/HandlerIAP.scala
@@ -6,7 +6,7 @@ import com.gu.soft_opt_in_consent_setter.HandlerIAP.{Acquisition, MessageBody, U
 import com.gu.soft_opt_in_consent_setter.models._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.{Decoder, ParsingFailure}
-import io.circe.generic.auto._
+import io.circe.generic.semiauto._
 import io.circe.parser.{decode => circeDecode}
 
 import scala.jdk.CollectionConverters._
@@ -61,6 +61,10 @@ object HandlerIAP extends LazyLogging with RequestHandler[SQSEvent, Unit] {
       previousProductName: Option[String],
       userConsentsOverrides: Option[UserConsentsOverrides],
   )
+  object MessageBody {
+    implicit val decoderUserConsentsOverrides: Decoder[UserConsentsOverrides] = deriveDecoder[UserConsentsOverrides]
+    implicit val decoder: Decoder[MessageBody] = deriveDecoder[MessageBody]
+  }
 
   def handleError[T <: Exception](exception: T) = {
     Metrics.put(event = "failed_run")

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IAPMessageProcessor.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/IAPMessageProcessor.scala
@@ -4,7 +4,7 @@ import com.gu.soft_opt_in_consent_setter.HandlerIAP.{Acquisition, Cancellation, 
 import com.gu.soft_opt_in_consent_setter.models.ConsentsMapping.similarGuardianProducts
 import com.gu.soft_opt_in_consent_setter.models.{ConsentsMapping, SoftOptInConfig, SoftOptInError}
 import com.typesafe.scalalogging.StrictLogging
-import io.circe.generic.auto._
+import io.circe.generic.semiauto._
 import io.circe.syntax._
 
 import scala.util.{Failure, Success}

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/MpapiConnector.scala
@@ -3,13 +3,17 @@ package com.gu.soft_opt_in_consent_setter
 import com.gu.soft_opt_in_consent_setter.models.{MpapiConfig, SoftOptInError}
 import io.circe.Decoder
 import io.circe.parser.decode
-import io.circe.generic.auto._
+import io.circe.generic.semiauto._
 import scalaj.http.{Http, HttpResponse}
 
 import scala.util.Try
 
 case class MobileSubscriptions(subscriptions: List[MobileSubscription])
 case class MobileSubscription(valid: Boolean, softOptInProductName: String)
+object MobileSubscriptions {
+  implicit val decoderMobileSubscription: Decoder[MobileSubscription] = deriveDecoder
+  implicit val decoderMobileSubscriptions: Decoder[MobileSubscriptions] = deriveDecoder
+}
 
 class MpapiConnector(config: MpapiConfig) {
 

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnector.scala
@@ -11,7 +11,7 @@ import com.gu.soft_opt_in_consent_setter.models.{
 }
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.Decoder
-import io.circe.generic.auto._
+import io.circe.generic.semiauto._
 import io.circe.parser.decode
 import scalaj.http.{Http, HttpOptions, HttpRequest, HttpResponse}
 
@@ -148,7 +148,7 @@ object SalesforceConnector {
     response.left
       .map(i => SoftOptInError(s"SalesforceConnector: Salesforce authentication failed: $i", i))
       .flatMap { result =>
-        decode[SalesforceAuth](result.body).left
+        decode[SalesforceAuth](result.body)(deriveDecoder[SalesforceAuth]).left
           .map(i =>
             SoftOptInError(
               s"SalesforceConnector: Could not decode SfAuthDetails: $i. String to decode: ${result.body}",

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfAssociatedSub.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfAssociatedSub.scala
@@ -1,5 +1,12 @@
 package com.gu.soft_opt_in_consent_setter.models
 
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
 case class SFAssociatedSubResponse(totalSize: Int, done: Boolean, records: Seq[SFAssociatedSubRecord])
+object SFAssociatedSubResponse {
+  implicit val decoderSFAssociatedSubRecord: Decoder[SFAssociatedSubRecord] = deriveDecoder
+  implicit val decoder: Decoder[SFAssociatedSubResponse] = deriveDecoder
+}
 
 case class SFAssociatedSubRecord(Product__c: String, IdentityID__c: String)

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfCompositeRequest.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfCompositeRequest.scala
@@ -1,5 +1,8 @@
 package com.gu.soft_opt_in_consent_setter.models
 
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
 case class SFCompositeResponse(responses: List[SFResponse]) {
   lazy val hasErrors: Boolean = responses.exists(!_.success)
   lazy val errorsAsString: Option[String] =
@@ -8,6 +11,10 @@ case class SFCompositeResponse(responses: List[SFResponse]) {
 
 case class SFResponse(id: Option[String], success: Boolean, errors: List[SFResponseError]) {
   def errorAsString: Option[String] = if (success) None else Some(s"Errors: ${errors.map(a => a.errorAsString)}.")
+}
+object SFResponse {
+  implicit val decoderSFResponseError: Decoder[SFResponseError] = deriveDecoder
+  implicit val decoder: Decoder[SFResponse] = deriveDecoder
 }
 
 case class SFResponseError(statusCode: String, message: String, fields: List[String]) {

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfSubRecord.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfSubRecord.scala
@@ -1,5 +1,8 @@
 package com.gu.soft_opt_in_consent_setter.models
 
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
 case class SFSubRecord(
     Id: String,
     Name: String,
@@ -32,3 +35,12 @@ case class Subscription_Rate_Plan_Updates__r(
 case class SFBuyer(IdentityID__c: String)
 
 case class SFSubRecordResponse(totalSize: Int, done: Boolean, records: Seq[SFSubRecord])
+object SFSubRecordResponse {
+  implicit val decoderSFBuyer: Decoder[SFBuyer] = deriveDecoder
+  implicit val decoderSFSubscription: Decoder[SFSubscription__r] = deriveDecoder
+  implicit val decoderSubscription_Rate_Plan_Updates__r: Decoder[Subscription_Rate_Plan_Updates__r] = deriveDecoder
+  implicit val decoderSubscriptionRatePlanUpdateRecord: Decoder[SubscriptionRatePlanUpdateRecord] = deriveDecoder
+  implicit val decoderSFSubRecord: Decoder[SFSubRecord] = deriveDecoder
+
+  implicit val decoder: Decoder[SFSubRecordResponse] = deriveDecoder
+}

--- a/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfSubRecordUpdate.scala
+++ b/handlers/soft-opt-in-consent-setter/src/main/scala/com/gu/soft_opt_in_consent_setter/models/sfSubRecordUpdate.scala
@@ -1,5 +1,8 @@
 package com.gu.soft_opt_in_consent_setter.models
 
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+
 case class SFSubRecordUpdate(
     Id: String,
     Soft_Opt_in_Last_Stage_Processed__c: Option[String] = None,
@@ -11,6 +14,11 @@ case class Attributes(`type`: String)
 
 case class SFSubRecordUpdateRequest(records: Seq[SFSubRecordUpdate]) {
   def allOrNone = false
+}
+object SFSubRecordUpdateRequest {
+  implicit val encoderAttributes: Encoder[Attributes] = deriveEncoder[Attributes]
+  implicit val encoderSFSubRecordUpdate: Encoder[SFSubRecordUpdate] = deriveEncoder[SFSubRecordUpdate]
+  implicit val encoder: Encoder[SFSubRecordUpdateRequest] = deriveEncoder[SFSubRecordUpdateRequest]
 }
 
 object SFSubRecordUpdate {

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com/gu/soft_opt_in_consent_setter/JsonCodecSpec.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com/gu/soft_opt_in_consent_setter/JsonCodecSpec.scala
@@ -5,7 +5,6 @@ import com.gu.soft_opt_in_consent_setter.models.SFSubRecordResponse
 import com.gu.soft_opt_in_consent_setter.testData.SFSubscriptionTestData.{subRecord2, subRecord3}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
-import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.scalatest.Inside
 

--- a/handlers/soft-opt-in-consent-setter/src/test/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnectorTests.scala
+++ b/handlers/soft-opt-in-consent-setter/src/test/scala/com/gu/soft_opt_in_consent_setter/SalesforceConnectorTests.scala
@@ -13,7 +13,6 @@ import com.gu.soft_opt_in_consent_setter.testData.SalesforceTestData.{
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
-import io.circe.generic.auto._
 
 class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with EitherValues {
 


### PR DESCRIPTION
pre-refactor to make it easier to review https://github.com/guardian/support-service-lambdas/pull/2912

This PR changes soft-opt-in-consent-setter to use [semiauto](https://circe.github.io/circe/codecs/semiauto-derivation.html) instead of [auto](https://circe.github.io/circe/codecs/auto-derivation.html) decoders.

Although this means there's more boiler plate as we can't use `derives` syntax in scala 2, it means that

- we won't accidentally conjoure up a decoder for something that shouldn't.
- It's more typical in our code to do it this way, and
- in the context of the following PR, it means we're less likely to accidentally mix up WireMessageBody and MessageBody either in the code or the tests.