### PR TITLE
Add +digital rate plans to National Delivery supported products

### DIFF
--- a/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
+++ b/lib/zuora-core/src/main/scala/com/gu/zuora/subscription/SupportedProduct.scala
@@ -277,8 +277,11 @@ object SupportedProduct {
       annualIssueLimitPerEdition = 5,
       ratePlans = List(
         SupportedRatePlan("Weekend", weekendCharges),
+        SupportedRatePlan("Weekend+", weekendCharges),
         SupportedRatePlan("Everyday", everyDayCharges),
+        SupportedRatePlan("Everyday+", everyDayCharges),
         SupportedRatePlan("Sixday", sixDayCharges),
+        SupportedRatePlan("Sixday+", sixDayCharges),
       ),
     ),
   )


### PR DESCRIPTION
## What does this change?
In July 2025, we started to sell the "+Digital" rate plan options for National Delivery for the first time. 

Because these were not explicitly supported in the library used by holiday-stop-api, this meant that customers (and CSRs) were not able to add holiday stops or delivery issues. 

In the holiday-stop-api we would see this error:

`ERROR com.gu.util.reader.Types$ -- Failed to extract subscription data from subscription: ZuoraApiFailure(Could not derive product type as there are no supported rateplan charges)`

Users in MMA will see the "oops" error:
<img width="686" height="251" alt="Screenshot 2025-07-29 at 16 10 38" src="https://github.com/user-attachments/assets/2391fd1b-9c22-4ac0-9e6d-cde825fbfb4b" />

## How to test
Acquire a new National Delivery subscription with one of the +digital rate plans, and verify that you can now add Holiday Stops (and delivery issues)