### PR TITLE
Fix the linting errors in write-off-unpaid-invoices project

### DIFF
--- a/handlers/write-off-unpaid-invoices/package.json
+++ b/handlers/write-off-unpaid-invoices/package.json
@@ -6,7 +6,7 @@
 		"it-test": "jest --group=integration",
 		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr write-off-unpaid-invoices.zip ./*.js",
+		"package": "pnpm type-check && pnpm check-formatting && pnpm lint && pnpm test && pnpm build && cd target && zip -qr write-off-unpaid-invoices.zip ./*.js",
 		"type-check": "tsc --noEmit",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts"

--- a/handlers/write-off-unpaid-invoices/src/handlers/getUnpaidInvoices.ts
+++ b/handlers/write-off-unpaid-invoices/src/handlers/getUnpaidInvoices.ts
@@ -1,6 +1,6 @@
 import { uploadFileToS3 } from '@modules/aws/s3';
-import { buildAuthClient, runQuery } from '@modules/bigquery/src/bigquery';
 import { getSSMParam } from '@modules/aws/ssm';
+import { buildAuthClient, runQuery } from '@modules/bigquery/src/bigquery';
 
 export const handler = async ({ filePath }: { filePath: string }) => {
 	const gcpConfig = await getSSMParam(
@@ -9,7 +9,7 @@ export const handler = async ({ filePath }: { filePath: string }) => {
 
 	const authClient = await buildAuthClient(gcpConfig);
 
-	const [jsonContent, _] = await runQuery(
+	const [jsonContent] = await runQuery(
 		authClient,
 		process.env.GCP_PROJECT_ID!,
 		query,

--- a/handlers/write-off-unpaid-invoices/test/handlers/writeOffInvoices.test.ts
+++ b/handlers/write-off-unpaid-invoices/test/handlers/writeOffInvoices.test.ts
@@ -1,16 +1,16 @@
-import {
-	getInvoice,
-	getInvoiceItems,
-	creditInvoice,
-} from '@modules/zuora/invoice';
+import { getAccount } from '@modules/zuora/account';
 import { applyCreditToAccountBalance } from '@modules/zuora/creditBalanceAdjustment';
 import {
-	handler,
-	cancelSourceToCommentMap,
+	creditInvoice,
+	getInvoice,
+	getInvoiceItems,
+} from '@modules/zuora/invoice';
+import {
 	type CancelSource,
+	cancelSourceToCommentMap,
+	handler,
 	type LambdaEvent,
 } from '../../src/handlers/writeOffInvoices';
-import { getAccount } from '@modules/zuora/account';
 
 jest.mock('@modules/zuora/zuoraClient', () => ({
 	ZuoraClient: {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The write-off-unpaid-invoices project had linting errors in it, but these weren't failing the build because lint wasn't being run in CI. This PR fixes the errors and ensures that lint will be run for this project in future.