### PR TITLE
Refactor/add sqs handler unit tests

### DIFF
--- a/handlers/stripe-disputes/test/services/cancelSubscriptionService.test.ts
+++ b/handlers/stripe-disputes/test/services/cancelSubscriptionService.test.ts
@@ -1,0 +1,199 @@
+import type { Logger } from '@modules/routing/logger';
+import { cancelSubscription } from '@modules/zuora/subscription';
+import type { ZuoraSubscription } from '@modules/zuora/types';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { cancelSubscriptionService } from '../../src/services/cancelSubscriptionService';
+
+jest.mock('@modules/zuora/subscription');
+jest.mock('dayjs', () =>
+	jest.fn(() => ({
+		format: jest.fn(() => '2023-11-04'),
+	})),
+);
+
+describe('cancelSubscriptionService', () => {
+	const mockLogger = {
+		log: jest.fn(),
+		error: jest.fn(),
+		mutableAddContext: jest.fn(),
+		resetContext: jest.fn(),
+		getMessage: jest.fn(),
+	} as unknown as jest.Mocked<Logger>;
+
+	const mockZuoraClient = {} as ZuoraClient;
+
+	const createMockSubscription = (
+		status: string,
+		subscriptionNumber = 'SUB-12345',
+	): ZuoraSubscription => ({
+		id: 'sub_123',
+		subscriptionNumber,
+		status,
+		accountNumber: 'ACC-12345',
+		contractEffectiveDate: new Date('2023-01-01'),
+		serviceActivationDate: new Date('2023-01-01'),
+		customerAcceptanceDate: new Date('2023-01-01'),
+		subscriptionStartDate: new Date('2023-01-01'),
+		subscriptionEndDate: new Date('2024-01-01'),
+		lastBookingDate: new Date('2023-10-01'),
+		termStartDate: new Date('2023-01-01'),
+		termEndDate: new Date('2024-01-01'),
+		ratePlans: [],
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should cancel active subscription successfully', async () => {
+		const mockSubscription = createMockSubscription('Active');
+		const mockCancelResponse = { Success: true, Id: 'cancel_123' };
+		(cancelSubscription as jest.Mock).mockResolvedValue(mockCancelResponse);
+
+		const result = await cancelSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			mockSubscription,
+		);
+
+		expect(result).toBe(true);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Canceling active subscription: SUB-12345',
+		);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Subscription cancellation response:',
+			JSON.stringify(mockCancelResponse),
+		);
+		expect(cancelSubscription).toHaveBeenCalledWith(
+			mockZuoraClient,
+			'SUB-12345',
+			expect.objectContaining({ format: expect.any(Function) }),
+			false,
+			undefined,
+			'EndOfLastInvoicePeriod',
+		);
+	});
+
+	it('should skip cancellation for inactive subscription (Cancelled)', async () => {
+		const mockSubscription = createMockSubscription('Cancelled');
+
+		const result = await cancelSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			mockSubscription,
+		);
+
+		expect(result).toBe(false);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Subscription already inactive (Cancelled), skipping cancellation',
+		);
+		expect(cancelSubscription).not.toHaveBeenCalled();
+	});
+
+	it('should skip cancellation for inactive subscription (Expired)', async () => {
+		const mockSubscription = createMockSubscription('Expired');
+
+		const result = await cancelSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			mockSubscription,
+		);
+
+		expect(result).toBe(false);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Subscription already inactive (Expired), skipping cancellation',
+		);
+		expect(cancelSubscription).not.toHaveBeenCalled();
+	});
+
+	it('should skip cancellation for inactive subscription (Suspended)', async () => {
+		const mockSubscription = createMockSubscription('Suspended');
+
+		const result = await cancelSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			mockSubscription,
+		);
+
+		expect(result).toBe(false);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Subscription already inactive (Suspended), skipping cancellation',
+		);
+		expect(cancelSubscription).not.toHaveBeenCalled();
+	});
+
+	it('should throw error when cancellation fails', async () => {
+		const mockSubscription = createMockSubscription('Active');
+		const mockCancelResponse = {
+			Success: false,
+			Errors: ['Cannot cancel subscription'],
+		};
+		(cancelSubscription as jest.Mock).mockResolvedValue(mockCancelResponse);
+
+		await expect(
+			cancelSubscriptionService(mockLogger, mockZuoraClient, mockSubscription),
+		).rejects.toThrow('Failed to cancel subscription in Zuora');
+
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Canceling active subscription: SUB-12345',
+		);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Subscription cancellation response:',
+			JSON.stringify(mockCancelResponse),
+		);
+	});
+
+	it('should handle different subscription numbers', async () => {
+		const mockSubscription = createMockSubscription('Active', 'SUB-67890');
+		const mockCancelResponse = { Success: true, Id: 'cancel_456' };
+		(cancelSubscription as jest.Mock).mockResolvedValue(mockCancelResponse);
+
+		const result = await cancelSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			mockSubscription,
+		);
+
+		expect(result).toBe(true);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Canceling active subscription: SUB-67890',
+		);
+		expect(cancelSubscription).toHaveBeenCalledWith(
+			mockZuoraClient,
+			'SUB-67890',
+			expect.objectContaining({ format: expect.any(Function) }),
+			false,
+			undefined,
+			'EndOfLastInvoicePeriod',
+		);
+	});
+
+	it('should propagate errors from cancelSubscription API call', async () => {
+		const mockSubscription = createMockSubscription('Active');
+		const error = new Error('Network error');
+		(cancelSubscription as jest.Mock).mockRejectedValue(error);
+
+		await expect(
+			cancelSubscriptionService(mockLogger, mockZuoraClient, mockSubscription),
+		).rejects.toThrow('Network error');
+
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Canceling active subscription: SUB-12345',
+		);
+	});
+
+	it('should use correct cancellation policy', async () => {
+		const mockSubscription = createMockSubscription('Active');
+		const mockCancelResponse = { Success: true, Id: 'cancel_789' };
+		(cancelSubscription as jest.Mock).mockResolvedValue(mockCancelResponse);
+
+		await cancelSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			mockSubscription,
+		);
+
+		const cancelCall = (cancelSubscription as jest.Mock).mock.calls[0];
+		expect(cancelCall[5]).toBe('EndOfLastInvoicePeriod');
+	});
+});

