### PR TITLE
Migrate holiday-stop-processor from CloudFormation to native CDK

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,6 +6,7 @@ import { CancellationSfCasesApi } from '../lib/cancellation-sf-cases-api';
 import { DiscountApi } from '../lib/discount-api';
 import { DiscountExpiryNotifier } from '../lib/discount-expiry-notifier';
 import { GenerateProductCatalog } from '../lib/generate-product-catalog';
+import { HolidayStopProcessor } from '../lib/holiday-stop-processor';
 import { MetricPushApi } from '../lib/metric-push-api';
 import { MParticleApi } from '../lib/mparticle-api';
 import { NegativeInvoicesProcessor } from '../lib/negative-invoices-processor';
@@ -367,6 +368,15 @@ new MParticleApi(app, 'mparticle-api-CODE', {
 	stage: 'CODE',
 });
 new MParticleApi(app, 'mparticle-api-PROD', {
+	stack: 'support',
+	stage: 'PROD',
+});
+
+new HolidayStopProcessor(app, 'holiday-stop-processor-CODE', {
+	stack: 'support',
+	stage: 'CODE',
+});
+new HolidayStopProcessor(app, 'holiday-stop-processor-PROD', {
 	stack: 'support',
 	stage: 'PROD',
 });

--- a/cdk/lib/holiday-stop-processor.test.ts
+++ b/cdk/lib/holiday-stop-processor.test.ts
@@ -38,6 +38,7 @@ describe('HolidayStopProcessor stack', () => {
 		// Check that EventInvokeConfig is created with no retries
 		template.hasResourceProperties('AWS::Lambda::EventInvokeConfig', {
 			MaximumRetryAttempts: 0,
+			MaximumEventAgeInSeconds: 3600,
 			Qualifier: '$LATEST',
 		});
 
@@ -55,6 +56,7 @@ describe('HolidayStopProcessor stack', () => {
 						],
 					},
 				],
+				Version: '2012-10-17',
 			},
 		});
 	});
@@ -127,6 +129,8 @@ describe('HolidayStopProcessor stack', () => {
 			PolicyDocument: {
 				Statement: [
 					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
 						Resource: [
 							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/zuoraRest-CODE*.json',
 							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/sfAuth-CODE*.json',
@@ -134,6 +138,7 @@ describe('HolidayStopProcessor stack', () => {
 						],
 					},
 				],
+				Version: '2012-10-17',
 			},
 		});
 
@@ -142,6 +147,8 @@ describe('HolidayStopProcessor stack', () => {
 			PolicyDocument: {
 				Statement: [
 					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
 						Resource: [
 							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/zuoraRest-PROD*.json',
 							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/sfAuth-PROD*.json',
@@ -149,6 +156,7 @@ describe('HolidayStopProcessor stack', () => {
 						],
 					},
 				],
+				Version: '2012-10-17',
 			},
 		});
 	});

