### PR TITLE
Simple version of adding the customer facing name to the User Benefits API

### DIFF
--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -1,6 +1,5 @@
 import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
 import { getCustomerFacingName } from '@modules/product-catalog/productCatalog';
-
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 
 export const benefitsListHandler = async (
@@ -64,7 +63,11 @@ const getHtmlBody = (): string => {
 						${Object.entries(productBenefitMapping)
 							.map(
 								([key, value]) =>
-									`<tr><td>${key}</td><td>${getCustomerFacingName(key)}</td><td>${value.join(', ')}</td></tr>`,
+									`<tr>` +
+									`<td>${key}</td>` +
+									`<td>${getCustomerFacingName(key)}</td>` +
+									`<td>${value.join(', ')}</td>` +
+									`</tr>`,
 							)
 							.join('')}
 				</table>

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -43,29 +43,29 @@ export function isDeliveryProduct(
 
 // Eventually all but OneTimeContribution will come from a custom field in Zuora's Product Catalog
 const customerFacingNameMapping: Record<ProductKey, string> = {
-    GuardianAdLite: 'Guardian Ad-Lite',
-    SupporterPlus: 'All-access digital',
-    TierThree: 'Digital + print',
-    DigitalSubscription: 'The Guardian Digital Edition',
-    HomeDelivery: 'Newspaper Home Delivery',
-    NationalDelivery: 'Newspaper Home Delivery',
-    NewspaperVoucher: 'Newspaper Voucher',
-    SubscriptionCard: 'Newspaper Subscription Card',
-    SupporterMembership: 'Supporter Membership',
-    PartnerMembership: 'Partner Membership',
-    PatronMembership: 'Patron Membership',
-    GuardianPatron: 'Guardian Patron',
-    GuardianWeeklyDomestic: 'Guardian Weekly',
-    GuardianWeeklyRestOfWorld: 'Guardian Weekly',
-    GuardianWeeklyZoneA: 'Guardian Weekly',
-    GuardianWeeklyZoneB: 'Guardian Weekly',
-    GuardianWeeklyZoneC: 'Guardian Weekly',
-    Contribution: 'Support',
-    OneTimeContribution: 'Support just once',
+	GuardianAdLite: 'Guardian Ad-Lite',
+	SupporterPlus: 'All-access digital',
+	TierThree: 'Digital + print',
+	DigitalSubscription: 'The Guardian Digital Edition',
+	HomeDelivery: 'Newspaper Home Delivery',
+	NationalDelivery: 'Newspaper Home Delivery',
+	NewspaperVoucher: 'Newspaper Voucher',
+	SubscriptionCard: 'Newspaper Subscription Card',
+	SupporterMembership: 'Supporter Membership',
+	PartnerMembership: 'Partner Membership',
+	PatronMembership: 'Patron Membership',
+	GuardianPatron: 'Guardian Patron',
+	GuardianWeeklyDomestic: 'Guardian Weekly',
+	GuardianWeeklyRestOfWorld: 'Guardian Weekly',
+	GuardianWeeklyZoneA: 'Guardian Weekly',
+	GuardianWeeklyZoneB: 'Guardian Weekly',
+	GuardianWeeklyZoneC: 'Guardian Weekly',
+	Contribution: 'Support',
+	OneTimeContribution: 'Support just once',
 };
 
 export function getCustomerFacingName(productKey: unknown): string {
-    return customerFacingNameMapping[productKey as ProductKey];
+	return customerFacingNameMapping[productKey as ProductKey];
 }
 
 export type Product<P extends ProductKey> = ProductCatalog[P];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
It is a simpler version of adding the customer facing name to the User Benefits API.

We can either rebase this over https://github.com/guardian/support-service-lambdas/pull/3028, or vice-versa.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- [x] Deploy via RiffRaff to CODE then visit `.../benefits/list`

Before:
<img width="1086" height="779" alt="Screenshot 2025-08-22 at 09 14 06" src="https://github.com/user-attachments/assets/11602f93-125c-45de-a936-2e60d397b6e7" />

After:

<img width="1289" height="771" alt="Screenshot 2025-08-22 at 09 14 16" src="https://github.com/user-attachments/assets/8acd21d5-528f-49e1-957a-eb55c8ab16f4" />

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Much lower than https://github.com/guardian/support-service-lambdas/pull/3028 as it only affects a view from an endpoint.

## Trello

https://trello.com/c/F5qXyVPK/603-add-customer-facing-name-to-product-catalog-service