--- a/handlers/stripe-disputes/test/services/getSubscriptionService.test.ts
+++ b/handlers/stripe-disputes/test/services/getSubscriptionService.test.ts
@@ -1,0 +1,109 @@
+import type { Logger } from '@modules/routing/logger';
+import { getSubscription } from '@modules/zuora/subscription';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { getSubscriptionService } from '../../src/services/getSubscriptionService';
+
+jest.mock('@modules/zuora/subscription');
+
+describe('getSubscriptionService', () => {
+	const mockLogger = {
+		log: jest.fn(),
+		error: jest.fn(),
+		mutableAddContext: jest.fn(),
+		resetContext: jest.fn(),
+		getMessage: jest.fn(),
+	} as unknown as jest.Mocked<Logger>;
+
+	const mockZuoraClient = {} as ZuoraClient;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should retrieve subscription successfully when subscription number is provided', async () => {
+		const mockSubscription = {
+			id: 'sub_123',
+			subscriptionNumber: 'SUB-12345',
+			status: 'Active',
+			accountNumber: 'ACC-12345',
+		};
+
+		(getSubscription as jest.Mock).mockResolvedValue(mockSubscription);
+
+		const result = await getSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			'SUB-12345',
+		);
+
+		expect(result).toEqual(mockSubscription);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Retrieved subscription number: SUB-12345',
+		);
+		expect(mockLogger.log).toHaveBeenCalledWith('Subscription status: Active');
+		expect(getSubscription).toHaveBeenCalledWith(mockZuoraClient, 'SUB-12345');
+	});
+
+	it('should return null when subscription number is undefined', async () => {
+		const result = await getSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			undefined,
+		);
+
+		expect(result).toBeNull();
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'No subscription found, skipping Zuora operations',
+		);
+		expect(getSubscription).not.toHaveBeenCalled();
+	});
+
+	it('should return null when subscription number is empty string', async () => {
+		const result = await getSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			'',
+		);
+
+		expect(result).toBeNull();
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'No subscription found, skipping Zuora operations',
+		);
+		expect(getSubscription).not.toHaveBeenCalled();
+	});
+
+	it('should handle subscription with different status', async () => {
+		const mockSubscription = {
+			id: 'sub_456',
+			subscriptionNumber: 'SUB-67890',
+			status: 'Cancelled',
+			accountNumber: 'ACC-67890',
+		};
+
+		(getSubscription as jest.Mock).mockResolvedValue(mockSubscription);
+
+		const result = await getSubscriptionService(
+			mockLogger,
+			mockZuoraClient,
+			'SUB-67890',
+		);
+
+		expect(result).toEqual(mockSubscription);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Subscription status: Cancelled',
+		);
+	});
+
+	it('should propagate errors from getSubscription', async () => {
+		const error = new Error('Zuora API error');
+		(getSubscription as jest.Mock).mockRejectedValue(error);
+
+		await expect(
+			getSubscriptionService(mockLogger, mockZuoraClient, 'SUB-12345'),
+		).rejects.toThrow('Zuora API error');
+
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Retrieved subscription number: SUB-12345',
+		);
+	});
+});

