### PR TITLE
negative invoices processor - exclude cancelled invoices

### DIFF
--- a/handlers/negative-invoices-processor/src/handlers/getInvoices.ts
+++ b/handlers/negative-invoices-processor/src/handlers/getInvoices.ts
@@ -59,6 +59,7 @@ const query = (): string =>
         inv.amount < 0
         AND inv.balance != 0
         AND sub.status = 'Active'
+		AND inv.Status = 'Posted'
     GROUP BY 
         inv.id, inv.invoice_number
 `;


### PR DESCRIPTION
## What does this changes
Sometimes invoices are cancelled in Zuora by CSRs. Attempting to balance a cancelled invoice will result in an error, so filter these out from the query.