### PR TITLE
Refactor zuora account types

### DIFF
--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -26,7 +26,7 @@ import { zuoraDateFormat } from '../../../modules/zuora/src/utils/common';
 import { EligibilityChecker } from './eligibilityChecker';
 import { generateCancellationDiscountConfirmationEmail } from './generateCancellationDiscountConfirmationEmail';
 import { getDiscountFromSubscription } from './productToDiscountMapping';
-import { ZuoraAccount } from '@modules/zuora/types/objects/account';
+import { ZuoraAccount } from '../../../modules/zuora/src/types/objects/account';
 
 export const previewDiscountEndpoint = async (
 	logger: Logger,

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -22,11 +22,11 @@ import { getZuoraCatalog } from '@modules/zuora-catalog/S3';
 import type { APIGatewayProxyEventHeaders } from 'aws-lambda';
 import dayjs from 'dayjs';
 import { getAccount } from '../../../modules/zuora/src/account';
+import type { ZuoraAccount } from '../../../modules/zuora/src/types/objects/account';
 import { zuoraDateFormat } from '../../../modules/zuora/src/utils/common';
 import { EligibilityChecker } from './eligibilityChecker';
 import { generateCancellationDiscountConfirmationEmail } from './generateCancellationDiscountConfirmationEmail';
 import { getDiscountFromSubscription } from './productToDiscountMapping';
-import { ZuoraAccount } from '../../../modules/zuora/src/types/objects/account';
 
 export const previewDiscountEndpoint = async (
 	logger: Logger,

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -4,7 +4,6 @@ import { Lazy } from '@modules/lazy';
 import type { Logger } from '@modules/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import type { Stage } from '@modules/stage';
-import { getAccount } from '@modules/zuora/account';
 import {
 	getBillingPreview,
 	getNextInvoice,
@@ -18,17 +17,16 @@ import { addDiscount, previewDiscount } from '@modules/zuora/discount';
 import { isNotRemovedOrDiscount } from '@modules/zuora/rateplan';
 import { getSubscription } from '@modules/zuora/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type {
-	ZuoraAccount,
-	ZuoraSubscription,
-} from '@modules/zuora/zuoraSchemas';
+import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
 import { getZuoraCatalog } from '@modules/zuora-catalog/S3';
 import type { APIGatewayProxyEventHeaders } from 'aws-lambda';
 import dayjs from 'dayjs';
+import { getAccount } from '../../../modules/zuora/src/account';
 import { zuoraDateFormat } from '../../../modules/zuora/src/utils/common';
 import { EligibilityChecker } from './eligibilityChecker';
 import { generateCancellationDiscountConfirmationEmail } from './generateCancellationDiscountConfirmationEmail';
 import { getDiscountFromSubscription } from './productToDiscountMapping';
+import { ZuoraAccount } from '@modules/zuora/types/objects/account';
 
 export const previewDiscountEndpoint = async (
 	logger: Logger,

--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -11,12 +11,12 @@ import type { SimpleInvoiceItem } from '@modules/zuora/billingPreview';
 import type { RatePlan, ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
+import type { ZuoraAccount } from '../../../modules/zuora/src/types/objects/account';
 import type { CatalogInformation } from './catalogInformation';
 import { getCatalogInformation } from './catalogInformation';
 import type { Discount } from './discounts';
 import { getDiscount } from './discounts';
 import type { ProductSwitchRequestBody } from './schemas';
-import type { ZuoraAccount } from '../../../modules/zuora/src/types/objects/account';
 
 export type AccountInformation = {
 	id: string;

--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -16,7 +16,7 @@ import { getCatalogInformation } from './catalogInformation';
 import type { Discount } from './discounts';
 import { getDiscount } from './discounts';
 import type { ProductSwitchRequestBody } from './schemas';
-import { ZuoraAccount } from '../../../modules/zuora/src/types/objects/account';
+import type { ZuoraAccount } from '../../../modules/zuora/src/types/objects/account';
 
 export type AccountInformation = {
 	id: string;

--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -8,11 +8,7 @@ import { prettyPrint } from '@modules/prettyPrint';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import type { SimpleInvoiceItem } from '@modules/zuora/billingPreview';
-import type {
-	RatePlan,
-	ZuoraAccount,
-	ZuoraSubscription,
-} from '@modules/zuora/zuoraSchemas';
+import type { RatePlan, ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import type { CatalogInformation } from './catalogInformation';
@@ -20,6 +16,7 @@ import { getCatalogInformation } from './catalogInformation';
 import type { Discount } from './discounts';
 import { getDiscount } from './discounts';
 import type { ProductSwitchRequestBody } from './schemas';
+import { ZuoraAccount } from '../../../modules/zuora/src/types/objects/account';
 
 export type AccountInformation = {
 	id: string;

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -7,10 +7,10 @@ import { ValidationError } from '@modules/errors';
 import { Lazy } from '@modules/lazy';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
-import { zuoraAccountSchema } from '../../../modules/zuora/src/types/objects/account';
 import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
 import { zuoraSubscriptionResponseSchema } from '@modules/zuora/zuoraSchemas';
 import dayjs from 'dayjs';
+import { zuoraAccountSchema } from '../../../modules/zuora/src/types/objects/account';
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import {
 	previewResponseFromZuoraResponse,

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -7,11 +7,9 @@ import { ValidationError } from '@modules/errors';
 import { Lazy } from '@modules/lazy';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
+import { zuoraAccountSchema } from '../../../modules/zuora/src/types/objects/account';
 import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
-import {
-	zuoraAccountSchema,
-	zuoraSubscriptionResponseSchema,
-} from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from '@modules/zuora/zuoraSchemas';
 import dayjs from 'dayjs';
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import {

--- a/modules/zuora/src/account.ts
+++ b/modules/zuora/src/account.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import type { ZuoraClient } from './zuoraClient';
 import {
-	zuoraAccountSchema,
 	ZuoraSuccessResponse,
 	zuoraSuccessResponseSchema,
 } from './zuoraSchemas';
-import type { ZuoraAccount } from './zuoraSchemas';
+import { zuoraAccountSchema } from './types/objects/account';
+import type { ZuoraAccount } from './types/objects/account';
 
 export const getAccount = async (
 	zuoraClient: ZuoraClient,

--- a/modules/zuora/src/subscription.ts
+++ b/modules/zuora/src/subscription.ts
@@ -1,16 +1,13 @@
 import type { Dayjs } from 'dayjs';
 import { zuoraDateFormat } from './utils/common';
 import type { ZuoraClient } from './zuoraClient';
-import type {
-	ZuoraSubscription,
-	ZuoraSubscriptionsFromAccountResponse,
-	ZuoraSuccessResponse,
-} from './zuoraSchemas';
+import type { ZuoraSubscription, ZuoraSuccessResponse } from './zuoraSchemas';
 import {
 	zuoraSubscriptionResponseSchema,
-	zuoraSubscriptionsFromAccountSchema,
 	zuoraSuccessResponseSchema,
 } from './zuoraSchemas';
+import { zuoraSubscriptionsFromAccountSchema } from './types/objects/account';
+import type { ZuoraSubscriptionsFromAccountResponse } from './types/objects/account';
 
 export const cancelSubscription = async (
 	zuoraClient: ZuoraClient,

--- a/modules/zuora/src/types/objects/account.ts
+++ b/modules/zuora/src/types/objects/account.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { zuoraResponseSchema } from '../httpResponse';
+import { zuoraSubscriptionSchema } from '@modules/zuora/zuoraSchemas';
+
+export const zuoraAccountBasicInfoSchema = z
+	.object({
+		id: z.string(),
+		IdentityId__c: z.string(),
+	})
+	.transform((obj) => ({
+		id: obj.id,
+		identityId: obj.IdentityId__c,
+	}));
+
+export const metricsSchema = z.object({
+	totalInvoiceBalance: z.number(),
+	currency: z.string(),
+});
+export const billToContactSchema = z.object({
+	firstName: z.string(),
+	lastName: z.string(),
+	workEmail: z.string(),
+});
+
+export const billingAndPaymentSchema = z.object({
+	currency: z.string(),
+	defaultPaymentMethodId: z.string(),
+});
+
+export const zuoraAccountSchema = zuoraResponseSchema.extend({
+	basicInfo: zuoraAccountBasicInfoSchema,
+	billingAndPayment: billingAndPaymentSchema,
+	billToContact: billToContactSchema,
+	metrics: metricsSchema,
+});
+
+export type ZuoraAccount = z.infer<typeof zuoraAccountSchema>;
+
+export const zuoraSubscriptionsFromAccountSchema = zuoraResponseSchema.extend({
+	subscriptions: z.array(zuoraSubscriptionSchema).optional(),
+});
+
+export type ZuoraSubscriptionsFromAccountResponse = z.infer<
+	typeof zuoraSubscriptionsFromAccountSchema
+>;

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -1,6 +1,5 @@
 import { BillingPeriodValues } from '@modules/billingPeriod';
 import { z } from 'zod';
-import { zuoraResponseSchema } from './types';
 
 // --------------- Auth ---------------
 export type OAuthClientCredentials = z.infer<
@@ -74,50 +73,6 @@ export type ZuoraSubscription = z.infer<typeof zuoraSubscriptionSchema>;
 export type RatePlan = ZuoraSubscription['ratePlans'][number];
 
 export type RatePlanCharge = RatePlan['ratePlanCharges'][number];
-
-// --------------- Account ---------------
-export const zuoraAccountBasicInfoSchema = z
-	.object({
-		id: z.string(),
-		IdentityId__c: z.string(),
-	})
-	.transform((obj) => ({
-		id: obj.id,
-		identityId: obj.IdentityId__c,
-	}));
-
-export const metricsSchema = z.object({
-	totalInvoiceBalance: z.number(),
-	currency: z.string(),
-});
-export const billToContactSchema = z.object({
-	firstName: z.string(),
-	lastName: z.string(),
-	workEmail: z.string(),
-});
-
-export const billingAndPaymentSchema = z.object({
-	currency: z.string(),
-	defaultPaymentMethodId: z.string(),
-});
-
-export const zuoraAccountSchema = z.object({
-	success: z.boolean(),
-	basicInfo: zuoraAccountBasicInfoSchema,
-	billingAndPayment: billingAndPaymentSchema,
-	billToContact: billToContactSchema,
-	metrics: metricsSchema,
-});
-
-export type ZuoraAccount = z.infer<typeof zuoraAccountSchema>;
-
-export const zuoraSubscriptionsFromAccountSchema = zuoraResponseSchema.extend({
-	subscriptions: z.array(zuoraSubscriptionSchema).optional(),
-});
-
-export type ZuoraSubscriptionsFromAccountResponse = z.infer<
-	typeof zuoraSubscriptionsFromAccountSchema
->;
 
 // --------------- Subscribe ---------------
 export const zuoraSubscribeResponseSchema = z.array(

--- a/modules/zuora/test/subscription.test.ts
+++ b/modules/zuora/test/subscription.test.ts
@@ -8,14 +8,16 @@ import {
 
 import type {
 	ZuoraSubscription,
-	ZuoraSubscriptionsFromAccountResponse,
 	ZuoraSuccessResponse,
 } from '@modules/zuora/zuoraSchemas';
 import {
 	zuoraSubscriptionResponseSchema,
-	zuoraSubscriptionsFromAccountSchema,
 	zuoraSuccessResponseSchema,
 } from '@modules/zuora/zuoraSchemas';
+import {
+	ZuoraSubscriptionsFromAccountResponse,
+	zuoraSubscriptionsFromAccountSchema,
+} from '../../../modules/zuora/src/types/objects/account';
 
 jest.mock('@modules/zuora/zuoraClient');
 

--- a/modules/zuora/test/subscription.test.ts
+++ b/modules/zuora/test/subscription.test.ts
@@ -14,10 +14,8 @@ import {
 	zuoraSubscriptionResponseSchema,
 	zuoraSuccessResponseSchema,
 } from '@modules/zuora/zuoraSchemas';
-import {
-	ZuoraSubscriptionsFromAccountResponse,
-	zuoraSubscriptionsFromAccountSchema,
-} from '../../../modules/zuora/src/types/objects/account';
+import { zuoraSubscriptionsFromAccountSchema } from '../../../modules/zuora/src/types/objects/account';
+import type { ZuoraSubscriptionsFromAccountResponse } from '../../../modules/zuora/src/types/objects/account';
 
 jest.mock('@modules/zuora/zuoraClient');
 

--- a/modules/zuora/test/zuoraSchemas.test.ts
+++ b/modules/zuora/test/zuoraSchemas.test.ts
@@ -1,7 +1,5 @@
-import {
-	zuoraSubscriptionResponseSchema,
-	zuoraSubscriptionsFromAccountSchema,
-} from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionsFromAccountSchema } from '../../../modules/zuora/src/types/objects/account';
 import subscriptionJson from './fixtures/subscription.json';
 import subscriptionsFromAccountJson from './fixtures/subscriptions-from-account-number-response.json';
 


### PR DESCRIPTION
## What does this change?
Refactors Zuora account type definitions by moving them out of zuoraSchemas.ts and into dedicated file within the zuora/types/objects/ directory.

There are no logic changes, and existing functionality remains unchanged.

### Why?
- To improve code organization and maintainability
- Make Zuora types easier to discover, manage, and update

### Risks
Broken imports due to the relocation of type definitions. Any such issues should be surfaced by the automated build process.