### PR TITLE
don't try to refund free student supporter pluses

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
@@ -44,10 +44,14 @@ object RefundSupporterPlus {
         _.postInvoices(refundInvoiceDetails.negativeInvoiceId, refundInput.cancellationBillingDate),
       )
       _ <- ZIO.log(s"Amount to refund is ${refundInvoiceDetails.refundAmount}")
-      _ <- InvoicingApiRefund.refund(
-        refundInput.subscriptionName,
-        refundInvoiceDetails.refundAmount,
-      )
+      _ <-
+        if (refundInvoiceDetails.refundAmount == BigDecimal(0))
+          ZIO.log("skipping zero refund")
+        else
+          InvoicingApiRefund.refund(
+            refundInput.subscriptionName,
+            refundInvoiceDetails.refundAmount,
+          )
       _ <- ensureThatNegativeInvoiceBalanceIsZero(refundInvoiceDetails)
     } yield ()
 


### PR DESCRIPTION
We have noticed some alarms where product-move-refund has been trying to refund 0.00.
https://865473395570-3z35t5l4.eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fproduct-switch-refund-PROD/log-events/2025$252F08$252F07$252F$255B$2524LATEST$255D7f4d4f42d65041ec91d849db99e98031$3Fstart$3D1754576917026$26refEventId$3D39128372760050307578900607072730731284997743969675182097
from line https://github.com/guardian/support-service-lambdas/blob/30031f07d9a9b6876a198c099978ef219a7755b4/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala#L46
This goes to the invoicing-api-refund lambda which tries to query for payments, and fails because there aren't any.

https://github.com/guardian/invoicing-api/blob/ee6b97f7df6b0d33114ea36f177e78b22c6a2c66/src/main/scala/com/gu/invoicing/refund/Program.scala#L51

Then the item remains in the queue, reattempting for several days until it trips the dead letter alarm.

This PR changes prouct-move-api so that if the refund is zero, it logs and moves on.

Alternative valid approaches not taken include
- making the refund api do a no-op if it's zero
- making the refund api throw a 4xx if it's zero and changes to the above lambda to trap the specific error code
- above 4xx changes as well as this PR (not to attempt the call)

Testing - all unit testing still passes, no specific tests added