### PR TITLE
Refactor zuora subscription types

### DIFF
--- a/handlers/discount-api/test/eligibilityChecker.test.ts
+++ b/handlers/discount-api/test/eligibilityChecker.test.ts
@@ -4,10 +4,8 @@ import {
 	itemsForSubscription,
 	toSimpleInvoiceItems,
 } from '@modules/zuora/billingPreview';
-import {
-	billingPreviewSchema,
-	zuoraSubscriptionResponseSchema,
-} from '@modules/zuora/zuoraSchemas';
+import { billingPreviewSchema } from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from '../../../modules/zuora/src/types/objects/subscription';
 import { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import dayjs from 'dayjs';

--- a/handlers/discount-api/test/getDiscountFromSubscription.test.ts
+++ b/handlers/discount-api/test/getDiscountFromSubscription.test.ts
@@ -1,5 +1,6 @@
 import { DataExtensionNames } from '@modules/email/email';
-import { zuoraSubscriptionResponseSchema } from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from '../../../modules/zuora/src/types/objects/subscription';
+
 import type { Discount } from '../src/productToDiscountMapping';
 import {
 	catalog,

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -7,11 +7,9 @@ import { ValidationError } from '@modules/errors';
 import { Lazy } from '@modules/lazy';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
-import type { ZuoraSubscription } from '@modules/zuora/zuoraSchemas';
-import {
-	zuoraAccountSchema,
-	zuoraSubscriptionResponseSchema,
-} from '@modules/zuora/zuoraSchemas';
+import type { ZuoraSubscription } from '../../../modules/zuora/src/types/objects/subscription';
+import { zuoraAccountSchema } from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from '../../../modules/zuora/src/types/objects/subscription';
 import dayjs from 'dayjs';
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import {

--- a/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmounts.test.ts
+++ b/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmounts.test.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@modules/logger';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
-import { zuoraSubscriptionResponseSchema } from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from '../../../modules/zuora/src/types/objects/subscription';
 import zuoraCatalogFixture from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import { getSupporterPlusData } from '../src/updateSupporterPlusAmount';
 import subscriptionJson from './fixtures/subscription.json';

--- a/modules/zuora/src/subscription.ts
+++ b/modules/zuora/src/subscription.ts
@@ -1,13 +1,13 @@
 import type { Dayjs } from 'dayjs';
 import { zuoraDateFormat } from './utils/common';
 import type { ZuoraClient } from './zuoraClient';
+import type { ZuoraSubscription } from './types/objects/subscription';
 import type {
-	ZuoraSubscription,
 	ZuoraSubscriptionsFromAccountResponse,
 	ZuoraSuccessResponse,
 } from './zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from './types/objects/subscription';
 import {
-	zuoraSubscriptionResponseSchema,
 	zuoraSubscriptionsFromAccountSchema,
 	zuoraSuccessResponseSchema,
 } from './zuoraSchemas';

--- a/modules/zuora/src/types/objects/subscription.ts
+++ b/modules/zuora/src/types/objects/subscription.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { BillingPeriodValues } from '@modules/billingPeriod';
+import { zuoraResponseSchema } from '../httpResponse';
+
+export const zuoraSubscriptionSchema = z.object({
+	id: z.string(),
+	accountNumber: z.string(),
+	subscriptionNumber: z.string(),
+	status: z.string(),
+	contractEffectiveDate: z.coerce.date(),
+	serviceActivationDate: z.coerce.date(),
+	customerAcceptanceDate: z.coerce.date(),
+	subscriptionStartDate: z.coerce.date(),
+	subscriptionEndDate: z.coerce.date(),
+	lastBookingDate: z.coerce.date(),
+	termStartDate: z.coerce.date(),
+	termEndDate: z.coerce.date(),
+	ratePlans: z.array(
+		z.object({
+			id: z.string(),
+			lastChangeType: z.optional(z.string()),
+			productId: z.string(),
+			productName: z.string(),
+			productRatePlanId: z.string(),
+			ratePlanName: z.string(),
+			ratePlanCharges: z.array(
+				z.object({
+					id: z.string(),
+					productRatePlanChargeId: z.string(),
+					number: z.string(),
+					name: z.string(),
+					type: z.string(),
+					model: z.string(),
+					currency: z.string(),
+					effectiveStartDate: z.coerce.date(),
+					effectiveEndDate: z.coerce.date(),
+					billingPeriod: z.nullable(z.enum(BillingPeriodValues)),
+					processedThroughDate: z.coerce.date(),
+					chargedThroughDate: z.coerce.date().nullable(),
+					upToPeriodsType: z.nullable(z.string()),
+					upToPeriods: z.nullable(z.number()),
+					price: z.nullable(z.number()),
+					discountPercentage: z.nullable(z.number()),
+				}),
+			),
+		}),
+	),
+});
+
+export const zuoraSubscriptionResponseSchema = zuoraResponseSchema.merge(
+	zuoraSubscriptionSchema,
+);
+
+export type ZuoraSubscription = z.infer<typeof zuoraSubscriptionSchema>;
+
+export type RatePlan = ZuoraSubscription['ratePlans'][number];
+
+export type RatePlanCharge = RatePlan['ratePlanCharges'][number];

--- a/modules/zuora/src/zuoraSchemas.ts
+++ b/modules/zuora/src/zuoraSchemas.ts
@@ -18,63 +18,6 @@ export const zuoraBearerTokenSchema = z.object({
 	expires_in: z.number(),
 });
 
-// --------------- Subscription ---------------
-export const zuoraSubscriptionSchema = z.object({
-	id: z.string(),
-	accountNumber: z.string(),
-	subscriptionNumber: z.string(),
-	status: z.string(),
-	contractEffectiveDate: z.coerce.date(),
-	serviceActivationDate: z.coerce.date(),
-	customerAcceptanceDate: z.coerce.date(),
-	subscriptionStartDate: z.coerce.date(),
-	subscriptionEndDate: z.coerce.date(),
-	lastBookingDate: z.coerce.date(),
-	termStartDate: z.coerce.date(),
-	termEndDate: z.coerce.date(),
-	ratePlans: z.array(
-		z.object({
-			id: z.string(),
-			lastChangeType: z.optional(z.string()),
-			productId: z.string(),
-			productName: z.string(),
-			productRatePlanId: z.string(),
-			ratePlanName: z.string(),
-			ratePlanCharges: z.array(
-				z.object({
-					id: z.string(),
-					productRatePlanChargeId: z.string(),
-					number: z.string(),
-					name: z.string(),
-					type: z.string(),
-					model: z.string(),
-					currency: z.string(),
-					effectiveStartDate: z.coerce.date(),
-					effectiveEndDate: z.coerce.date(),
-					billingPeriod: z.nullable(z.enum(BillingPeriodValues)),
-					processedThroughDate: z.coerce.date(),
-					chargedThroughDate: z.coerce.date().nullable(),
-					upToPeriodsType: z.nullable(z.string()),
-					upToPeriods: z.nullable(z.number()),
-					price: z.nullable(z.number()),
-					discountPercentage: z.nullable(z.number()),
-				}),
-			),
-		}),
-	),
-});
-export const zuoraSubscriptionResponseSchema = z
-	.object({
-		success: z.boolean(),
-	})
-	.merge(zuoraSubscriptionSchema);
-
-export type ZuoraSubscription = z.infer<typeof zuoraSubscriptionSchema>;
-
-export type RatePlan = ZuoraSubscription['ratePlans'][number];
-
-export type RatePlanCharge = RatePlan['ratePlanCharges'][number];
-
 // --------------- Account ---------------
 export const zuoraAccountBasicInfoSchema = z
 	.object({

--- a/modules/zuora/test/subscription.test.ts
+++ b/modules/zuora/test/subscription.test.ts
@@ -6,13 +6,13 @@ import {
 	getSubscriptionsByAccountNumber,
 } from '@modules/zuora/subscription';
 
+import type { ZuoraSubscription } from '../../../modules/zuora/src/types/objects/subscription';
 import type {
-	ZuoraSubscription,
 	ZuoraSubscriptionsFromAccountResponse,
 	ZuoraSuccessResponse,
 } from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from '../../../modules/zuora/src/types/objects/subscription';
 import {
-	zuoraSubscriptionResponseSchema,
 	zuoraSubscriptionsFromAccountSchema,
 	zuoraSuccessResponseSchema,
 } from '@modules/zuora/zuoraSchemas';

--- a/modules/zuora/test/zuoraClientIntegration.test.ts
+++ b/modules/zuora/test/zuoraClientIntegration.test.ts
@@ -8,8 +8,8 @@ import { Logger } from '@modules/logger';
 import { BearerTokenProvider } from '../src/auth/bearerTokenProvider';
 import { getOAuthClientCredentials } from '../src/auth/oAuthCredentials';
 import { ZuoraClient } from '../src/zuoraClient';
-import type { ZuoraSubscription } from '../src/zuoraSchemas';
-import { zuoraSubscriptionResponseSchema } from '../src/zuoraSchemas';
+import type { ZuoraSubscription } from '../src//types/objects/subscription';
+import { zuoraSubscriptionResponseSchema } from '../src/types/objects/subscription';
 
 test('ZuoraClient', async () => {
 	const stage = 'CODE';

--- a/modules/zuora/test/zuoraSchemas.test.ts
+++ b/modules/zuora/test/zuoraSchemas.test.ts
@@ -1,7 +1,5 @@
-import {
-	zuoraSubscriptionResponseSchema,
-	zuoraSubscriptionsFromAccountSchema,
-} from '@modules/zuora/zuoraSchemas';
+import { zuoraSubscriptionResponseSchema } from '../src/types/objects/subscription';
+import { zuoraSubscriptionsFromAccountSchema } from '@modules/zuora/zuoraSchemas';
 import subscriptionJson from './fixtures/subscription.json';
 import subscriptionsFromAccountJson from './fixtures/subscriptions-from-account-number-response.json';
 


### PR DESCRIPTION
## What does this change?
Refactors Zuora subscription type definitions by moving them out of zuoraSchemas.ts and into dedicated file within the zuora/types/objects/ directory.

There are no logic changes, and existing functionality remains unchanged.

### Why?
- To improve code organization and maintainability
- Make Zuora types easier to discover, manage, and update

### Risks
Broken imports due to the relocation of type definitions. Any such issues should be surfaced by the automated build process.