### PR TITLE
Send supporter-product-data alarms to Portfolio

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -78,6 +78,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'stripe-intent',
 		'workers',
 		'payment-api',
+		'supporter-product-data',
 
 		// support-service-lambdas
 		'catalog-service',


### PR DESCRIPTION
## What does this change?

This routes alarms for supporter-product-data to the Portfolio alarms chat channel. See also guardian/support-frontend#7177.