### PR TITLE
illustration of dependency injection of side effects plus tweaks

### DIFF
--- a/handlers/mparticle-api/src/index.ts
+++ b/handlers/mparticle-api/src/index.ts
@@ -3,20 +3,31 @@ import type {
 	APIGatewayProxyResult,
 	Handler,
 } from 'aws-lambda';
-import { httpRouter } from './routers/http';
+import { baseUrlForStage, httpRouter } from './routers/http';
 import {
 	BatonRerEventRequest,
 	BatonRerEventResponse,
 } from './routers/baton/types-and-schemas';
 import { batonRerRouter } from './routers/baton';
+import { MParticleDataSubjectClient } from './apis/data-subject-requests';
+import { getAppConfig, getEnv } from './utils/config';
+import { MParticleEventsClient } from './apis/events';
 
 export const handlerHttp: Handler<
 	APIGatewayProxyEvent,
 	APIGatewayProxyResult
 > = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
+		const { mParticleDataSubjectClient, mParticleEventsClient, stage } =
+			await services();
+		const router = httpRouter(
+			mParticleDataSubjectClient,
+			mParticleEventsClient,
+			baseUrlForStage(stage),
+		);
+
 		console.debug('Processing HTTP request');
-		return httpRouter.routeRequest(event);
+		return router.routeRequest(event);
 	} catch (error) {
 		console.error('HTTP handler error:', error);
 		return {
@@ -31,10 +42,34 @@ export const handlerBaton: Handler<
 	BatonRerEventResponse
 > = async (event: BatonRerEventRequest): Promise<BatonRerEventResponse> => {
 	try {
+		const { mParticleDataSubjectClient, mParticleEventsClient, stage } =
+			await services();
+		const router = batonRerRouter(
+			mParticleDataSubjectClient,
+			mParticleEventsClient,
+			baseUrlForStage(stage),
+			stage === 'PROD',
+		);
+
 		console.debug('Processing Baton RER event');
-		return batonRerRouter.routeRequest(event);
+		return router.routeRequest(event);
 	} catch (error) {
 		console.error('Baton RER handler error:', error);
 		throw error; // Re-throw to trigger Lambda retry mechanism
 	}
 };
+
+async function services() {
+	console.log('Starting lambda');
+	const config = await getAppConfig();
+	return {
+		mParticleDataSubjectClient: MParticleDataSubjectClient.create(
+			config.workspace,
+		),
+		mParticleEventsClient: MParticleEventsClient.create(
+			config.inputPlatform,
+			config.pod,
+		),
+		stage: getEnv('STAGE'),
+	};
+}

--- a/handlers/mparticle-api/src/routers/baton.ts
+++ b/handlers/mparticle-api/src/routers/baton.ts
@@ -8,6 +8,8 @@ import {
 	BatonRerEventRequestSchema,
 	ValidationError,
 } from './baton/types-and-schemas';
+import { MParticleDataSubjectClient } from '../apis/data-subject-requests';
+import { MParticleEventsClient } from '../apis/events';
 
 export function validateRequest(
 	data: BatonRerEventRequest,
@@ -20,16 +22,27 @@ export function validateRequest(
 	return result.data;
 }
 
-export const batonRerRouter = {
+export const batonRerRouter = (
+	mParticleDataSubjectClient: MParticleDataSubjectClient,
+	mParticleEventsClient: MParticleEventsClient,
+	httpRouterBaseUrl: string,
+	isProd: boolean,
+) => ({
 	routeRequest: async (
 		event: BatonRerEventRequest,
 	): Promise<BatonRerEventResponse> => {
 		const validatedEvent = validateRequest(event);
 		switch (validatedEvent.action) {
 			case 'initiate':
-				return handleInitiateRequest(validatedEvent);
+				return handleInitiateRequest(
+					mParticleDataSubjectClient,
+					mParticleEventsClient,
+					httpRouterBaseUrl,
+					validatedEvent,
+					isProd,
+				);
 			case 'status':
-				return handleStatusRequest(validatedEvent);
+				return handleStatusRequest(mParticleDataSubjectClient, validatedEvent);
 		}
 	},
-};
+});

--- a/handlers/mparticle-api/src/routers/baton/handle-status-request.ts
+++ b/handlers/mparticle-api/src/routers/baton/handle-status-request.ts
@@ -1,12 +1,16 @@
 import type { DataSubjectRequestState } from '../../../interfaces/data-subject-request-state';
 import { DataSubjectRequestStatus } from '../../../interfaces/data-subject-request-state';
-import { getStatusOfDataSubjectRequest } from '../../apis/data-subject-requests';
+import {
+	getStatusOfDataSubjectRequest,
+	MParticleDataSubjectClient,
+} from '../../apis/data-subject-requests';
 import type {
 	BatonRerEventStatusRequest,
 	BatonRerEventStatusResponse,
 } from './types-and-schemas';
 
 export async function handleStatusRequest(
+	mParticleDataSubjectClient: MParticleDataSubjectClient,
 	request: BatonRerEventStatusRequest,
 ): Promise<BatonRerEventStatusResponse> {
 	const mapStatus = (
@@ -25,7 +29,10 @@ export async function handleStatusRequest(
 	};
 
 	const dataSubjectRequestState: DataSubjectRequestState =
-		await getStatusOfDataSubjectRequest(request.initiationReference);
+		await getStatusOfDataSubjectRequest(
+			mParticleDataSubjectClient,
+			request.initiationReference,
+		);
 
 	const response: BatonRerEventStatusResponse = {
 		requestType: 'RER' as const,

--- a/handlers/mparticle-api/src/routers/http/data-subject-request-callback.ts
+++ b/handlers/mparticle-api/src/routers/http/data-subject-request-callback.ts
@@ -1,7 +1,10 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { z } from 'zod';
 import type { DataSubjectRequestCallback } from '../../../interfaces/data-subject-request-callback';
-import { processDataSubjectRequestCallback } from '../../apis/data-subject-requests';
+import {
+	MParticleDataSubjectClient,
+	processDataSubjectRequestCallback,
+} from '../../apis/data-subject-requests';
 import { validateDataSubjectRequestCallback } from '../../utils/validate-data-subject-request-callback';
 
 export const dataSubjectRequestCallbackParser = {
@@ -34,7 +37,9 @@ export const dataSubjectRequestCallbackParser = {
 	}),
 };
 
-export function dataSubjectRequestCallbackHandler() {
+export function dataSubjectRequestCallbackHandler(
+	mParticleDataSubjectClient: MParticleDataSubjectClient,
+) {
 	return async (
 		event: APIGatewayProxyEvent,
 		parsed: { path: { requestId: string }; body: DataSubjectRequestCallback },
@@ -44,6 +49,7 @@ export function dataSubjectRequestCallbackHandler() {
 				([k]) => k.toLowerCase() === key.toLowerCase(),
 			)?.[1];
 		const callbackValidationResult = await validateDataSubjectRequestCallback(
+			mParticleDataSubjectClient,
 			getHeader('x-opendsr-processor-domain'),
 			getHeader('x-opendsr-signature'),
 			event.body,

--- a/handlers/mparticle-api/src/routers/http/get-data-subject-request-status.ts
+++ b/handlers/mparticle-api/src/routers/http/get-data-subject-request-status.ts
@@ -1,6 +1,9 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { z } from 'zod';
-import { getStatusOfDataSubjectRequest } from '../../apis/data-subject-requests';
+import {
+	getStatusOfDataSubjectRequest,
+	MParticleDataSubjectClient,
+} from '../../apis/data-subject-requests';
 
 export const requestIdPathParser = {
 	path: z.object({
@@ -8,7 +11,9 @@ export const requestIdPathParser = {
 	}),
 };
 
-export function getDataSubjectRequestStatusHandler() {
+export function getDataSubjectRequestStatusHandler(
+	mParticleDataSubjectClient: MParticleDataSubjectClient,
+) {
 	return async (
 		event: APIGatewayProxyEvent,
 		parsed: { path: { requestId: string }; body: unknown },
@@ -16,7 +21,10 @@ export function getDataSubjectRequestStatusHandler() {
 		return {
 			statusCode: 200,
 			body: JSON.stringify(
-				await getStatusOfDataSubjectRequest(parsed.path.requestId),
+				await getStatusOfDataSubjectRequest(
+					mParticleDataSubjectClient,
+					parsed.path.requestId,
+				),
 			),
 		};
 	};

--- a/handlers/mparticle-api/src/routers/http/submit-data-subject-request.ts
+++ b/handlers/mparticle-api/src/routers/http/submit-data-subject-request.ts
@@ -1,7 +1,10 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { z } from 'zod';
 import type { DataSubjectRequestForm } from '../../../interfaces/data-subject-request-form';
-import { submitDataSubjectRequest } from '../../apis/data-subject-requests';
+import {
+	MParticleDataSubjectClient,
+	submitDataSubjectRequest,
+} from '../../apis/data-subject-requests';
 import { setUserAttributesForRightToErasureRequest } from '../../apis/events';
 
 export const dataSubjectRequestFormParser = {
@@ -15,7 +18,10 @@ export const dataSubjectRequestFormParser = {
 	}),
 };
 
-export function submitDataSubjectRequestHandler() {
+export function submitDataSubjectRequestHandler(
+	mParticleDataSubjectClient: MParticleDataSubjectClient,
+	httpRouterBaseUrl: string,
+) {
 	return async (
 		event: APIGatewayProxyEvent,
 		parsed: { path: unknown; body: DataSubjectRequestForm },
@@ -40,7 +46,13 @@ export function submitDataSubjectRequestHandler() {
 
 		return {
 			statusCode: 201,
-			body: JSON.stringify(await submitDataSubjectRequest(parsed.body)),
+			body: JSON.stringify(
+				await submitDataSubjectRequest(
+					mParticleDataSubjectClient,
+					httpRouterBaseUrl,
+					parsed.body,
+				),
+			),
 		};
 	};
 }

--- a/handlers/mparticle-api/src/routers/http/upload-event-batch.ts
+++ b/handlers/mparticle-api/src/routers/http/upload-event-batch.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { z } from 'zod';
 import type { EventBatch } from '../../../interfaces/event-batch';
-import { uploadAnEventBatch } from '../../apis/events';
+import { MParticleEventsClient, uploadAnEventBatch } from '../../apis/events';
 
 export const eventBatchParser = {
 	body: z.object({
@@ -26,14 +26,18 @@ export const eventBatchParser = {
 	}),
 };
 
-export function uploadEventBatchHandler() {
+export function uploadEventBatchHandler(
+	mParticleEventsClient: MParticleEventsClient,
+) {
 	return async (
 		event: APIGatewayProxyEvent,
 		parsed: { path: unknown; body: EventBatch },
 	): Promise<APIGatewayProxyResult> => {
 		return {
 			statusCode: 201,
-			body: JSON.stringify(await uploadAnEventBatch(parsed.body)),
+			body: JSON.stringify(
+				await uploadAnEventBatch(mParticleEventsClient, parsed.body),
+			),
 		};
 	};
 }

--- a/handlers/mparticle-api/src/utils/make-http-request.ts
+++ b/handlers/mparticle-api/src/utils/make-http-request.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod';
+
 export class HttpError extends Error {
 	public statusCode: number;
 	public statusText: string;
@@ -32,6 +34,7 @@ export async function makeHttpRequest<T>(
 	url: string,
 	options: {
 		method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+		schema: z.ZodType<T, z.ZodTypeDef, unknown>;
 		baseURL?: string;
 		headers?: Record<string, string>;
 		body?: unknown;
@@ -68,7 +71,7 @@ export async function makeHttpRequest<T>(
 		}
 
 		try {
-			const data = (await response.json()) as T;
+			const data = options.schema.parse(await response.json());
 			return { success: true, data };
 		} catch {
 			return {

--- a/handlers/mparticle-api/src/utils/validate-data-subject-request-callback.ts
+++ b/handlers/mparticle-api/src/utils/validate-data-subject-request-callback.ts
@@ -1,7 +1,8 @@
 import * as crypto from 'crypto';
 import * as tls from 'tls';
 import { X509Certificate } from '@peculiar/x509';
-import { requestDataSubjectApi } from '../apis/data-subject-requests';
+import { MParticleDataSubjectClient } from '../apis/data-subject-requests';
+import { z } from 'zod';
 
 const ALLOWED_PROCESSOR_DOMAINS = [
 	'opendsr.mparticle.com',
@@ -26,17 +27,19 @@ let cachedProcessorCertificate:
  * @returns https://docs.mparticle.com/developers/apis/dsr-api/v3/#example-response-body
  */
 async function getProcessorDomainCertificate(
+	mParticleDataSubjectClient: MParticleDataSubjectClient,
 	expirationRetry?: boolean,
 ): Promise<{
 	parsed: X509Certificate;
 	pem: string;
 } | null> {
 	if (!cachedProcessorCertificate) {
-		const discoveryResponse = await requestDataSubjectApi<{
-			processor_certificate: string;
-		}>('/discovery', {
-			method: 'GET',
+		const schema = z.object({
+			processor_certificate: z.string(),
 		});
+		const discoveryResponse = await mParticleDataSubjectClient.get<{
+			processor_certificate: string;
+		}>('/discovery', schema);
 
 		if (!discoveryResponse.success) {
 			console.error('Could not Discover Processor Certificate.');
@@ -73,7 +76,7 @@ async function getProcessorDomainCertificate(
 				'Certificate has expired. Attempting to refresh certificate...',
 			);
 			cachedProcessorCertificate = undefined;
-			return getProcessorDomainCertificate(true);
+			return getProcessorDomainCertificate(mParticleDataSubjectClient, true);
 		}
 
 		console.error(
@@ -121,6 +124,7 @@ async function validateCertificateChain(
  * @param {string} signature - The value of the 'x-opendsr-signature' header
  */
 export const validateDataSubjectRequestCallback = async (
+	mParticleDataSubjectClient: MParticleDataSubjectClient,
 	processorDomain: string | undefined,
 	signature: string | undefined,
 	payload: string | null,
@@ -143,7 +147,7 @@ export const validateDataSubjectRequestCallback = async (
 	const processorCertificate: {
 		parsed: X509Certificate;
 		pem: string;
-	} | null = await getProcessorDomainCertificate();
+	} | null = await getProcessorDomainCertificate(mParticleDataSubjectClient);
 	if (!processorCertificate) {
 		console.error(
 			'Could not obtain Processor Certificate to perform Data Subject Request Callback validation.',

--- a/modules/routing/src/router.ts
+++ b/modules/routing/src/router.ts
@@ -17,7 +17,7 @@ export type Route<TPath, TBody> = {
 	path: string;
 	handler: (
 		event: APIGatewayProxyEvent,
-		parsed: { path: TPath; body: TBody }
+		parsed: { path: TPath; body: TBody },
 	) => Promise<APIGatewayProxyResult>;
 	parser?: {
 		path?: z.Schema<TPath>;
@@ -26,7 +26,7 @@ export type Route<TPath, TBody> = {
 };
 
 export function createRoute<TPath, TBody>(
-	route: Route<TPath, TBody>
+	route: Route<TPath, TBody>,
 ): Route<unknown, unknown> {
 	return route as Route<unknown, unknown>;
 }
@@ -38,7 +38,7 @@ export const NotFoundResponse = {
 
 function matchPath(
 	routePath: string,
-	eventPath: string
+	eventPath: string,
 ): { params: Record<string, string> } | undefined {
 	const routeParts = routePath.split('/').filter(Boolean);
 	const eventParts = eventPath.split('/').filter(Boolean);
@@ -64,34 +64,47 @@ function matchPath(
 }
 
 export class Router {
-	constructor(private routes: ReadonlyArray<Route<unknown, unknown>>) { }
+	constructor(private routes: ReadonlyArray<Route<unknown, unknown>>) {}
 	async routeRequest(
 		event: APIGatewayProxyEvent,
 	): Promise<APIGatewayProxyResult> {
+		console.log('Router: request', event);
 		try {
 			for (const route of this.routes) {
 				const matchResult = matchPath(route.path, event.path);
-				if (route.httpMethod.toUpperCase() === event.httpMethod.toUpperCase() && matchResult) {
+				if (
+					route.httpMethod.toUpperCase() === event.httpMethod.toUpperCase() &&
+					matchResult
+				) {
 					const eventWithParams = {
 						...event,
-						pathParameters: { ...(event.pathParameters ?? {}), ...matchResult.params },
+						pathParameters: {
+							...(event.pathParameters ?? {}),
+							...matchResult.params,
+						},
 					};
 
 					let parsedPath, parsedBody;
 					try {
-						parsedPath = route.parser?.path?.parse(eventWithParams.pathParameters);
+						parsedPath = route.parser?.path?.parse(
+							eventWithParams.pathParameters,
+						);
 						parsedBody = route.parser?.body?.parse(
-							eventWithParams.body ? JSON.parse(eventWithParams.body) : undefined,
+							eventWithParams.body
+								? JSON.parse(eventWithParams.body)
+								: undefined,
 						);
 					} catch (error) {
 						if (error instanceof z.ZodError) {
-							return {
+							const response = {
 								statusCode: 400,
 								body: JSON.stringify({
 									error: 'Invalid request',
 									details: error.errors,
 								}),
 							};
+							console.log('Router: response: validation failure', response);
+							return response;
 						}
 						throw error;
 					}
@@ -102,20 +115,27 @@ export class Router {
 					});
 				}
 			}
+			console.log('Router: response: route not found', NotFoundResponse);
 			return NotFoundResponse;
 		} catch (error) {
 			console.log('Caught exception with message: ', error);
 			if (error instanceof ValidationError) {
-				console.log(`Validation failure: ${error.message}`);
-				return {
+				const response = {
 					body: error.message,
 					statusCode: 400,
 				};
+				console.log(
+					`Router: response: validation failure: ${error.message}`,
+					response,
+				);
+				return response;
 			}
-			return {
+			const InternalServerError = {
 				body: 'Internal server error',
 				statusCode: 500,
 			};
+			console.error('Router: response: unhandled error', InternalServerError);
+			return InternalServerError;
 		}
 	}
 }


### PR DESCRIPTION
TODO:
1. resolve/address all outstanding comments on https://github.com/guardian/support-service-lambdas/pull/2920 that could not be completed before merging
2. decide whether also to implement dependency injection as illustrated in this PR

---

This PR is a demo on top of https://github.com/guardian/support-service-lambdas/pull/2920

specifically this comment https://github.com/guardian/support-service-lambdas/pull/2920#discussion_r2213738806

The main change is to show how we can inject the external dependencies as parameters similarly how we do with zuora client 
https://github.com/guardian/support-service-lambdas/blob/db568862b899ab115fa1a5ddf16d6abdaf99d5b0/modules/zuora/src/zuoraClient.ts
This is partly to make more pure functions which helps testability, but also readability as it makes it clearer which functions are going to do API calls/side effects and which are not.

For zuora API you may notice we also tend to split each API call into a separate file also, this is because zuora has a LOT of APIs available, but I didn't go to those lengths in this PR as we only call a few APIs.

See inline comments for more.  I didn't have a chance to check if it compiles or the tests work, but I hope it's useful enough to get an idea.