### PR TITLE
Prevent duplicate subscriptions from being created using Zuora idempotency key

### DIFF
--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -82,7 +82,7 @@ function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 
 	const newAccount = buildNewAccountObject({
 		accountName: accountName,
-		createdRequestId: createdRequestId, // TODO: could use Idempotency-Key header instead?
+		createdRequestId: createdRequestId,
 		salesforceAccountId: salesforceAccountId,
 		salesforceContactId: salesforceContactId,
 		identityId: identityId,
@@ -139,5 +139,6 @@ export const createSubscription = async <T extends PaymentMethod>(
 		zuoraClient,
 		buildCreateSubscriptionRequest(productCatalog, inputFields),
 		createSubscriptionResponseSchema,
+		inputFields.createdRequestId,
 	);
 };

--- a/modules/zuora/src/orders/orderRequests.ts
+++ b/modules/zuora/src/orders/orderRequests.ts
@@ -47,10 +47,14 @@ export function executeOrderRequest<
 	zuoraClient: ZuoraClient,
 	orderRequest: CreateOrderRequest,
 	responseSchema: T,
+	idempotencyKey?: string,
 ): Promise<O> {
 	const path = `/v1/orders`;
 	const body = JSON.stringify(orderRequest);
-	return zuoraClient.post(path, body, responseSchema);
+	const headers = idempotencyKey
+		? { 'idempotency-key': idempotencyKey }
+		: undefined;
+	return zuoraClient.post(path, body, responseSchema, headers);
 }
 
 export function previewOrderRequest<


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
In the existing CreateZuoraSubscription lambda we have a custom mechanism which checks that each run of the state machine will only ever create one subscription, no matter how many times the lambda is retried. [See code here](https://github.com/guardian/support-frontend/blob/7462182e48c0fe349945b2fe38883dc4c6d9aa4c/support-workers/src/main/scala/com/gu/zuora/ZuoraSubscriptionCreator.scala#L31)

We need to reproduce this functionality in the new Typescript version of the lambda, however rather than using this custom mechanism, we can use a [Zuora Idempotency Key](https://developer.zuora.com/docs/guides/idempotent-requests). 
The way that this works is that if we execute a request with an idempotency key which has already succeeded in the last 24 hours, Zuora will return the response from the original request without repeating the action.


[**Trello Card**](https://trello.com/c/vmaewQey/1846-prevent-duplicates)