### PR TITLE
Migrate holiday-stop-api from CloudFormation to native CDK

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -29,6 +29,7 @@ import { UpdateSupporterPlusAmount } from '../lib/update-supporter-plus-amount';
 import { UserBenefits } from '../lib/user-benefits';
 import { WriteOffUnpaidInvoices } from '../lib/write-off-unpaid-invoices';
 import { ZuoraSalesforceLinkRemover } from '../lib/zuora-salesforce-link-remover';
+import { HolidayStopApi } from '../lib/holiday-stop-api';
 
 const app = new App();
 const membershipHostedZoneId = 'Z1E4V12LQGXFEC';
@@ -367,6 +368,14 @@ new MParticleApi(app, 'mparticle-api-CODE', {
 	stage: 'CODE',
 });
 new MParticleApi(app, 'mparticle-api-PROD', {
+	stack: 'support',
+	stage: 'PROD',
+});
+new HolidayStopApi(app, 'holiday-stop-api-CODE', {
+	stack: 'support',
+	stage: 'CODE',
+});
+new HolidayStopApi(app, 'holiday-stop-api-PROD', {
 	stack: 'support',
 	stage: 'PROD',
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,6 +6,7 @@ import { CancellationSfCasesApi } from '../lib/cancellation-sf-cases-api';
 import { DiscountApi } from '../lib/discount-api';
 import { DiscountExpiryNotifier } from '../lib/discount-expiry-notifier';
 import { GenerateProductCatalog } from '../lib/generate-product-catalog';
+import { HolidayStopApi } from '../lib/holiday-stop-api';
 import { MetricPushApi } from '../lib/metric-push-api';
 import { MParticleApi } from '../lib/mparticle-api';
 import { NegativeInvoicesProcessor } from '../lib/negative-invoices-processor';
@@ -29,7 +30,6 @@ import { UpdateSupporterPlusAmount } from '../lib/update-supporter-plus-amount';
 import { UserBenefits } from '../lib/user-benefits';
 import { WriteOffUnpaidInvoices } from '../lib/write-off-unpaid-invoices';
 import { ZuoraSalesforceLinkRemover } from '../lib/zuora-salesforce-link-remover';
-import { HolidayStopApi } from '../lib/holiday-stop-api';
 
 const app = new App();
 const membershipHostedZoneId = 'Z1E4V12LQGXFEC';

--- a/cdk/lib/holiday-stop-api.test.ts
+++ b/cdk/lib/holiday-stop-api.test.ts
@@ -1,0 +1,132 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { HolidayStopApi } from './holiday-stop-api';
+
+describe('HolidayStopApi stack', () => {
+	it('creates the expected resources', () => {
+		const app = new App();
+		const stack = new HolidayStopApi(app, 'HolidayStopApi', {
+			stack: 'support',
+			stage: 'TEST',
+		});
+
+		const template = Template.fromStack(stack);
+
+		// Check that lambda function is created
+		template.hasResourceProperties('AWS::Lambda::Function', {
+			FunctionName: 'holiday-stop-api-TEST',
+			Handler: 'com.gu.holiday_stops.Handler::apply',
+			Runtime: 'java21',
+			MemorySize: 1536,
+			Timeout: 300,
+		});
+
+		// Check that API Gateway is created
+		template.hasResourceProperties('AWS::ApiGateway::RestApi', {
+			Name: 'support-TEST-holiday-stop-api',
+		});
+
+		// Check that usage plan is created
+		template.hasResourceProperties('AWS::ApiGateway::UsagePlan', {
+			UsagePlanName: 'holiday-stop-api',
+			Description: 'REST endpoints for holiday-stop-api',
+		});
+
+		// Check that API key is created
+		template.hasResourceProperties('AWS::ApiGateway::ApiKey', {
+			Name: 'holiday-stop-api-key-TEST',
+			Description: 'Used by manage-frontend',
+		});
+
+		// Check that custom domain name is created
+		template.hasResourceProperties('AWS::ApiGateway::DomainName', {
+			DomainName: 'holiday-stop-api-code.support.guardianapis.com',
+			EndpointConfiguration: {
+				Types: ['REGIONAL'],
+			},
+		});
+
+		// Check that IAM policy exists for S3 access
+		template.resourceCountIs('AWS::IAM::Policy', 1);
+	});
+
+	it('creates alarms only for PROD stage', () => {
+		const app = new App();
+		const codeStack = new HolidayStopApi(app, 'HolidayStopApiCode', {
+			stack: 'support',
+			stage: 'CODE',
+		});
+
+		const prodStack = new HolidayStopApi(app, 'HolidayStopApiProd', {
+			stack: 'support',
+			stage: 'PROD',
+		});
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// CODE should not have alarms
+		codeTemplate.resourceCountIs('AWS::CloudWatch::Alarm', 0);
+
+		// PROD should have alarms
+		prodTemplate.resourcePropertiesCountIs('AWS::CloudWatch::Alarm', {}, 1);
+
+		// Verify the alarm configuration for PROD
+		prodTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+			AlarmName: '5XX rate from holiday-stop-api-PROD',
+			AlarmDescription: 'Holiday stop API exceeded the allowed 5XX error rate',
+			ComparisonOperator: 'GreaterThanThreshold',
+			Threshold: 5,
+			EvaluationPeriods: 1,
+			TreatMissingData: 'notBreaching',
+		});
+	});
+
+	it('uses correct S3 bucket URNs and domain names for different stages', () => {
+		const app = new App();
+		const codeStack = new HolidayStopApi(app, 'HolidayStopApiCode', {
+			stack: 'support',
+			stage: 'CODE',
+		});
+
+		const prodStack = new HolidayStopApi(app, 'HolidayStopApiProd', {
+			stack: 'support',
+			stage: 'PROD',
+		});
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// Check domain names are correct for each stage
+		codeTemplate.hasResourceProperties('AWS::ApiGateway::DomainName', {
+			DomainName: 'holiday-stop-api-code.support.guardianapis.com',
+		});
+
+		prodTemplate.hasResourceProperties('AWS::ApiGateway::DomainName', {
+			DomainName: 'holiday-stop-api.support.guardianapis.com',
+		});
+
+		// Check that both stages have IAM policies (the specific S3 bucket resources are complex to match)
+		codeTemplate.resourceCountIs('AWS::IAM::Policy', 1);
+		prodTemplate.resourceCountIs('AWS::IAM::Policy', 1);
+	});
+
+	it('creates all required API Gateway endpoints', () => {
+		const app = new App();
+		const stack = new HolidayStopApi(app, 'HolidayStopApi', {
+			stack: 'support',
+			stage: 'TEST',
+		});
+
+		const template = Template.fromStack(stack);
+
+		// Check that multiple methods are created for different endpoints
+		// The exact count will depend on the GuApiGatewayWithLambdaByPath implementation
+		template.resourceCountIs('AWS::ApiGateway::Method', 8); // 8 endpoints defined in the targets array
+
+		// Check that API key is required for endpoints
+		template.hasResourceProperties('AWS::ApiGateway::Method', {
+			ApiKeyRequired: true,
+		});
+	});
+});