--- a/handlers/stripe-disputes/test/services/rejectPaymentService.test.ts
+++ b/handlers/stripe-disputes/test/services/rejectPaymentService.test.ts
@@ -1,0 +1,122 @@
+import type { Logger } from '@modules/routing/logger';
+import { isZuoraRequestSuccess } from '@modules/zuora/helpers';
+import { rejectPayment } from '@modules/zuora/payment';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { rejectPaymentService } from '../../src/services/rejectPaymentService';
+
+jest.mock('@modules/zuora/payment');
+jest.mock('@modules/zuora/helpers');
+
+describe('rejectPaymentService', () => {
+	const mockLogger = {
+		log: jest.fn(),
+		error: jest.fn(),
+		mutableAddContext: jest.fn(),
+		resetContext: jest.fn(),
+		getMessage: jest.fn(),
+	} as unknown as jest.Mocked<Logger>;
+
+	const mockZuoraClient = {} as ZuoraClient;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should reject payment successfully when payment number is provided', async () => {
+		const mockResponse = { Success: true, Id: 'payment_123' };
+		(rejectPayment as jest.Mock).mockResolvedValue(mockResponse);
+		(isZuoraRequestSuccess as jest.Mock).mockReturnValue(true);
+
+		const result = await rejectPaymentService(
+			mockLogger,
+			mockZuoraClient,
+			'P-12345',
+		);
+
+		expect(result).toBe(true);
+		expect(mockLogger.log).toHaveBeenCalledWith('Rejecting payment: P-12345');
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Payment rejection response:',
+			JSON.stringify(mockResponse),
+		);
+		expect(rejectPayment).toHaveBeenCalledWith(
+			mockZuoraClient,
+			'P-12345',
+			'chargeback',
+		);
+		expect(isZuoraRequestSuccess).toHaveBeenCalledWith(mockResponse);
+	});
+
+	it('should return false when payment number is undefined', async () => {
+		const result = await rejectPaymentService(
+			mockLogger,
+			mockZuoraClient,
+			undefined,
+		);
+
+		expect(result).toBe(false);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'No payment number found, skipping payment rejection',
+		);
+		expect(rejectPayment).not.toHaveBeenCalled();
+	});
+
+	it('should return false when payment number is empty string', async () => {
+		const result = await rejectPaymentService(mockLogger, mockZuoraClient, '');
+
+		expect(result).toBe(false);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'No payment number found, skipping payment rejection',
+		);
+		expect(rejectPayment).not.toHaveBeenCalled();
+	});
+
+	it('should throw error when payment rejection fails', async () => {
+		const mockResponse = { Success: false, Errors: ['Payment not found'] };
+		(rejectPayment as jest.Mock).mockResolvedValue(mockResponse);
+		(isZuoraRequestSuccess as jest.Mock).mockReturnValue(false);
+
+		await expect(
+			rejectPaymentService(mockLogger, mockZuoraClient, 'P-12345'),
+		).rejects.toThrow('Failed to reject payment in Zuora');
+
+		expect(mockLogger.log).toHaveBeenCalledWith('Rejecting payment: P-12345');
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Payment rejection response:',
+			JSON.stringify(mockResponse),
+		);
+		expect(isZuoraRequestSuccess).toHaveBeenCalledWith(mockResponse);
+	});
+
+	it('should handle different payment numbers', async () => {
+		const mockResponse = { Success: true, Id: 'payment_456' };
+		(rejectPayment as jest.Mock).mockResolvedValue(mockResponse);
+		(isZuoraRequestSuccess as jest.Mock).mockReturnValue(true);
+
+		const result = await rejectPaymentService(
+			mockLogger,
+			mockZuoraClient,
+			'P-67890',
+		);
+
+		expect(result).toBe(true);
+		expect(mockLogger.log).toHaveBeenCalledWith('Rejecting payment: P-67890');
+		expect(rejectPayment).toHaveBeenCalledWith(
+			mockZuoraClient,
+			'P-67890',
+			'chargeback',
+		);
+	});
+
+	it('should propagate errors from rejectPayment API call', async () => {
+		const error = new Error('Network error');
+		(rejectPayment as jest.Mock).mockRejectedValue(error);
+
+		await expect(
+			rejectPaymentService(mockLogger, mockZuoraClient, 'P-12345'),
+		).rejects.toThrow('Network error');
+
+		expect(mockLogger.log).toHaveBeenCalledWith('Rejecting payment: P-12345');
+		expect(isZuoraRequestSuccess).not.toHaveBeenCalled();
+	});
+});

