### PR TITLE
Negative invoices processor - detect failures

### DIFF
--- a/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
+++ b/cdk/lib/__snapshots__/negative-invoices-processor.test.ts.snap
@@ -11,6 +11,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -517,6 +518,226 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "detectfailureslambdaC74342D4": {
+      "DependsOn": [
+        "detectfailureslambdaServiceRoleDefaultPolicy3DDBCAA1",
+        "detectfailureslambdaServiceRoleF1228A8B",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "STACK": "support",
+            "STAGE": "CODE",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-detect-failures-CODE",
+        "Handler": "detectFailures.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "detectfailureslambdaServiceRoleF1228A8B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "detectfailureslambdaServiceRoleDefaultPolicy3DDBCAA1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/CODE/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "detectfailureslambdaServiceRoleDefaultPolicy3DDBCAA1",
+        "Roles": [
+          {
+            "Ref": "detectfailureslambdaServiceRoleF1228A8B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "detectfailureslambdaServiceRoleF1228A8B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "docreditbalancerefundlambda2AAB1C48": {
       "DependsOn": [
@@ -1116,7 +1337,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}}},"Save results to S3":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}}}}},"Save results to S3":{"Next":"Alarm on failures","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -1124,6 +1345,17 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
               {
                 "Fn::GetAtt": [
                   "saveresultslambda2CAFC532",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Alarm on failures":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "detectfailureslambdaC74342D4",
                   "Arn",
                 ],
               },
@@ -1207,6 +1439,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 1`] = `
                       {
                         "Fn::GetAtt": [
                           "saveresultslambda2CAFC532",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "detectfailureslambdaC74342D4",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "detectfailureslambdaC74342D4",
                           "Arn",
                         ],
                       },
@@ -1796,6 +2054,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -2302,6 +2561,226 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "detectfailureslambdaC74342D4": {
+      "DependsOn": [
+        "detectfailureslambdaServiceRoleDefaultPolicy3DDBCAA1",
+        "detectfailureslambdaServiceRoleF1228A8B",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "negative-invoices-processor",
+            "STACK": "support",
+            "STAGE": "PROD",
+            "Stage": "PROD",
+          },
+        },
+        "FunctionName": "negative-invoices-processor-detect-failures-PROD",
+        "Handler": "detectFailures.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "detectfailureslambdaServiceRoleF1228A8B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "detectfailureslambdaServiceRoleDefaultPolicy3DDBCAA1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/negative-invoices-processor/negative-invoices-processor.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/negative-invoices-processor/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "detectfailureslambdaServiceRoleDefaultPolicy3DDBCAA1",
+        "Roles": [
+          {
+            "Ref": "detectfailureslambdaServiceRoleF1228A8B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "detectfailureslambdaServiceRoleF1228A8B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "negative-invoices-processor",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "docreditbalancerefundlambda2AAB1C48": {
       "DependsOn": [
@@ -2901,7 +3380,7 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}}}}},"Save results to S3":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}}}}},"Save results to S3":{"Next":"Alarm on failures","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2909,6 +3388,17 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
               {
                 "Fn::GetAtt": [
                   "saveresultslambda2CAFC532",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"Alarm on failures":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":10,"MaxAttempts":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "detectfailureslambdaC74342D4",
                   "Arn",
                 ],
               },
@@ -3027,6 +3517,32 @@ exports[`The negative-invoices-processor stack matches the snapshot 2`] = `
                       {
                         "Fn::GetAtt": [
                           "saveresultslambda2CAFC532",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "detectfailureslambdaC74342D4",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "detectfailureslambdaC74342D4",
                           "Arn",
                         ],
                       },

--- a/handlers/negative-invoices-processor/riff-raff.yaml
+++ b/handlers/negative-invoices-processor/riff-raff.yaml
@@ -26,4 +26,5 @@ deployments:
         - negative-invoices-processor-apply-credit-to-account-balance-
         - negative-invoices-processor-do-credit-balance-refund-
         - negative-invoices-processor-save-results-
+        - negative-invoices-processor-detect-failures-
     dependencies: [negative-invoices-processor-cloudformation]

--- a/handlers/negative-invoices-processor/src/handlers/detectFailures.ts
+++ b/handlers/negative-invoices-processor/src/handlers/detectFailures.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/require-await -- this is required to ensure the lambda returns a value*/
 
 import { DetectFailuresInputSchema } from '../types';
-import type { DetectFailuresInput, ProcessedInvoice } from '../types';
+import type { DetectFailuresInput } from '../types';
+import { ProcessedInvoice } from '../types/shared';
 
 export const handler = async (event: DetectFailuresInput) => {
 	try {

--- a/handlers/negative-invoices-processor/src/handlers/detectFailures.ts
+++ b/handlers/negative-invoices-processor/src/handlers/detectFailures.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/require-await -- this is required to ensure the lambda returns a value*/
+
+import { DetectFailuresInputSchema } from '../types';
+import type { DetectFailuresInput, ProcessedInvoice } from '../types';
+
+export const handler = async (event: DetectFailuresInput) => {
+	try {
+		const parsedEvent = DetectFailuresInputSchema.parse(event);
+		const failureDetected = await failureExistsOnInvoiceProcessingAttempt(
+			parsedEvent.processedInvoices,
+			parsedEvent.s3UploadAttemptStatus,
+		);
+
+		if (failureDetected) {
+			throw new Error('Failure occurred. Check logs.');
+		}
+	} catch (error) {
+		console.log('Error occurred:', error);
+		throw new Error(
+			error instanceof Error ? error.message : JSON.stringify(error, null, 2),
+		);
+	}
+	return {};
+};
+
+export const failureExistsOnInvoiceProcessingAttempt = async (
+	processedInvoices: ProcessedInvoice[],
+	s3UploadAttemptStatus: string,
+): Promise<boolean> => {
+	if (s3UploadAttemptStatus === 'error') {
+		return true;
+	}
+
+	return processedInvoices.some((invoice) =>
+		invoiceHasAtLeastOneProcessingFailure(invoice),
+	);
+};
+
+export function invoiceHasAtLeastOneProcessingFailure(
+	invoice: ProcessedInvoice,
+): boolean {
+	const {
+		applyCreditToAccountBalanceAttempt,
+		checkForActiveSubAttempt,
+		checkForActivePaymentMethodAttempt,
+	} = invoice;
+
+	return (
+		!applyCreditToAccountBalanceAttempt.Success ||
+		!checkForActiveSubAttempt?.Success ||
+		!checkForActivePaymentMethodAttempt?.Success
+	);
+}

--- a/handlers/negative-invoices-processor/src/handlers/detectFailures.ts
+++ b/handlers/negative-invoices-processor/src/handlers/detectFailures.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/require-await -- this is required to ensure the lambda returns a value*/
 import { DetectFailuresInputSchema } from '../types';
 import type { DetectFailuresInput } from '../types';
-import { ProcessedInvoice } from '../types/shared';
+import type { ProcessedInvoice } from '../types/shared';
 
 export const handler = async (event: DetectFailuresInput) => {
 	try {

--- a/handlers/negative-invoices-processor/src/handlers/detectFailures.ts
+++ b/handlers/negative-invoices-processor/src/handlers/detectFailures.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/require-await -- this is required to ensure the lambda returns a value*/
-
 import { DetectFailuresInputSchema } from '../types';
 import type { DetectFailuresInput } from '../types';
 import { ProcessedInvoice } from '../types/shared';

--- a/handlers/negative-invoices-processor/src/types/handlers/DetectFailures.ts
+++ b/handlers/negative-invoices-processor/src/types/handlers/DetectFailures.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+import { SaveResultsOutputSchema } from './SaveResults';
+
+export const DetectFailuresInputSchema = SaveResultsOutputSchema;
+export type DetectFailuresInput = z.infer<typeof DetectFailuresInputSchema>;

--- a/handlers/negative-invoices-processor/src/types/handlers/index.ts
+++ b/handlers/negative-invoices-processor/src/types/handlers/index.ts
@@ -44,3 +44,9 @@ export {
 	type SaveResultsInput,
 	type SaveResultsOutput,
 } from './SaveResults';
+
+// DetectFailures exports
+export {
+	DetectFailuresInputSchema,
+	type DetectFailuresInput,
+} from './DetectFailures';

--- a/handlers/negative-invoices-processor/src/types/shared/index.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/index.ts
@@ -4,3 +4,8 @@ export {
 	InvoiceRecordsArraySchema,
 	type InvoiceRecord,
 } from './invoiceSchemas';
+
+export {
+	ProcessedInvoiceSchema,
+	type ProcessedInvoice,
+} from './processedInvoice';

--- a/handlers/negative-invoices-processor/src/types/shared/processedInvoice.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/processedInvoice.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { InvoiceSchema } from './invoiceSchemas';
+import { ApplyCreditToAccountBalanceAttemptSchema } from '../handlers/ApplyCreditToAccountBalance';
+import {
+	CheckForActivePaymentMethodAttemptSchema,
+	CheckForActiveSubAttemptSchema,
+	RefundAttemptSchema,
+} from '../handlers';
+
+export const ProcessedInvoiceSchema = InvoiceSchema.extend({
+	applyCreditToAccountBalanceAttempt: ApplyCreditToAccountBalanceAttemptSchema,
+	checkForActiveSubAttempt: CheckForActiveSubAttemptSchema.optional(),
+	checkForActivePaymentMethodAttempt:
+		CheckForActivePaymentMethodAttemptSchema.optional(),
+	refundAttempt: RefundAttemptSchema.optional(),
+});
+
+export type ProcessedInvoice = z.infer<typeof ProcessedInvoiceSchema>;

--- a/handlers/negative-invoices-processor/src/types/shared/processedInvoice.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/processedInvoice.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { InvoiceSchema } from './invoiceSchemas';
 import { ApplyCreditToAccountBalanceAttemptSchema } from '../handlers/ApplyCreditToAccountBalance';
-import {
-	CheckForActivePaymentMethodAttemptSchema,
-	CheckForActiveSubAttemptSchema,
-	RefundAttemptSchema,
-} from '../handlers';
+import { CheckForActiveSubAttemptSchema } from '../handlers/CheckForActiveSub';
+import { CheckForActivePaymentMethodAttemptSchema } from '../handlers/GetPaymentMethods';
+import { RefundAttemptSchema } from '../handlers/DoCreditBalanceRefund';
 
 export const ProcessedInvoiceSchema = InvoiceSchema.extend({
 	applyCreditToAccountBalanceAttempt: ApplyCreditToAccountBalanceAttemptSchema,

--- a/handlers/negative-invoices-processor/test/handlers/detectFailures.test.ts
+++ b/handlers/negative-invoices-processor/test/handlers/detectFailures.test.ts
@@ -1,0 +1,456 @@
+import {
+	failureExistsOnInvoiceProcessingAttempt,
+	handler,
+	invoiceHasAtLeastOneProcessingFailure,
+} from '../../src/handlers/detectFailures';
+import type { DetectFailuresInput } from '../../src/types';
+import type { ProcessedInvoice } from '../../src/types/shared';
+
+jest.mock('@modules/validation/index', () => ({
+	validateInput: jest.fn(<T>(input: T): T => input),
+}));
+
+describe('detectFailures handler', () => {
+	describe('invoiceHasAtLeastOneProcessingFailure', () => {
+		it('should return true when applyCreditToAccountBalanceAttempt fails', () => {
+			const invoice: ProcessedInvoice = {
+				invoiceId: 'INV-001',
+				accountId: 'ACC-001',
+				invoiceNumber: 'INV-001',
+				invoiceBalance: 100,
+				applyCreditToAccountBalanceAttempt: {
+					Success: false,
+					error: 'Credit application failed',
+				},
+				checkForActiveSubAttempt: {
+					Success: true,
+					hasActiveSub: true,
+				},
+				checkForActivePaymentMethodAttempt: {
+					Success: true,
+					hasActivePaymentMethod: true,
+					activePaymentMethods: [],
+				},
+			};
+
+			const result = invoiceHasAtLeastOneProcessingFailure(invoice);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when checkForActiveSubAttempt fails', () => {
+			const invoice: ProcessedInvoice = {
+				invoiceId: 'INV-001',
+				accountId: 'ACC-001',
+				invoiceNumber: 'INV-001',
+				invoiceBalance: 100,
+				applyCreditToAccountBalanceAttempt: {
+					Success: true,
+				},
+				checkForActiveSubAttempt: {
+					Success: false,
+					error: 'Active sub check failed',
+				},
+				checkForActivePaymentMethodAttempt: {
+					Success: true,
+					hasActivePaymentMethod: true,
+					activePaymentMethods: [],
+				},
+			};
+
+			const result = invoiceHasAtLeastOneProcessingFailure(invoice);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when checkForActivePaymentMethodAttempt fails', () => {
+			const invoice: ProcessedInvoice = {
+				invoiceId: 'INV-001',
+				accountId: 'ACC-001',
+				invoiceNumber: 'INV-001',
+				invoiceBalance: 100,
+				applyCreditToAccountBalanceAttempt: {
+					Success: true,
+				},
+				checkForActiveSubAttempt: {
+					Success: true,
+					hasActiveSub: true,
+				},
+				checkForActivePaymentMethodAttempt: {
+					Success: false,
+					error: 'Payment method check failed',
+				},
+			};
+
+			const result = invoiceHasAtLeastOneProcessingFailure(invoice);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when checkForActiveSubAttempt is undefined', () => {
+			const invoice: ProcessedInvoice = {
+				invoiceId: 'INV-001',
+				accountId: 'ACC-001',
+				invoiceNumber: 'INV-001',
+				invoiceBalance: 100,
+				applyCreditToAccountBalanceAttempt: {
+					Success: true,
+				},
+				// checkForActiveSubAttempt is undefined
+				checkForActivePaymentMethodAttempt: {
+					Success: true,
+					hasActivePaymentMethod: true,
+					activePaymentMethods: [],
+				},
+			};
+
+			const result = invoiceHasAtLeastOneProcessingFailure(invoice);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when checkForActivePaymentMethodAttempt is undefined', () => {
+			const invoice: ProcessedInvoice = {
+				invoiceId: 'INV-001',
+				accountId: 'ACC-001',
+				invoiceNumber: 'INV-001',
+				invoiceBalance: 100,
+				applyCreditToAccountBalanceAttempt: {
+					Success: true,
+				},
+				checkForActiveSubAttempt: {
+					Success: true,
+					hasActiveSub: true,
+				},
+				// checkForActivePaymentMethodAttempt is undefined
+			};
+
+			const result = invoiceHasAtLeastOneProcessingFailure(invoice);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when all attempts succeed', () => {
+			const invoice: ProcessedInvoice = {
+				invoiceId: 'INV-001',
+				accountId: 'ACC-001',
+				invoiceNumber: 'INV-001',
+				invoiceBalance: 100,
+				applyCreditToAccountBalanceAttempt: {
+					Success: true,
+				},
+				checkForActiveSubAttempt: {
+					Success: true,
+					hasActiveSub: true,
+				},
+				checkForActivePaymentMethodAttempt: {
+					Success: true,
+					hasActivePaymentMethod: true,
+					activePaymentMethods: [],
+				},
+			};
+
+			const result = invoiceHasAtLeastOneProcessingFailure(invoice);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when multiple attempts fail', () => {
+			const invoice: ProcessedInvoice = {
+				invoiceId: 'INV-001',
+				accountId: 'ACC-001',
+				invoiceNumber: 'INV-001',
+				invoiceBalance: 100,
+				applyCreditToAccountBalanceAttempt: {
+					Success: false,
+					error: 'Credit application failed',
+				},
+				checkForActiveSubAttempt: {
+					Success: false,
+					error: 'Active sub check failed',
+				},
+				checkForActivePaymentMethodAttempt: {
+					Success: false,
+					error: 'Payment method check failed',
+				},
+			};
+
+			const result = invoiceHasAtLeastOneProcessingFailure(invoice);
+
+			expect(result).toBe(true);
+		});
+	});
+
+	describe('failureExistsOnInvoiceProcessingAttempt', () => {
+		it('should return true when s3UploadAttemptStatus is error', async () => {
+			const processedInvoices: ProcessedInvoice[] = [
+				{
+					invoiceId: 'INV-001',
+					accountId: 'ACC-001',
+					invoiceNumber: 'INV-001',
+					invoiceBalance: 100,
+					applyCreditToAccountBalanceAttempt: {
+						Success: true,
+					},
+					checkForActiveSubAttempt: {
+						Success: true,
+						hasActiveSub: true,
+					},
+					checkForActivePaymentMethodAttempt: {
+						Success: true,
+						hasActivePaymentMethod: true,
+						activePaymentMethods: [],
+					},
+				},
+			];
+
+			const result = await failureExistsOnInvoiceProcessingAttempt(
+				processedInvoices,
+				'error',
+			);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when s3UploadAttemptStatus is success and all invoices succeed', async () => {
+			const processedInvoices: ProcessedInvoice[] = [
+				{
+					invoiceId: 'INV-001',
+					accountId: 'ACC-001',
+					invoiceNumber: 'INV-001',
+					invoiceBalance: 100,
+					applyCreditToAccountBalanceAttempt: {
+						Success: true,
+					},
+					checkForActiveSubAttempt: {
+						Success: true,
+						hasActiveSub: true,
+					},
+					checkForActivePaymentMethodAttempt: {
+						Success: true,
+						hasActivePaymentMethod: true,
+						activePaymentMethods: [],
+					},
+				},
+				{
+					invoiceId: 'INV-002',
+					accountId: 'ACC-002',
+					invoiceNumber: 'INV-002',
+					invoiceBalance: 200,
+					applyCreditToAccountBalanceAttempt: {
+						Success: true,
+					},
+					checkForActiveSubAttempt: {
+						Success: true,
+						hasActiveSub: true,
+					},
+					checkForActivePaymentMethodAttempt: {
+						Success: true,
+						hasActivePaymentMethod: true,
+						activePaymentMethods: [],
+					},
+				},
+			];
+
+			const result = await failureExistsOnInvoiceProcessingAttempt(
+				processedInvoices,
+				'success',
+			);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when s3UploadAttemptStatus is success but at least one invoice fails', async () => {
+			const processedInvoices: ProcessedInvoice[] = [
+				{
+					invoiceId: 'INV-001',
+					accountId: 'ACC-001',
+					invoiceNumber: 'INV-001',
+					invoiceBalance: 100,
+					applyCreditToAccountBalanceAttempt: {
+						Success: true,
+					},
+					checkForActiveSubAttempt: {
+						Success: true,
+						hasActiveSub: true,
+					},
+					checkForActivePaymentMethodAttempt: {
+						Success: true,
+						hasActivePaymentMethod: true,
+						activePaymentMethods: [],
+					},
+				},
+				{
+					invoiceId: 'INV-002',
+					accountId: 'ACC-002',
+					invoiceNumber: 'INV-002',
+					invoiceBalance: 200,
+					applyCreditToAccountBalanceAttempt: {
+						Success: false,
+						error: 'Credit application failed',
+					},
+					checkForActiveSubAttempt: {
+						Success: true,
+						hasActiveSub: true,
+					},
+					checkForActivePaymentMethodAttempt: {
+						Success: true,
+						hasActivePaymentMethod: true,
+						activePaymentMethods: [],
+					},
+				},
+			];
+
+			const result = await failureExistsOnInvoiceProcessingAttempt(
+				processedInvoices,
+				'success',
+			);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when processedInvoices is empty and s3UploadAttemptStatus is success', async () => {
+			const processedInvoices: ProcessedInvoice[] = [];
+
+			const result = await failureExistsOnInvoiceProcessingAttempt(
+				processedInvoices,
+				'success',
+			);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when processedInvoices is empty but s3UploadAttemptStatus is error', async () => {
+			const processedInvoices: ProcessedInvoice[] = [];
+
+			const result = await failureExistsOnInvoiceProcessingAttempt(
+				processedInvoices,
+				'error',
+			);
+
+			expect(result).toBe(true);
+		});
+	});
+
+	describe('handler', () => {
+		it('should not throw when no failures are detected', async () => {
+			const event: DetectFailuresInput = {
+				invoicesCount: 1,
+				invoices: [
+					{
+						invoiceId: 'INV-001',
+						accountId: 'ACC-001',
+						invoiceNumber: 'INV-001',
+						invoiceBalance: 100,
+					},
+				],
+				processedInvoices: [
+					{
+						invoiceId: 'INV-001',
+						accountId: 'ACC-001',
+						invoiceNumber: 'INV-001',
+						invoiceBalance: 100,
+						applyCreditToAccountBalanceAttempt: {
+							Success: true,
+						},
+						checkForActiveSubAttempt: {
+							Success: true,
+							hasActiveSub: true,
+						},
+						checkForActivePaymentMethodAttempt: {
+							Success: true,
+							hasActivePaymentMethod: true,
+							activePaymentMethods: [],
+						},
+					},
+				],
+				s3UploadAttemptStatus: 'success',
+				filePath: 'test-file-path',
+			};
+
+			const result = await handler(event);
+			expect(result).toEqual({});
+		});
+
+		it('should throw error when failures are detected', async () => {
+			const event: DetectFailuresInput = {
+				invoicesCount: 1,
+				invoices: [
+					{
+						invoiceId: 'INV-001',
+						accountId: 'ACC-001',
+						invoiceNumber: 'INV-001',
+						invoiceBalance: 100,
+					},
+				],
+				processedInvoices: [
+					{
+						invoiceId: 'INV-001',
+						accountId: 'ACC-001',
+						invoiceNumber: 'INV-001',
+						invoiceBalance: 100,
+						applyCreditToAccountBalanceAttempt: {
+							Success: false,
+							error: 'Credit application failed',
+						},
+						checkForActiveSubAttempt: {
+							Success: true,
+							hasActiveSub: true,
+						},
+						checkForActivePaymentMethodAttempt: {
+							Success: true,
+							hasActivePaymentMethod: true,
+							activePaymentMethods: [],
+						},
+					},
+				],
+				s3UploadAttemptStatus: 'success',
+				filePath: 'test-file-path',
+			};
+
+			await expect(handler(event)).rejects.toThrow(
+				'Failure occurred. Check logs.',
+			);
+		});
+
+		it('should throw error when s3UploadAttemptStatus is error', async () => {
+			const event: DetectFailuresInput = {
+				invoicesCount: 1,
+				invoices: [
+					{
+						invoiceId: 'INV-001',
+						accountId: 'ACC-001',
+						invoiceNumber: 'INV-001',
+						invoiceBalance: 100,
+					},
+				],
+				processedInvoices: [
+					{
+						invoiceId: 'INV-001',
+						accountId: 'ACC-001',
+						invoiceNumber: 'INV-001',
+						invoiceBalance: 100,
+						applyCreditToAccountBalanceAttempt: {
+							Success: true,
+						},
+						checkForActiveSubAttempt: {
+							Success: true,
+							hasActiveSub: true,
+						},
+						checkForActivePaymentMethodAttempt: {
+							Success: true,
+							hasActivePaymentMethod: true,
+							activePaymentMethods: [],
+						},
+					},
+				],
+				s3UploadAttemptStatus: 'error',
+				filePath: 'test-file-path',
+			};
+
+			await expect(handler(event)).rejects.toThrow(
+				'Failure occurred. Check logs.',
+			);
+		});
+	});
+});

--- a/handlers/negative-invoices-processor/test/handlers/detectFailures.test.ts
+++ b/handlers/negative-invoices-processor/test/handlers/detectFailures.test.ts
@@ -6,10 +6,6 @@ import {
 import type { DetectFailuresInput } from '../../src/types';
 import type { ProcessedInvoice } from '../../src/types/shared';
 
-jest.mock('@modules/validation/index', () => ({
-	validateInput: jest.fn(<T>(input: T): T => input),
-}));
-
 describe('detectFailures handler', () => {
 	describe('invoiceHasAtLeastOneProcessingFailure', () => {
 		it('should return true when applyCreditToAccountBalanceAttempt fails', () => {


### PR DESCRIPTION
## What does this change?
- add functionality to detect failures from the state machine json payload

_example of json payload containing a failure:_
```
{
  "invoicesCount": 1,
  "invoices": [
    {
      "invoiceId": "8ad085298634dd3801863a557084647d",
      "accountId": "8ad0877b843cb3df01843defacdf7706",
      "invoiceNumber": "INV00340121",
      "invoiceBalance": -20
    }
  ],
  "processedInvoices": [
    {
      "invoiceId": "8ad085298634dd3801863a557084647d",
      "accountId": "8ad0877b843cb3df01843defacdf7706",
      "invoiceNumber": "INV00340121",
      "invoiceBalance": -20,
      "applyCreditToAccountBalanceAttempt": {
        "Success": false, //<-- failure
        "error": "Bad Request"
      }
    }
  ],
  "s3UploadAttemptStatus": "success",
  "filePath": "2025-07-08/2025-07-08T10:41:07.516Z.json"
}
```

<img width="780" alt="Screenshot 2025-07-08 at 11 44 59" src="https://github.com/user-attachments/assets/32c658e9-2035-49b7-bfb3-c51af3d1b45e" />


## How to test

- automated tests have been added that verify that when failures occur in any of the interactions with Zuora, a failure is detected and an error is thrown
- simulate an error in an interaction with Zuora (e.g. try to apply credit to an account balance referencing an invoice without a negative balance), and verify an error gets thrown:
<img width="965" alt="Screenshot 2025-07-08 at 11 47 28" src="https://github.com/user-attachments/assets/5ffc1ebc-a9d0-4023-aba5-d8257d573802" />

### Coming next
- fire an alarm when error is is thrown