### PR TITLE
add manual runner to send holiday stop confirmation email

### DIFF
--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
@@ -40,7 +40,7 @@ object Handler extends Logging {
     )
   }
 
-  private def handle(apiGatewayRequest: ApiGatewayRequest): ApiResponse = {
+  def handle(apiGatewayRequest: ApiGatewayRequest): ApiResponse = {
     val useOldSend = apiGatewayRequest.queryStringParameters.flatMap(_.get("oldApi")).map(_.toBoolean).getOrElse(false)
     if (useOldSend) {
       apiGatewayRequest

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/RunManual.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/RunManual.scala
@@ -1,0 +1,24 @@
+package com.gu.batchemailsender.api.batchemail
+
+import com.gu.util.apigateway.ApiGatewayRequest
+
+// run this to send an email in CODE/test env
+// change the email and ids to your own
+object RunManual {
+
+  def main(args: Array[String]): Unit = {
+    val email = "test.user@guardian.co.uk"
+    val sfcontactId = "123473658AAA"
+    val identityId = "12345"
+    val body = s"""{"batch_items":[{"payload":{"to_address":"$email","subscriber_id":"A-1234","sf_contact_id":"$sfcontactId","record_id":"123rec","product":"Newspaper - National Delivery","next_charge_date":"2025-09-25","modified_by_customer":true,"last_name":"Batchemailsender","identity_id":"$identityId","holiday_stop_request":{"stopped_issue_count":"14","stopped_credit_summaries":[{"credit_date":"2025-10-25","credit_amount":43.86}],"stopped_credit_sum":"43.86","holiday_start_date":"2025-09-26","holiday_end_date":"2025-10-11","currency_symbol":"&pound;","bulk_suspension_reason":null},"first_name":"SupportServiceLambdas","email_stage":"create","digital_voucher":null,"delivery_address_change":null},"object_name":"Holiday_Stop_Request__c"}]}"""
+    val apiGatewayRequest = ApiGatewayRequest(
+      Some("POST"),
+      Some(Map("oldApi" -> "true")),
+      Some(body),
+      Some(Map("content-type" -> "application/json")),
+      None, Some("/email-batch")
+    )
+    Handler.handle(apiGatewayRequest)
+  }
+
+}


### PR DESCRIPTION
We had reports of formatting issues for the above email.  Since the preview in braze is non existent, and you can't easily get the html, I wrote a little snippet to send out the email to a custom ID (me)

Adding it to the repo so others can use it if necessary.