### PR TITLE
Add +Digital rate plans for National Delivery

### DIFF
--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/PlanId.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/PlanId.scala
@@ -116,9 +116,15 @@ object PlanId {
 
   case object NationalDeliveryWeekend extends PlanId("national_delivery_weekend") with NationalDeliveryPlanId
 
+  case object NationalDeliveryWeekendPlus extends PlanId("national_delivery_weekend_plus") with NationalDeliveryPlanId
+
   case object NationalDeliveryEveryday extends PlanId("national_delivery_everyday") with NationalDeliveryPlanId
 
+  case object NationalDeliveryEverydayPlus extends PlanId("national_delivery_everyday_plus") with NationalDeliveryPlanId
+
   case object NationalDeliverySixday extends PlanId("national_delivery_sixday") with NationalDeliveryPlanId
+
+  case object NationalDeliverySixdayPlus extends PlanId("national_delivery_sixday_plus") with NationalDeliveryPlanId
 
   val enabledVoucherPlans = List(
     VoucherEveryDay,
@@ -190,6 +196,9 @@ object PlanId {
     NationalDeliverySixday,
     NationalDeliveryEveryday,
     NationalDeliveryWeekend,
+    NationalDeliverySixdayPlus,
+    NationalDeliveryEverydayPlus,
+    NationalDeliveryWeekendPlus,
   )
 
   val enabledTierThreePlans = List(

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -165,11 +165,17 @@ object ZuoraIds {
       everyday: ProductRatePlanId,
       weekend: ProductRatePlanId,
       sixDay: ProductRatePlanId,
+      everydayPlus: ProductRatePlanId,
+      weekendPlus: ProductRatePlanId,
+      sixDayPlus: ProductRatePlanId
   ) {
     val byApiPlanId: Map[PlanId, ProductRatePlanId] = Map(
       NationalDeliveryEveryday -> everyday,
       NationalDeliveryWeekend -> weekend,
       NationalDeliverySixday -> sixDay,
+      NationalDeliveryEverydayPlus -> everydayPlus,
+      NationalDeliveryWeekendPlus -> weekendPlus,
+      NationalDeliverySixdayPlus -> sixDayPlus
     )
   }
 
@@ -313,6 +319,9 @@ object ZuoraIds {
           everyday = ProductRatePlanId("8a12999f8a268c57018a27ebe31414a4"),
           weekend = ProductRatePlanId("8a12999f8a268c57018a27ebe868150c"),
           sixDay = ProductRatePlanId("8a12999f8a268c57018a27ebfd721883"),
+          everydayPlus = ProductRatePlanId("8a1280be96d33dbf0196d48a632616f4"),
+          weekendPlus = ProductRatePlanId("8a1280be96d33dbf0196d487b55c1283"),
+          sixDayPlus = ProductRatePlanId("8a12994696d3587b0196d484491e3beb"),
         ),
         TierThreeZuoraIds(
           monthlyDomestic = ProductRatePlanId("8a1299788ff2ec100190025fccc32bb1"),
@@ -410,6 +419,9 @@ object ZuoraIds {
           everyday = ProductRatePlanId("8ad096ca8992481d018992a363bd17ad"),
           weekend = ProductRatePlanId("8ad096ca8992481d018992a36256175e"),
           sixDay = ProductRatePlanId("8ad096ca8992481d018992a35f60171b"),
+          everydayPlus = ProductRatePlanId("71a116628be96ab11606b51ec6060555"),
+          weekendPlus = ProductRatePlanId("71a1166283a96ab11606b50ebbb50381"),
+          sixDayPlus = ProductRatePlanId("71a1383e2a796aafcb16b527842001ca"),
         ),
         TierThreeZuoraIds(
           monthlyDomestic = ProductRatePlanId("8ad097b48ff26452019001cebac92376"),


### PR DESCRIPTION
## What does this change?
Adds the "Print+Digital" rate plans for National Delivery, making them available for CSR acquisitions in Salesforce.

## How to test
Deploy on CODE. In Salesforce, load the "New Subscription" page from a Billing Account with a National Delivery suitable address and verify that the new digital rate plans appear as expected.

## How can we measure success?
CSRs can now acquire customers to the preferred "Print+Digital" plans across all print products.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
