### PR TITLE
Create shared types in zuora module and negative invoices processor

### DIFF
--- a/handlers/negative-invoices-processor/src/types/shared/applyCreditToAccountBalance.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/applyCreditToAccountBalance.ts
@@ -1,0 +1,12 @@
+import { zuoraResponseSchema } from '@modules/zuora/types';
+import { z } from 'zod';
+
+export const ApplyCreditToAccountBalanceResponseSchema =
+	zuoraResponseSchema.extend({
+		Id: z.string().optional(),
+	});
+
+export const ApplyCreditToAccountBalanceResultSchema = z.object({
+	applyCreditToAccountBalanceAttempt: ApplyCreditToAccountBalanceResponseSchema,
+	error: z.string().optional(),
+});

--- a/handlers/negative-invoices-processor/src/types/shared/index.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/index.ts
@@ -1,11 +1,31 @@
 // Shared schemas used across multiple handlers
 export {
+	ApplyCreditToAccountBalanceResponseSchema,
+	ApplyCreditToAccountBalanceResultSchema,
+} from './applyCreditToAccountBalance';
+
+export {
 	InvoiceSchema,
 	InvoiceRecordsArraySchema,
 	type InvoiceRecord,
 } from './invoiceSchemas';
 
 export {
+	PaymentMethodResponseSchema,
+	PaymentMethodResultSchema,
+	PaymentMethodSchema,
+	type PaymentMethod,
+} from './paymentMethod';
+
+export {
 	ProcessedInvoiceSchema,
 	type ProcessedInvoice,
 } from './processedInvoice';
+
+export {
+	RefundResponseSchema,
+	RefundResultSchema,
+	type RefundResponse,
+} from './refund';
+
+export { ActiveSubscriptionResultSchema } from './subscription';

