### PR TITLE
make package.jsons more consistent

### DIFF
--- a/handlers/alarms-handler/package.json
+++ b/handlers/alarms-handler/package.json
@@ -4,9 +4,9 @@
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
 		"type-check": "tsc --noEmit",
-		"build": "esbuild --bundle --platform=node --target=node18 --outdir=target/ src/index.ts src/indexScheduled.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts src/indexScheduled.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr alarms-handler.zip ./*.js",
+		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr alarms-handler.zip ./*.js.map ./*.js",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts"
 	},

--- a/handlers/discount-api/package.json
+++ b/handlers/discount-api/package.json
@@ -4,7 +4,7 @@
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
     "type-check": "tsc --noEmit",
-    "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts --sourcemap",
+    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr discount-api.zip ./*.js.map ./*.js",
     "check-formatting": "prettier --check **.ts",

--- a/handlers/discount-expiry-notifier/package.json
+++ b/handlers/discount-expiry-notifier/package.json
@@ -4,9 +4,9 @@
 	"scripts": {
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
-		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr discount-expiry-notifier.zip ./*.js",
+		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr discount-expiry-notifier.zip ./*.js.map ./*.js",
 		"type-check": "tsc --noEmit",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts",

--- a/handlers/generate-product-catalog/package.json
+++ b/handlers/generate-product-catalog/package.json
@@ -4,9 +4,9 @@
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
     "type-check": "tsc --noEmit",
-    "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
+    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr generate-product-catalog.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr generate-product-catalog.zip ./*.js.map ./*.js",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   },

--- a/handlers/metric-push-api/package.json
+++ b/handlers/metric-push-api/package.json
@@ -4,9 +4,9 @@
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
 		"type-check": "tsc --noEmit",
-		"build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
 		"lint": "eslint src/**/*.ts src/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr metric-push-api.zip ./*.js",
+		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr metric-push-api.zip ./*.js.map ./*.js",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts"
 	},

--- a/handlers/mparticle-api/package.json
+++ b/handlers/mparticle-api/package.json
@@ -4,9 +4,9 @@
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
     "type-check": "tsc --noEmit",
-    "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
+    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr mparticle-api.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr mparticle-api.zip ./*.js.map ./*.js",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
     "check-config": "ts-node runManual/runLoadConfig.ts"

--- a/handlers/negative-invoices-processor/package.json
+++ b/handlers/negative-invoices-processor/package.json
@@ -4,9 +4,9 @@
 	"scripts": {
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
-		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr negative-invoices-processor.zip ./*.js",
+		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr negative-invoices-processor.zip ./*.js.map ./*.js",
 		"type-check": "tsc --noEmit",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts",

--- a/handlers/observer-data-export/package.json
+++ b/handlers/observer-data-export/package.json
@@ -4,9 +4,9 @@
 	"scripts": {
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
-		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr observer-data-export.zip ./*.js",
+		"package": "pnpm type-check && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr observer-data-export.zip ./*.js.map ./*.js",
 		"type-check": "tsc --noEmit",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts"

--- a/handlers/press-reader-entitlements/package.json
+++ b/handlers/press-reader-entitlements/package.json
@@ -4,9 +4,9 @@
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
     "type-check": "tsc --noEmit",
-    "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
+    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr press-reader-entitlements.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr press-reader-entitlements.zip ./*.js.map ./*.js",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   },

--- a/handlers/product-switch-api/package.json
+++ b/handlers/product-switch-api/package.json
@@ -4,7 +4,7 @@
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
 		"type-check": "tsc --noEmit",
-		"build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts --sourcemap",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
 		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr product-switch-api.zip ./*.js.map ./*.js",
 		"check-formatting": "prettier --check **.ts",

--- a/handlers/salesforce-disaster-recovery-health-check/package.json
+++ b/handlers/salesforce-disaster-recovery-health-check/package.json
@@ -4,9 +4,9 @@
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
 		"type-check": "tsc --noEmit",
-		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr salesforce-disaster-recovery-health-check.zip ./*.js",
+		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr salesforce-disaster-recovery-health-check.zip ./*.js.map ./*.js",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts"
 	},

--- a/handlers/salesforce-disaster-recovery/package.json
+++ b/handlers/salesforce-disaster-recovery/package.json
@@ -4,9 +4,9 @@
 	"scripts": {
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
-		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr salesforce-disaster-recovery.zip ./*.js",
+		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr salesforce-disaster-recovery.zip ./*.js.map ./*.js",
 		"type-check": "tsc --noEmit",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts"

--- a/handlers/stripe-disputes/package.json
+++ b/handlers/stripe-disputes/package.json
@@ -4,9 +4,9 @@
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
     "type-check": "tsc --noEmit",
-    "build": "mkdir -p target && esbuild --bundle --platform=node --target=node18 --outfile=target/producer.js src/producer.ts && esbuild --bundle --platform=node --target=node18 --outfile=target/consumer.js src/consumer.ts",
+    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/producer.ts src/consumer.ts --sourcemap",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr stripe-disputes.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr stripe-disputes.zip ./*.js.map ./*.js",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   },

--- a/handlers/ticket-tailor-webhook/package.json
+++ b/handlers/ticket-tailor-webhook/package.json
@@ -4,9 +4,9 @@
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
     "type-check": "tsc --noEmit",
-    "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
+    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr ticket-tailor-webhook.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr ticket-tailor-webhook.zip ./*.js.map ./*.js",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   },

--- a/handlers/update-supporter-plus-amount/package.json
+++ b/handlers/update-supporter-plus-amount/package.json
@@ -4,9 +4,9 @@
     "test": "jest --group=-integration",
     "it-test": "jest --group=integration",
     "type-check": "tsc --noEmit",
-    "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
+    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr update-supporter-plus-amount.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr update-supporter-plus-amount.zip ./*.js.map ./*.js",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   },

--- a/handlers/user-benefits/package.json
+++ b/handlers/user-benefits/package.json
@@ -3,9 +3,9 @@
   "scripts": {
     "test": "jest --group=-integration",
     "type-check": "tsc --noEmit",
-    "build": "esbuild --bundle --platform=node --target=node18 --outfile=target/index.js src/index.ts",
+    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr user-benefits.zip ./*.js",
+    "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr user-benefits.zip ./*.js.map ./*.js",
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts"
   },

--- a/handlers/write-off-unpaid-invoices/package.json
+++ b/handlers/write-off-unpaid-invoices/package.json
@@ -4,9 +4,9 @@
 	"scripts": {
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
-		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm check-formatting && pnpm lint && pnpm test && pnpm build && cd target && zip -qr write-off-unpaid-invoices.zip ./*.js",
+		"package": "pnpm type-check && pnpm check-formatting && pnpm lint && pnpm test && pnpm build && cd target && zip -qr write-off-unpaid-invoices.zip ./*.js.map ./*.js",
 		"type-check": "tsc --noEmit",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts"

--- a/handlers/zuora-salesforce-link-remover/package.json
+++ b/handlers/zuora-salesforce-link-remover/package.json
@@ -4,9 +4,9 @@
 	"scripts": {
 		"test": "jest --group=-integration",
 		"it-test": "jest --group=integration",
-		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target src/handlers/*.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap",
 		"lint": "eslint src/**/*.ts test/**/*.ts",
-		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target; zip -qr zuora-salesforce-link-remover.zip ./*.js",
+		"package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target; zip -qr zuora-salesforce-link-remover.zip ./*.js.map ./*.js",
 		"type-check": "tsc --noEmit",
 		"check-formatting": "prettier --check **.ts",
 		"fix-formatting": "prettier --write **.ts"


### PR DESCRIPTION
At the moment we are building to node18 on some lambdas, but running on node 20.

Also, we don't produce source maps for all lambdas. (they allow node to see source line numbers and function names when running in AWS)

This PR changes all the package.jsons to be consistent in both of the above.