### PR TITLE
make sendemail use the SQS module to avoid URL errors

### DIFF
--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -1,6 +1,5 @@
 import type { SendMessageCommandOutput } from '@aws-sdk/client-sqs';
-import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
-import { awsConfig } from '@modules/aws/config';
+import { sendMessageToQueue } from '@modules/aws/sqs';
 import { prettyPrint } from '@modules/prettyPrint';
 import type { Stage } from '@modules/stage';
 
@@ -51,16 +50,14 @@ export const sendEmail = async (
 	log: (messsage: string) => void = console.log,
 ): Promise<SendMessageCommandOutput> => {
 	const queueName = `braze-emails-${stage}`;
-	const client = new SQSClient(awsConfig);
 	log(
 		`Sending email message ${prettyPrint(emailMessage)} to queue ${queueName}`,
 	);
-	const command = new SendMessageCommand({
-		QueueUrl: queueName,
-		MessageBody: JSON.stringify(emailMessage),
-	});
 
-	const response = await client.send(command);
+	const response = await sendMessageToQueue({
+		queueName,
+		messageBody: JSON.stringify(emailMessage),
+	});
 	log(`Response from email send was ${prettyPrint(response)}`);
 	return response;
 };


### PR DESCRIPTION
following on from https://github.com/guardian/support-service-lambdas/pull/3027

There is one use of SQS that was still not using the lookup version of the sqs client.  This was causing a type error (see screenshot below) even though it was actually working.  This clutters up the logs especially when you're looking for "ERROR"

This PR updates sendEmail to use the logic that looks up the url first.

Tested in CODE
Before https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fupdate-supporter-plus-amount-CODE/log-events/2025$252F09$252F19$252F$255B$2524LATEST$255Dd40ec1814740416c9b9adaca959f3a90
<img width="812" height="438" alt="image" src="https://github.com/user-attachments/assets/318111fc-0210-4735-aaf4-411ab45bab00" />
After https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fupdate-supporter-plus-amount-CODE/log-events/2025$252F09$252F22$252F$255B$2524LATEST$255Db0732ada7f254a768a7d20b9a55adf63
<img width="1734" height="367" alt="image" src="https://github.com/user-attachments/assets/0f25f92b-1e73-47e1-88bc-2d4511469537" />
(...and the email still arrived)