### PR TITLE
Add a generic type for product purchases

### DIFF
--- a/modules/product-catalog/src/generateProductPurchaseSchema.ts
+++ b/modules/product-catalog/src/generateProductPurchaseSchema.ts
@@ -17,6 +17,13 @@ const header = `
 // product and rate plan passed in the support-workers state
 
 import { z } from 'zod';
+import { ProductKey } from '@modules/product-catalog/productCatalog';
+`;
+
+const footer = `
+	export type ProductPurchase = z.infer<typeof productPurchaseSchema>;
+	// Generic type for a specific product
+	export type ProductPurchaseFor<P extends ProductKey> = Extract<ProductPurchase,{ product: P }>;
 `;
 
 export const generateProductPurchaseSchema = (
@@ -34,6 +41,7 @@ export const generateProductPurchaseSchema = (
 	export const productPurchaseSchema = z.discriminatedUnion('product', [
 		${zuoraProductsSchema}
 		]);
+	${footer}
 	`;
 };
 

--- a/modules/product-catalog/src/productPurchaseSchema.ts
+++ b/modules/product-catalog/src/productPurchaseSchema.ts
@@ -4,8 +4,20 @@
 // product and rate plan passed in the support-workers state
 
 import { z } from 'zod';
+import type { ProductKey } from '@modules/product-catalog/productCatalog';
 
 export const productPurchaseSchema = z.discriminatedUnion('product', [
+	z.object({
+		product: z.literal('SupporterPlus'),
+		ratePlan: z.union([
+			z.literal('OneYearStudent'),
+			z.literal('V1DeprecatedMonthly'),
+			z.literal('V1DeprecatedAnnual'),
+			z.literal('Monthly'),
+			z.literal('Annual'),
+		]),
+		amount: z.number(),
+	}),
 	z.object({
 		product: z.literal('Contribution'),
 		ratePlan: z.union([z.literal('Annual'), z.literal('Monthly')]),
@@ -69,17 +81,6 @@ export const productPurchaseSchema = z.discriminatedUnion('product', [
 			z.literal('V1DeprecatedMonthly'),
 			z.literal('V2DeprecatedMonthly'),
 		]),
-	}),
-	z.object({
-		product: z.literal('SupporterPlus'),
-		ratePlan: z.union([
-			z.literal('OneYearStudent'),
-			z.literal('V1DeprecatedMonthly'),
-			z.literal('V1DeprecatedAnnual'),
-			z.literal('Monthly'),
-			z.literal('Annual'),
-		]),
-		amount: z.number(),
 	}),
 	z.object({
 		product: z.literal('GuardianWeeklyDomestic'),
@@ -169,3 +170,8 @@ export const productPurchaseSchema = z.discriminatedUnion('product', [
 ]);
 
 export type ProductPurchase = z.infer<typeof productPurchaseSchema>;
+// Generic type for a specific product
+export type ProductPurchaseFor<P extends ProductKey> = Extract<
+	ProductPurchase,
+	{ product: P }
+>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We already generate a 'product purchase' schema which creates a union of all valid products and rate plan combinations for use by support-frontend. 

This PR adds a `ProductPurchase` type for this inferred from the schema and a generic type `ProductPurchaseFor<T extends ProductKey>` which takes a product type and allows client code to specify what type of product it is interested in.

### Usage
Compiler error because HomeDelivery does not have a rate plan called Monthly:
<img width="537" height="118" alt="Screenshot 2025-08-12 at 15 22 56" src="https://github.com/user-attachments/assets/93fcdde5-bf27-4448-83bc-6473973fed20" />
This is a valid HomeDelivery rate plan:
<img width="537" height="118" alt="Screenshot 2025-08-12 at 15 23 17" src="https://github.com/user-attachments/assets/353f509c-71d0-4ee7-bf83-da697d2c6728" />
This is an error because Contribution requires an amount field:
<img width="537" height="117" alt="Screenshot 2025-08-12 at 15 24 11" src="https://github.com/user-attachments/assets/cdbe5725-1d86-4097-afb1-9a5f9ae186c7" />
This is now valid:
<img width="537" height="141" alt="Screenshot 2025-08-12 at 15 24 34" src="https://github.com/user-attachments/assets/689e42cf-2218-43a8-a49a-de9974d6686e" />
