### PR TITLE
Add LastPlanAddedDate__c to New Product API (Task 3/4)

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -48,6 +48,7 @@ object CreateSubscription {
         AcquisitionSource__c: String,
         CreatedByCSR__c: String,
         DeliveryAgent__c: Option[String],
+        LastPlanAddedDate__c: String,
     )
 
     implicit val writesRequest: OWrites[WireCreateRequest] = Json.writes[WireCreateRequest]
@@ -65,6 +66,7 @@ object CreateSubscription {
       AcquisitionSource__c = acquisitionSource.value,
       CreatedByCSR__c = createdByCSR.value,
       DeliveryAgent__c = deliveryAgent.map(_.value),
+      LastPlanAddedDate__c = currentDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
       subscribeToRatePlans = ratePlans.map { ratePlan =>
         SubscribeToRatePlans(
           productRatePlanId = ratePlan.productRatePlanId.value,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -43,6 +43,7 @@ class CreateSubscriptionTest extends AnyFlatSpec with Matchers {
       AcquisitionSource__c = "sourcesource",
       CreatedByCSR__c = "csrcsr",
       DeliveryAgent__c = None,
+      LastPlanAddedDate__c = "2018-07-02",
       subscribeToRatePlans = List(
         SubscribeToRatePlans(
           productRatePlanId = "hiProductRatePlanId",


### PR DESCRIPTION
### Origin
Based on the indication from @johnduffell "add similar logic to new product api" on [PR #7040](https://github.com/guardian/support-frontend/pull/7040).

### Problem
The 14-day refund bug occurs because cancellation logic uses `effectiveStartDate`, which incorrectly updates on price rises/renewals, making customers eligible for refunds when they shouldn't be.

### Solution
Add `LastPlanAddedDate__c` custom field to all new subscription creation endpoints in the new-product-api, setting it to the current date. This field only updates on genuine new subscriptions, not price changes.

### Changes
- **CreateSubscription.scala**: Added `LastPlanAddedDate__c` to `WireCreateRequest` and set to current date
- **CreateSubscriptionTest.scala**: Updated test expectations to include the new field

### Coverage
This change applies to ALL subscription types created via new-product-api:
- SupporterPlus, Contributions, Paper, Digipack, GuardianWeekly, TierThree

### Integration with Previous Work
- **Task 1: [PR #7040](https://github.com/guardian/support-frontend/pull/7040)**: Added field to support-frontend for new subscription acquisitions ✅
- **Task 2: [PR #2875](https://github.com/guardian/support-service-lambdas/pull/2875)**: Added field to product switching APIs (RC→S+, Membership→RC) ✅  
- **Task 3: This PR**: Adds field to remaining new subscription creation endpoints ✅
- **Task 4: [PR #2951](https://github.com/guardian/support-service-lambdas/pull/2951)**: After 14-day waiting period, update cancellation logic to use `LastPlanAddedDate__c` instead of `effectiveStartDate`

This completes the field population phase. Once deployed and after 14 days, Task 4 can safely switch the cancellation logic to fix the refund bug.