### PR TITLE
Set LastPlanAddedDate__c custom field

### DIFF
--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -116,10 +116,11 @@ function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 	const customFields = {
 		DeliveryAgent__c: deliveryAgent.toString(),
 		ReaderType__c: readerType,
+		LastPlanAddedDate__c: zuoraDateFormat(contractEffectiveDate),
 	};
 	return {
 		newAccount: newAccount,
-		orderDate: zuoraDateFormat(dayjs()),
+		orderDate: zuoraDateFormat(contractEffectiveDate),
 		description: `Created by createSubscription.ts in support-service-lambdas`,
 		subscriptions: [
 			{

--- a/modules/zuora/src/orders/orderRequests.ts
+++ b/modules/zuora/src/orders/orderRequests.ts
@@ -30,7 +30,7 @@ export type OrderRequest = AccountOrderRequest & {
 		subscriptionNumber?: string;
 		orderActions: OrderAction[];
 		customFields?: {
-			LastPlanAddedDate__c?: string;
+			LastPlanAddedDate__c: string;
 			DeliveryAgent__c?: string;
 			ReaderType__c?: string;
 		};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We need to set the LastPlanAddedDate__c custom field when creating new subscriptions to support various MMA functions, see https://github.com/guardian/support-frontend/pull/7040 for more information.