### PR TITLE
Move zuora-datalake-export alarms to Platform

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -112,6 +112,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'zuora-oracle-fusion',
 		'write-off-unpaid-invoices',
 		'negative-invoices-processor',
+		'zuora-datalake-export',
 
 		// stripe
 		'stripe-patrons-data',


### PR DESCRIPTION
## What does this change?

Adds `zuora-datalake-export` to the Platform Team alarm mapping so that we can receive alerts about errors in this Lambda.