### PR TITLE
Add auth folder to zuora module

### DIFF
--- a/handlers/product-switch-api/test/amendments.test.ts
+++ b/handlers/product-switch-api/test/amendments.test.ts
@@ -1,4 +1,4 @@
-import type { BearerTokenProvider } from '@modules/zuora/bearerTokenProvider';
+import type { BearerTokenProvider } from '@modules/zuora/auth/bearerTokenProvider';
 import type { Logger } from '@modules/zuora/logger';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { getLastAmendment } from '../src/amendments';

--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -1,6 +1,6 @@
-import { zuoraServerUrl } from './common';
-import type { OAuthClientCredentials, ZuoraBearerToken } from './zuoraSchemas';
-import { zuoraBearerTokenSchema } from './zuoraSchemas';
+import { zuoraServerUrl } from '../common';
+import type { OAuthClientCredentials, ZuoraBearerToken } from '../zuoraSchemas';
+import { zuoraBearerTokenSchema } from '../zuoraSchemas';
 
 export class BearerTokenProvider {
 	private bearerToken: ZuoraBearerToken | null = null;

--- a/modules/zuora/src/auth/oAuthCredentials.ts
+++ b/modules/zuora/src/auth/oAuthCredentials.ts
@@ -4,8 +4,8 @@ import {
 } from '@aws-sdk/client-secrets-manager';
 import { awsConfig } from '@modules/aws/config';
 import type { Stage } from '@modules/stage';
-import type { OAuthClientCredentials } from './zuoraSchemas';
-import { oAuthClientCredentialsSchema } from './zuoraSchemas';
+import type { OAuthClientCredentials } from '../zuoraSchemas';
+import { oAuthClientCredentialsSchema } from '../zuoraSchemas';
 
 export const getOAuthClientCredentials = async (
 	stage: Stage,

--- a/modules/zuora/src/zuoraClient.ts
+++ b/modules/zuora/src/zuoraClient.ts
@@ -3,7 +3,7 @@ import type { z } from 'zod';
 import { Logger } from '@modules/zuora/logger';
 import { BearerTokenProvider } from './auth/bearerTokenProvider';
 import { zuoraServerUrl } from './common';
-import { getOAuthClientCredentials } from './oAuthCredentials';
+import { getOAuthClientCredentials } from './auth/oAuthCredentials';
 import { generateZuoraError } from './zuoraErrorHandler';
 import type { ZuoraResponse } from './types/httpResponse';
 

--- a/modules/zuora/src/zuoraClient.ts
+++ b/modules/zuora/src/zuoraClient.ts
@@ -1,7 +1,7 @@
 import type { Stage } from '@modules/stage';
 import type { z } from 'zod';
 import { Logger } from '@modules/zuora/logger';
-import { BearerTokenProvider } from './bearerTokenProvider';
+import { BearerTokenProvider } from './auth/bearerTokenProvider';
 import { zuoraServerUrl } from './common';
 import { getOAuthClientCredentials } from './oAuthCredentials';
 import { generateZuoraError } from './zuoraErrorHandler';

--- a/modules/zuora/test/mocks/mockZuoraClient.ts
+++ b/modules/zuora/test/mocks/mockZuoraClient.ts
@@ -1,5 +1,5 @@
 import type { Stage } from '@modules/stage';
-import { BearerTokenProvider } from '@modules/zuora/bearerTokenProvider';
+import { BearerTokenProvider } from '@modules/zuora/auth/bearerTokenProvider';
 import { Logger } from '@modules/zuora/logger';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 

--- a/modules/zuora/test/mocks/mockZuoraClient.ts
+++ b/modules/zuora/test/mocks/mockZuoraClient.ts
@@ -1,5 +1,5 @@
 import type { Stage } from '@modules/stage';
-import { BearerTokenProvider } from '@modules/zuora/auth/bearerTokenProvider';
+import { BearerTokenProvider } from '../../src/auth/bearerTokenProvider';
 import { Logger } from '@modules/zuora/logger';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 

--- a/modules/zuora/test/mocks/mockZuoraClient.ts
+++ b/modules/zuora/test/mocks/mockZuoraClient.ts
@@ -1,7 +1,7 @@
 import type { Stage } from '@modules/stage';
-import { BearerTokenProvider } from '../../src/auth/bearerTokenProvider';
 import { Logger } from '@modules/zuora/logger';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { BearerTokenProvider } from '../../src/auth/bearerTokenProvider';
 
 class MockZuoraClient extends ZuoraClient {
 	constructor() {

--- a/modules/zuora/test/zuoraClient.test.ts
+++ b/modules/zuora/test/zuoraClient.test.ts
@@ -8,14 +8,14 @@ import { z } from 'zod';
 global.fetch = jest.fn();
 
 // Mock the dependencies
-jest.mock('../src/oAuthCredentials', () => ({
+jest.mock('../src/auth/oAuthCredentials', () => ({
 	getOAuthClientCredentials: jest.fn().mockResolvedValue({
 		client_id: 'test_client',
 		client_secret: 'test_secret',
 	}),
 }));
 
-jest.mock('../src/bearerTokenProvider');
+jest.mock('../src/auth/bearerTokenProvider');
 jest.mock('../src/common', () => ({
 	zuoraServerUrl: jest.fn(() => 'https://rest.apisandbox.zuora.com'),
 }));

--- a/modules/zuora/test/zuoraClient.test.ts
+++ b/modules/zuora/test/zuoraClient.test.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@modules/zuora/logger';
 import { ZuoraError } from '@modules/zuora/zuoraError';
-import { BearerTokenProvider } from '../src/bearerTokenProvider';
+import { BearerTokenProvider } from '../src/auth/bearerTokenProvider';
 import { ZuoraClient } from '../src/zuoraClient';
 import { z } from 'zod';
 

--- a/modules/zuora/test/zuoraClientIntegration.test.ts
+++ b/modules/zuora/test/zuoraClientIntegration.test.ts
@@ -6,7 +6,7 @@
 
 import { Logger } from '@modules/zuora/logger';
 import { BearerTokenProvider } from '../src/auth/bearerTokenProvider';
-import { getOAuthClientCredentials } from '../src/oAuthCredentials';
+import { getOAuthClientCredentials } from '../src/auth/oAuthCredentials';
 import { ZuoraClient } from '../src/zuoraClient';
 import type { ZuoraSubscription } from '../src/zuoraSchemas';
 import { zuoraSubscriptionResponseSchema } from '../src/zuoraSchemas';

--- a/modules/zuora/test/zuoraClientIntegration.test.ts
+++ b/modules/zuora/test/zuoraClientIntegration.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { Logger } from '@modules/zuora/logger';
-import { BearerTokenProvider } from '../src/bearerTokenProvider';
+import { BearerTokenProvider } from '../src/auth/bearerTokenProvider';
 import { getOAuthClientCredentials } from '../src/oAuthCredentials';
 import { ZuoraClient } from '../src/zuoraClient';
 import type { ZuoraSubscription } from '../src/zuoraSchemas';

--- a/modules/zuora/test/zuoraIntegration.test.ts
+++ b/modules/zuora/test/zuoraIntegration.test.ts
@@ -4,7 +4,7 @@
  * @group integration
  */
 
-import { BearerTokenProvider } from '../src/bearerTokenProvider';
+import { BearerTokenProvider } from '../src/auth/bearerTokenProvider';
 import { getOAuthClientCredentials } from '../src/oAuthCredentials';
 import { getSubscription } from '../src/subscription';
 import { ZuoraClient } from '../src/zuoraClient';

--- a/modules/zuora/test/zuoraIntegration.test.ts
+++ b/modules/zuora/test/zuoraIntegration.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { BearerTokenProvider } from '../src/auth/bearerTokenProvider';
-import { getOAuthClientCredentials } from '../src/oAuthCredentials';
+import { getOAuthClientCredentials } from '../src/auth/oAuthCredentials';
 import { getSubscription } from '../src/subscription';
 import { ZuoraClient } from '../src/zuoraClient';
 


### PR DESCRIPTION
## What does this change?

**Add auth folder to Zuora module**

Introduces an auth folder to the Zuora module, providing a dedicated location for authentication logic and related resources. This change aims to improve code organization and maintainability within the Zuora integration. 

Coming next
- improve the folder structure of zuora module by adding:
  - objects
  - utils
  - actions
  - error