--- a/cdk/lib/holiday-stop-processor.test.ts
+++ b/cdk/lib/holiday-stop-processor.test.ts
@@ -1,0 +1,138 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { HolidayStopProcessor } from './holiday-stop-processor';
+
+describe('HolidayStopProcessor stack', () => {
+	it('creates the expected resources', () => {
+		const app = new App();
+		const stack = new HolidayStopProcessor(app, 'HolidayStopProcessor', {
+			stack: 'support',
+			stage: 'TEST',
+		});
+
+		const template = Template.fromStack(stack);
+
+		// Check that lambda function is created
+		template.hasResourceProperties('AWS::Lambda::Function', {
+			FunctionName: 'holiday-stop-processor-TEST',
+			Handler: 'com.gu.holidaystopprocessor.Handler::handle',
+			Runtime: 'java21',
+			MemorySize: 1232,
+			Timeout: 900,
+		});
+
+		// Check that EventBridge rule is created
+		template.hasResourceProperties('AWS::Events::Rule', {
+			Description: 'Trigger processing of holiday stops every 20 mins (to ensure successful processing of all batches within 24 hours)',
+			ScheduleExpression: 'cron(0/20 * ? * * *)',
+			State: 'ENABLED',
+		});
+
+		// Check that lambda permission is created
+		template.hasResourceProperties('AWS::Lambda::Permission', {
+			Action: 'lambda:InvokeFunction',
+			Principal: 'events.amazonaws.com',
+		});
+
+		// Check that EventInvokeConfig is created with no retries
+		template.hasResourceProperties('AWS::Lambda::EventInvokeConfig', {
+			MaximumRetryAttempts: 0,
+			Qualifier: '$LATEST',
+		});
+
+		// Check that IAM role has correct policies
+		template.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: [
+					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
+						Resource: [
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/TEST/zuoraRest-TEST*.json',
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/TEST/sfAuth-TEST*.json',
+							'arn:aws:s3:::fulfilment-date-calculator-code/*', // TEST uses CODE config
+						],
+					},
+				],
+			},
+		});
+	});
+
+	it('creates alarms only for PROD stage', () => {
+		const app = new App();
+		const codeStack = new HolidayStopProcessor(app, 'HolidayStopProcessorCode', {
+			stack: 'support',
+			stage: 'CODE',
+		});
+
+		const prodStack = new HolidayStopProcessor(app, 'HolidayStopProcessorProd', {
+			stack: 'support',
+			stage: 'PROD',
+		});
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// CODE should not have alarms
+		codeTemplate.resourceCountIs('AWS::CloudWatch::Alarm', 0);
+
+		// PROD should have alarms
+		prodTemplate.resourcePropertiesCountIs('AWS::CloudWatch::Alarm', {}, 1);
+		
+		// Verify the alarm configuration for PROD
+		prodTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+			AlarmName: 'URGENT 9-5 - PROD: Failed to process holiday stops',
+			ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+			Threshold: 1,
+			DatapointsToAlarm: 10,
+			EvaluationPeriods: 240,
+			TreatMissingData: 'notBreaching',
+		});
+	});
+
+	it('uses correct S3 bucket URNs for different stages', () => {
+		const app = new App();
+		const codeStack = new HolidayStopProcessor(app, 'HolidayStopProcessorCode', {
+			stack: 'support',
+			stage: 'CODE',
+		});
+
+		const prodStack = new HolidayStopProcessor(app, 'HolidayStopProcessorProd', {
+			stack: 'support',
+			stage: 'PROD',
+		});
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// CODE should use fulfilment-date-calculator-code bucket
+		codeTemplate.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: [
+					{
+						Resource: [
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/zuoraRest-CODE*.json',
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/sfAuth-CODE*.json',
+							'arn:aws:s3:::fulfilment-date-calculator-code/*',
+						],
+					},
+				],
+			},
+		});
+
+		// PROD should use fulfilment-date-calculator-prod bucket
+		prodTemplate.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: [
+					{
+						Resource: [
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/zuoraRest-PROD*.json',
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/sfAuth-PROD*.json',
+							'arn:aws:s3:::fulfilment-date-calculator-prod/*',
+						],
+					},
+				],
+			},
+		});
+	});
+});

