### PR TITLE
bigquery key rotation

### DIFF
--- a/lib/google-bigquery/src/main/scala/com/gu/google/BigQueryConfig.scala
+++ b/lib/google-bigquery/src/main/scala/com/gu/google/BigQueryConfig.scala
@@ -7,5 +7,5 @@ case class BigQueryConfig(bigQueryCredentials: JsObject)
 
 object BigQueryConfig {
   implicit val bigQueryConfigReads = Json.reads[BigQueryConfig]
-  implicit val location = ConfigLocation[BigQueryConfig](path = "bigQuery", version = 2)
+  implicit val location = ConfigLocation[BigQueryConfig](path = "bigQuery", version = 3)
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The keys used by the [identity-retention-lambda](https://github.com/guardian/support-service-lambdas/tree/main/handlers/identity-retention) have been rotated and this will use the latest versions

I was able to create the new files in S3 and upload them to the membership account

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
