### PR TITLE
Add isDeliveryProduct to product catalog

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -31,6 +31,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm --filter "./modules/**" check-formatting
+      - run: pnpm --filter "./modules/**" build
       - run: pnpm --filter "./modules/**" lint
       - run: pnpm --filter "./modules/**" test
 

--- a/modules/aws/package.json
+++ b/modules/aws/package.json
@@ -4,7 +4,8 @@
 	"scripts": {
 		"test": "jest --group=-integration",
 		"check-formatting": "prettier --check **.ts",
-		"fix-formatting": "prettier --write **.ts"
+		"fix-formatting": "prettier --write **.ts",
+		"build": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "^3.848.0",

--- a/modules/bigquery/package.json
+++ b/modules/bigquery/package.json
@@ -6,7 +6,8 @@
 		"it-test": "jest --group=integration",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts",
-		"lint": "eslint src/**/*.ts test/**/*.ts"
+		"lint": "eslint src/**/*.ts test/**/*.ts",
+		"build": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.848.0",

--- a/modules/email/package.json
+++ b/modules/email/package.json
@@ -6,7 +6,8 @@
     "it-test": "jest --group=integration",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts",
-    "lint": "eslint src/**/*.ts test/**/*.ts"
+    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "build": "tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.848.0"

--- a/modules/package.json
+++ b/modules/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
+    "build": "tsc --noEmit",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   }

--- a/modules/product-catalog/package.json
+++ b/modules/product-catalog/package.json
@@ -17,6 +17,7 @@
     "it-test": "jest --group=integration",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts",
