### PR TITLE
Migrate delivery-records-api from CloudFormation to native CDK

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,6 +3,7 @@ import { App } from 'aws-cdk-lib';
 import { AlarmsHandler } from '../lib/alarms-handler';
 import { BatchEmailSender } from '../lib/batch-email-sender';
 import { CancellationSfCasesApi } from '../lib/cancellation-sf-cases-api';
+import { DeliveryRecordsApi } from '../lib/delivery-records-api';
 import { DiscountApi } from '../lib/discount-api';
 import { DiscountExpiryNotifier } from '../lib/discount-expiry-notifier';
 import { GenerateProductCatalog } from '../lib/generate-product-catalog';
@@ -367,6 +368,15 @@ new MParticleApi(app, 'mparticle-api-CODE', {
 	stage: 'CODE',
 });
 new MParticleApi(app, 'mparticle-api-PROD', {
+	stack: 'support',
+	stage: 'PROD',
+});
+
+new DeliveryRecordsApi(app, 'delivery-records-api-CODE', {
+	stack: 'support',
+	stage: 'CODE',
+});
+new DeliveryRecordsApi(app, 'delivery-records-api-PROD', {
 	stack: 'support',
 	stage: 'PROD',
 });

--- a/cdk/lib/delivery-records-api.test.ts
+++ b/cdk/lib/delivery-records-api.test.ts
@@ -76,7 +76,8 @@ describe('DeliveryRecordsApi stack', () => {
 					{
 						Effect: 'Allow',
 						Action: 's3:GetObject',
-						Resource: 'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/TEST/*',
+						Resource:
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/TEST/*',
 					},
 				]),
 				Version: '2012-10-17',
@@ -86,23 +87,15 @@ describe('DeliveryRecordsApi stack', () => {
 
 	it('creates alarms only for PROD stage', () => {
 		const app = new App();
-		const codeStack = new DeliveryRecordsApi(
-			app,
-			'DeliveryRecordsApiCode',
-			{
-				stack: 'support',
-				stage: 'CODE',
-			},
-		);
+		const codeStack = new DeliveryRecordsApi(app, 'DeliveryRecordsApiCode', {
+			stack: 'support',
+			stage: 'CODE',
+		});
 
-		const prodStack = new DeliveryRecordsApi(
-			app,
-			'DeliveryRecordsApiProd',
-			{
-				stack: 'support',
-				stage: 'PROD',
-			},
-		);
+		const prodStack = new DeliveryRecordsApi(app, 'DeliveryRecordsApiProd', {
+			stack: 'support',
+			stage: 'PROD',
+		});
 
 		const codeTemplate = Template.fromStack(codeStack);
 		const prodTemplate = Template.fromStack(prodStack);
@@ -127,23 +120,15 @@ describe('DeliveryRecordsApi stack', () => {
 
 	it('uses correct domain names and API names for different stages', () => {
 		const app = new App();
-		const codeStack = new DeliveryRecordsApi(
-			app,
-			'DeliveryRecordsApiCode',
-			{
-				stack: 'support',
-				stage: 'CODE',
-			},
-		);
+		const codeStack = new DeliveryRecordsApi(app, 'DeliveryRecordsApiCode', {
+			stack: 'support',
+			stage: 'CODE',
+		});
 
-		const prodStack = new DeliveryRecordsApi(
-			app,
-			'DeliveryRecordsApiProd',
-			{
-				stack: 'support',
-				stage: 'PROD',
-			},
-		);
+		const prodStack = new DeliveryRecordsApi(app, 'DeliveryRecordsApiProd', {
+			stack: 'support',
+			stage: 'PROD',
+		});
 
 		const codeTemplate = Template.fromStack(codeStack);
 		const prodTemplate = Template.fromStack(prodStack);
@@ -177,23 +162,15 @@ describe('DeliveryRecordsApi stack', () => {
 
 	it('uses correct S3 bucket URNs for different stages', () => {
 		const app = new App();
-		const codeStack = new DeliveryRecordsApi(
-			app,
-			'DeliveryRecordsApiCode',
-			{
-				stack: 'support',
-				stage: 'CODE',
-			},
-		);
+		const codeStack = new DeliveryRecordsApi(app, 'DeliveryRecordsApiCode', {
+			stack: 'support',
+			stage: 'CODE',
+		});
 
-		const prodStack = new DeliveryRecordsApi(
-			app,
-			'DeliveryRecordsApiProd',
-			{
-				stack: 'support',
-				stage: 'PROD',
-			},
-		);
+		const prodStack = new DeliveryRecordsApi(app, 'DeliveryRecordsApiProd', {
+			stack: 'support',
+			stage: 'PROD',
+		});
 
 		const codeTemplate = Template.fromStack(codeStack);
 		const prodTemplate = Template.fromStack(prodStack);
@@ -205,7 +182,8 @@ describe('DeliveryRecordsApi stack', () => {
 					{
 						Effect: 'Allow',
 						Action: 's3:GetObject',
-						Resource: 'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/*',
+						Resource:
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/*',
 					},
 				]),
 				Version: '2012-10-17',
@@ -219,7 +197,8 @@ describe('DeliveryRecordsApi stack', () => {
 					{
 						Effect: 'Allow',
 						Action: 's3:GetObject',
-						Resource: 'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/*',
+						Resource:
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/*',
 					},
 				]),
 				Version: '2012-10-17',

--- a/cdk/lib/delivery-records-api.test.ts
+++ b/cdk/lib/delivery-records-api.test.ts
@@ -1,5 +1,5 @@
 import { App } from 'aws-cdk-lib';
-import { Template, Match } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { DeliveryRecordsApi } from './delivery-records-api';
 
 describe('DeliveryRecordsApi stack', () => {

--- a/cdk/lib/delivery-records-api.test.ts
+++ b/cdk/lib/delivery-records-api.test.ts
@@ -1,0 +1,229 @@
+import { App } from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { DeliveryRecordsApi } from './delivery-records-api';
+
+describe('DeliveryRecordsApi stack', () => {
+	it('creates the expected resources', () => {
+		const app = new App();
+		const stack = new DeliveryRecordsApi(app, 'DeliveryRecordsApi', {
+			stack: 'support',
+			stage: 'TEST',
+		});
+
+		const template = Template.fromStack(stack);
+
+		// Check that lambda function is created
+		template.hasResourceProperties('AWS::Lambda::Function', {
+			Handler: 'com.gu.delivery_records_api.Handler::handle',
+			Runtime: 'java21',
+			MemorySize: 1536,
+			Timeout: 300,
+			Architectures: ['arm64'],
+		});
+
+		// Check that API Gateway is created
+		template.hasResourceProperties('AWS::ApiGateway::RestApi', {
+			Name: 'delivery-records-api-CODE',
+			Description: 'api for accessing delivery records in salesforce',
+		});
+
+		// Check that API Gateway method has API key requirement
+		template.hasResourceProperties('AWS::ApiGateway::Method', {
+			ApiKeyRequired: true,
+		});
+
+		// Check that Usage Plan is created
+		template.hasResourceProperties('AWS::ApiGateway::UsagePlan', {
+			UsagePlanName: 'delivery-records-api',
+		});
+
+		// Check that API Key is created
+		template.hasResourceProperties('AWS::ApiGateway::ApiKey', {
+			Name: 'delivery-records-api-key-TEST',
+			Description: 'Used by manage-frontend',
+		});
+
+		// Check that Usage Plan Key is created
+		template.hasResourceProperties('AWS::ApiGateway::UsagePlanKey', {
+			KeyType: 'API_KEY',
+		});
+
+		// Check that custom domain name is created
+		template.hasResourceProperties('AWS::ApiGateway::DomainName', {
+			DomainName: 'delivery-records-api-code.support.guardianapis.com',
+			EndpointConfiguration: {
+				Types: ['REGIONAL'],
+			},
+		});
+
+		// Check that base path mapping is created
+		template.hasResourceProperties('AWS::ApiGateway::BasePathMapping', {
+			Stage: 'TEST',
+		});
+
+		// Check that DNS record is created
+		template.hasResourceProperties('AWS::Route53::RecordSet', {
+			HostedZoneName: 'support.guardianapis.com.',
+			Name: 'delivery-records-api-code.support.guardianapis.com',
+			Type: 'CNAME',
+			TTL: '120',
+		});
+
+		// Check that IAM role has correct S3 permissions
+		template.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: Match.arrayWith([
+					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
+						Resource: 'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/TEST/*',
+					},
+				]),
+				Version: '2012-10-17',
+			},
+		});
+	});
+
+	it('creates alarms only for PROD stage', () => {
+		const app = new App();
+		const codeStack = new DeliveryRecordsApi(
+			app,
+			'DeliveryRecordsApiCode',
+			{
+				stack: 'support',
+				stage: 'CODE',
+			},
+		);
+
+		const prodStack = new DeliveryRecordsApi(
+			app,
+			'DeliveryRecordsApiProd',
+			{
+				stack: 'support',
+				stage: 'PROD',
+			},
+		);
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// CODE should not have alarms
+		codeTemplate.resourceCountIs('AWS::CloudWatch::Alarm', 0);
+
+		// PROD should have alarms
+		prodTemplate.resourcePropertiesCountIs('AWS::CloudWatch::Alarm', {}, 1);
+
+		// Verify the alarm configuration for PROD
+		prodTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+			AlarmName: '5XX rate from delivery-records-api-PROD',
+			AlarmDescription:
+				'Delivery records API exceeded the allowed 5XX error rate',
+			ComparisonOperator: 'GreaterThanThreshold',
+			Threshold: 2,
+			EvaluationPeriods: 1,
+			TreatMissingData: 'notBreaching',
+		});
+	});
+
+	it('uses correct domain names and API names for different stages', () => {
+		const app = new App();
+		const codeStack = new DeliveryRecordsApi(
+			app,
+			'DeliveryRecordsApiCode',
+			{
+				stack: 'support',
+				stage: 'CODE',
+			},
+		);
+
+		const prodStack = new DeliveryRecordsApi(
+			app,
+			'DeliveryRecordsApiProd',
+			{
+				stack: 'support',
+				stage: 'PROD',
+			},
+		);
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// CODE should use CODE domain and API name
+		codeTemplate.hasResourceProperties('AWS::ApiGateway::RestApi', {
+			Name: 'delivery-records-api-CODE',
+		});
+
+		codeTemplate.hasResourceProperties('AWS::ApiGateway::DomainName', {
+			DomainName: 'delivery-records-api-code.support.guardianapis.com',
+		});
+
+		codeTemplate.hasResourceProperties('AWS::Route53::RecordSet', {
+			Name: 'delivery-records-api-code.support.guardianapis.com',
+		});
+
+		// PROD should use PROD domain and API name
+		prodTemplate.hasResourceProperties('AWS::ApiGateway::RestApi', {
+			Name: 'delivery-records-api-PROD',
+		});
+
+		prodTemplate.hasResourceProperties('AWS::ApiGateway::DomainName', {
+			DomainName: 'delivery-records-api.support.guardianapis.com',
+		});
+
+		prodTemplate.hasResourceProperties('AWS::Route53::RecordSet', {
+			Name: 'delivery-records-api.support.guardianapis.com',
+		});
+	});
+
+	it('uses correct S3 bucket URNs for different stages', () => {
+		const app = new App();
+		const codeStack = new DeliveryRecordsApi(
+			app,
+			'DeliveryRecordsApiCode',
+			{
+				stack: 'support',
+				stage: 'CODE',
+			},
+		);
+
+		const prodStack = new DeliveryRecordsApi(
+			app,
+			'DeliveryRecordsApiProd',
+			{
+				stack: 'support',
+				stage: 'PROD',
+			},
+		);
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// CODE should use CODE stage in S3 bucket path
+		codeTemplate.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: Match.arrayWith([
+					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
+						Resource: 'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/*',
+					},
+				]),
+				Version: '2012-10-17',
+			},
+		});
+
+		// PROD should use PROD stage in S3 bucket path
+		prodTemplate.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: Match.arrayWith([
+					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
+						Resource: 'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/*',
+					},
+				]),
+				Version: '2012-10-17',
+			},
+		});
+	});
+});

--- a/cdk/lib/delivery-records-api.ts
+++ b/cdk/lib/delivery-records-api.ts
@@ -41,7 +41,7 @@ export class DeliveryRecordsApi extends GuStack {
 				domainName: 'delivery-records-api.support.guardianapis.com',
 				apiName: 'delivery-records-api-PROD',
 			},
-		}[this.stage] || {
+		}[this.stage] ?? {
 			domainName: 'delivery-records-api-code.support.guardianapis.com',
 			apiName: 'delivery-records-api-CODE',
 		};

--- a/cdk/lib/delivery-records-api.ts
+++ b/cdk/lib/delivery-records-api.ts
@@ -1,0 +1,166 @@
+import { GuApiLambda } from '@guardian/cdk';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { App } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
+import {
+	ApiKey,
+	ApiKeySourceType,
+	CfnBasePathMapping,
+	CfnDomainName,
+	CfnUsagePlanKey,
+	UsagePlan,
+} from 'aws-cdk-lib/aws-apigateway';
+import {
+	ComparisonOperator,
+	Metric,
+	TreatMissingData,
+} from 'aws-cdk-lib/aws-cloudwatch';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Architecture, LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
+
+export class DeliveryRecordsApi extends GuStack {
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+
+		const app = 'delivery-records-api';
+		const functionName = `${app}-${this.stage}`;
+
+		// Map stage-specific configurations
+		const stageConfig: {
+			domainName: string;
+			apiName: string;
+		} = {
+			CODE: {
+				domainName: 'delivery-records-api-code.support.guardianapis.com',
+				apiName: 'delivery-records-api-CODE',
+			},
+			PROD: {
+				domainName: 'delivery-records-api.support.guardianapis.com',
+				apiName: 'delivery-records-api-PROD',
+			},
+		}[this.stage] || {
+			domainName: 'delivery-records-api-code.support.guardianapis.com',
+			apiName: 'delivery-records-api-CODE',
+		};
+
+		// Create the main API Lambda with proxy pattern
+		const deliveryRecordsApiLambda = new GuApiLambda(
+			this,
+			'DeliveryRecordsApi',
+			{
+				fileName: 'delivery-records-api.jar',
+				handler: 'com.gu.delivery_records_api.Handler::handle',
+				runtime: Runtime.JAVA_21,
+				memorySize: 1536,
+				timeout: Duration.minutes(5),
+				environment: {
+					Stage: this.stage,
+				},
+				app: app,
+				api: {
+					id: functionName,
+					restApiName: stageConfig.apiName,
+					description: 'api for accessing delivery records in salesforce',
+					proxy: true, // Uses {proxy+} pattern like the original CloudFormation
+					deployOptions: {
+						stageName: this.stage,
+					},
+					apiKeySourceType: ApiKeySourceType.HEADER,
+					defaultMethodOptions: {
+						apiKeyRequired: true,
+					},
+				},
+				monitoringConfiguration: {
+					noMonitoring: true, // We'll create custom alarms
+				},
+				architecture: Architecture.ARM_64,
+				loggingFormat: LoggingFormat.TEXT,
+			},
+		);
+
+		// Add S3 permissions for private credentials
+		deliveryRecordsApiLambda.addToRolePolicy(
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: ['s3:GetObject'],
+				resources: [
+					`arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${this.stage}/*`,
+				],
+			}),
+		);
+
+		// Create API usage plan and key
+		const usagePlan = new UsagePlan(this, 'DeliveryRecordsApiUsagePlan', {
+			name: 'delivery-records-api',
+			apiStages: [
+				{
+					stage: deliveryRecordsApiLambda.api.deploymentStage,
+					api: deliveryRecordsApiLambda.api,
+				},
+			],
+		});
+
+		const apiKey = new ApiKey(this, 'DeliveryRecordsApiKey', {
+			apiKeyName: `${app}-key-${this.stage}`,
+			description: 'Used by manage-frontend',
+		});
+
+		new CfnUsagePlanKey(this, 'DeliveryRecordsApiUsagePlanKey', {
+			keyId: apiKey.keyId,
+			keyType: 'API_KEY',
+			usagePlanId: usagePlan.usagePlanId,
+		});
+
+		// Custom domain name
+		const domainName = new CfnDomainName(this, 'DeliveryRecordsApiDomainName', {
+			regionalCertificateArn: `arn:aws:acm:${this.region}:${this.account}:certificate/b384a6a0-2f54-4874-b99b-96eeff96c009`,
+			domainName: stageConfig.domainName,
+			endpointConfiguration: {
+				types: ['REGIONAL'],
+			},
+		});
+
+		new CfnBasePathMapping(this, 'DeliveryRecordsApiBasePathMapping', {
+			restApiId: deliveryRecordsApiLambda.api.restApiId,
+			domainName: domainName.ref,
+			stage: this.stage,
+		});
+
+		// DNS record
+		new CfnRecordSet(this, 'DeliveryRecordsApiDNSRecord', {
+			hostedZoneName: 'support.guardianapis.com.',
+			name: stageConfig.domainName,
+			type: 'CNAME',
+			ttl: '120',
+			resourceRecords: [domainName.attrRegionalDomainName],
+		});
+
+		// Create PROD-only CloudWatch alarm for 5XX errors
+		if (this.stage === 'PROD') {
+			new SrLambdaAlarm(this, '5XXApiAlarm', {
+				app,
+				alarmName: `5XX rate from ${stageConfig.apiName}`,
+				alarmDescription:
+					'Delivery records API exceeded the allowed 5XX error rate',
+				evaluationPeriods: 1,
+				threshold: 2,
+				comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+				treatMissingData: TreatMissingData.NOT_BREACHING,
+				metric: new Metric({
+					metricName: '5XXError',
+					namespace: 'AWS/ApiGateway',
+					dimensionsMap: {
+						ApiName: stageConfig.apiName,
+						Stage: this.stage,
+					},
+					statistic: 'Sum',
+					period: Duration.hours(1),
+				}),
+				lambdaFunctionNames: deliveryRecordsApiLambda.functionName,
+			});
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR migrates the `delivery-records-api` from a CloudFormation template (`cfn.yaml`) to a native CDK implementation, improving maintainability and consistency with other Guardian projects.

## What's Changed

### 🆕 New Files
- **`cdk/lib/delivery-records-api.ts`** - Complete CDK stack implementation
- **`cdk/lib/delivery-records-api.test.ts`** - Unit tests for the new stack

### 📝 Modified Files
- **`cdk/bin/cdk.ts`** - Added DeliveryRecordsApi stack instantiation for CODE and PROD environments

### 🗑️ Files to Remove (Post-Deployment)
- **`handlers/delivery-records-api/cfn.yaml`** - Original CloudFormation template (will be removed after successful deployment)

## Breaking Changes

None - this is a like-for-like migration maintaining full backward compatibility.

## Related Issues

This addresses the ongoing [initiative to migrate all CloudFormation templates to native CDK](https://trello.com/c/JU31sVP1) implementations across the support-service-lambdas repository.

---

**Note**: The original CloudFormation template will be removed in a follow-up PR after successful deployment and verification of the CDK implementation.
