### PR TITLE
Make references to Last_Mandate_Event__c optional in sf-gocardless-sync

### DIFF
--- a/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/Handler.scala
+++ b/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/Handler.scala
@@ -118,7 +118,7 @@ object Handler extends Logging {
   } yield sfMandateMap + (gcMandateEventDetail.mandate.id -> MandateLookupDetail(
     Id = sfMandate.Id,
     GoCardless_Mandate_ID__c = gcMandateEventDetail.mandate.id,
-    Last_Mandate_Event__c = newMandateWithEventId.id,
+    Last_Mandate_Event__c = Some(newMandateWithEventId.id),
     Status_Changed_At__c = EventHappenedAt(gcMandateEventDetail.event.created_at),
   ))
 

--- a/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandate.scala
+++ b/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandate.scala
@@ -85,6 +85,7 @@ object SalesforceDDMandate extends Logging {
     case class MandateLookupDetail(
         Id: MandateSfId,
         GoCardless_Mandate_ID__c: GoCardlessMandateID,
+        Last_Mandate_Event__c: Option[MandateEventSfId],
         Status_Changed_At__c: EventHappenedAt,
     ) extends WithMandateSfId
     implicit val reads = Json.reads[MandateLookupDetail]
@@ -100,7 +101,7 @@ object SalesforceDDMandate extends Logging {
       sfGet.setupRequest(toRequest).parse[MandateSearchQueryResponse].map(toResponse).runRequest
 
     def toRequest(mandateIDs: List[GoCardlessMandateID]) = {
-      val soqlQuery = s"SELECT Id, GoCardless_Mandate_ID__c, Status_Changed_At__c " +
+      val soqlQuery = s"SELECT Id, GoCardless_Mandate_ID__c, Last_Mandate_Event__c, Status_Changed_At__c " +
         s"FROM DD_Mandate__c " +
         s"WHERE GoCardless_Mandate_ID__c IN (${mandateIDs.map(mandateID => s"'${mandateID.value}'").mkString(", ")})"
       logger.info(s"using SF query : $soqlQuery")

--- a/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandate.scala
+++ b/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandate.scala
@@ -86,7 +86,7 @@ object SalesforceDDMandate extends Logging {
         Id: MandateSfId,
         GoCardless_Mandate_ID__c: GoCardlessMandateID,
         Last_Mandate_Event__c: Option[MandateEventSfId],
-        Status_Changed_At__c: EventHappenedAt,
+        Status_Changed_At__c: Option[EventHappenedAt],
     ) extends WithMandateSfId
     implicit val reads = Json.reads[MandateLookupDetail]
 

--- a/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandate.scala
+++ b/handlers/sf-gocardless-sync/src/main/scala/com/gu/sf_gocardless_sync/salesforce/SalesforceDDMandate.scala
@@ -85,7 +85,6 @@ object SalesforceDDMandate extends Logging {
     case class MandateLookupDetail(
         Id: MandateSfId,
         GoCardless_Mandate_ID__c: GoCardlessMandateID,
-        Last_Mandate_Event__c: MandateEventSfId,
         Status_Changed_At__c: EventHappenedAt,
     ) extends WithMandateSfId
     implicit val reads = Json.reads[MandateLookupDetail]
@@ -101,7 +100,7 @@ object SalesforceDDMandate extends Logging {
       sfGet.setupRequest(toRequest).parse[MandateSearchQueryResponse].map(toResponse).runRequest
 
     def toRequest(mandateIDs: List[GoCardlessMandateID]) = {
-      val soqlQuery = s"SELECT Id, GoCardless_Mandate_ID__c, Last_Mandate_Event__c, Status_Changed_At__c " +
+      val soqlQuery = s"SELECT Id, GoCardless_Mandate_ID__c, Status_Changed_At__c " +
         s"FROM DD_Mandate__c " +
         s"WHERE GoCardless_Mandate_ID__c IN (${mandateIDs.map(mandateID => s"'${mandateID.value}'").mkString(", ")})"
       logger.info(s"using SF query : $soqlQuery")


### PR DESCRIPTION
## What does this change?
We've recently started deleting old DD Mandate Events in Salesforce to save on storage space (see https://github.com/guardian/salesforce/pull/1255).

Since these are deleted, we've started seeing some problems in the sf-gocardless-sync Lambda because it's not seeing any value for the `Last_Mandate_Event__c` and `Status_Changed_At__c` fields in some of the `DD_Mandate__c` records that its trying to process. 

These fields are used to determine whether the events picked up from GoCardless are actually newer than the `Last_Mandate_Event` already on each `DD_Mandate__c` record. As we're only deleting events older than 12 months, and our Lambda should only be getting very recent events, it's reasonably to assume that if there is no `Last_Mandate_Event` associated with a `DD_Mandate__c` then the event is newer.

## How to test
Run the Lambda and you should note in the logs that several mandates are picked up for processing. For one of those, remove the current "Last Mandate Event" value on the associated DD Mandate record - run the lambda again and verify that the Lambda runs without errors and the Last Mandate event is populated back onto the DD Mandate.
