### PR TITLE
Negative invoices processor remove prod mock responses

### DIFF
--- a/handlers/negative-invoices-processor/src/handlers/checkForActiveSub.ts
+++ b/handlers/negative-invoices-processor/src/handlers/checkForActiveSub.ts
@@ -15,21 +15,13 @@ export const handler = async (
 			zuoraClient,
 			parsedEvent.accountId,
 		);
-		console.log('checkForActiveSub hasActiveSub:', hasActiveSub);
 		return {
 			...parsedEvent,
 			checkForActiveSubAttempt: {
 				Success: true,
-				hasActiveSub: false,
+				hasActiveSub,
 			},
 		};
-		// return {
-		// 	...parsedEvent,
-		// 	checkForActiveSubAttempt: {
-		// 		Success: true,
-		// 		hasActiveSub,
-		// 	},
-		// };
 	} catch (error) {
 		return {
 			...event,

--- a/handlers/negative-invoices-processor/src/handlers/getInvoices.ts
+++ b/handlers/negative-invoices-processor/src/handlers/getInvoices.ts
@@ -59,7 +59,6 @@ const query = (): string =>
         inv.amount < 0
         AND inv.balance != 0
         AND sub.status = 'Active'
-        AND inv.id = '8a12916d97bec37d0197d38fbf507fd5'
     GROUP BY 
         inv.id, inv.invoice_number
 `;


### PR DESCRIPTION
## What does this change?
Revert the changes made in this [PR](https://github.com/guardian/support-service-lambdas/pull/2932) to test the execution flow in production.

Upon deployment of the changes in this PR, the solution is ready for use in production. Next step will be just to add a schedule so that it runs once per day