--- a/cdk/lib/holiday-stop-api.ts
+++ b/cdk/lib/holiday-stop-api.ts
@@ -1,0 +1,218 @@
+import { GuApiGatewayWithLambdaByPath } from '@guardian/cdk';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
+import type { App } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
+import {
+	ApiKey,
+	CfnBasePathMapping,
+	CfnDomainName,
+	CfnUsagePlanKey,
+	UsagePlan,
+} from 'aws-cdk-lib/aws-apigateway';
+import {
+	ComparisonOperator,
+	Metric,
+	TreatMissingData,
+} from 'aws-cdk-lib/aws-cloudwatch';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Architecture, LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
+
+export class HolidayStopApi extends GuStack {
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+
+		const app = 'holiday-stop-api';
+		const functionName = `${app}-${this.stage}`;
+
+		// Map stage-specific configurations
+		const stageConfig: {
+			domainName: string;
+			fulfilmentDatesBucketUrn: string;
+		} = {
+			CODE: {
+				domainName: 'holiday-stop-api-code.support.guardianapis.com',
+				fulfilmentDatesBucketUrn:
+					'arn:aws:s3:::fulfilment-date-calculator-code/*',
+			},
+			PROD: {
+				domainName: 'holiday-stop-api.support.guardianapis.com',
+				fulfilmentDatesBucketUrn:
+					'arn:aws:s3:::fulfilment-date-calculator-prod/*',
+			},
+		}[this.stage] || {
+			domainName: 'holiday-stop-api-code.support.guardianapis.com',
+			fulfilmentDatesBucketUrn:
+				'arn:aws:s3:::fulfilment-date-calculator-code/*',
+		};
+
+		// Create the main API Lambda
+		const holidayStopApiLambda = new GuLambdaFunction(this, 'HolidayStopApi', {
+			fileName: 'holiday-stop-api.jar',
+			handler: 'com.gu.holiday_stops.Handler::apply',
+			runtime: Runtime.JAVA_21,
+			memorySize: 1536,
+			timeout: Duration.minutes(5),
+			environment: {
+				Stage: this.stage,
+			},
+			app: app,
+			functionName: functionName,
+			architecture: Architecture.ARM_64,
+			loggingFormat: LoggingFormat.TEXT,
+		});
+
+		// Add S3 permissions for private credentials
+		holidayStopApiLambda.addToRolePolicy(
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: ['s3:GetObject'],
+				resources: [
+					`arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${this.stage}/*`,
+				],
+			}),
+		);
+
+		// Add S3 permissions for fulfilment dates calculator bucket
+		holidayStopApiLambda.addToRolePolicy(
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: ['s3:GetObject'],
+				resources: [stageConfig.fulfilmentDatesBucketUrn],
+			}),
+		);
+
+		// Create API Gateway with all endpoints
+		const apiGateway = new GuApiGatewayWithLambdaByPath(this, {
+			app: app,
+			monitoringConfiguration: {
+				noMonitoring: true, // We'll create custom alarms
+			},
+			targets: [
+				{
+					path: '/potential/{subscriptionName}',
+					httpMethod: 'GET',
+					lambda: holidayStopApiLambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/hsr',
+					httpMethod: 'POST',
+					lambda: holidayStopApiLambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/bulk-hsr',
+					httpMethod: 'POST',
+					lambda: holidayStopApiLambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/hsr/{subscriptionName}',
+					httpMethod: 'GET',
+					lambda: holidayStopApiLambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/hsr/{subscriptionName}/{holidayStopRequestId}',
+					httpMethod: 'DELETE',
+					lambda: holidayStopApiLambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/hsr/{subscriptionName}/{holidayStopRequestId}',
+					httpMethod: 'PATCH',
+					lambda: holidayStopApiLambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/hsr/{subscriptionName}/cancel',
+					httpMethod: 'GET',
+					lambda: holidayStopApiLambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/hsr/{subscriptionName}/cancel',
+					httpMethod: 'POST',
+					lambda: holidayStopApiLambda,
+					apiKeyRequired: true,
+				},
+			],
+		});
+
+		// Create usage plan and API key
+		const usagePlan = new UsagePlan(this, 'HolidayStopApiUsagePlan', {
+			name: 'holiday-stop-api',
+			description: 'REST endpoints for holiday-stop-api',
+			apiStages: [
+				{
+					stage: apiGateway.api.deploymentStage,
+					api: apiGateway.api,
+				},
+			],
+		});
+
+		const apiKey = new ApiKey(this, 'HolidayStopApiKey', {
+			apiKeyName: `${app}-key-${this.stage}`,
+			description: 'Used by manage-frontend',
+		});
+
+		new CfnUsagePlanKey(this, 'HolidayStopApiUsagePlanKey', {
+			keyId: apiKey.keyId,
+			keyType: 'API_KEY',
+			usagePlanId: usagePlan.usagePlanId,
+		});
+
+		// Custom domain name
+		const domainName = new CfnDomainName(this, 'HolidayStopApiDomainName', {
+			regionalCertificateArn: `arn:aws:acm:${this.region}:${this.account}:certificate/b384a6a0-2f54-4874-b99b-96eeff96c009`,
+			domainName: stageConfig.domainName,
+			endpointConfiguration: {
+				types: ['REGIONAL'],
+			},
+		});
+
+		new CfnBasePathMapping(this, 'HolidayStopApiBasePathMapping', {
+			restApiId: apiGateway.api.restApiId,
+			domainName: domainName.ref,
+			stage: this.stage,
+		});
+
+		// DNS record
+		new CfnRecordSet(this, 'HolidayStopApiDNSRecord', {
+			hostedZoneName: 'support.guardianapis.com.',
+			name: stageConfig.domainName,
+			type: 'CNAME',
+			ttl: '120',
+			resourceRecords: [domainName.attrRegionalDomainName],
+		});
+
+		// Create PROD-only CloudWatch alarm for 5XX errors
+		if (this.stage === 'PROD') {
+			new SrLambdaAlarm(this, '5XXApiAlarm', {
+				app,
+				alarmName: `5XX rate from ${functionName}`,
+				alarmDescription:
+					'Holiday stop API exceeded the allowed 5XX error rate',
+				evaluationPeriods: 1,
+				threshold: 5,
+				comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+				treatMissingData: TreatMissingData.NOT_BREACHING,
+				metric: new Metric({
+					metricName: '5XXError',
+					namespace: 'AWS/ApiGateway',
+					dimensionsMap: {
+						ApiName: functionName,
+						Stage: this.stage,
+					},
+					statistic: 'Sum',
+					period: Duration.hours(1),
+				}),
+				lambdaFunctionNames: holidayStopApiLambda.functionName,
+			});
+		}
+	}
+}

