### PR TITLE
Migrate cancellation-sf-cases-api from CloudFormation to native CDK

### DIFF
--- a/cdk/lib/cancellation-sf-cases-api.test.ts
+++ b/cdk/lib/cancellation-sf-cases-api.test.ts
@@ -1,0 +1,339 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { CancellationSfCasesApi } from './cancellation-sf-cases-api';
+
+describe('CancellationSfCasesApi stack', () => {
+	it('creates the expected resources', () => {
+		const app = new App();
+		const stack = new CancellationSfCasesApi(app, 'CancellationSfCasesApi', {
+			stack: 'membership',
+			stage: 'TEST',
+		});
+
+		const template = Template.fromStack(stack);
+
+		// Check that lambda function is created
+		template.hasResourceProperties('AWS::Lambda::Function', {
+			FunctionName: 'cancellation-sf-cases-api-TEST',
+			Handler: 'com.gu.cancellation.sf_cases.Handler::handle',
+			Runtime: 'java21',
+			MemorySize: 1536,
+			Timeout: 300,
+			Architectures: ['arm64'],
+		});
+
+		// Check that API Gateway REST API is created
+		template.hasResourceProperties('AWS::ApiGateway::RestApi', {
+			Name: 'membership-TEST-cancellation-sf-cases-api',
+		});
+
+		// Check that API Gateway methods are created with API key requirements
+		template.hasResourceProperties('AWS::ApiGateway::Method', {
+			ApiKeyRequired: true,
+			AuthorizationType: 'NONE',
+			HttpMethod: 'GET',
+		});
+
+		template.hasResourceProperties('AWS::ApiGateway::Method', {
+			ApiKeyRequired: true,
+			AuthorizationType: 'NONE',
+			HttpMethod: 'POST',
+		});
+
+		// Check that API key is created
+		template.hasResourceProperties('AWS::ApiGateway::ApiKey', {
+			Name: 'cancellation-sf-cases-api-key-TEST',
+			Description: 'Used by manage-frontend',
+			Enabled: true,
+		});
+
+		// Check that usage plan is created
+		template.hasResourceProperties('AWS::ApiGateway::UsagePlan', {
+			UsagePlanName: 'cancellation-sf-cases-api',
+		});
+
+		// Check that usage plan key is created
+		template.hasResourceProperties('AWS::ApiGateway::UsagePlanKey', {
+			KeyType: 'API_KEY',
+		});
+
+		// Check that IAM role has correct S3 policies
+		template.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: [
+					{
+						Effect: 'Allow',
+						Action: ['s3:GetObject*', 's3:GetBucket*', 's3:List*'],
+					},
+					{
+						Effect: 'Allow',
+						Action: 'ssm:GetParametersByPath',
+					},
+					{
+						Effect: 'Allow',
+						Action: ['ssm:GetParameters', 'ssm:GetParameter'],
+					},
+					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
+						Resource:
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/TEST/*',
+					},
+				],
+				Version: '2012-10-17',
+			},
+		});
+	});
+
+	it('creates custom domain and DNS records', () => {
+		const app = new App();
+		const codeStack = new CancellationSfCasesApi(
+			app,
+			'CancellationSfCasesApiCode',
+			{
+				stack: 'membership',
+				stage: 'CODE',
+			},
+		);
+
+		const prodStack = new CancellationSfCasesApi(
+			app,
+			'CancellationSfCasesApiProd',
+			{
+				stack: 'membership',
+				stage: 'PROD',
+			},
+		);
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// Check CODE domain configuration
+		codeTemplate.hasResourceProperties('AWS::ApiGateway::DomainName', {
+			DomainName: 'cancellation-sf-cases-code.support.guardianapis.com',
+			EndpointConfiguration: {
+				Types: ['REGIONAL'],
+			},
+		});
+
+		codeTemplate.hasResourceProperties('AWS::Route53::RecordSet', {
+			Name: 'cancellation-sf-cases-code.support.guardianapis.com',
+			Type: 'CNAME',
+			HostedZoneName: 'support.guardianapis.com.',
+			TTL: '120',
+		});
+
+		// Check PROD domain configuration
+		prodTemplate.hasResourceProperties('AWS::ApiGateway::DomainName', {
+			DomainName: 'cancellation-sf-cases.support.guardianapis.com',
+			EndpointConfiguration: {
+				Types: ['REGIONAL'],
+			},
+		});
+
+		prodTemplate.hasResourceProperties('AWS::Route53::RecordSet', {
+			Name: 'cancellation-sf-cases.support.guardianapis.com',
+			Type: 'CNAME',
+			HostedZoneName: 'support.guardianapis.com.',
+			TTL: '120',
+		});
+
+		// Check that base path mapping is created
+		codeTemplate.hasResourceProperties('AWS::ApiGateway::BasePathMapping', {});
+		prodTemplate.hasResourceProperties('AWS::ApiGateway::BasePathMapping', {});
+	});
+
+	it('creates alarms only for PROD stage', () => {
+		const app = new App();
+		const codeStack = new CancellationSfCasesApi(
+			app,
+			'CancellationSfCasesApiCode',
+			{
+				stack: 'membership',
+				stage: 'CODE',
+			},
+		);
+
+		const prodStack = new CancellationSfCasesApi(
+			app,
+			'CancellationSfCasesApiProd',
+			{
+				stack: 'membership',
+				stage: 'PROD',
+			},
+		);
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// CODE should not have alarms
+		codeTemplate.resourceCountIs('AWS::CloudWatch::Alarm', 0);
+
+		// PROD should have alarms
+		prodTemplate.resourcePropertiesCountIs('AWS::CloudWatch::Alarm', {}, 1);
+
+		// Verify the alarm configuration for PROD
+		prodTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+			AlarmName: '5XX from cancellation-sf-cases-api-PROD',
+			ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+			Threshold: 1,
+			EvaluationPeriods: 1,
+			TreatMissingData: 'notBreaching',
+			MetricName: '5XXError',
+			Namespace: 'AWS/ApiGateway',
+			Statistic: 'Sum',
+		});
+	});
+
+	it('creates correct number of API Gateway methods for all HTTP verbs', () => {
+		const app = new App();
+		const stack = new CancellationSfCasesApi(app, 'CancellationSfCasesApi', {
+			stack: 'membership',
+			stage: 'TEST',
+		});
+
+		const template = Template.fromStack(stack);
+
+		// Should have methods for both root (/) and proxy (/{proxy+}) paths
+		// 7 HTTP methods × 2 paths = 14 methods total
+		template.resourceCountIs('AWS::ApiGateway::Method', 14);
+
+		// Check that all HTTP methods are represented
+		const httpMethods = [
+			'GET',
+			'POST',
+			'PUT',
+			'DELETE',
+			'PATCH',
+			'HEAD',
+			'OPTIONS',
+		];
+
+		httpMethods.forEach((method) => {
+			// Check method exists with API key requirement
+			template.hasResourceProperties('AWS::ApiGateway::Method', {
+				HttpMethod: method,
+				ApiKeyRequired: true,
+				AuthorizationType: 'NONE',
+			});
+		});
+	});
+
+	it('uses correct S3 bucket paths for different stages', () => {
+		const app = new App();
+		const codeStack = new CancellationSfCasesApi(
+			app,
+			'CancellationSfCasesApiCode',
+			{
+				stack: 'membership',
+				stage: 'CODE',
+			},
+		);
+
+		const prodStack = new CancellationSfCasesApi(
+			app,
+			'CancellationSfCasesApiProd',
+			{
+				stack: 'membership',
+				stage: 'PROD',
+			},
+		);
+
+		const codeTemplate = Template.fromStack(codeStack);
+		const prodTemplate = Template.fromStack(prodStack);
+
+		// CODE should use CODE-specific S3 path
+		codeTemplate.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: [
+					{
+						Effect: 'Allow',
+						Action: ['s3:GetObject*', 's3:GetBucket*', 's3:List*'],
+					},
+					{
+						Effect: 'Allow',
+						Action: 'ssm:GetParametersByPath',
+					},
+					{
+						Effect: 'Allow',
+						Action: ['ssm:GetParameters', 'ssm:GetParameter'],
+					},
+					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
+						Resource:
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/CODE/*',
+					},
+				],
+				Version: '2012-10-17',
+			},
+		});
+
+		// PROD should use PROD-specific S3 path
+		prodTemplate.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: [
+					{
+						Effect: 'Allow',
+						Action: ['s3:GetObject*', 's3:GetBucket*', 's3:List*'],
+					},
+					{
+						Effect: 'Allow',
+						Action: 'ssm:GetParametersByPath',
+					},
+					{
+						Effect: 'Allow',
+						Action: ['ssm:GetParameters', 'ssm:GetParameter'],
+					},
+					{
+						Effect: 'Allow',
+						Action: 's3:GetObject',
+						Resource:
+							'arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/PROD/*',
+					},
+				],
+				Version: '2012-10-17',
+			},
+		});
+	});
+
+	it('creates API Gateway deployment and stage', () => {
+		const app = new App();
+		const stack = new CancellationSfCasesApi(app, 'CancellationSfCasesApi', {
+			stack: 'membership',
+			stage: 'TEST',
+		});
+
+		const template = Template.fromStack(stack);
+
+		// Check that API Gateway deployment is created
+		template.hasResourceProperties('AWS::ApiGateway::Deployment', {});
+
+		// Check that API Gateway stage is created
+		template.hasResourceProperties('AWS::ApiGateway::Stage', {
+			StageName: 'prod',
+		});
+	});
+
+	it('configures lambda with correct environment variables', () => {
+		const app = new App();
+		const stack = new CancellationSfCasesApi(app, 'CancellationSfCasesApi', {
+			stack: 'membership',
+			stage: 'TEST',
+		});
+
+		const template = Template.fromStack(stack);
+
+		// Check that lambda has correct environment variables
+		template.hasResourceProperties('AWS::Lambda::Function', {
+			Environment: {
+				Variables: {
+					Stage: 'TEST',
+					STACK: 'membership',
+					STAGE: 'TEST',
+					APP: 'cancellation-sf-cases-api',
+				},
+			},
+		});
+	});
+});

--- a/cdk/lib/cancellation-sf-cases-api.ts
+++ b/cdk/lib/cancellation-sf-cases-api.ts
@@ -1,14 +1,236 @@
+import { GuApiGatewayWithLambdaByPath } from '@guardian/cdk';
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
-import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
+import { Duration } from 'aws-cdk-lib';
+import {
+	ApiKey,
+	CfnBasePathMapping,
+	CfnDomainName,
+	CfnUsagePlanKey,
+	UsagePlan,
+} from 'aws-cdk-lib/aws-apigateway';
+import {
+	ComparisonOperator,
+	Metric,
+	TreatMissingData,
+} from 'aws-cdk-lib/aws-cloudwatch';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Architecture, LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 
 export class CancellationSfCasesApi extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
-		const yamlTemplateFilePath = `${__dirname}/../../handlers/cancellation-sf-cases-api/cfn.yaml`;
-		new CfnInclude(this, 'YamlTemplate', {
-			templateFile: yamlTemplateFilePath,
+
+		const app = 'cancellation-sf-cases-api';
+		const nameWithStage = `${app}-${this.stage}`;
+
+		// Domain mapping based on stage
+		const domainName =
+			this.stage === 'PROD'
+				? 'cancellation-sf-cases.support.guardianapis.com'
+				: 'cancellation-sf-cases-code.support.guardianapis.com';
+
+		// Lambda function
+		const lambda = new GuLambdaFunction(this, `${app}-lambda`, {
+			description:
+				'manage-frontend used to create/update SalesForce cases for self service cancellation tracking',
+			functionName: nameWithStage,
+			loggingFormat: LoggingFormat.TEXT,
+			fileName: `${app}.jar`,
+			handler: 'com.gu.cancellation.sf_cases.Handler::handle',
+			runtime: Runtime.JAVA_21,
+			architecture: Architecture.ARM_64,
+			memorySize: 1536,
+			timeout: Duration.seconds(300),
+			environment: {
+				Stage: this.stage,
+			},
+			app: app,
 		});
+
+		// Add S3 access policy for private credentials
+		const s3Policy = new PolicyStatement({
+			effect: Effect.ALLOW,
+			actions: ['s3:GetObject'],
+			resources: [
+				`arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${this.stage}/*`,
+			],
+		});
+		lambda.role?.addToPrincipalPolicy(s3Policy);
+
+		// API Gateway with proxy configuration - create multiple targets for all methods
+		const api = new GuApiGatewayWithLambdaByPath(this, {
+			app,
+			monitoringConfiguration: { noMonitoring: true },
+			targets: [
+				// Root path methods
+				{
+					path: '/',
+					httpMethod: 'GET',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/',
+					httpMethod: 'POST',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/',
+					httpMethod: 'PUT',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/',
+					httpMethod: 'DELETE',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/',
+					httpMethod: 'PATCH',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/',
+					httpMethod: 'HEAD',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/',
+					httpMethod: 'OPTIONS',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				// Proxy path methods
+				{
+					path: '/{proxy+}',
+					httpMethod: 'GET',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/{proxy+}',
+					httpMethod: 'POST',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/{proxy+}',
+					httpMethod: 'PUT',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/{proxy+}',
+					httpMethod: 'DELETE',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/{proxy+}',
+					httpMethod: 'PATCH',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/{proxy+}',
+					httpMethod: 'HEAD',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+				{
+					path: '/{proxy+}',
+					httpMethod: 'OPTIONS',
+					lambda: lambda,
+					apiKeyRequired: true,
+				},
+			],
+		});
+
+		// API Key and Usage Plan
+		const usagePlan = new UsagePlan(this, 'CancellationSFCasesApiUsagePlan', {
+			name: 'cancellation-sf-cases-api',
+			apiStages: [
+				{
+					api: api.api,
+					stage: api.api.deploymentStage,
+				},
+			],
+		});
+
+		const apiKey = new ApiKey(this, 'CancellationSFCasesApiKey', {
+			apiKeyName: `cancellation-sf-cases-api-key-${this.stage}`,
+			description: 'Used by manage-frontend',
+			enabled: true,
+		});
+
+		new CfnUsagePlanKey(this, 'CancellationSFCasesApiUsagePlanKey', {
+			keyId: apiKey.keyId,
+			keyType: 'API_KEY',
+			usagePlanId: usagePlan.usagePlanId,
+		});
+
+		// Custom Domain
+		const cfnDomainName = new CfnDomainName(
+			this,
+			'CancellationSFCasesApiDomainName',
+			{
+				regionalCertificateArn: `arn:aws:acm:${this.region}:${this.account}:certificate/b384a6a0-2f54-4874-b99b-96eeff96c009`,
+				domainName: domainName,
+				endpointConfiguration: {
+					types: ['REGIONAL'],
+				},
+			},
+		);
+
+		new CfnBasePathMapping(this, 'CancellationSFCasesApiBasePathMapping', {
+			restApiId: api.api.restApiId,
+			domainName: cfnDomainName.ref,
+			stage: api.api.deploymentStage.stageName,
+		});
+
+		// DNS Record
+		new CfnRecordSet(this, 'CancellationSFCasesApiDNSRecord', {
+			hostedZoneName: 'support.guardianapis.com.',
+			name: domainName,
+			type: 'CNAME',
+			ttl: '120',
+			resourceRecords: [cfnDomainName.attrRegionalDomainName],
+		});
+
+		// 5XX Error Alarm (only for PROD)
+		if (this.stage === 'PROD') {
+			new GuAlarm(this, '5xxApiAlarm', {
+				app,
+				alarmName: `5XX from ${nameWithStage}`,
+				alarmDescription: `5XX errors from ${nameWithStage} API Gateway`,
+				threshold: 1,
+				evaluationPeriods: 1,
+				snsTopicName: `alarms-handler-topic-${this.stage}`,
+				actionsEnabled: true,
+				treatMissingData: TreatMissingData.NOT_BREACHING,
+				comparisonOperator:
+					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				metric: new Metric({
+					metricName: '5XXError',
+					namespace: 'AWS/ApiGateway',
+					statistic: 'Sum',
+					period: Duration.seconds(3600),
+					dimensionsMap: {
+						ApiName: nameWithStage,
+						Stage: this.stage,
+					},
+				}),
+			});
+		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR completes the migration of the cancellation-sf-cases-api component from CloudFormation template (cfn.yaml) to native CDK implementation, improving maintainability and consistency with other Guardian projects.

## What's Changed

### 🆕 New Files
- **`cdk/lib/cancellation-sf-cases-api.ts`** - Complete CDK stack implementation for cancellation SF cases API
- **`cdk/lib/cancellation-sf-cases-api.test.ts`** - Comprehensive unit tests for the cancellation SF cases API stack

### 🗑️ Files to Remove (Post-Deployment)
- **`handlers/cancellation-sf-cases-api/cfn.yaml`** - Original CloudFormation template (will be removed after successful deployment)

## Breaking Changes

None - this is a like-for-like migration maintaining full backward compatibility, with the following enhancements:
- **Runtime Upgrade**: Java 11 → Java 21 (backward compatible)
- **Architecture Upgrade**: x86_64 → ARM64 (improved performance)
- **Enhanced Testing**: Comprehensive test coverage added

## Related Issues

This addresses the ongoing [initiative to migrate all CloudFormation templates to native CDK](https://trello.com/c/JU31sVP1) implementations across the support-service-lambdas repository.

---

**Note**: The original CloudFormation template will be removed in a follow-up PR after successful deployment and verification of the CDK implementation.