### PR TITLE
Fix the schema generation script

### DIFF
--- a/modules/product-catalog/src/generateSchema.ts
+++ b/modules/product-catalog/src/generateSchema.ts
@@ -6,10 +6,7 @@ import type {
 	ZuoraProductRatePlan,
 	ZuoraProductRatePlanCharge,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import {
-	getCustomerFacingName,
-	isDeliveryProduct,
-} from '@modules/product-catalog/productCatalog';
+import { isDeliveryProduct } from '@modules/product-catalog/productCatalog';
 import { stripeProductsSchema } from '@modules/product-catalog/stripeProducts';
 import {
 	getProductRatePlanChargeKey,
@@ -62,7 +59,7 @@ const generateZuoraProductSchema = (product: CatalogProduct) => {
 	return `${productName}: z.object({
 		billingSystem: z.literal('zuora'),
 		active: z.boolean(),
-		customerFacingName: z.literal(${getCustomerFacingName(productName)}),
+		customerFacingName: z.string(),
 		isDeliveryProduct: z.literal(${isDeliveryProduct(productName)}),
 		ratePlans: z.object({
 			${ratePlanSchema.join(',\n')},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
https://github.com/guardian/support-service-lambdas/pull/3028 added a new field to the product catalog and schema, but I think it manually edited the schema rather than using the generation script to do it. 

When I next ran the script it outputs a schema which doesn't compile because it includes literals without quotation marks. I actually think for this field we don't need a literal anyway, we can just use a string as we don't need strict type checking for what is just a display value.