### PR TITLE
Add missing read policy on mparticle-api http handler

### DIFF
--- a/cdk/lib/__snapshots__/mparticle-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/mparticle-api.test.ts.snap
@@ -863,6 +863,38 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
+                "s3:PutObject",
+                "s3:ListBucket",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "SarResultsBucketParameter",
+                      },
+                      "/mparticle-results/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "SarResultsBucketParameter",
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -2039,6 +2071,38 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "s3:PutObject",
+                "s3:ListBucket",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "SarResultsBucketParameter",
+                      },
+                      "/mparticle-results/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "SarResultsBucketParameter",
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
             {
               "Action": [
                 "s3:GetObject*",

--- a/cdk/lib/mparticle-api.ts
+++ b/cdk/lib/mparticle-api.ts
@@ -36,23 +36,23 @@ export class MParticleApi extends GuStack {
 		// this must be the same as used in the code
 		const sarS3BaseKey = 'mparticle-results/';
 
-		// HTTP API Lambda
-		const httpLambda = new SrLambda(this, `${app}-http-lambda`, {
-			app,
-			fileName: `${app}.zip`,
-			handler: 'index.handlerHttp',
-			functionName: `${app}-http-${this.stage}`,
-		});
-
-		// make sure our lambda can write to and list objects in the central baton bucket
+		// make sure our lambdas can write to and list objects in the central baton bucket
 		// https://github.com/guardian/baton/?tab=readme-ov-file#:~:text=The%20convention%20is%20to%20write%20these%20to%20the%20gu%2Dbaton%2Dresults%20bucket%20that%20is%20hosted%20in%20the%20baton%20AWS%20account.
 		// s3:ListBucket permission is needed to check if files already exist before downloading
-		const s3BatonWritePolicy: PolicyStatement = new PolicyStatement({
+		const s3BatonReadAndWritePolicy: PolicyStatement = new PolicyStatement({
 			actions: ['s3:PutObject', 's3:ListBucket'],
 			resources: [
 				`arn:aws:s3:::${sarResultsBucket}/${sarS3BaseKey}*`, // for PutObject
 				`arn:aws:s3:::${sarResultsBucket}`, // for ListBucket
 			],
+		});
+
+		const httpLambda = new SrLambda(this, `${app}-http-lambda`, {
+			app,
+			fileName: `${app}.zip`,
+			handler: 'index.handlerHttp',
+			functionName: `${app}-http-${this.stage}`,
+			initialPolicy: [s3BatonReadAndWritePolicy],
 		});
 
 		const batonLambda = new SrLambda(this, `${app}-baton-lambda`, {
@@ -61,7 +61,7 @@ export class MParticleApi extends GuStack {
 			handler: 'index.handlerBaton',
 			functionName: `${app}-baton-${this.stage}`,
 			timeout: Duration.seconds(30), // Longer timeout for data processing
-			initialPolicy: [s3BatonWritePolicy],
+			initialPolicy: [s3BatonReadAndWritePolicy],
 		});
 
 		const apiGateway = new GuApiGatewayWithLambdaByPath(this, {


### PR DESCRIPTION
## What does this change?

This PR fixes a permission issue with the mParticle API HTTP lambda that was preventing it from writing Subject Access Request (SAR) result files to the S3 bucket `gu-baton-results-prod`.

**Problem**: The HTTP lambda was encountering `AccessDenied` errors when trying to write SAR result files to S3:
```
AccessDenied: User: arn:aws:sts::865473395570:assumed-role/support-PROD-mparticle-ap-mparticleapihttplambdaSer-EqlbzZXUjEop/mparticle-api-http-PROD is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::gu-baton-results-prod/mparticle-results/34aabb03-e70b-4e0c-b43d-6bed8e0b2ca5.zip"
```

**Root Cause**: The S3 policy (`s3:PutObject` and `s3:ListBucket` permissions) was only applied to the Baton lambda, but the HTTP lambda also needs these permissions. When mParticle completes a SAR request, it sends a callback to the HTTP lambda which then downloads the results file and stores it in S3 using the `batonS3Writer`.

**Solution**: 
- Added the S3 policy to both the HTTP lambda and Baton lambda
- Renamed the policy variable to `s3BatonReadAndWritePolicy` for better clarity
- Reorganized the code structure to define the policy before both lambda definitions
- Updated comments to reflect that both lambdas need S3 access

## How to test

1. **On PROD before this change**: SAR requests would complete in mParticle, but the callback would fail with an S3 AccessDenied error when trying to save the results file
2. **On PROD after this change**: SAR requests should complete successfully with results files properly saved to `gu-baton-results-prod/mparticle-results/`
3. **To verify the fix**: Monitor CloudWatch logs for the mParticle HTTP lambda - you should see successful S3 writes instead of AccessDenied errors

## How can we measure success?

- **Error reduction**: CloudWatch logs should show no more S3 AccessDenied errors from the mParticle HTTP lambda
- **Successful SAR completions**: mParticle SAR callback processing should complete successfully, with files properly stored in the Baton results bucket

## Have we considered potential risks?

**Low risk change**: This is purely an IAM permission fix that grants necessary access that was missing. No functional logic changes.

**Risks**:
- **None significant**: Adding S3 permissions to the HTTP lambda only grants it access it should have had from the beginning
- **Deployment**: Standard CDK deployment - no special deployment considerations needed

**Mitigation**: The change is minimal and follows the same permission pattern already established for the Baton lambda.

## Images

Not applicable - infrastructure/permission change only.

## Accessibility

Not applicable - infrastructure/permission change only.