### PR TITLE
Add mandatory product specific fields to the product purchase schema

### DIFF
--- a/modules/product-catalog/src/generateProductPurchaseSchema.ts
+++ b/modules/product-catalog/src/generateProductPurchaseSchema.ts
@@ -5,7 +5,7 @@ import type {
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import {
 	isDeliveryProduct,
-	isNewspaperProduct,
+	requiresDeliveryInstructions,
 } from '@modules/product-catalog/productCatalog';
 import {
 	getProductRatePlanKey,
@@ -75,7 +75,7 @@ const generateProductSpecificFields = (productName: string): string => {
 		let fields = `
 			firstDeliveryDate: dateOrDateStringSchema,
 			deliveryContact: deliveryContactSchema,`;
-		if (isNewspaperProduct(productName)) {
+		if (requiresDeliveryInstructions(productName)) {
 			fields += `
 			deliveryInstructions: z.string(),`;
 			if (productName === 'NationalDelivery') {

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -30,11 +30,8 @@ export const deliveryProducts: ProductKey[] = [
 	'GuardianWeeklyZoneC',
 ] as const;
 
-export type NewspaperProductKey = (typeof newspaperProducts)[number];
-export function isNewspaperProduct(
-	productKey: unknown,
-): productKey is NewspaperProductKey {
-	return newspaperProducts.includes(productKey as NewspaperProductKey);
+export function requiresDeliveryInstructions(productKey: unknown): boolean {
+	return productKey === 'HomeDelivery' || productKey === 'NationalDelivery';
 }
 
 export type DeliveryProductKey = (typeof deliveryProducts)[number];

--- a/modules/product-catalog/src/productPurchaseSchema.ts
+++ b/modules/product-catalog/src/productPurchaseSchema.ts
@@ -135,7 +135,6 @@ export const productPurchaseSchema = z.discriminatedUnion('product', [
 		]),
 		firstDeliveryDate: dateOrDateStringSchema,
 		deliveryContact: deliveryContactSchema,
-		deliveryInstructions: z.string(),
 	}),
 	z.object({
 		product: z.literal('GuardianWeeklyZoneA'),
@@ -171,7 +170,6 @@ export const productPurchaseSchema = z.discriminatedUnion('product', [
 		]),
 		firstDeliveryDate: dateOrDateStringSchema,
 		deliveryContact: deliveryContactSchema,
-		deliveryInstructions: z.string(),
 	}),
 	z.object({
 		product: z.literal('HomeDelivery'),

--- a/modules/product-catalog/test/productPurchaseSchema.test.ts
+++ b/modules/product-catalog/test/productPurchaseSchema.test.ts
@@ -101,6 +101,14 @@ describe('productPurchaseSchema', () => {
 				ratePlan: 'Monthly',
 			}).error,
 		).toBeUndefined();
+		expect(
+			productPurchaseSchema.safeParse({
+				product: 'SubscriptionCard',
+				ratePlan: 'SixdayPlus',
+				firstDeliveryDate: '2023-10-01',
+				deliveryContact: contact,
+			}).error,
+		).toBeUndefined();
 	});
 	test('it can handle either string or date for firstDeliveryDate', () => {
 		expect(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The product-catalog defines a schema and type for valid product and rateplan combinations which is used by support-workers to ensure type safety when dealing with subscription purchases.

This PR extends that schema to also include fields which are mandatory for a particular type of purchase, for instance any delivery product requires a first delivery date and a delivery contact (address + name).