--- a/cdk/lib/holiday-stop-processor.test.ts
+++ b/cdk/lib/holiday-stop-processor.test.ts
@@ -23,7 +23,8 @@ describe('HolidayStopProcessor stack', () => {
 
 		// Check that EventBridge rule is created
 		template.hasResourceProperties('AWS::Events::Rule', {
-			Description: 'Trigger processing of holiday stops every 20 mins (to ensure successful processing of all batches within 24 hours)',
+			Description:
+				'Trigger processing of holiday stops every 20 mins (to ensure successful processing of all batches within 24 hours)',
 			ScheduleExpression: 'cron(0/20 * ? * * *)',
 			State: 'ENABLED',
 		});
@@ -60,15 +61,23 @@ describe('HolidayStopProcessor stack', () => {
 
 	it('creates alarms only for PROD stage', () => {
 		const app = new App();
-		const codeStack = new HolidayStopProcessor(app, 'HolidayStopProcessorCode', {
-			stack: 'support',
-			stage: 'CODE',
-		});
+		const codeStack = new HolidayStopProcessor(
+			app,
+			'HolidayStopProcessorCode',
+			{
+				stack: 'support',
+				stage: 'CODE',
+			},
+		);
 
-		const prodStack = new HolidayStopProcessor(app, 'HolidayStopProcessorProd', {
-			stack: 'support',
-			stage: 'PROD',
-		});
+		const prodStack = new HolidayStopProcessor(
+			app,
+			'HolidayStopProcessorProd',
+			{
+				stack: 'support',
+				stage: 'PROD',
+			},
+		);
 
 		const codeTemplate = Template.fromStack(codeStack);
 		const prodTemplate = Template.fromStack(prodStack);
@@ -78,7 +87,7 @@ describe('HolidayStopProcessor stack', () => {
 
 		// PROD should have alarms
 		prodTemplate.resourcePropertiesCountIs('AWS::CloudWatch::Alarm', {}, 1);
-		
+
 		// Verify the alarm configuration for PROD
 		prodTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
 			AlarmName: 'URGENT 9-5 - PROD: Failed to process holiday stops',
@@ -92,15 +101,23 @@ describe('HolidayStopProcessor stack', () => {
 
 	it('uses correct S3 bucket URNs for different stages', () => {
 		const app = new App();
-		const codeStack = new HolidayStopProcessor(app, 'HolidayStopProcessorCode', {
-			stack: 'support',
-			stage: 'CODE',
-		});
+		const codeStack = new HolidayStopProcessor(
+			app,
+			'HolidayStopProcessorCode',
+			{
+				stack: 'support',
+				stage: 'CODE',
+			},
+		);
 
-		const prodStack = new HolidayStopProcessor(app, 'HolidayStopProcessorProd', {
-			stack: 'support',
-			stage: 'PROD',
-		});
+		const prodStack = new HolidayStopProcessor(
+			app,
+			'HolidayStopProcessorProd',
+			{
+				stack: 'support',
+				stage: 'PROD',
+			},
+		);
 
 		const codeTemplate = Template.fromStack(codeStack);
 		const prodTemplate = Template.fromStack(prodStack);

--- a/cdk/lib/holiday-stop-processor.ts
+++ b/cdk/lib/holiday-stop-processor.ts
@@ -32,6 +32,11 @@ export class HolidayStopProcessor extends GuStack {
 					'arn:aws:s3:::fulfilment-date-calculator-prod/*',
 				scheduleName: 'holiday-stop-processor-schedule',
 			},
+			TEST: {
+				fulfilmentDatesBucketUrn:
+					'arn:aws:s3:::fulfilment-date-calculator-code/*', // TEST uses CODE config
+				scheduleName: 'holiday-stop-processor-schedule-test',
+			},
 		};
 
 		const config = stageConfig[this.stage as keyof typeof stageConfig];

--- a/cdk/lib/holiday-stop-processor.ts
+++ b/cdk/lib/holiday-stop-processor.ts
@@ -1,0 +1,110 @@
+import { GuScheduledLambda } from '@guardian/cdk';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { App } from 'aws-cdk-lib';
+import { CfnCondition, Duration, Fn } from 'aws-cdk-lib';
+import { ComparisonOperator, Metric, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
+import { Schedule } from 'aws-cdk-lib/aws-events';
+import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
+
+export class HolidayStopProcessor extends GuStack {
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+
+		const app = 'holiday-stop-processor';
+		const functionName = `${app}-${this.stage}`;
+
+		// Map stage-specific configurations
+		const stageConfig = {
+			CODE: {
+				fulfilmentDatesBucketUrn: 'arn:aws:s3:::fulfilment-date-calculator-code/*',
+				scheduleName: 'holiday-stop-processor-schedule-code',
+			},
+			PROD: {
+				fulfilmentDatesBucketUrn: 'arn:aws:s3:::fulfilment-date-calculator-prod/*',
+				scheduleName: 'holiday-stop-processor-schedule',
+			},
+		};
+
+		const config = stageConfig[this.stage as keyof typeof stageConfig];
+
+		// Create the scheduled lambda
+		const holidayStopProcessorLambda = new GuScheduledLambda(this, 'HolidayStopProcessor', {
+			app,
+			fileName: `${app}.jar`,
+			functionName,
+			description: 'Updates subscriptions with outstanding holiday stops. Source - https://github.com/guardian/support-service-lambdas/tree/main/handlers/holiday-stop-processor',
+			handler: 'com.gu.holidaystopprocessor.Handler::handle',
+			runtime: Runtime.JAVA_21,
+			memorySize: 1232,
+			timeout: Duration.seconds(900),
+			loggingFormat: LoggingFormat.TEXT,
+			environment: {
+				Stage: this.stage,
+			},
+			monitoringConfiguration: {
+				noMonitoring: true, // We'll create custom alarms
+			},
+			rules: [
+				{
+					schedule: Schedule.expression('cron(0/20 * ? * * *)'), // Every 20 minutes
+					description: 'Trigger processing of holiday stops every 20 mins (to ensure successful processing of all batches within 24 hours)',
+				},
+			],
+		});
+
+		// Set maximum retry attempts to 0 (as processor runs every 20 mins anyway, there's no need to retry)
+		holidayStopProcessorLambda.configureAsyncInvoke({
+			maxEventAge: Duration.hours(1),
+			retryAttempts: 0,
+		});
+
+		// ---- IAM Policies ---- //
+		const s3Policy = new Policy(this, 'S3Policy', {
+			statements: [
+				new PolicyStatement({
+					effect: Effect.ALLOW,
+					actions: ['s3:GetObject'],
+					resources: [
+						`arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${this.stage}/zuoraRest-${this.stage}*.json`,
+						`arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${this.stage}/sfAuth-${this.stage}*.json`,
+						config.fulfilmentDatesBucketUrn,
+					],
+				}),
+			],
+		});
+
+		// Attach policy to lambda role
+		holidayStopProcessorLambda.role?.attachInlinePolicy(s3Policy);
+
+		// ---- CloudWatch Alarm (PROD only) ---- //
+		const isProd = new CfnCondition(this, 'IsProd', {
+			expression: Fn.conditionEquals(this.stage, 'PROD'),
+		});
+
+		if (this.stage === 'PROD') {
+			new SrLambdaAlarm(this, 'HolidayStopProcessorFailureAlarm', {
+				app,
+				alarmName: 'URGENT 9-5 - PROD: Failed to process holiday stops',
+				alarmDescription: `IMPACT: If this goes unaddressed at least one subscription that was supposed to be suspended will be fulfilled. Until we document how to deal with likely problems please alert the Value team. For general advice, see https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk`,
+				comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				metric: new Metric({
+					metricName: 'Errors',
+					namespace: 'AWS/Lambda',
+					statistic: 'Sum',
+					period: Duration.seconds(60),
+					dimensionsMap: {
+						FunctionName: functionName,
+					},
+				}),
+				threshold: 1,
+				datapointsToAlarm: 10,
+				evaluationPeriods: 240,
+				treatMissingData: TreatMissingData.NOT_BREACHING,
+				lambdaFunctionNames: functionName,
+			});
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR migrates the `holiday-stop-processor` from a CloudFormation template (`cfn.yaml`) to a native CDK implementation, improving maintainability and consistency with other Guardian projects.

## What's Changed

### 🆕 New Files
- **`cdk/lib/holiday-stop-processor.ts`** - Complete CDK stack implementation
- **`cdk/lib/holiday-stop-processor.test.ts`** - Unit tests for the new stack

### 📝 Modified Files
- **`cdk/bin/cdk.ts`** - Added HolidayStopProcessor stack instantiation for CODE and PROD environments

### 🗑️ Files to Remove (Post-Deployment)
- **`handlers/holiday-stop-processor/cfn.yaml`** - Original CloudFormation template (will be removed after successful deployment)

## Breaking Changes

None - this is a like-for-like migration maintaining full backward compatibility.

## Related Issues

This addresses the ongoing [initiative to migrate all CloudFormation templates to native CDK](https://trello.com/c/JU31sVP1) implementations across the support-service-lambdas repository.

---

**Note**: The original CloudFormation template will be removed in a follow-up PR after successful deployment and verification of the CDK implementation.
