### PR TITLE
In Product Switch API handle ZuoraError

### DIFF
--- a/handlers/product-switch-api/src/amendments.ts
+++ b/handlers/product-switch-api/src/amendments.ts
@@ -16,7 +16,7 @@ const getLastAmendment = async (
 		);
 		return response;
 	} catch (error) {
-		if (error.instanceof ZuoraError && error.code === 50000040) {
+		if (error instanceof ZuoraError && error.code === 50000040) {
 			console.log(`No amendments found for subscription ${subscriptionNumber}`);
 			return undefined;
 		}

--- a/handlers/product-switch-api/src/amendments.ts
+++ b/handlers/product-switch-api/src/amendments.ts
@@ -20,7 +20,9 @@ const getLastAmendment = async (
 			console.log(`No amendments found for subscription ${subscriptionNumber}`);
 			return undefined;
 		}
-		console.log(`Failed to get amendment for subscription ${subscriptionNumber}`);
+		console.log(
+			`Failed to get amendment for subscription ${subscriptionNumber}`,
+		);
 		throw error;
 	}
 };

--- a/handlers/product-switch-api/src/amendments.ts
+++ b/handlers/product-switch-api/src/amendments.ts
@@ -1,5 +1,5 @@
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { ZuoraError } from '@modules/zuora/zuoraError';
+import { ZuoraError } from '@modules/zuora/zuoraError';
 import { zuoraSuccessResponseSchema } from '@modules/zuora/zuoraSchemas';
 import dayjs from 'dayjs';
 import type { ZuoraGetAmendmentResponse } from './schemas';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This changes how the product switch API handles the response from Zuora when getting amendments.
There has been worked done recently on consolidating how Zuora success/error responses are handled and now in the case where there is no amendments an error is thrown which is not handled and the switch fails.

## How to test

- [ ] Deploy main to CODE and check we're seeing the same error as in PROD when doing a product switch.
- [ ] Deploy this branch to CODE and check product switch succeeds.

## How can we measure success?

We should no longer be getting alarms from Product Switch API in PROD