### PR TITLE
make update-supporter-plus-amount lambda use the Router

### DIFF
--- a/handlers/update-supporter-plus-amount/src/index.ts
+++ b/handlers/update-supporter-plus-amount/src/index.ts
@@ -1,8 +1,8 @@
 import { sendEmail } from '@modules/email/email';
-import { ValidationError } from '@modules/errors';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { logger } from '@modules/routing/logger';
+import { createRoute, Router } from '@modules/routing/router';
 import type { Stage } from '@modules/stage';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type {
@@ -10,59 +10,61 @@ import type {
 	APIGatewayProxyResult,
 	Handler,
 } from 'aws-lambda';
+import { z } from 'zod';
+import type { RequestBody } from './schema';
 import { requestBodySchema } from './schema';
 import { createThankYouEmail } from './sendEmail';
 import { updateSupporterPlusAmount } from './updateSupporterPlusAmount';
-import { getSubscriptionNumberFromUrl } from './urlParsing';
 
 const stage = process.env.STAGE as Stage;
 
-export const handler: Handler = async (
-	event: APIGatewayProxyEvent,
-): Promise<APIGatewayProxyResult> => {
-	logger.log(`Input is ${JSON.stringify(event)}`);
-	const response = await routeRequest(event);
-	logger.log(`Response is ${JSON.stringify(response)}`);
-	return response;
-};
+const pathParserSchema = z.object({
+	subscriptionNumber: z
+		.string()
+		.regex(
+			/^A-S\d+$/,
+			'Subscription number must start with A-S and be followed by digits',
+		),
+});
 
-const routeRequest = async (event: APIGatewayProxyEvent) => {
-	try {
-		const subscriptionNumber = getSubscriptionNumberFromUrl(event.path);
-		logger.mutableAddContext(subscriptionNumber);
-		const eventBody = getIfDefined(event.body, 'No request body provided');
-		const requestBody = requestBodySchema.parse(JSON.parse(eventBody));
-		const identityId = getIfDefined(
-			event.headers['x-identity-id'],
-			'Identity ID not found in request',
-		);
-		const zuoraClient = await ZuoraClient.create(stage);
-		const productCatalog = await getProductCatalogFromApi(stage);
-		const emailFields = await updateSupporterPlusAmount(
-			zuoraClient,
-			productCatalog,
-			identityId,
-			subscriptionNumber,
-			requestBody.newPaymentAmount,
-		);
-		await sendEmail(stage, createThankYouEmail(emailFields));
-		return {
-			body: JSON.stringify({ message: 'Success' }),
-			statusCode: 200,
-		};
-	} catch (error) {
-		logger.log('Caught error in index.ts ', error);
-		if (error instanceof ValidationError) {
-			logger.log(`Validation failure: ${error.message}`);
-			return {
-				body: error.message,
-				statusCode: 400,
-			};
-		} else {
-			return {
-				body: 'Unexpected error while carrying out the request',
-				statusCode: 500,
-			};
-		}
-	}
-};
+export type PathParser = z.infer<typeof pathParserSchema>;
+
+// main entry from AWS
+export const handler: Handler = Router([
+	createRoute<PathParser, RequestBody>({
+		httpMethod: 'POST',
+		path: '/update-supporter-plus-amount/{subscriptionNumber}',
+		handler: handleUpdateAmount,
+		parser: {
+			path: pathParserSchema,
+			body: requestBodySchema,
+		},
+	}),
+]);
+
+async function handleUpdateAmount(
+	event: APIGatewayProxyEvent,
+	parsed: { path: PathParser; body: RequestBody },
+): Promise<APIGatewayProxyResult> {
+	const subscriptionNumber = parsed.path.subscriptionNumber;
+	logger.mutableAddContext(subscriptionNumber);
+	const requestBody = parsed.body;
+	const identityId = getIfDefined(
+		event.headers['x-identity-id'],
+		'Identity ID not found in request',
+	);
+	const zuoraClient = await ZuoraClient.create(stage);
+	const productCatalog = await getProductCatalogFromApi(stage);
+	const emailFields = await updateSupporterPlusAmount(
+		zuoraClient,
+		productCatalog,
+		identityId,
+		subscriptionNumber,
+		requestBody.newPaymentAmount,
+	);
+	await sendEmail(stage, createThankYouEmail(emailFields));
+	return {
+		body: JSON.stringify({ message: 'Success' }),
+		statusCode: 200,
+	};
+}

--- a/handlers/update-supporter-plus-amount/src/schema.ts
+++ b/handlers/update-supporter-plus-amount/src/schema.ts
@@ -3,3 +3,5 @@ import { z } from 'zod';
 export const requestBodySchema = z.object({
 	newPaymentAmount: z.number(),
 });
+
+export type RequestBody = z.infer<typeof requestBodySchema>;


### PR DESCRIPTION
This lambda adds the subscription id as context for the logger.  However nothing is clearing the context between each request, so the subscription ids build up each time it's called.

The Router automatically clears the context on each request, and this lambda predates the router.

This PR changes the above lambda to use the Router.

Tested in CODE and working fine - this has two consecutive requests in the log:
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fupdate-supporter-plus-amount-CODE/log-events/2025$252F09$252F17$252F$255B$2524LATEST$255D6fff6b89ad4541c8a89aa0126d9b8538