### PR TITLE
Stop holiday-stop-api sending duplicated authorisation headers in Salesforce requests

### DIFF
--- a/lib/effects/src/main/scala/com/gu/effects/Http.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/Http.scala
@@ -27,11 +27,10 @@ object Http extends Logging {
 
     { request: Request =>
       val maybeBodySummary = Option(request.body).map(bodySummary)
-      val headersSummary = request.headers.asScala.map { h => s"${h.getFirst}: ${h.getSecond}" }.mkString(", ")
       logger.info(
-        s"HTTP request: ${request.method} ${request.url}" +
-          maybeBodySummary.map(summary => s", body:  $summary").getOrElse("") +
-          s", headers: {$headersSummary}" // TODO:delete comment - Logging request headers
+        s"HTTP request: ${request.method} ${request.url}" + maybeBodySummary
+          .map(summary => s", body:  $summary")
+          .getOrElse(""),
       )
       val response = restClient.newCall(request).execute
       logger.info(s"HTTP response: ${response.code}")
@@ -49,10 +48,7 @@ object Http extends Logging {
       .build()
 
     { request: Request =>
-      val headersSummary = request.headers.asScala.map { h => s"${h.getFirst}: ${h.getSecond}" }.mkString(", ")
-      logger.info(
-                s"HTTP request: ${request.method} ${request.url} ${request.headers.toMultimap.size}, headers: {$headersSummary}"
-      )
+      logger.info(s"HTTP request: ${request.method} ${request.url} ${request.headers.toMultimap.size}")
       val response = restClient.newCall(request).execute
       logger.info(s"HTTP response: ${response.code}")
       response

--- a/lib/effects/src/main/scala/com/gu/effects/Http.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/Http.scala
@@ -27,10 +27,11 @@ object Http extends Logging {
 
     { request: Request =>
       val maybeBodySummary = Option(request.body).map(bodySummary)
+      val headersSummary = request.headers.asScala.map { h => s"${h.getFirst}: ${h.getSecond}" }.mkString(", ")
       logger.info(
-        s"HTTP request: ${request.method} ${request.url}" + maybeBodySummary
-          .map(summary => s", body:  $summary")
-          .getOrElse(""),
+        s"HTTP request: ${request.method} ${request.url}" +
+          maybeBodySummary.map(summary => s", body:  $summary").getOrElse("") +
+          s", headers: {$headersSummary}" // TODO:delete comment - Logging request headers
       )
       val response = restClient.newCall(request).execute
       logger.info(s"HTTP response: ${response.code}")
@@ -48,7 +49,10 @@ object Http extends Logging {
       .build()
 
     { request: Request =>
-      logger.info(s"HTTP request: ${request.method} ${request.url} ${request.headers.toMultimap.size}")
+      val headersSummary = request.headers.asScala.map { h => s"${h.getFirst}: ${h.getSecond}" }.mkString(", ")
+      logger.info(
+                s"HTTP request: ${request.method} ${request.url} ${request.headers.toMultimap.size}, headers: {$headersSummary}"
+      )
       val response = restClient.newCall(request).execute
       logger.info(s"HTTP response: ${response.code}")
       response

--- a/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -28,8 +28,12 @@ object SalesforceClient extends LazyLogging {
 
   private def withAuthAndBaseUrl(sfAuth: SalesforceAuth)(requestInfo: StringHttpRequest): Request = {
     val builder = requestInfo.requestMethod.builder
-    val authHeaders = getAuthHeaders(sfAuth.access_token)
-    val headersWithAuth: List[Header] = requestInfo.headers ++ authHeaders
+    val hasAuthHeader = requestInfo.headers.exists(h =>
+      h.name.equalsIgnoreCase("Authorization") || h.name.equalsIgnoreCase("X-SFDC-Session")
+    )
+    val headersWithAuth =     
+      if (hasAuthHeader) requestInfo.headers
+      else requestInfo.headers ++ getAuthHeaders(sfAuth.access_token)
 
     logger.info(s"SalesforceClient: Final headers for request: ${headersWithAuth.map(h => s"${h.name}: ${h.value}").mkString(", ")}")
 

--- a/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -31,6 +31,8 @@ object SalesforceClient extends LazyLogging {
     val authHeaders = getAuthHeaders(sfAuth.access_token)
     val headersWithAuth: List[Header] = requestInfo.headers ++ authHeaders
 
+    logger.info(s"SalesforceClient: Final headers for request: ${headersWithAuth.map(h => s"${h.name}: ${h.value}").mkString(", ")}")
+
     val builderWithHeaders = headersWithAuth.foldLeft(builder)((builder: Request.Builder, header: Header) => {
       builder.addHeader(header.name, header.value)
     })
@@ -46,6 +48,7 @@ object SalesforceClient extends LazyLogging {
   def withAlternateAccessTokenIfPresentInHeaderList(
       headers: Option[Map[String, String]],
   ): StringHttpRequest => StringHttpRequest =
+    logger.info(s"withAlternateAccessTokenIfPresentInHeaderList called with headers: $headers")
     withMaybeAlternateAccessToken(headers.flatMap(_.get("X-Ephemeral-Salesforce-Access-Token")))
 
   def withMaybeAlternateAccessToken(

--- a/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -53,7 +53,10 @@ object SalesforceClient extends LazyLogging {
   )(requestInfo: StringHttpRequest): StringHttpRequest =
     maybeAlternateAccessToken
       .map { alternateAccessToken =>
-        requestInfo.copy(headers = requestInfo.headers ++ getAuthHeaders(alternateAccessToken))
+        val nonAuthHeaders = requestInfo.headers.filterNot(header =>
+          header.name.equalsIgnoreCase("Authorization") || header.name.equalsIgnoreCase("X-SFDC-Session")
+        )
+        requestInfo.copy(headers = nonAuthHeaders ++ getAuthHeaders(alternateAccessToken))
       }
       .getOrElse(requestInfo)
 

--- a/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -47,9 +47,11 @@ object SalesforceClient extends LazyLogging {
 
   def withAlternateAccessTokenIfPresentInHeaderList(
       headers: Option[Map[String, String]],
-  ): StringHttpRequest => StringHttpRequest =
+  ): StringHttpRequest => StringHttpRequest = {
     logger.info(s"withAlternateAccessTokenIfPresentInHeaderList called with headers: $headers")
     withMaybeAlternateAccessToken(headers.flatMap(_.get("X-Ephemeral-Salesforce-Access-Token")))
+  }
+
 
   def withMaybeAlternateAccessToken(
       maybeAlternateAccessToken: Option[String],

--- a/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -35,8 +35,6 @@ object SalesforceClient extends LazyLogging {
       if (hasAuthHeader) requestInfo.headers
       else requestInfo.headers ++ getAuthHeaders(sfAuth.access_token)
 
-    logger.info(s"SalesforceClient: Final headers for request: ${headersWithAuth.map(h => s"${h.name}: ${h.value}").mkString(", ")}")
-
     val builderWithHeaders = headersWithAuth.foldLeft(builder)((builder: Request.Builder, header: Header) => {
       builder.addHeader(header.name, header.value)
     })
@@ -51,10 +49,8 @@ object SalesforceClient extends LazyLogging {
 
   def withAlternateAccessTokenIfPresentInHeaderList(
       headers: Option[Map[String, String]],
-  ): StringHttpRequest => StringHttpRequest = {
-    logger.info(s"withAlternateAccessTokenIfPresentInHeaderList called with headers: $headers")
+  ): StringHttpRequest => StringHttpRequest =
     withMaybeAlternateAccessToken(headers.flatMap(_.get("X-Ephemeral-Salesforce-Access-Token")))
-  }
 
 
   def withMaybeAlternateAccessToken(


### PR DESCRIPTION
## What does this change?

### Problem background
In the Salesforce sandbox we were seeing an issue where the holiday-stop-api would get a 400 error from Salesforce for some callouts. The 400 error was quite unusual, it was returning a html page as if it was a UI error:

<img width="1182" height="832" alt="Screenshot 2025-09-02 at 15 55 07" src="https://github.com/user-attachments/assets/cab7db8c-e8c1-4a2a-b314-dc59ae6dafa5" />

On further investigation, this seems to be related to the authentication headers added to the requests. Requests from holiday-stop-api have two headers:

1. `Authorization` - used for a bearer token e.g. `Bearer abcdef.123456789`
2. `X-SFDC-Session` - used for a session ID passed in from Salesforce to allow for the holiday-stop-api to actually "masquerade" as the CSR using the function so that additions/edits appear to made by them instead of an integration user.

The session ID is not always provided, only when the service is called from the Salesforce UI - i.e. from MMA no session ID is provided.

But holiday-stop-api actually sends BOTH headers. They are both populated by the session ID if provided, if not they are both populated with an oauth access token. Salesforce seems to be happy to work out what it should actually use.

We found that holiday-stop-api, when receiving the session id in the initial request, is actually sending two versions of each header - one version with the session id and one version with the oauth access token 😵 here's a Cloudwatch log line with some extra logging added to show the headers sent:

<img width="1681" height="201" alt="Screenshot 2025-09-02 at 15 59 08" src="https://github.com/user-attachments/assets/28bacc18-8826-4b32-8f7a-c09711ea6ce1" />

I have been able to duplicate this unusual 400 error by using the same duplicate headers in postman.

If we forced Salesforce to not send the session ID, the errors would stop - because only one version of each header is then sent.

> [!WARNING]
> What I cannot explain is how this is working in production. It also must have been working in the sandbox until very recently - I was actually testing another change up until Thursday last week and I'm sure it was working! Unless this is all a weird dream. Maybe Salesforce made some sort of change??
>
> It's possible this is somehow related to the `INVALID_SESSION_ID` errors that we've long experienced with holiday-stop-api but never quite figured out?

### Solution
We always make sure to only send one version of the authorisation headers on each request.

## How to test
In Salesforce, use the Holiday Stop edit UI to make an amendment. Previously this would fail to load because holiday-stop-api needs to query SF. Withdrawals were also broken.

## How can we measure success?
The Holiday Stop UI should be functional again in the sandbox AND we should avoid this problem appearing in production.

## Have we considered potential risks?
This should not impact holiday stops made through MMA which are not provided with the `X-Ephemeral-Salesforce-Access-Token` header.

In Salesforce, we should be able to verify that this hasn't completely broken the UI quickly. We can be ready to roll back if there any problems.