### PR TITLE
Rename `SupportInternationalisationId` to `SupportRegionId`

### DIFF
--- a/modules/internationalisation/src/countryGroup.ts
+++ b/modules/internationalisation/src/countryGroup.ts
@@ -28,20 +28,21 @@ export type CountryGroupName =
 	| 'New Zealand'
 	| 'Canada';
 
-export type SupportInternationalisationId =
-	| 'uk'
-	| 'us'
-	| 'au'
-	| 'eu'
-	| 'int'
-	| 'nz'
-	| 'ca';
+export enum SupportRegionId {
+	UK = 'uk',
+	US = 'us',
+	AU = 'au',
+	EU = 'eu',
+	INT = 'int',
+	NZ = 'nz',
+	CA = 'ca',
+}
 
 export type CountryGroup = {
 	name: CountryGroupName;
 	currency: IsoCurrency;
 	countries: IsoCountry[];
-	supportInternationalisationId: SupportInternationalisationId;
+	supportRegionId: SupportRegionId;
 };
 type CountryGroups = Record<CountryGroupId, CountryGroup>;
 export const countryGroups: CountryGroups = {
@@ -49,19 +50,19 @@ export const countryGroups: CountryGroups = {
 		name: 'United Kingdom',
 		currency: 'GBP',
 		countries: ['GB', 'FK', 'GI', 'GG', 'IM', 'JE', 'SH'],
-		supportInternationalisationId: 'uk',
+		supportRegionId: SupportRegionId.UK,
 	},
 	UnitedStates: {
 		name: 'United States',
 		currency: 'USD',
 		countries: ['US'],
-		supportInternationalisationId: 'us',
+		supportRegionId: SupportRegionId.US,
 	},
 	AUDCountries: {
 		name: 'Australia',
 		currency: 'AUD',
 		countries: ['AU', 'KI', 'NR', 'NF', 'TV'],
-		supportInternationalisationId: 'au',
+		supportRegionId: SupportRegionId.AU,
 	},
 	EURCountries: {
 		name: 'Europe',
@@ -129,7 +130,7 @@ export const countryGroups: CountryGroups = {
 			'UA',
 			'MK',
 		],
-		supportInternationalisationId: 'eu',
+		supportRegionId: SupportRegionId.EU,
 	},
 	International: {
 		name: 'International',
@@ -308,18 +309,18 @@ export const countryGroups: CountryGroups = {
 			'ZM',
 			'ZW',
 		],
-		supportInternationalisationId: 'int',
+		supportRegionId: SupportRegionId.INT,
 	},
 	NZDCountries: {
 		name: 'New Zealand',
 		currency: 'NZD',
 		countries: ['NZ', 'CK'],
-		supportInternationalisationId: 'nz',
+		supportRegionId: SupportRegionId.NZ,
 	},
 	Canada: {
 		name: 'Canada',
 		currency: 'CAD',
 		countries: ['CA'],
-		supportInternationalisationId: 'ca',
+		supportRegionId: SupportRegionId.CA,
 	},
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR renames the `SupportInternationalisationId` type to `SupportRegionId` I think this is clearer for a number of reasons:
- It makes more sense to talk about a support region than a 'support internationalisation'
- It is more concise - quite a lot shorter to type
- There is no spelling ambiguity (internationalization vs internationalisation)

It also changes the implementation to use a Typescript enum rather than a plain type to allow us to access the values as an array where we need them.

This type is used extensively in support-frontend so there is an [accompanying PR here](https://github.com/guardian/support-frontend/pull/7304) to update those usages.