--- a/handlers/stripe-disputes/test/services/writeOffInvoiceService.test.ts
+++ b/handlers/stripe-disputes/test/services/writeOffInvoiceService.test.ts
@@ -1,0 +1,168 @@
+import type { Logger } from '@modules/routing/logger';
+import { isZuoraRequestSuccess } from '@modules/zuora/helpers';
+import { writeOffInvoice } from '@modules/zuora/invoice';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { writeOffInvoiceService } from '../../src/services/writeOffInvoiceService';
+
+jest.mock('@modules/zuora/invoice');
+jest.mock('@modules/zuora/helpers');
+
+describe('writeOffInvoiceService', () => {
+	const mockLogger = {
+		log: jest.fn(),
+		error: jest.fn(),
+		mutableAddContext: jest.fn(),
+		resetContext: jest.fn(),
+		getMessage: jest.fn(),
+	} as unknown as jest.Mocked<Logger>;
+
+	const mockZuoraClient = {} as ZuoraClient;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should write off invoice successfully when invoice ID is provided', async () => {
+		const mockResponse = { Success: true, Id: 'writeoff_123' };
+		(writeOffInvoice as jest.Mock).mockResolvedValue(mockResponse);
+		(isZuoraRequestSuccess as jest.Mock).mockReturnValue(true);
+
+		const result = await writeOffInvoiceService(
+			mockLogger,
+			mockZuoraClient,
+			'INV-12345',
+			'du_test456',
+		);
+
+		expect(result).toBe(true);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Writing off invoice: INV-12345',
+		);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Invoice write-off response:',
+			JSON.stringify(mockResponse),
+		);
+		expect(writeOffInvoice).toHaveBeenCalledWith(
+			mockZuoraClient,
+			'INV-12345',
+			'Invoice write-off due to Stripe dispute closure. Dispute ID: du_test456',
+		);
+		expect(isZuoraRequestSuccess).toHaveBeenCalledWith(mockResponse);
+	});
+
+	it('should return false when invoice ID is undefined', async () => {
+		const result = await writeOffInvoiceService(
+			mockLogger,
+			mockZuoraClient,
+			undefined,
+			'du_test456',
+		);
+
+		expect(result).toBe(false);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'No invoice ID found, skipping invoice write-off',
+		);
+		expect(writeOffInvoice).not.toHaveBeenCalled();
+	});
+
+	it('should return false when invoice ID is empty string', async () => {
+		const result = await writeOffInvoiceService(
+			mockLogger,
+			mockZuoraClient,
+			'',
+			'du_test456',
+		);
+
+		expect(result).toBe(false);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'No invoice ID found, skipping invoice write-off',
+		);
+		expect(writeOffInvoice).not.toHaveBeenCalled();
+	});
+
+	it('should throw error when invoice write-off fails', async () => {
+		const mockResponse = { Success: false, Errors: ['Invoice not found'] };
+		(writeOffInvoice as jest.Mock).mockResolvedValue(mockResponse);
+		(isZuoraRequestSuccess as jest.Mock).mockReturnValue(false);
+
+		await expect(
+			writeOffInvoiceService(
+				mockLogger,
+				mockZuoraClient,
+				'INV-12345',
+				'du_test456',
+			),
+		).rejects.toThrow('Failed to write off invoice in Zuora');
+
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Writing off invoice: INV-12345',
+		);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Invoice write-off response:',
+			JSON.stringify(mockResponse),
+		);
+		expect(isZuoraRequestSuccess).toHaveBeenCalledWith(mockResponse);
+	});
+
+	it('should handle different dispute IDs in comment', async () => {
+		const mockResponse = { Success: true, Id: 'writeoff_456' };
+		(writeOffInvoice as jest.Mock).mockResolvedValue(mockResponse);
+		(isZuoraRequestSuccess as jest.Mock).mockReturnValue(true);
+
+		const result = await writeOffInvoiceService(
+			mockLogger,
+			mockZuoraClient,
+			'INV-67890',
+			'du_test789',
+		);
+
+		expect(result).toBe(true);
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Writing off invoice: INV-67890',
+		);
+		expect(writeOffInvoice).toHaveBeenCalledWith(
+			mockZuoraClient,
+			'INV-67890',
+			'Invoice write-off due to Stripe dispute closure. Dispute ID: du_test789',
+		);
+	});
+
+	it('should propagate errors from writeOffInvoice API call', async () => {
+		const error = new Error('Network error');
+		(writeOffInvoice as jest.Mock).mockRejectedValue(error);
+
+		await expect(
+			writeOffInvoiceService(
+				mockLogger,
+				mockZuoraClient,
+				'INV-12345',
+				'du_test456',
+			),
+		).rejects.toThrow('Network error');
+
+		expect(mockLogger.log).toHaveBeenCalledWith(
+			'Writing off invoice: INV-12345',
+		);
+		expect(isZuoraRequestSuccess).not.toHaveBeenCalled();
+	});
+
+	it('should handle invoice IDs with special characters', async () => {
+		const mockResponse = { Success: true, Id: 'writeoff_789' };
+		(writeOffInvoice as jest.Mock).mockResolvedValue(mockResponse);
+		(isZuoraRequestSuccess as jest.Mock).mockReturnValue(true);
+
+		const result = await writeOffInvoiceService(
+			mockLogger,
+			mockZuoraClient,
+			'8a8082c17f2b9b24017f2b9b3b4e0015',
+			'du_test456',
+		);
+
+		expect(result).toBe(true);
+		expect(writeOffInvoice).toHaveBeenCalledWith(
+			mockZuoraClient,
+			'8a8082c17f2b9b24017f2b9b3b4e0015',
+			'Invoice write-off due to Stripe dispute closure. Dispute ID: du_test456',
+		);
+	});
+});


### PR DESCRIPTION
## What does this change?

  This PR adds comprehensive unit tests for the newly extracted SQS handler service modules. These tests ensure that each service correctly handles various
  scenarios including success cases, error conditions, and edge cases.

  Test coverage includes:
  - Cancel subscription service: Active/inactive subscription handling, error scenarios
  - Get subscription service: Valid/invalid subscription retrieval
  - Reject payment service: Payment rejection success and failure cases
  - Write-off invoice service: Invoice write-off operations and error handling

  ## How to test

  1. Run `pnpm test` in the handlers/stripe-disputes directory
  2. Verify all new tests pass
  3. Check test coverage report to ensure adequate coverage of service modules
  4. Run existing integration tests to ensure no regression

  ## How can we measure success?

  - Increased test coverage for dispute processing logic
  - All unit tests passing in CI/CD pipeline
  - Reduced risk of bugs in production
  - Faster feedback loop for developers making changes

  ## Have we considered potential risks?

  - No production code changes, only tests added
  - Tests are isolated using Jest mocks to avoid external dependencies
  - Tests follow existing patterns in the codebase