### PR TITLE
Add tests for the order requests we use to create subscriptions

### DIFF
--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -54,7 +54,7 @@ export type CreateSubscriptionInputFields<T extends PaymentMethod> = {
 	collectPayment?: boolean;
 };
 
-function buildCreateSubscriptionRequest<T extends PaymentMethod>(
+export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 	productCatalog: ProductCatalog,
 	promotions: Promotion[],
 	{

--- a/modules/zuora/test/__snapshots__/buildCreateSubscriptionRequest.test.ts.snap
+++ b/modules/zuora/test/__snapshots__/buildCreateSubscriptionRequest.test.ts.snap
@@ -1,0 +1,307 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the buildCreateSubscriptionRequest function builds request with applied promotion 1`] = `
+{
+  "description": "Created by createSubscription.ts in support-service-lambdas",
+  "newAccount": {
+    "autoPay": true,
+    "billCycleDay": 0,
+    "billToContact": {
+      "country": "GB",
+      "firstName": "A",
+      "lastName": "B",
+      "workEmail": "test@test.com",
+    },
+    "crmId": "sf-acc-1",
+    "currency": "GBP",
+    "customFields": {
+      "CreatedRequestId__c": "request-123",
+      "IdentityId__c": "id-1",
+      "sfContactId__c": "sf-con-1",
+    },
+    "name": "Test Account",
+    "paymentGateway": "Stripe PaymentIntents GNM Membership",
+    "paymentMethod": {
+      "cardNumber": "42424242424242",
+      "cardType": "Visa",
+      "expirationMonth": 12,
+      "expirationYear": 2099,
+      "secondTokenId": "test_second_token_id",
+      "tokenId": "test_token_id",
+      "type": "CreditCardReferenceTransaction",
+    },
+    "soldToContact": undefined,
+  },
+  "orderDate": "2025-09-01",
+  "processingOptions": {
+    "collectPayment": true,
+    "runBilling": true,
+  },
+  "subscriptions": [
+    {
+      "customFields": {
+        "DeliveryAgent__c": "",
+        "LastPlanAddedDate__c": "2025-09-01",
+        "ReaderType__c": "Direct",
+      },
+      "orderActions": [
+        {
+          "createSubscription": {
+            "subscribeToRatePlans": [
+              {
+                "chargeOverrides": [
+                  {
+                    "pricing": {
+                      "recurringFlatFee": {
+                        "listPrice": 0,
+                      },
+                    },
+                    "productRatePlanChargeId": "8ad09ea0858682bb0185880ac57f4c4c",
+                  },
+                ],
+                "productRatePlanId": "8ad08cbd8586721c01858804e3275376",
+              },
+              {
+                "chargeOverrides": [
+                  {
+                    "endDate": {
+                      "endDateCondition": "Fixed_Period",
+                      "upToPeriods": 3,
+                      "upToPeriodsType": "Months",
+                    },
+                    "pricing": {
+                      "discount": {
+                        "discountPercentage": 10,
+                      },
+                    },
+                    "productRatePlanChargeId": "2c92c0f957220b5d0157299c97a60bbd",
+                  },
+                ],
+                "productRatePlanId": "2c92c0f85721ff7c01572942235b6d7a",
+              },
+            ],
+            "terms": {
+              "autoRenew": true,
+              "initialTerm": {
+                "period": 12,
+                "periodType": "Month",
+                "termType": "TERMED",
+              },
+              "renewalSetting": "RENEW_WITH_SPECIFIC_TERM",
+              "renewalTerms": [
+                {
+                  "period": 12,
+                  "periodType": "Month",
+                },
+              ],
+            },
+          },
+          "triggerDates": [
+            {
+              "name": "ContractEffective",
+              "triggerDate": "2025-09-01",
+            },
+            {
+              "name": "CustomerAcceptance",
+              "triggerDate": "2025-09-05",
+            },
+          ],
+          "type": "CreateSubscription",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`the buildCreateSubscriptionRequest function builds request with gift recipient 1`] = `
+{
+  "description": "Created by createSubscription.ts in support-service-lambdas",
+  "newAccount": {
+    "autoPay": true,
+    "billCycleDay": 0,
+    "billToContact": {
+      "country": "GB",
+      "firstName": "A",
+      "lastName": "B",
+      "workEmail": "test@test.com",
+    },
+    "crmId": "sf-acc-1",
+    "currency": "GBP",
+    "customFields": {
+      "CreatedRequestId__c": "request-123",
+      "IdentityId__c": "id-1",
+      "sfContactId__c": "sf-con-1",
+    },
+    "name": "Test Account",
+    "paymentGateway": "Stripe PaymentIntents GNM Membership",
+    "paymentMethod": {
+      "cardNumber": "42424242424242",
+      "cardType": "Visa",
+      "expirationMonth": 12,
+      "expirationYear": 2099,
+      "secondTokenId": "test_second_token_id",
+      "tokenId": "test_token_id",
+      "type": "CreditCardReferenceTransaction",
+    },
+    "soldToContact": {
+      "SpecialDeliveryInstructions__c": undefined,
+      "address1": "90 York Way",
+      "city": "London",
+      "country": "GB",
+      "firstName": "G",
+      "lastName": "W",
+      "postalCode": "N19GU",
+      "workEmail": "test@test.com",
+    },
+  },
+  "orderDate": "2025-09-01",
+  "processingOptions": {
+    "collectPayment": true,
+    "runBilling": true,
+  },
+  "subscriptions": [
+    {
+      "customFields": {
+        "DeliveryAgent__c": "",
+        "LastPlanAddedDate__c": "2025-09-01",
+        "ReaderType__c": "Gift",
+      },
+      "orderActions": [
+        {
+          "createSubscription": {
+            "subscribeToRatePlans": [
+              {
+                "chargeOverrides": [],
+                "productRatePlanId": "2c92c0f867cae0700167eff921734f7b",
+              },
+            ],
+            "terms": {
+              "autoRenew": false,
+              "initialTerm": {
+                "period": 369,
+                "periodType": "Day",
+                "termType": "TERMED",
+              },
+              "renewalSetting": "RENEW_WITH_SPECIFIC_TERM",
+              "renewalTerms": [
+                {
+                  "period": 12,
+                  "periodType": "Month",
+                },
+              ],
+            },
+          },
+          "triggerDates": [
+            {
+              "name": "ContractEffective",
+              "triggerDate": "2025-09-01",
+            },
+            {
+              "name": "CustomerAcceptance",
+              "triggerDate": "2025-09-05",
+            },
+          ],
+          "type": "CreateSubscription",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`the buildCreateSubscriptionRequest function builds request without promotion or gift 1`] = `
+{
+  "description": "Created by createSubscription.ts in support-service-lambdas",
+  "newAccount": {
+    "autoPay": true,
+    "billCycleDay": 0,
+    "billToContact": {
+      "country": "GB",
+      "firstName": "A",
+      "lastName": "B",
+      "workEmail": "test@test.com",
+    },
+    "crmId": "sf-acc-1",
+    "currency": "GBP",
+    "customFields": {
+      "CreatedRequestId__c": "request-123",
+      "IdentityId__c": "id-1",
+      "sfContactId__c": "sf-con-1",
+    },
+    "name": "Test Account",
+    "paymentGateway": "Stripe PaymentIntents GNM Membership",
+    "paymentMethod": {
+      "cardNumber": "42424242424242",
+      "cardType": "Visa",
+      "expirationMonth": 12,
+      "expirationYear": 2099,
+      "secondTokenId": "test_second_token_id",
+      "tokenId": "test_token_id",
+      "type": "CreditCardReferenceTransaction",
+    },
+    "soldToContact": undefined,
+  },
+  "orderDate": "2025-09-01",
+  "processingOptions": {
+    "collectPayment": true,
+    "runBilling": true,
+  },
+  "subscriptions": [
+    {
+      "customFields": {
+        "DeliveryAgent__c": "",
+        "LastPlanAddedDate__c": "2025-09-01",
+        "ReaderType__c": "Direct",
+      },
+      "orderActions": [
+        {
+          "createSubscription": {
+            "subscribeToRatePlans": [
+              {
+                "chargeOverrides": [
+                  {
+                    "pricing": {
+                      "recurringFlatFee": {
+                        "listPrice": 0,
+                      },
+                    },
+                    "productRatePlanChargeId": "8ad09ea0858682bb0185880ac57f4c4c",
+                  },
+                ],
+                "productRatePlanId": "8ad08cbd8586721c01858804e3275376",
+              },
+            ],
+            "terms": {
+              "autoRenew": true,
+              "initialTerm": {
+                "period": 12,
+                "periodType": "Month",
+                "termType": "TERMED",
+              },
+              "renewalSetting": "RENEW_WITH_SPECIFIC_TERM",
+              "renewalTerms": [
+                {
+                  "period": 12,
+                  "periodType": "Month",
+                },
+              ],
+            },
+          },
+          "triggerDates": [
+            {
+              "name": "ContractEffective",
+              "triggerDate": "2025-09-01",
+            },
+            {
+              "name": "CustomerAcceptance",
+              "triggerDate": "2025-09-05",
+            },
+          ],
+          "type": "CreateSubscription",
+        },
+      ],
+    },
+  ],
+}
+`;

--- a/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
+++ b/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
@@ -1,0 +1,222 @@
+import {
+	buildCreateSubscriptionRequest,
+	CreateSubscriptionInputFields,
+} from '../src/createSubscription/createSubscription';
+import { ReaderType } from '../src/createSubscription/readerType';
+import { AppliedPromotion, Promotion } from '@modules/promotions/schema';
+import dayjs from 'dayjs';
+import { IsoCurrency } from '@modules/internationalisation/currency';
+import { Stage } from '@modules/stage';
+import {
+	CreditCardReferenceTransaction,
+	PaymentGateway,
+} from '@modules/zuora/orders/paymentMethods';
+import { CreateSubscriptionOrderAction } from '@modules/zuora/orders/orderActions';
+import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
+import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
+import { SupportRegionId } from '@modules/internationalisation/countryGroup';
+
+const contractEffectiveDate = dayjs('2025-09-01');
+const customerAcceptanceDate = dayjs('2025-09-05');
+
+jest.mock('../src/createSubscription/subscriptionDates', () => ({
+	getSubscriptionDates: jest.fn(() => ({
+		contractEffectiveDate: dayjs(contractEffectiveDate),
+		customerAcceptanceDate: dayjs(customerAcceptanceDate),
+	})),
+}));
+
+const productCatalog = generateProductCatalog(code);
+const promotions: Promotion[] = [
+	{
+		name: 'Test Promo',
+		promotionType: { name: 'percent_discount', amount: 10, durationMonths: 3 },
+		appliesTo: {
+			countries: new Set(['GB']),
+			productRatePlanIds: new Set(['8ad08cbd8586721c01858804e3275376']),
+		},
+		codes: { 'Channel 0': ['PROMO10'] },
+		starts: new Date('2024-01-01'),
+		expires: new Date('2099-01-01'),
+	},
+	{
+		name: 'Patron Promo',
+		promotionType: { name: 'percent_discount', amount: 10, durationMonths: 3 },
+		appliesTo: {
+			countries: new Set(['GB']),
+			productRatePlanIds: new Set(['8ad08cbd8586721c01858804e3275376']),
+		},
+		codes: { 'Channel 0': ['TEST_PATRON'] },
+		starts: new Date('2024-01-01'),
+		expires: new Date('2099-01-01'),
+	},
+];
+
+const paymentMethod = {
+	type: 'CreditCardReferenceTransaction' as const,
+	tokenId: 'test_token_id',
+	secondTokenId: 'test_second_token_id',
+	cardNumber: '42424242424242',
+	cardType: 'Visa',
+	expirationMonth: 12,
+	expirationYear: 2099,
+};
+
+const baseStripeInput = {
+	stage: 'CODE' as Stage,
+	accountName: 'Test Account',
+	createdRequestId: 'request-123',
+	salesforceAccountId: 'sf-acc-1',
+	salesforceContactId: 'sf-con-1',
+	identityId: 'id-1',
+	currency: 'GBP' as IsoCurrency,
+	paymentGateway:
+		'Stripe PaymentIntents GNM Membership' as PaymentGateway<CreditCardReferenceTransaction>,
+	paymentMethod: paymentMethod,
+	billToContact: {
+		firstName: 'A',
+		lastName: 'B',
+		workEmail: 'test@test.com',
+		country: 'GB',
+	},
+};
+
+const supporterPlusInput: CreateSubscriptionInputFields<CreditCardReferenceTransaction> =
+	{
+		...baseStripeInput,
+		productPurchase: {
+			product: 'SupporterPlus',
+			ratePlan: 'Monthly',
+			amount: 12,
+		},
+	};
+const guardianWeeklyGiftInput: CreateSubscriptionInputFields<CreditCardReferenceTransaction> =
+	{
+		...baseStripeInput,
+		productPurchase: {
+			product: 'GuardianWeeklyDomestic',
+			ratePlan: 'OneYearGift',
+			firstDeliveryDate: dayjs().add(1, 'month').toDate(),
+			deliveryContact: {
+				firstName: 'G',
+				lastName: 'W',
+				workEmail: 'test@test.com',
+				country: 'GB',
+				address1: '90 York Way',
+				city: 'London',
+				postalCode: 'N19GU',
+			},
+		},
+	};
+
+const isCreateSubscriptionOrderAction = (
+	obj: any,
+): obj is CreateSubscriptionOrderAction => {
+	return (
+		obj &&
+		typeof obj === 'object' &&
+		'type' in obj &&
+		obj.type === 'CreateSubscription'
+	);
+};
+
+describe('the buildCreateSubscriptionRequest function', () => {
+	it('builds request without promotion or gift', () => {
+		const request = buildCreateSubscriptionRequest(
+			productCatalog,
+			promotions,
+			supporterPlusInput,
+		);
+		if (!('newAccount' in request)) {
+			throw new Error('Expected newAccount in request');
+		}
+		expect(request.newAccount.name).toEqual('Test Account');
+		expect(request.subscriptions[0]?.orderActions[0]?.type).toBe(
+			'CreateSubscription',
+		);
+		expect(request.subscriptions[0]?.customFields?.ReaderType__c).toBe(
+			ReaderType.Direct,
+		);
+		expect(request.processingOptions.runBilling).toBe(true);
+		expect(request.processingOptions.collectPayment).toBe(true);
+		expect(request).toMatchSnapshot();
+	});
+
+	it('builds request with applied promotion', () => {
+		const input = {
+			...supporterPlusInput,
+			appliedPromotion: {
+				promoCode: 'PROMO10',
+				supportRegionId: SupportRegionId.UK,
+			} as AppliedPromotion,
+		};
+		const request = buildCreateSubscriptionRequest(
+			productCatalog,
+			promotions,
+			input,
+		);
+		const orderAction = request.subscriptions[0]?.orderActions[0];
+		if (!isCreateSubscriptionOrderAction(orderAction)) {
+			throw new Error('Expected CreateOrderRequest');
+		}
+
+		expect(orderAction.createSubscription.subscribeToRatePlans.length).toBe(2);
+		expect(request.subscriptions[0]?.customFields?.ReaderType__c).toBe(
+			ReaderType.Direct,
+		);
+		expect(request).toMatchSnapshot();
+	});
+
+	it('builds request with gift recipient', () => {
+		const input = {
+			...guardianWeeklyGiftInput,
+			giftRecipient: {
+				email: 'gift@domain.com',
+				firstName: 'Gift',
+				lastName: 'Recipient',
+			},
+		};
+		const request = buildCreateSubscriptionRequest(
+			productCatalog,
+			promotions,
+			input,
+		);
+		expect(request.subscriptions[0]?.customFields?.ReaderType__c).toBe(
+			ReaderType.Gift,
+		);
+		expect(request).toMatchSnapshot();
+	});
+
+	it('sets the correct ReaderType for a patron promotion', () => {
+		const input = {
+			...supporterPlusInput,
+			appliedPromotion: {
+				promoCode: 'TEST_PATRON',
+				supportRegionId: SupportRegionId.UK,
+			} as AppliedPromotion,
+		};
+		const request = buildCreateSubscriptionRequest(
+			productCatalog,
+			promotions,
+			input,
+		);
+		expect(request.subscriptions[0]?.customFields?.ReaderType__c).toBe(
+			ReaderType.Patron,
+		);
+	});
+
+	it('sets runBilling and collectPayment to false if specified', () => {
+		const input = {
+			...supporterPlusInput,
+			runBilling: false,
+			collectPayment: false,
+		};
+		const request = buildCreateSubscriptionRequest(
+			productCatalog,
+			promotions,
+			input,
+		);
+		expect(request.processingOptions.runBilling).toBe(false);
+		expect(request.processingOptions.collectPayment).toBe(false);
+	});
+});


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