+    "build": "tsc --noEmit",
     "lint": "eslint src/**/*.ts test/**/*.ts"
   },
   "devDependencies": {

--- a/modules/product-catalog/src/generateProductCatalog.ts
+++ b/modules/product-catalog/src/generateProductCatalog.ts
@@ -6,6 +6,7 @@ import type {
 	ZuoraProductRatePlanCharge,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
+import { isDeliveryProduct } from '@modules/product-catalog/productCatalog';
 import { stripeProducts } from '@modules/product-catalog/stripeProducts';
 import {
 	activeProducts,
@@ -86,11 +87,13 @@ const getBillingPeriod = (productRatePlan: ZuoraProductRatePlan) => {
 
 const getZuoraProduct = (
 	isActive: boolean,
+	isDeliveryProduct: boolean,
 	productRatePlans: ZuoraProductRatePlan[],
 ) => {
 	return {
 		billingSystem: 'zuora',
 		active: isActive,
+		isDeliveryProduct,
 		ratePlans: arrayToObject(
 			productRatePlans
 				.filter((productRatePlan) =>
@@ -128,6 +131,7 @@ export const generateProductCatalog = (
 			return {
 				[productName]: getZuoraProduct(
 					activeProducts.includes(productName),
+					isDeliveryProduct(productName),
 					product.productRatePlans,
 				),
 			};

--- a/modules/product-catalog/src/generateSchema.ts
+++ b/modules/product-catalog/src/generateSchema.ts
@@ -6,7 +6,7 @@ import type {
 	ZuoraProductRatePlan,
 	ZuoraProductRatePlanCharge,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import { deliveryProducts } from '@modules/product-catalog/productCatalog';
+import { isDeliveryProduct } from '@modules/product-catalog/productCatalog';
 import { stripeProductsSchema } from '@modules/product-catalog/stripeProducts';
 import {
 	getProductRatePlanChargeKey,
@@ -55,12 +55,11 @@ const generateZuoraProductSchema = (product: CatalogProduct) => {
 	const ratePlanSchema = supportedRatePlans.map((productRatePlan) =>
 		generateProductRatePlanSchema(productRatePlan),
 	);
-	const isDeliveryProduct = deliveryProducts.includes(productName);
 
 	return `${productName}: z.object({
 		billingSystem: z.literal('zuora'),
 		active: z.boolean(),
-		isDeliveryProduct: z.literal(${isDeliveryProduct}),
+		isDeliveryProduct: z.literal(${isDeliveryProduct(productName)}),
 		ratePlans: z.object({
 			${ratePlanSchema.join(',\n')},
 		}),

--- a/modules/product-catalog/src/generateSchema.ts
+++ b/modules/product-catalog/src/generateSchema.ts
@@ -6,6 +6,7 @@ import type {
 	ZuoraProductRatePlan,
 	ZuoraProductRatePlanCharge,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
+import { deliveryProducts } from '@modules/product-catalog/productCatalog';
 import { stripeProductsSchema } from '@modules/product-catalog/stripeProducts';
 import {
 	getProductRatePlanChargeKey,
@@ -19,8 +20,7 @@ const header = `
 // ---------- This file is auto-generated. Do not edit manually. -------------
 
 import { z } from 'zod';
-
-export const productCatalogSchema = z.object({`;
+`;
 
 const footer = `});`;
 
@@ -29,11 +29,19 @@ export const generateSchema = (catalog: ZuoraCatalog): string => {
 		isSupportedProduct(product.name),
 	);
 
+	const productKeys = supportedZuoraProducts.map((product) =>
+		getZuoraProductKey(product.name),
+	);
+
 	const zuoraProductsSchema = supportedZuoraProducts
 		.map((product) => generateZuoraProductSchema(product))
 		.join(',\n');
 
 	return `${header}
+	  export const productKeys = ${JSON.stringify(productKeys)} as const;
+	  export const productKeySchema = z.enum(productKeys);
+	  
+		export const productCatalogSchema = z.object({
 		${stripeProductsSchema},
 		${zuoraProductsSchema}
 		${footer}`;
@@ -47,10 +55,12 @@ const generateZuoraProductSchema = (product: CatalogProduct) => {
 	const ratePlanSchema = supportedRatePlans.map((productRatePlan) =>
 		generateProductRatePlanSchema(productRatePlan),
 	);
+	const isDeliveryProduct = deliveryProducts.includes(productName);
 
 	return `${productName}: z.object({
 		billingSystem: z.literal('zuora'),
 		active: z.boolean(),
+		isDeliveryProduct: z.literal(${isDeliveryProduct}),
 		ratePlans: z.object({
 			${ratePlanSchema.join(',\n')},
 		}),

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -7,6 +7,26 @@ export type ProductCatalog = z.infer<typeof productCatalogSchema>;
 
 // -------- Product --------
 export type ProductKey = keyof ProductCatalog;
+export const deliveryProducts = [
+	'HomeDelivery',
+	'NationalDelivery',
+	'SubscriptionCard',
+	'NewspaperVoucher',
+	'TierThree',
+	'GuardianWeeklyRestOfWorld',
+	'GuardianWeeklyDomestic',
+	'GuardianWeeklyZoneA',
+	'GuardianWeeklyZoneB',
+	'GuardianWeeklyZoneC',
+] as const;
+export type DeliveryProductKey = (typeof deliveryProducts)[number];
+
+export function isDeliveryProduct(
+	productKey: unknown,
+): productKey is DeliveryProductKey {
+	return deliveryProducts.includes(productKey as DeliveryProductKey);
+}
+
 export type Product<P extends ProductKey> = ProductCatalog[P];
 
 // -------- Product Rate Plan --------

--- a/modules/product-catalog/src/productCatalogSchema.ts
+++ b/modules/product-catalog/src/productCatalogSchema.ts
@@ -2,10 +2,32 @@
 
 import { z } from 'zod';
 
+export const productKeys = [
+	'SupporterPlus',
+	'Contribution',
+	'GuardianWeeklyRestOfWorld',
+	'GuardianAdLite',
+	'TierThree',
+	'DigitalSubscription',
+	'NationalDelivery',
+	'SupporterMembership',
+	'GuardianWeeklyDomestic',
+	'SubscriptionCard',
+	'GuardianWeeklyZoneA',
+	'GuardianWeeklyZoneB',
+	'GuardianWeeklyZoneC',
+	'NewspaperVoucher',
+	'HomeDelivery',
+	'PatronMembership',
+	'PartnerMembership',
+] as const;
+export const productKeySchema = z.enum(productKeys);
+
 export const productCatalogSchema = z.object({
 	Contribution: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -46,6 +68,7 @@ export const productCatalogSchema = z.object({
 	DigitalSubscription: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -135,6 +158,7 @@ export const productCatalogSchema = z.object({
 	GuardianAdLite: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			Monthly: z.object({
 				billingPeriod: z.literal('Month'),
@@ -151,6 +175,7 @@ export const productCatalogSchema = z.object({
 	GuardianPatron: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('stripe'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			GuardianPatron: z.object({
 				billingPeriod: z.literal('Month'),
@@ -167,6 +192,7 @@ export const productCatalogSchema = z.object({
 	GuardianWeeklyDomestic: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -258,6 +284,7 @@ export const productCatalogSchema = z.object({
 	GuardianWeeklyRestOfWorld: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -314,6 +341,7 @@ export const productCatalogSchema = z.object({
 	GuardianWeeklyZoneA: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -340,6 +368,7 @@ export const productCatalogSchema = z.object({
 	GuardianWeeklyZoneB: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -380,6 +409,7 @@ export const productCatalogSchema = z.object({
 	GuardianWeeklyZoneC: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -420,6 +450,7 @@ export const productCatalogSchema = z.object({
 	HomeDelivery: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Everyday: z.object({
 				billingPeriod: z.literal('Month'),
@@ -613,6 +644,7 @@ export const productCatalogSchema = z.object({
 	NationalDelivery: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Everyday: z.object({
 				billingPeriod: z.literal('Month'),
@@ -760,6 +792,7 @@ export const productCatalogSchema = z.object({
 	NewspaperVoucher: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Everyday: z.object({
 				billingPeriod: z.literal('Month'),
@@ -953,6 +986,7 @@ export const productCatalogSchema = z.object({
 	OneTimeContribution: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('stripe'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			OneTime: z.object({
 				billingPeriod: z.literal('OneTime'),
@@ -969,6 +1003,7 @@ export const productCatalogSchema = z.object({
 	PartnerMembership: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -1015,6 +1050,7 @@ export const productCatalogSchema = z.object({
 	PatronMembership: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -1061,6 +1097,7 @@ export const productCatalogSchema = z.object({
 	SubscriptionCard: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			Everyday: z.object({
 				billingPeriod: z.literal('Month'),
@@ -1254,6 +1291,7 @@ export const productCatalogSchema = z.object({
 	SupporterMembership: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -1344,6 +1382,7 @@ export const productCatalogSchema = z.object({
 	SupporterPlus: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(false),
 		ratePlans: z.object({
 			Annual: z.object({
 				billingPeriod: z.literal('Annual'),
@@ -1444,6 +1483,7 @@ export const productCatalogSchema = z.object({
 	TierThree: z.object({
 		active: z.boolean(),
 		billingSystem: z.literal('zuora'),
+		isDeliveryProduct: z.literal(true),
 		ratePlans: z.object({
 			DomesticAnnual: z.object({
 				billingPeriod: z.literal('Annual'),

--- a/modules/product-catalog/src/stripeProducts.ts
+++ b/modules/product-catalog/src/stripeProducts.ts
@@ -10,6 +10,7 @@ export const stripeProducts: Partial<
 	GuardianPatron: {
 		billingSystem: 'stripe',
 		active: true,
+		isDeliveryProduct: false,
 		ratePlans: {
 			GuardianPatron: {
 				id: 'guardian_patron',
@@ -26,6 +27,7 @@ export const stripeProducts: Partial<
 	OneTimeContribution: {
 		billingSystem: 'stripe',
 		active: true,
+		isDeliveryProduct: false,
 		ratePlans: {
 			OneTime: {
 				id: 'single_contribution',
@@ -44,6 +46,7 @@ export const stripeProducts: Partial<
 export const stripeProductsSchema = `GuardianPatron: z.object({
 	billingSystem: z.literal('stripe'),
 	active: z.boolean(),
+	isDeliveryProduct: z.literal(false),
 	ratePlans: z.object({
 		GuardianPatron: z.object({
 			id: z.string(),
@@ -60,6 +63,7 @@ export const stripeProductsSchema = `GuardianPatron: z.object({
 OneTimeContribution: z.object({
 	billingSystem: z.literal('stripe'),
 	active: z.boolean(),
+	isDeliveryProduct: z.literal(false),
 	ratePlans: z.object({
 		OneTime: z.object({
 			id: z.string(),

--- a/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
+++ b/modules/product-catalog/test/__snapshots__/generateProductCatalog.test.ts.snap
@@ -18,6 +18,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "Contribution": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -58,6 +59,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "DigitalSubscription": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -147,6 +149,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "GuardianAdLite": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Monthly": {
         "billingPeriod": "Month",
@@ -165,6 +168,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "GuardianPatron": {
     "active": true,
     "billingSystem": "stripe",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "GuardianPatron": {
         "billingPeriod": "Month",
@@ -181,6 +185,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyDomestic": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -272,6 +277,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyRestOfWorld": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -343,6 +349,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyZoneA": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -377,6 +384,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyZoneB": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -417,6 +425,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyZoneC": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -457,6 +466,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "HomeDelivery": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -670,6 +680,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "NationalDelivery": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -829,6 +840,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "NewspaperVoucher": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -1045,6 +1057,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "OneTimeContribution": {
     "active": true,
     "billingSystem": "stripe",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "OneTime": {
         "billingPeriod": "OneTime",
@@ -1061,6 +1074,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "PartnerMembership": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -1115,6 +1129,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "PatronMembership": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -1169,6 +1184,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "SubscriptionCard": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -1385,6 +1401,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "SupporterMembership": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -1479,6 +1496,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "SupporterPlus": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -1599,6 +1617,7 @@ exports[`code Generated product catalog matches snapshot 1`] = `
   "TierThree": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "DomesticAnnual": {
         "billingPeriod": "Annual",
@@ -1779,6 +1798,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "Contribution": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -1819,6 +1839,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "DigitalSubscription": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -1908,6 +1929,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "GuardianAdLite": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Monthly": {
         "billingPeriod": "Month",
@@ -1926,6 +1948,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "GuardianPatron": {
     "active": true,
     "billingSystem": "stripe",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "GuardianPatron": {
         "billingPeriod": "Month",
@@ -1942,6 +1965,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyDomestic": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -2033,6 +2057,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyRestOfWorld": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -2104,6 +2129,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyZoneA": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -2136,6 +2162,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyZoneB": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -2176,6 +2203,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "GuardianWeeklyZoneC": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -2216,6 +2244,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "HomeDelivery": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -2429,6 +2458,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "NationalDelivery": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -2588,6 +2618,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "NewspaperVoucher": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -2801,6 +2832,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "OneTimeContribution": {
     "active": true,
     "billingSystem": "stripe",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "OneTime": {
         "billingPeriod": "OneTime",
@@ -2817,6 +2849,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "PartnerMembership": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -2871,6 +2904,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "PatronMembership": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -2925,6 +2959,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "SubscriptionCard": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "Everyday": {
         "billingPeriod": "Month",
@@ -3138,6 +3173,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "SupporterMembership": {
     "active": false,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -3232,6 +3268,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "SupporterPlus": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": false,
     "ratePlans": {
       "Annual": {
         "billingPeriod": "Annual",
@@ -3332,6 +3369,7 @@ exports[`prod Generated product catalog matches snapshot 1`] = `
   "TierThree": {
     "active": true,
     "billingSystem": "zuora",
+    "isDeliveryProduct": true,
     "ratePlans": {
       "DomesticAnnual": {
         "billingPeriod": "Annual",

--- a/modules/salesforce/package.json
+++ b/modules/salesforce/package.json
@@ -6,7 +6,8 @@
     "it-test": "jest --group=integration",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts",
-    "lint": "eslint src/**/*.ts test/**/*.ts"
+    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "build": "tsc --noEmit"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/modules/secrets-manager/package.json
+++ b/modules/secrets-manager/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "check-formatting": "prettier --check **/*.ts",
     "test": "jest --group=-integration",
+    "build": "tsc --noEmit",
     "lint": "eslint src/**/*.ts test/**/*.ts"
   },
   "dependencies": {

--- a/modules/sync-supporter-product-data/package.json
+++ b/modules/sync-supporter-product-data/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "sync-user": "ts-node ./src/syncUser.ts",
+    "build": "tsc --noEmit",
     "lint": "eslint src/**/*.ts"
   },
   "devDependencies": {

--- a/modules/zuora-catalog/package.json
+++ b/modules/zuora-catalog/package.json
@@ -6,6 +6,7 @@
     "it-test": "jest --group=integration",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts",
+    "build": "tsc --noEmit",
     "lint": "eslint src/**/*.ts test/**/*.ts"
   },
   "dependencies": {

--- a/modules/zuora/package.json
+++ b/modules/zuora/package.json
@@ -6,6 +6,7 @@
     "it-test": "jest --group=integration",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts",
+    "build": "tsc --noEmit",
     "lint": "eslint src/**/*.ts test/**/*.ts"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Add a deliveryProducts array and associated type which definitively records which products have a delivery element. 
- Add a productKeys array to match the `ProductKey` type to make runtime checks easier.
- Add a field `isDeliveryProduct` to the product catalog so that consumers of the API can tell which products have a delivery element. 