### PR TITLE
Feat/stripe webhook signature verification

### DIFF
--- a/handlers/stripe-disputes/package.json
+++ b/handlers/stripe-disputes/package.json
@@ -13,9 +13,11 @@
   "dependencies": {
     "aws-sdk": "^2.1692.0",
     "dayjs": "^1.11.13",
+    "stripe": "^18.5.0",
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.147"
+    "@types/aws-lambda": "^8.10.147",
+    "@types/stripe": "^8.0.417"
   }
 }

--- a/handlers/stripe-disputes/src/producer.ts
+++ b/handlers/stripe-disputes/src/producer.ts
@@ -2,6 +2,10 @@ import { Logger } from '@modules/routing/logger';
 import { Router } from '@modules/routing/router';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { handleStripeWebhook } from './services';
+import { getSecretValue } from '@modules/secrets-manager/getSecret';
+import { StripeCredentials } from './types';
+import { stageFromEnvironment } from '@modules/stage';
+import Stripe from 'stripe';
 
 const logger = new Logger();
 
@@ -23,9 +27,42 @@ export const handler = async (
 ): Promise<APIGatewayProxyResult | void> => {
 	logger.log(`Input: ${JSON.stringify(event)}`);
 
+	const stripeSignature: string | undefined = event.headers['stripe-signature'];
+
+	if (!stripeSignature) {
+		logger.error('Missing Stripe-Signature header');
+		return {
+			statusCode: 400,
+			body: JSON.stringify({ message: 'Missing Stripe-Signature header' }),
+		};
+	}
+
+	const endpointSecretObject: StripeCredentials =
+		await getSecretValue<StripeCredentials>(
+			`${stageFromEnvironment()}/Stripe/ConnectedApp/StripeDisputeWebhooks`,
+		);
+
+	// const stripeInstance = new Stripe(endpointSecretObject.secret_key);
+	// let stripeEvent: Stripe.Event | null = null;
+
+	try {
+		new Stripe(endpointSecretObject.secret_key).webhooks.constructEvent(
+			JSON.stringify(event.body),
+			stripeSignature,
+			endpointSecretObject.secret_key,
+		);
+	} catch (err) {
+		const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+		logger.error(`Error verifying Stripe webhook signature: ${errorMessage}`);
+		return {
+			statusCode: 403,
+			body: JSON.stringify({ message: `Webhook Error: ${errorMessage}` }),
+		};
+	}
+
 	if (isApiGatewayEvent(event)) {
 		logger.log('Processing API Gateway webhook event');
-		const response = await router(event);
+		const response: APIGatewayProxyResult = await router(event);
 		logger.log(`Webhook response: ${JSON.stringify(response)}`);
 		return response;
 	} else {

--- a/handlers/stripe-disputes/src/producer.ts
+++ b/handlers/stripe-disputes/src/producer.ts
@@ -30,7 +30,9 @@ export const handler = async (
 	const stripeSignature: string | undefined = event.headers['Stripe-Signature'];
 
 	logger.log(`Headers: ${JSON.stringify(event.headers)}`);
-	logger.log(`Stripe-Signature: ${JSON.stringify(event.headers['Stripe-Signature'])}`);
+	logger.log(
+		`Stripe-Signature: ${JSON.stringify(event.headers['Stripe-Signature'])}`,
+	);
 
 	if (!stripeSignature) {
 		logger.error('Missing Stripe-Signature header');

--- a/handlers/stripe-disputes/src/producer.ts
+++ b/handlers/stripe-disputes/src/producer.ts
@@ -29,6 +29,9 @@ export const handler = async (
 
 	const stripeSignature: string | undefined = event.headers['Stripe-Signature'];
 
+	logger.log(`Headers: ${JSON.stringify(event.headers)}`);
+	logger.log(`Stripe-Signature: ${JSON.stringify(event.headers['Stripe-Signature'])}`);
+
 	if (!stripeSignature) {
 		logger.error('Missing Stripe-Signature header');
 		return {

--- a/handlers/stripe-disputes/src/producer.ts
+++ b/handlers/stripe-disputes/src/producer.ts
@@ -48,9 +48,6 @@ export const handler = async (
 	const stripeSignature: string | undefined = event.headers['Stripe-Signature'];
 
 	logger.log(`Headers: ${JSON.stringify(event.headers)}`);
-	logger.log(
-		`Stripe-Signature: ${JSON.stringify(event.headers['Stripe-Signature'])}`,
-	);
 
 	if (!stripeSignature) {
 		logger.error('Missing Stripe-Signature header');
@@ -73,12 +70,8 @@ export const handler = async (
 			`${stageFromEnvironment()}/Stripe/ConnectedApp/StripeDisputeWebhooks`,
 		);
 
-	logger.log({
-		webhook_endpoint_secret: endpointSecretObject.webhook_endpoint_secret,
-		secret_key: endpointSecretObject.secret_key,
-	});
-
 	try {
+		// Doc: https://docs.stripe.com/identity/handle-verification-outcomes#create-webhook
 		new Stripe(endpointSecretObject.secret_key).webhooks.constructEvent(
 			event.body,
 			stripeSignature,

--- a/handlers/stripe-disputes/src/producer.ts
+++ b/handlers/stripe-disputes/src/producer.ts
@@ -27,7 +27,7 @@ export const handler = async (
 ): Promise<APIGatewayProxyResult | void> => {
 	logger.log(`Input: ${JSON.stringify(event)}`);
 
-	const stripeSignature: string | undefined = event.headers['stripe-signature'];
+	const stripeSignature: string | undefined = event.headers['Stripe-Signature'];
 
 	if (!stripeSignature) {
 		logger.error('Missing Stripe-Signature header');

--- a/handlers/stripe-disputes/src/producer.ts
+++ b/handlers/stripe-disputes/src/producer.ts
@@ -55,6 +55,11 @@ export const handler = async (
 			`${stageFromEnvironment()}/Stripe/ConnectedApp/StripeDisputeWebhooks`,
 		);
 
+	logger.log({
+		webhook_endpoint_secret: endpointSecretObject.webhook_endpoint_secret,
+		secret_key: endpointSecretObject.secret_key,
+	});
+
 	try {
 		new Stripe(endpointSecretObject.secret_key).webhooks.constructEvent(
 			event.body,

--- a/handlers/stripe-disputes/src/producer.ts
+++ b/handlers/stripe-disputes/src/producer.ts
@@ -42,6 +42,14 @@ export const handler = async (
 		};
 	}
 
+	if (!event.body) {
+		logger.error('Missing request body');
+		return {
+			statusCode: 400,
+			body: JSON.stringify({ message: 'Missing request body' }),
+		};
+	}
+
 	const endpointSecretObject: StripeCredentials =
 		await getSecretValue<StripeCredentials>(
 			`${stageFromEnvironment()}/Stripe/ConnectedApp/StripeDisputeWebhooks`,
@@ -49,9 +57,9 @@ export const handler = async (
 
 	try {
 		new Stripe(endpointSecretObject.secret_key).webhooks.constructEvent(
-			JSON.stringify(event.body),
+			event.body,
 			stripeSignature,
-			endpointSecretObject.secret_key,
+			endpointSecretObject.webhook_endpoint_secret,
 		);
 		logger.log('Processing API Gateway webhook event');
 		const response: APIGatewayProxyResult = await router(event);

--- a/handlers/stripe-disputes/src/types/index.ts
+++ b/handlers/stripe-disputes/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './salesforceTypes';
 export * from './zuoraPaymentTypes';
 export * from './zuoraInvoiceTypes';
 export * from './zuoraInvoiceItemTypes';
+export * from './stripeTypes';

--- a/handlers/stripe-disputes/src/types/salesforceTypes.ts
+++ b/handlers/stripe-disputes/src/types/salesforceTypes.ts
@@ -4,6 +4,10 @@ export type SalesforceCredentials = {
 	sandbox: boolean;
 };
 
+export type StripeCredentials = {
+	secret_key: string;
+};
+
 export type SalesforceAuthResponse = {
 	access_token: string;
 	instance_url: string;

--- a/handlers/stripe-disputes/src/types/salesforceTypes.ts
+++ b/handlers/stripe-disputes/src/types/salesforceTypes.ts
@@ -4,10 +4,6 @@ export type SalesforceCredentials = {
 	sandbox: boolean;
 };
 
-export type StripeCredentials = {
-	secret_key: string;
-};
-
 export type SalesforceAuthResponse = {
 	access_token: string;
 	instance_url: string;

--- a/handlers/stripe-disputes/src/types/stripeTypes.ts
+++ b/handlers/stripe-disputes/src/types/stripeTypes.ts
@@ -1,3 +1,4 @@
 export type StripeCredentials = {
 	secret_key: string;
+	webhook_endpoint_secret: string;
 };

--- a/handlers/stripe-disputes/src/types/stripeTypes.ts
+++ b/handlers/stripe-disputes/src/types/stripeTypes.ts
@@ -1,0 +1,3 @@
+export type StripeCredentials = {
+	secret_key: string;
+};

--- a/handlers/stripe-disputes/test/producer.test.ts
+++ b/handlers/stripe-disputes/test/producer.test.ts
@@ -125,6 +125,12 @@ describe('Producer Handler', () => {
 				'valid_signature',
 				'sk_test_mock_secret_key',
 			);
+			expect(mockLogger.log).toHaveBeenCalledWith(
+				`Headers: ${JSON.stringify(event.headers)}`,
+			);
+			expect(mockLogger.log).toHaveBeenCalledWith(
+				`Stripe-Signature: ${JSON.stringify(event.headers['Stripe-Signature'])}`,
+			);
 			expect(mockRouterInstance).toHaveBeenCalledWith(event);
 			expect(result).toBeDefined();
 		});
@@ -146,6 +152,12 @@ describe('Producer Handler', () => {
 
 			expect(mockLogger.log).toHaveBeenCalledWith(
 				`Input: ${JSON.stringify(event)}`,
+			);
+			expect(mockLogger.log).toHaveBeenCalledWith(
+				`Headers: ${JSON.stringify(event.headers)}`,
+			);
+			expect(mockLogger.log).toHaveBeenCalledWith(
+				`Stripe-Signature: ${JSON.stringify(event.headers['Stripe-Signature'])}`,
 			);
 			expect(mockLogger.log).toHaveBeenCalledWith(
 				`Webhook response: ${JSON.stringify(result)}`,

--- a/handlers/stripe-disputes/test/producer.test.ts
+++ b/handlers/stripe-disputes/test/producer.test.ts
@@ -13,6 +13,7 @@ const mockStripeWebhooksConstructEvent = jest.fn();
 
 const mockStripeCredentials = {
 	secret_key: 'sk_test_mock_secret_key',
+	webhook_endpoint_secret: 'whsec_test_mock_webhook_secret',
 };
 
 jest.mock('@modules/routing/logger', () => ({
@@ -121,9 +122,9 @@ describe('Producer Handler', () => {
 				'CODE/Stripe/ConnectedApp/StripeDisputeWebhooks',
 			);
 			expect(mockStripeWebhooksConstructEvent).toHaveBeenCalledWith(
-				'"{}"',
+				'{}',
 				'valid_signature',
-				'sk_test_mock_secret_key',
+				'whsec_test_mock_webhook_secret',
 			);
 			expect(mockLogger.log).toHaveBeenCalledWith(
 				`Headers: ${JSON.stringify(event.headers)}`,
@@ -207,6 +208,24 @@ describe('Producer Handler', () => {
 			expect(result).toEqual({
 				statusCode: 400,
 				body: JSON.stringify({ message: 'Missing Stripe-Signature header' }),
+			});
+			expect(mockRouterInstance).not.toHaveBeenCalled();
+		});
+
+		it('should return 400 when request body is missing', async () => {
+			const event = createMockApiGatewayEvent(
+				'/listen-dispute-created',
+				'POST',
+				null as any,
+				'valid_signature',
+			);
+
+			const result = await handler(event);
+
+			expect(mockLogger.error).toHaveBeenCalledWith('Missing request body');
+			expect(result).toEqual({
+				statusCode: 400,
+				body: JSON.stringify({ message: 'Missing request body' }),
 			});
 			expect(mockRouterInstance).not.toHaveBeenCalled();
 		});

--- a/handlers/stripe-disputes/test/producer.test.ts
+++ b/handlers/stripe-disputes/test/producer.test.ts
@@ -53,7 +53,7 @@ describe('Producer Handler', () => {
 		stripeSignature?: string,
 	): APIGatewayProxyEvent => ({
 		body,
-		headers: stripeSignature ? { 'stripe-signature': stripeSignature } : {},
+		headers: stripeSignature ? { 'Stripe-Signature': stripeSignature } : {},
 		multiValueHeaders: {},
 		httpMethod,
 		path,

--- a/handlers/stripe-disputes/test/producer.test.ts
+++ b/handlers/stripe-disputes/test/producer.test.ts
@@ -129,9 +129,6 @@ describe('Producer Handler', () => {
 			expect(mockLogger.log).toHaveBeenCalledWith(
 				`Headers: ${JSON.stringify(event.headers)}`,
 			);
-			expect(mockLogger.log).toHaveBeenCalledWith(
-				`Stripe-Signature: ${JSON.stringify(event.headers['Stripe-Signature'])}`,
-			);
 			expect(mockRouterInstance).toHaveBeenCalledWith(event);
 			expect(result).toBeDefined();
 		});
@@ -156,9 +153,6 @@ describe('Producer Handler', () => {
 			);
 			expect(mockLogger.log).toHaveBeenCalledWith(
 				`Headers: ${JSON.stringify(event.headers)}`,
-			);
-			expect(mockLogger.log).toHaveBeenCalledWith(
-				`Stripe-Signature: ${JSON.stringify(event.headers['Stripe-Signature'])}`,
 			);
 			expect(mockLogger.log).toHaveBeenCalledWith(
 				`Webhook response: ${JSON.stringify(result)}`,

--- a/handlers/stripe-disputes/test/producer.test.ts
+++ b/handlers/stripe-disputes/test/producer.test.ts
@@ -111,9 +111,9 @@ describe('Producer Handler', () => {
 	describe('Producer Webhook Processing', () => {
 		it('should handle webhook requests with valid signature', async () => {
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-created',
+				'/',
 				'POST',
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.created' }),
 				'valid_signature',
 			);
 			const result = await handler(event);
@@ -122,7 +122,7 @@ describe('Producer Handler', () => {
 				'CODE/Stripe/ConnectedApp/StripeDisputeWebhooks',
 			);
 			expect(mockStripeWebhooksConstructEvent).toHaveBeenCalledWith(
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.created' }),
 				'valid_signature',
 				'whsec_test_mock_webhook_secret',
 			);
@@ -138,9 +138,9 @@ describe('Producer Handler', () => {
 
 		it('should log producer input and response', async () => {
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-created',
+				'/',
 				'POST',
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.created' }),
 				'valid_signature',
 			);
 			const mockResponse = {
@@ -167,9 +167,9 @@ describe('Producer Handler', () => {
 
 		it('should handle dispute created webhook', async () => {
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-created',
+				'/',
 				'POST',
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.created' }),
 				'valid_signature',
 			);
 
@@ -180,9 +180,9 @@ describe('Producer Handler', () => {
 
 		it('should handle dispute closed webhook', async () => {
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-closed',
+				'/',
 				'POST',
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.closed' }),
 				'valid_signature',
 			);
 
@@ -195,9 +195,9 @@ describe('Producer Handler', () => {
 	describe('Stripe Signature Verification', () => {
 		it('should return 400 when Stripe signature is missing', async () => {
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-created',
+				'/',
 				'POST',
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.created' }),
 			);
 
 			const result = await handler(event);
@@ -214,7 +214,7 @@ describe('Producer Handler', () => {
 
 		it('should return 400 when request body is missing', async () => {
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-created',
+				'/',
 				'POST',
 				null as any,
 				'valid_signature',
@@ -232,9 +232,9 @@ describe('Producer Handler', () => {
 
 		it('should return 403 when Stripe signature verification fails', async () => {
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-created',
+				'/',
 				'POST',
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.created' }),
 				'invalid_signature',
 			);
 
@@ -257,9 +257,9 @@ describe('Producer Handler', () => {
 
 		it('should handle non-Error objects in signature verification', async () => {
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-created',
+				'/',
 				'POST',
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.created' }),
 				'invalid_signature',
 			);
 
@@ -282,9 +282,9 @@ describe('Producer Handler', () => {
 			mockStageFromEnvironment.mockReturnValue('PROD');
 
 			const event = createMockApiGatewayEvent(
-				'/listen-dispute-created',
+				'/',
 				'POST',
-				'{}',
+				JSON.stringify({ type: 'charge.dispute.created' }),
 				'valid_signature',
 			);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.18
+      stripe:
+        specifier: ^18.5.0
+        version: 18.5.0(@types/node@24.4.0)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -316,6 +319,9 @@ importers:
       '@types/aws-lambda':
         specifier: ^8.10.147
         version: 8.10.152
+      '@types/stripe':
+        specifier: ^8.0.417
+        version: 8.0.417(@types/node@24.4.0)
 
   handlers/ticket-tailor-webhook:
     dependencies:
@@ -1842,6 +1848,10 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/stripe@8.0.417':
+    resolution: {integrity: sha512-PTuqskh9YKNENnOHGVJBm4sM0zE8B1jZw1JIskuGAPkMB+OH236QeN8scclhYGPA4nG6zTtPXgwpXdp+HPDTVw==}
+    deprecated: This is a stub types definition. stripe provides its own type definitions, so you do not need this installed.
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -3846,6 +3856,10 @@ packages:
     resolution: {integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==}
     engines: {node: '>=6.0.0'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   querystring@0.2.0:
     resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
     engines: {node: '>=0.4.x'}
@@ -4119,6 +4133,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@18.5.0:
+    resolution: {integrity: sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==}
+    engines: {node: '>=12.*'}
+    peerDependencies:
+      '@types/node': '>=12.x.x'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
@@ -6840,6 +6863,12 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
+  '@types/stripe@8.0.417(@types/node@24.4.0)':
+    dependencies:
+      stripe: 18.5.0(@types/node@24.4.0)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@types/tough-cookie@4.0.5': {}
 
   '@types/uuid@9.0.8': {}
@@ -9394,6 +9423,10 @@ snapshots:
 
   pvutils@1.1.3: {}
 
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
   querystring@0.2.0: {}
 
   queue-microtask@1.2.3: {}
@@ -9711,6 +9744,12 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  stripe@18.5.0(@types/node@24.4.0):
+    dependencies:
+      qs: 6.14.0
+    optionalDependencies:
+      '@types/node': 24.4.0
 
   strnum@1.1.2: {}
 


### PR DESCRIPTION
What does this change?

  This PR implements Stripe webhook signature verification for the stripe-disputes handler to ensure that incoming webhook requests are genuinely from Stripe. Additionally, it
   refactors the webhook routing to handle Stripe's standard webhook delivery at the root path.

  Implementation includes:
  - Webhook signature verification using Stripe SDK's constructEvent method
  - Dynamic event type routing based on webhook payload (supports charge.dispute.created and charge.dispute.closed)
  - Integration with AWS Secrets Manager to securely retrieve both API key and webhook endpoint secret
  - Request validation for missing signature headers and body
  - Proper HTTP status codes (400 for bad request, 403 for invalid signature)
  - Comprehensive logging for debugging and monitoring
  - Updated routing from path-based (/listen-dispute-created) to root path (/) with event type parsing

  How to test

  With Stripe Cli: after stripe login by cli, you can run  **stripe trigger charge.dispute.created** AND/OR **stripe trigger charge.dispute.closed**

  1. Deploy to CODE environment
  2. Configure AWS Secrets Manager with both secret_key and webhook_endpoint_secret at CODE/Stripe/ConnectedApp/StripeDisputeWebhooks
  3. Send test webhooks from Stripe dashboard - should process successfully
  4. Send webhook with invalid signature - should be rejected with 403
  5. Send webhook without Stripe-Signature header - should be rejected with 400
  6. Send webhook without body - should be rejected with 400
  7. Monitor CloudWatch logs for detailed verification results and event routing
  8. Test with both charge.dispute.created and charge.dispute.closed events
  9. Verify unhandled event types return 200 with appropriate message

  How can we measure success?

  - All legitimate Stripe webhooks processed successfully with 200 status
  - Invalid/forged webhook requests rejected with 403 status
  - Malformed requests (missing header/body) rejected with 400 status
  - Zero unauthorized webhook processing
  - CloudWatch logs show clear verification trail for each request
  - Proper routing of dispute events to their respective handlers
  - No increase in webhook processing errors for valid requests from Stripe