### PR TITLE
raise cancellation refund invoices today rather than backdated

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val scala2Settings = Seq(
 )
 
 val scala3Settings = Seq(
-  scalaVersion := "3.7.1",
+  scalaVersion := "3.7.2",
   version := "0.0.1",
   organization := "com.gu",
   scalacOptions ++= Seq(

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundHandler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundHandler.scala
@@ -11,6 +11,7 @@ import zio.json.*
 import zio.{Exit, Runtime, Unsafe}
 
 import java.io.{OutputStream, PrintStream}
+import java.time.LocalDate
 import scala.jdk.CollectionConverters.*
 
 class RefundHandler extends RequestHandler[SQSEvent, Unit] {
@@ -52,7 +53,7 @@ class RefundHandler extends RequestHandler[SQSEvent, Unit] {
     Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(
         RefundSupporterPlus
-          .applyRefund(refundInput)
+          .applyRefund(refundInput, LocalDate.now())
           .provide(
             AwsS3Live.layer,
             AwsCredentialsLive.layer,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala
@@ -29,7 +29,7 @@ object RefundInput {
 }
 
 object RefundSupporterPlus {
-  def applyRefund(refundInput: RefundInput): ZIO[
+  def applyRefund(refundInput: RefundInput, today: LocalDate): ZIO[
     InvoicingApiRefund & CreditBalanceAdjustment & Stage & SttpBackend[Task, Any] & AwsS3 & InvoiceItemQuery &
       GetInvoice & InvoiceItemAdjustment & RunBilling & PostInvoices,
     Throwable | TransactionError,
@@ -37,7 +37,7 @@ object RefundSupporterPlus {
   ] =
     for {
       _ <- ZIO.log(s"Generating negative invoice for sub ${refundInput.subscriptionName}")
-      _ <- ZIO.serviceWithZIO[RunBilling](_.run(refundInput.accountId, refundInput.cancellationBillingDate))
+      _ <- ZIO.serviceWithZIO[RunBilling](_.run(refundInput.accountId, today, refundInput.cancellationBillingDate))
       _ <- ZIO.log(s"Getting invoice items for sub ${refundInput.subscriptionName}")
       refundInvoiceDetails <- GetRefundInvoiceDetails.get(refundInput.subscriptionName)
       _ <- ZIO.serviceWithZIO[PostInvoices](

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/manual/RefundSupporterPlusSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/manual/RefundSupporterPlusSpec.scala
@@ -27,6 +27,7 @@ object RunRefundLambdaLocally extends ZIOAppDefault {
           ZuoraAccountId("8ad090fd96d24cc20196d437f54a600f"),
           LocalDate.parse("2025-05-15"),
         ),
+        LocalDate.now(),
       )
       .provide(
         AwsS3Live.layer,
@@ -57,6 +58,7 @@ object BalanceInvoicesLocally extends ZIOAppDefault {
       _ <- RefundSupporterPlus
         .applyRefund(
           RefundInput(SubscriptionName("A-S00629631"), ZuoraAccountId("choose your id here"), LocalDate.now()),
+          LocalDate.now(),
         )
         .provide(
           AwsS3Live.layer,


### PR DESCRIPTION
When someone cancels their S+ within 14 days, we refund them automatically.

When they have set up a direct debit it can take up to a week to actually make the refund due to limitations of the DD system (`base can't be refunded because it is pending_submission`)

We handle this by retrying the refund lambda for up to a week.

We have moved the invoice generation to the async lambda for perf reasons in https://github.com/guardian/support-service-lambdas/pull/2826

It always uses the date of cancellation as both the target date and invoice date of the date of cancellation when generating the invoice.

Note that the invoice date must always be in the currently open accounting period.  Otherwise an error occurs `ZuoraError(ACCOUNTING_PERIOD_CLOSED,Invoices cannot be generated in a closed Accounting Period. Please enter another invoice date.)`

The problem at the moment is that since things may retry for a week, the billing call may fail due to the accounting period being closed.

The invoice date is only to show the date on the invoice, rather than to decide what the charges should be.  This means we should use the current date as the invoice date, to ensure it has not been closed.

See here for a definion of the different dates: https://knowledgecenter.zuora.com/Zuora_Billing/Bill_your_customers/AB_Automate_billing_document_generation/Bill_runs/AB_Create_bill_runs#:~:text=Run%20Dates%20section.-,Invoice%20Date%3A%20The%20invoice%20date%20displayed%20on%20the%20invoices.,default%2C%20the%20target%20date%20is%20equal%20to%20the%20bill%20run%20date.,-Creating%20a%20bill

This PR changes the run billing operation to use today's date for the invoice, rather than backdating it to the date of cancellation.  This will usually be the same, but it will avoid the `ACCOUNTING_PERIOD_CLOSED` error where it's on a retry since the period was closed.