### PR TITLE
Fix/add lambda stripe secrets permissions

### DIFF
--- a/cdk/lib/__snapshots__/stripe-disputes.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-disputes.test.ts.snap
@@ -237,6 +237,42 @@ exports[`The stripe disputes webhook API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "AllowSecretsManagerGetSecretValueonLambdaProducer260A5AB4": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:CODE/Stripe/ConnectedApp/StripeDisputeWebhooks-*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AllowSecretsManagerGetSecretValueonLambdaProducer260A5AB4",
+        "Roles": [
+          {
+            "Ref": "stripedisputeslambdaproducerServiceRoleF01BBA32",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "BasePathMapping": {
       "Properties": {
         "DomainName": {
@@ -1636,6 +1672,42 @@ exports[`The stripe disputes webhook API stack matches the snapshot 2`] = `
         "Roles": [
           {
             "Ref": "stripedisputeslambdaconsumerServiceRole234A464E",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AllowSecretsManagerGetSecretValueonLambdaProducer260A5AB4": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:PROD/Stripe/ConnectedApp/StripeDisputeWebhooks-*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AllowSecretsManagerGetSecretValueonLambdaProducer260A5AB4",
+        "Roles": [
+          {
+            "Ref": "stripedisputeslambdaproducerServiceRoleF01BBA32",
           },
         ],
       },

--- a/cdk/lib/stripe-disputes.ts
+++ b/cdk/lib/stripe-disputes.ts
@@ -175,6 +175,20 @@ export class StripeDisputes extends GuStack {
 		);
 
 		this.createPolicyAndAttachToLambdas(
+			[{ lambda: lambdaProducer, name: 'Lambda Producer' }],
+			[
+				new PolicyStatement({
+					effect: Effect.ALLOW,
+					actions: ['secretsmanager:GetSecretValue'],
+					resources: [
+						`arn:aws:secretsmanager:${this.region}:${this.account}:secret:${this.stage}/Stripe/ConnectedApp/StripeDisputeWebhooks-*`,
+					],
+				}),
+			],
+			'Allow Secrets Manager Get Secret Value',
+		);
+
+		this.createPolicyAndAttachToLambdas(
 			[{ lambda: lambdaConsumer, name: 'Lambda Consumer' }],
 			[
 				new PolicyStatement({


### PR DESCRIPTION
## What does this change?

  This PR adds the necessary IAM permissions for the Lambda producer to access Stripe webhook secrets stored in AWS Secrets Manager. This is required for
  webhook signature verification to ensure requests are legitimately from Stripe.

  Changes:
  - Added IAM policy for Lambda producer to read Stripe secrets
  - Scoped permissions to specific secret ARN pattern
  - Maintains existing Salesforce secret access permissions

  