--- a/handlers/negative-invoices-processor/src/types/shared/index.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/index.ts
@@ -13,7 +13,7 @@ export {
 export {
 	PaymentMethodResponseSchema,
 	PaymentMethodResultSchema,
-	PaymentMethodSchema,
+	NewPaymentMethodSchema,
 	type PaymentMethod,
 } from './paymentMethod';
 

--- a/handlers/negative-invoices-processor/src/types/shared/paymentMethod.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/paymentMethod.ts
@@ -1,0 +1,32 @@
+import {
+	BasePaymentMethodSchema,
+	zuoraResponseSchema,
+} from '@modules/zuora/types';
+import { z } from 'zod';
+
+export const PaymentMethodSchema = z.object({
+	...BasePaymentMethodSchema.pick({
+		id: true,
+		status: true,
+		type: true,
+		isDefault: true,
+	}).shape,
+});
+
+export type PaymentMethod = z.infer<typeof PaymentMethodSchema>;
+
+export const PaymentMethodResponseSchema = zuoraResponseSchema.extend({
+	creditcard: z.array(PaymentMethodSchema).optional(),
+	creditcardreferencetransaction: z.array(PaymentMethodSchema).optional(),
+	banktransfer: z.array(PaymentMethodSchema).optional(),
+	paypal: z.array(PaymentMethodSchema).optional(),
+});
+
+export type PaymentMethodResponse = z.infer<typeof PaymentMethodResponseSchema>;
+
+export const PaymentMethodResultSchema = z.object({
+	checkForActivePaymentMethodAttempt: PaymentMethodResponseSchema,
+	hasActivePaymentMethod: z.boolean().optional(),
+	activePaymentMethods: z.array(PaymentMethodSchema).optional(),
+	error: z.string().optional(),
+});

--- a/handlers/negative-invoices-processor/src/types/shared/paymentMethod.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/paymentMethod.ts
@@ -4,7 +4,9 @@ import {
 } from '@modules/zuora/types';
 import { z } from 'zod';
 
-export const PaymentMethodSchema = z.object({
+//todo update this name (remove 'New') when duplicate schema is removed from
+//handlers/negative-invoices-processor/src/types/handlers/GetPaymentMethods.ts
+export const NewPaymentMethodSchema = z.object({
 	...BasePaymentMethodSchema.pick({
 		id: true,
 		status: true,
@@ -13,13 +15,13 @@ export const PaymentMethodSchema = z.object({
 	}).shape,
 });
 
-export type PaymentMethod = z.infer<typeof PaymentMethodSchema>;
+export type PaymentMethod = z.infer<typeof NewPaymentMethodSchema>;
 
 export const PaymentMethodResponseSchema = zuoraResponseSchema.extend({
-	creditcard: z.array(PaymentMethodSchema).optional(),
-	creditcardreferencetransaction: z.array(PaymentMethodSchema).optional(),
-	banktransfer: z.array(PaymentMethodSchema).optional(),
-	paypal: z.array(PaymentMethodSchema).optional(),
+	creditcard: z.array(NewPaymentMethodSchema).optional(),
+	creditcardreferencetransaction: z.array(NewPaymentMethodSchema).optional(),
+	banktransfer: z.array(NewPaymentMethodSchema).optional(),
+	paypal: z.array(NewPaymentMethodSchema).optional(),
 });
 
 export type PaymentMethodResponse = z.infer<typeof PaymentMethodResponseSchema>;
@@ -27,6 +29,6 @@ export type PaymentMethodResponse = z.infer<typeof PaymentMethodResponseSchema>;
 export const PaymentMethodResultSchema = z.object({
 	checkForActivePaymentMethodAttempt: PaymentMethodResponseSchema,
 	hasActivePaymentMethod: z.boolean().optional(),
-	activePaymentMethods: z.array(PaymentMethodSchema).optional(),
+	activePaymentMethods: z.array(NewPaymentMethodSchema).optional(),
 	error: z.string().optional(),
 });

--- a/handlers/negative-invoices-processor/src/types/shared/refund.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/refund.ts
@@ -1,6 +1,6 @@
 import { zuoraResponseSchema } from '@modules/zuora/types';
 import { z } from 'zod';
-import { PaymentMethodSchema } from '.';
+import { NewPaymentMethodSchema } from '.';
 
 export const RefundResponseSchema = zuoraResponseSchema.extend({
 	Id: z.string().optional(),
@@ -10,7 +10,7 @@ export type RefundResponse = z.infer<typeof RefundResponseSchema>;
 
 export const RefundResultSchema = RefundResponseSchema.extend({
 	refundAttempt: RefundResponseSchema,
-	paymentMethod: PaymentMethodSchema.optional(),
+	paymentMethod: NewPaymentMethodSchema.optional(),
 	refundAmount: z.number().optional(),
 	error: z.string().optional(),
 });

--- a/handlers/negative-invoices-processor/src/types/shared/refund.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/refund.ts
@@ -1,0 +1,16 @@
+import { zuoraResponseSchema } from '@modules/zuora/types';
+import { z } from 'zod';
+import { PaymentMethodSchema } from '.';
+
+export const RefundResponseSchema = zuoraResponseSchema.extend({
+	Id: z.string().optional(),
+});
+
+export type RefundResponse = z.infer<typeof RefundResponseSchema>;
+
+export const RefundResultSchema = RefundResponseSchema.extend({
+	refundAttempt: RefundResponseSchema,
+	paymentMethod: PaymentMethodSchema.optional(),
+	refundAmount: z.number().optional(),
+	error: z.string().optional(),
+});

--- a/handlers/negative-invoices-processor/src/types/shared/subscription.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/subscription.ts
@@ -1,0 +1,15 @@
+import { zuoraResponseSchema } from '@modules/zuora/types';
+import { z } from 'zod';
+
+export const SubscriptionResponseSchema = zuoraResponseSchema;
+export type SubscriptionResponse = z.infer<typeof SubscriptionResponseSchema>;
+
+export const ActiveSubscriptionResultSchema = z.object({
+	checkForActiveSubAttempt: SubscriptionResponseSchema,
+	hasActiveSubscription: z.boolean().optional(),
+	error: z.string().optional(),
+});
+
+export type ActiveSubscriptionResult = z.infer<
+	typeof ActiveSubscriptionResultSchema
+>;

--- a/modules/zuora/src/types/httpResponse.ts
+++ b/modules/zuora/src/types/httpResponse.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+// Type definitions for Zuora response formats
+export type ZuoraReason = {
+	code: string;
+	message: string;
+};
+
+export type ZuoraErrorItem = {
+	Code: string;
+	Message: string;
+};
+
+// Zod schema definitions
+export const zuoraReasonSchema = z.object({
+	code: z.string(),
+	message: z.string(),
+});
+
+export const zuoraErrorItemSchema = z.object({
+	Code: z.string(),
+	Message: z.string(),
+});
+
+export const zuoraResponseSchema = z.object({
+	// Success indicators (some endpoints use different casing)
+	success: z.boolean().optional(),
+	Success: z.boolean().optional(),
+	// Error details in various formats
+	reasons: z.array(zuoraReasonSchema).optional(),
+	Errors: z.array(zuoraErrorItemSchema).optional(),
+	FaultCode: z.string().optional(),
+	FaultMessage: z.string().optional(),
+	code: z.string().optional(),
+	message: z.string().optional(),
+});
+export type ZuoraResponse = z.infer<typeof zuoraResponseSchema>;
+
+export const createQueryResponseSchema = <T extends z.ZodRawShape>(
+	recordShape: T,
+) => {
+	return z
+		.object({
+			done: z.boolean(),
+			size: z.number(),
+			records: z.array(z.object(recordShape)).optional(),
+		})
+		.strict();
+};

--- a/modules/zuora/src/types/index.ts
+++ b/modules/zuora/src/types/index.ts
@@ -1,0 +1,5 @@
+export { zuoraResponseSchema } from './httpResponse';
+export {
+	BasePaymentMethodSchema,
+	DefaultPaymentMethodResponseSchema,
+} from './objects/paymentMethod';

--- a/modules/zuora/src/types/objects/paymentMethod.ts
+++ b/modules/zuora/src/types/objects/paymentMethod.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+import { zuoraResponseSchema } from '../httpResponse';
+
+// Common fields for all payment methods
+export const BasePaymentMethodSchema = z.object({
+	id: z.string(),
+	type: z.string(),
+	isDefault: z.boolean(),
+	accountKey: z.string(),
+	paymentMethodNumber: z.string().nullable(),
+	status: z.string(),
+	lastTransaction: z.string().nullable(),
+	useDefaultRetryRule: z.boolean(),
+	bankIdentificationNumber: z.string().nullable(),
+	deviceSessionId: z.string().nullable(),
+	existingMandate: z.string().nullable(),
+	ipAddress: z.string().nullable(),
+	lastFailedSaleTransactionDate: z.string().nullable(),
+	lastTransactionDateTime: z.string().nullable(),
+	lastTransactionStatus: z.string().nullable(),
+	maxConsecutivePaymentFailures: z.number().nullable(),
+	numConsecutiveFailures: z.number(),
+	paymentRetryWindow: z.string().nullable(),
+	totalNumberOfProcessedPayments: z.number(),
+	totalNumberOfErrorPayments: z.number(),
+	createdDate: z.string(),
+	updatedDate: z.string(),
+	createdBy: z.string(),
+	updatedBy: z.string(),
+});
+
+// Account holder info schema
+const AccountHolderInfoSchema = z.object({
+	accountHolderName: z.string().nullable(),
+	phone: z.string().nullable(),
+	email: z.string().nullable(),
+	addressLine1: z.string().nullable(),
+	addressLine2: z.string().nullable(),
+	zipCode: z.string().nullable(),
+	city: z.string().nullable(),
+	country: z.string().nullable(),
+	state: z.string().nullable(),
+});
+
+// Mandate info schema
+const MandateInfoSchema = z.object({
+	mitProfileAction: z.string().nullable(),
+	mitProfileType: z.string().nullable(),
+	mitConsentAgreementSrc: z.string().nullable(),
+	mitConsentAgreementRef: z.string().nullable(),
+	mitTransactionId: z.string().nullable(),
+	mitProfileAgreedOn: z.string().nullable(),
+	mandateStatus: z.string().nullable(),
+	mandateReason: z.string().nullable(),
+	mandateId: z.string().nullable(),
+	mandateReceivedStatus: z.string().nullable().optional(),
+	existingMandateStatus: z.string().nullable().optional(),
+	mandateCreationDate: z.string().nullable().optional(),
+	mandateUpdateDate: z.string().nullable().optional(),
+});
+
+// Credit card payment method
+const CreditCardPaymentMethodSchema = BasePaymentMethodSchema.extend({
+	cardNumber: z.string(),
+	expirationMonth: z.number(),
+	expirationYear: z.number(),
+	creditCardType: z.string(),
+	accountHolderInfo: AccountHolderInfoSchema,
+	mandateInfo: MandateInfoSchema,
+	identityNumber: z.string().nullable(),
+});
+
+// Credit card reference transaction payment method
+const CreditCardReferenceTransactionSchema = BasePaymentMethodSchema.extend({
+	tokenId: z.string(),
+	secondTokenId: z.string(),
+	mandateInfo: MandateInfoSchema,
+	cardNumber: z.string(),
+	expirationMonth: z.number(),
+	expirationYear: z.number(),
+	creditCardType: z.string(),
+	accountHolderInfo: AccountHolderInfoSchema,
+	identityNumber: z.string().nullable(),
+});
+
+// PayPal payment method
+const PayPalPaymentMethodSchema = BasePaymentMethodSchema.extend({
+	BAID: z.string(),
+	email: z.string(),
+});
+
+// Bank transfer payment method
+const BankTransferPaymentMethodSchema = BasePaymentMethodSchema.extend({
+	bankTransferType: z.string(),
+	IBAN: z.string(),
+	businessIdentificationCode: z.string().nullable(),
+	accountNumber: z.string(),
+	bankCode: z.string(),
+	branchCode: z.string().nullable(),
+	identityNumber: z.string().nullable(),
+	accountHolderInfo: AccountHolderInfoSchema,
+	mandateInfo: MandateInfoSchema,
+});
+
+// Main payment method response schema
+export const DefaultPaymentMethodResponseSchema = zuoraResponseSchema.extend({
+	defaultPaymentMethodId: z.string(),
+	paymentGateway: z.string(),
+	creditcard: z.array(CreditCardPaymentMethodSchema).optional(),
+	creditcardreferencetransaction: z
+		.array(CreditCardReferenceTransactionSchema)
+		.optional(),
+	paypal: z.array(PayPalPaymentMethodSchema).optional(),
+	banktransfer: z.array(BankTransferPaymentMethodSchema).optional(),
+});


### PR DESCRIPTION
## Overview
This PR is the first step in a broader refactor to improve the maintainability and consistency of our Zuora integration logic, specifically how the typescript zuora global module handles http responses and uses types. 

The overall objective is to standardize and centralize response schemas and types for Zuora API interactions—paving the way for cleaner handler implementations, easier testing, and safer future changes.

**The larger refactor will:**

- Replace bespoke, inline response parsing and type definitions in handlers with shared schemas.
- Make error handling and data validation more robust and predictable.
- Reduce code duplication across handlers and modules.

### Changes in this PR
- Introduced new shared response schemas and types for Zuora API responses, payment methods, refunds, and subscriptions.
- Added files in handlers/negative-invoices-processor/src/types/shared/ and modules/zuora/src/types/ to define these schemas.

- No changes to handler or business logic files at this stage.
- No usages of these new schemas yet

### Next Steps
Follow-up PRs will:

- Refactor Handlers to Use Shared Schemas:
Update individual handler implementations (e.g., applyCreditToAccountBalance, checkForActiveSub, getPaymentMethods, doCreditBalanceRefund) to consume the new shared schemas.
- Update Type Definitions and ProcessedInvoiceSchema:
Replace legacy inline schemas in type definitions and aggregate types to reference the shared schemas.
- Enhance Error Handling & Testing:
Ensure all modules use the new error types and schemas, update tests accordingly, and regenerate snapshots.
- Cleanup Deprecated Code:
Remove old, redundant type definitions and utility functions.

**This PR is non-breaking and safe to merge independently.**
Subsequent PRs will build on these foundational changes.