### PR TITLE
Refactor zuora auth types

### DIFF
--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -1,6 +1,6 @@
 import { zuoraServerUrl } from '../utils/common';
-import type { OAuthClientCredentials, ZuoraBearerToken } from '../zuoraSchemas';
-import { zuoraBearerTokenSchema } from '../zuoraSchemas';
+import type { OAuthClientCredentials, ZuoraBearerToken } from '../types/auth';
+import { zuoraBearerTokenSchema } from '../types/auth';
 
 export class BearerTokenProvider {
 	private bearerToken: ZuoraBearerToken | null = null;

--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -1,6 +1,6 @@
-import { zuoraServerUrl } from '../utils/common';
 import type { OAuthClientCredentials, ZuoraBearerToken } from '../types/auth';
 import { zuoraBearerTokenSchema } from '../types/auth';
+import { zuoraServerUrl } from '../utils/common';
 
 export class BearerTokenProvider {
 	private bearerToken: ZuoraBearerToken | null = null;

--- a/modules/zuora/src/auth/oAuthCredentials.ts
+++ b/modules/zuora/src/auth/oAuthCredentials.ts
@@ -4,8 +4,8 @@ import {
 } from '@aws-sdk/client-secrets-manager';
 import { awsConfig } from '@modules/aws/config';
 import type { Stage } from '@modules/stage';
-import type { OAuthClientCredentials } from '../zuoraSchemas';
-import { oAuthClientCredentialsSchema } from '../zuoraSchemas';
+import type { OAuthClientCredentials } from '../types/auth';
+import { oAuthClientCredentialsSchema } from '../types/auth';
 
 export const getOAuthClientCredentials = async (
 	stage: Stage,

--- a/modules/zuora/src/types/auth.ts
+++ b/modules/zuora/src/types/auth.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export type OAuthClientCredentials = z.infer<
+	typeof oAuthClientCredentialsSchema
+>;
+export const oAuthClientCredentialsSchema = z.object({
+	clientId: z.string(),
+	clientSecret: z.string(),
+});
+
+export type ZuoraBearerToken = z.infer<typeof zuoraBearerTokenSchema>;
+
+export const zuoraBearerTokenSchema = z.object({
+	access_token: z.string(),
+	expires_in: z.number(),
+});

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -2,22 +2,6 @@ import { BillingPeriodValues } from '@modules/billingPeriod';
 import { z } from 'zod';
 import { zuoraResponseSchema } from './types';
 
-// --------------- Auth ---------------
-export type OAuthClientCredentials = z.infer<
-	typeof oAuthClientCredentialsSchema
->;
-export const oAuthClientCredentialsSchema = z.object({
-	clientId: z.string(),
-	clientSecret: z.string(),
-});
-
-export type ZuoraBearerToken = z.infer<typeof zuoraBearerTokenSchema>;
-
-export const zuoraBearerTokenSchema = z.object({
-	access_token: z.string(),
-	expires_in: z.number(),
-});
-
 // --------------- Subscription ---------------
 export const zuoraSubscriptionSchema = z.object({
 	id: z.string(),


### PR DESCRIPTION
## What does this change?
Refactors Zuora auth definitions by moving them out of zuoraSchemas.ts and into dedicated file within the zuora/types/ directory.

There are no logic changes, and existing functionality remains unchanged.

### Why?
- To improve code organization and maintainability
- Make Zuora types easier to discover, manage, and update

### Risks
Broken imports due to the relocation of type definitions. Any such issues should be surfaced by the automated build process.