### PR TITLE
only upload correct cfn templates

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -99,6 +99,7 @@ jobs:
           commentingEnabled: 'false'
           contentDirectories: |
             ${{ matrix.subproject }}-cloudformation:
-              - ./cdk/cdk.out
+              - ./cdk/cdk.out/${{ matrix.subproject }}-CODE.template.json
+              - ./cdk/cdk.out/${{ matrix.subproject }}-PROD.template.json
             ${{ matrix.subproject }}:
               - ./handlers/${{ matrix.subproject }}/target/${{ matrix.subproject }}.zip


### PR DESCRIPTION
We get occasional errors from guardian/actions-riff-raff@v4

```
Error: Unknown error. Check logs for more detail.
Error: XAmzContentSHA256Mismatch: The provided 'x-amz-content-sha256' header does not match what was computed.
Error: The provided 'x-amz-content-sha256' header does not match what was computed.
```
e.g. https://github.com/guardian/support-service-lambdas/actions/runs/18218384296/job/51872850477#step:11:81

I suspect uploading so many files makes it more likely - we produce every single CFN file and upload them all as part of the CDK build and upload.

This PR makes it only upload the correct files, rather than all of the ones that were generated.

deployed discount-api to CODE fine 
https://riffraff.gutools.co.uk/deployment/view/2d422257-3ea5-4c38-baa2-d2f160b9ea2a
and there are only the correct files now!
<img width="599" height="334" alt="image" src="https://github.com/user-attachments/assets/8e314bbd-baa8-4d91-8663-5a1b8d7e9da2" />
