### PR TITLE
refact(zuora-module): implemented generic typing for writeOffInvoice …

### DIFF
--- a/modules/zuora/src/invoice.ts
+++ b/modules/zuora/src/invoice.ts
@@ -1,5 +1,6 @@
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
+import { z } from 'zod';
 import { getInvoiceItemsSchema } from './types';
 import type { GetInvoiceItemsResponse } from './types';
 import {
@@ -11,7 +12,6 @@ import {
 import { getInvoiceSchema } from './types';
 import type { GetInvoiceResponse } from './types';
 import { zuoraResponseSchema } from './types';
-import type { ZuoraResponse } from './types';
 import { zuoraDateFormat } from './utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 
@@ -62,11 +62,14 @@ export const creditInvoice = async (
 	);
 };
 
-export const writeOffInvoice = async (
+export const writeOffInvoice = async <
+	T extends z.ZodType = typeof zuoraResponseSchema,
+>(
 	zuoraClient: ZuoraClient,
 	invoiceNumber: string,
 	comment: string,
-): Promise<ZuoraResponse> => {
+	schema?: T,
+): Promise<z.infer<T>> => {
 	console.log(`Writing off invoice ${invoiceNumber} with comment: ${comment}`);
 	const path = `/v1/invoices/${invoiceNumber}/write-off`;
 	const body = JSON.stringify({
@@ -74,5 +77,6 @@ export const writeOffInvoice = async (
 		memoDate: dayjs().format('YYYY-MM-DD'),
 		reasonCode: 'Write-off',
 	});
-	return zuoraClient.put(path, body, zuoraResponseSchema);
+	const finalSchema = (schema ?? zuoraResponseSchema) as T;
+	return zuoraClient.put(path, body, finalSchema);
 };


### PR DESCRIPTION
What does this change?

  This PR introduces several improvements to the stripe-disputes handler:

  1. Generic type support for writeOffInvoice function

  - Added generic type support to writeOffInvoice in @modules/zuora/src/invoice.ts following the same pattern as doRefund
  - Function signature now supports custom response schemas while maintaining backward compatibility
  - Updated comprehensive tests with dynamic typing support

  How to test

  ```
curl --request POST \
  --url https://stripe-disputes-code.support.guardianapis.com/listen-dispute-closed \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/11.4.0' \
  --header 'x-api-key: API_KEY_API_KEY_API_KEY_API_KEY_API_KEY_API_KEY_' \
  --data '{
  "id": "evt_0RystWItVxyc3Q6ncAbcGb9t",
  "object": "event",
  "api_version": "2019-08-14",
  "created": 1755861149,
  "data": {
    "object": {
      "id": "du_0RystVItVxyc3Q6n8IfZyZXt",
      "object": "dispute",
      "amount": 500,
      "balance_transaction": "txn_0RystVItVxyc3Q6nDwOJhj6Z",
      "balance_transactions": [
        {
          "id": "txn_0RystVItVxyc3Q6nDwOJhj6Z",
          "object": "balance_transaction",
          "amount": -500,
          "currency": "gbp",
          "net": -2000,
          "fee": 1500,
          "fee_details": [
            {
              "amount": 1500,
              "currency": "gbp",
              "type": "stripe_fee",
              "description": "Dispute fee",
              "application": null
            }
          ],
          "created": 1755861149,
          "available_on": 1756339200,
          "status": "pending",
          "reporting_category": "dispute",
          "balance_type": "payments",
          "exchange_rate": null,
          "type": "adjustment",
          "source": "du_0RystVItVxyc3Q6n8IfZyZXt",
          "description": "Chargeback withdrawal for ch_2RystUItVxyc3Q6n07hnQyX7"
        }
      ],
      "charge": "ch_2RystUItVxyc3Q6n07hnQyX7",
      "created": 1755861149,
      "currency": "gbp",
      "enhanced_eligibility_types": [],
      "evidence": {
        "access_activity_log": null,
        "billing_address": null,
        "cancellation_policy": null,
        "cancellation_policy_disclosure": null,
        "cancellation_rebuttal": null,
        "customer_communication": null,
        "customer_email_address": null,
        "customer_name": null,
        "customer_purchase_ip": null,
        "customer_signature": null,
        "duplicate_charge_documentation": null,
        "duplicate_charge_explanation": null,
        "duplicate_charge_id": null,
        "enhanced_evidence": {},
        "product_description": null,
        "receipt": null,
        "refund_policy": null,
        "refund_policy_disclosure": null,
        "refund_refusal_explanation": null,
        "service_date": null,
        "service_documentation": null,
        "shipping_address": null,
        "shipping_carrier": null,
        "shipping_date": null,
        "shipping_documentation": null,
        "shipping_tracking_number": null,
        "uncategorized_file": null,
        "uncategorized_text": null
      },
      "evidence_details": {
        "due_by": 1756598399,
        "has_evidence": false,
        "past_due": false,
        "submission_count": 0
      },
      "is_charge_refundable": false,
      "livemode": false,
      "metadata": {},
      "payment_intent": "pi_2RystUItVxyc3Q6n0qqOvNKK",
      "payment_method_details": {
        "type": "card",
        "card": {
          "brand": "visa",
          "network_reason_code": "C030"
        }
      },
      "reason": "noncompliant",
      "status": "needs_response"
    }
  },
  "livemode": false,
  "pending_webhooks": 2,
  "request": {
    "id": "req_6dJ5nbBCTB3Bt2",
    "idempotency_key": "2d5fea1a0aaf46279f75bc752341a6e8_withl3"
  },
  "type": "charge.dispute.closed"
}'
```

  And then check data in Zuora and logs in Cloudwatch ( https://eu-west-1.console.aws.amazon.com/cloudwatch/home?    region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstripe-disputes-consumer-CODE )

  How can we measure success?

  Job is done in Zuora or not, check data in Zuora and logs in Cloudwatch ( https://eu-west-1.console.aws.amazon.com/cloudwatch/home?    region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstripe-disputes-consumer-CODE )