--- a/cdk/lib/holiday-stop-api.ts
+++ b/cdk/lib/holiday-stop-api.ts
@@ -43,7 +43,7 @@ export class HolidayStopApi extends GuStack {
 				fulfilmentDatesBucketUrn:
 					'arn:aws:s3:::fulfilment-date-calculator-prod/*',
 			},
-		}[this.stage] || {
+		}[this.stage] ?? {
 			domainName: 'holiday-stop-api-code.support.guardianapis.com',
 			fulfilmentDatesBucketUrn:
 				'arn:aws:s3:::fulfilment-date-calculator-code/*',


### PR DESCRIPTION
## Summary

This PR migrates the `holiday-stop-api` from a CloudFormation template (`cfn.yaml`) to a native CDK implementation, improving maintainability and consistency with other Guardian projects.

## What's Changed

### 🆕 New Files
- **`cdk/lib/holiday-stop-api.ts`** - Complete CDK stack implementation
- **`cdk/lib/holiday-stop-api.test.ts`** - Unit tests for the new stack

### 📝 Modified Files
- **`cdk/bin/cdk.ts`** - Added HolidayStopApi stack instantiation for CODE and PROD environments

### 🗑️ Files to Remove (Post-Deployment)
- **`handlers/holiday-stop-api/cfn.yaml`** - Original CloudFormation template (will be removed after successful deployment)

## Breaking Changes

None - this is a like-for-like migration maintaining full backward compatibility.

## Related Issues

This addresses the ongoing [initiative to migrate all CloudFormation templates to native CDK](https://trello.com/c/JU31sVP1) implementations across the support-service-lambdas repository.

---

**Note**: The original CloudFormation template will be removed in a follow-up PR after successful deployment and verification of the CDK implementation.
