### PR TITLE
simplify manual sar status script

### DIFF
--- a/handlers/mparticle-api/runManual/invokeHandlerSARStatus.ts
+++ b/handlers/mparticle-api/runManual/invokeHandlerSARStatus.ts
@@ -1,12 +1,9 @@
-import {
-	BatonSarEventStatusRequest,
-	InitiationReference,
-} from '../src/routers/baton/types-and-schemas';
-import { batonRerRouter } from '../src/routers/baton';
+import { InitiationReference } from '../src/routers/baton/types-and-schemas';
 import { ConfigSchema } from '../src/utils/config';
 import { loadConfig } from '@modules/aws/appConfig';
 import { MParticleClient } from '../src/apis/mparticleClient';
 import { BatonS3WriterImpl } from '../src/apis/batonS3Writer';
+import { handleSarStatus } from '../src/routers/baton/handle-sar-status';
 
 /*
  **************************************************************************
@@ -22,41 +19,26 @@ import { BatonS3WriterImpl } from '../src/apis/batonS3Writer';
 const initiationReference: InitiationReference =
 	'6fd4c21e-a661-464b-8388-b09bf81604fc' as InitiationReference;
 
-const handlerTestEvent: BatonSarEventStatusRequest = {
-	initiationReference,
-	requestType: 'SAR',
-	action: 'status',
-};
-
 const sarS3BaseKey = 'handleSarStatusIntegrationTest/';
 const sarResultsBucket = 'support-service-lambdas-test';
 
 loadConfig('CODE', 'support', 'mparticle-api', ConfigSchema).then((config) => {
 	const mParticleDataSubjectClient =
 		MParticleClient.createMParticleDataSubjectClient(config.workspace);
-	const mParticleEventsAPIClient = MParticleClient.createEventsApiClient(
-		config.inputPlatform,
-		config.pod,
-	);
 
-	const mockDate = () => new Date(0);
 	const batonS3Writer = new BatonS3WriterImpl(
 		sarResultsBucket,
 		sarS3BaseKey,
-		mockDate,
+		() => new Date(),
 	);
 
-	batonRerRouter(
-		//TODO call the child not the router
+	handleSarStatus(
 		mParticleDataSubjectClient,
-		mParticleEventsAPIClient,
-		false,
 		batonS3Writer,
-	)
-		.routeRequest(handlerTestEvent)
-		.then((out) => {
-			console.log(out);
-			const consoleUrl = `http://eu-west-1.console.aws.amazon.com/s3/buckets/${sarResultsBucket}?prefix=${sarS3BaseKey}`;
-			console.log('check the results in the console', consoleUrl);
-		});
+		initiationReference,
+	).then((out) => {
+		console.log(out);
+		const consoleUrl = `http://eu-west-1.console.aws.amazon.com/s3/buckets/${sarResultsBucket}?prefix=${sarS3BaseKey}`;
+		console.log('check the results in the console', consoleUrl);
+	});
 });


### PR DESCRIPTION
Following on from https://github.com/guardian/support-service-lambdas/pull/3009

This PR simplifies the SAR status manual script as discussed in the mobbing review session, to only construct the required services, and not create the whole router.