### PR TITLE
calculate the correct actual amount for product switches

### DIFF
--- a/handlers/product-switch-api/src/switchInformation.ts
+++ b/handlers/product-switch-api/src/switchInformation.ts
@@ -225,7 +225,7 @@ export const getSwitchInformationWithOwnerCheck = async (
 		input,
 		startNewTerm,
 		contributionAmount,
-		actualTotalPrice: userDesiredAmount,
+		actualTotalPrice: contributionAmount + actualBasePrice,
 		account: userInformation,
 		subscription: subscriptionInformation,
 		catalog: catalogInformation,

--- a/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
+++ b/handlers/product-switch-api/test/contributionToSupporterPlus.test.ts
@@ -364,7 +364,7 @@ test('When newAmount is specified, it calculates contribution based on newAmount
 	expect(switchInformation.contributionAmount).toBe(30); // £150 - £120 = £30
 });
 
-test('When newAmount is not specified, it uses previousAmount without validation', async () => {
+test('When newAmount is not specified, use the old amount with the base price as a floor', async () => {
 	const productCatalog = getProductCatalogFromFixture();
 	const subscription = zuoraSubscriptionResponseSchema.parse(subscriptionJson);
 	const account = zuoraAccountSchema.parse(accountJson);
@@ -383,8 +383,8 @@ test('When newAmount is not specified, it uses previousAmount without validation
 		today,
 	);
 
-	// Should use the previous amount (£50) and have zero contribution (since £50 < £120)
-	expect(switchInformation.actualTotalPrice).toBe(50);
+	// Should use the floor price (£120) and have zero contribution (since £50 < £120)
+	expect(switchInformation.actualTotalPrice).toBe(120);
 	expect(switchInformation.contributionAmount).toBe(0);
 });
 


### PR DESCRIPTION
We had a bug report come in that after switching from £5 contribution to S+ (base price £12) the thank you email said £5 which was incorrect.

The actual subscription was correct, but the bug was that the switch api falls back to the old subscription price if there's no amount provided in the request.

Trello: https://trello.com/c/Czy8tAU0
Logs: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fproduct-switch-api-PROD/log-events$3Fstart$3D1757687760000$26end$3D1757687820000

This PR makes it calculate the actual amount for use later in the process (emails and salesforce tracking), which is minimised to the base price even if it's lower.

Testing... I have not done any additional testing as it's so minor