### PR TITLE
update buildcheck readme to latest

### DIFF
--- a/buildcheck/README.md
+++ b/buildcheck/README.md
@@ -1,36 +1,31 @@
 # Buildcheck - build file checker
 
 ## What is buildcheck?
-Buildcheck checks the content of the build files for all lambda modules and their associated cdk modules during CI.
+Buildcheck checks the content of the build files for all lambdas during CI.
 
 The expected content is defined programmatically in typescript, similar to how CDK defines cloudformation.
 
-If you edit the build definition, it's easy to refresh the build files using the update command provided.
+After editing the build definition, it's easy to refresh the build files using `pnpm snapshot:update`.
 
 ## Quick start: How do I...?
 ### ...add a dependency
-1. open [data/build.ts](data/build.ts) 
+1. open [data/build.ts](data/build.ts)
 1. add it to the dependencies section of your lambda definition
 1. run `pnpm snapshot:update`
 ### ...bump a version
 1. open [data/dependencies.ts](data/dependencies.ts)
 1. edit the version number accordingly
-1. `pnpm snapshot:update`
+1. run `pnpm snapshot:update`
 ### ...fix failing buildcheck in CI
 1. run `pnpm snapshot:update` to refresh the full set of build files
 1. review (if necessary update the build definition and run snapshot:update again)
 1. commit and push
 
-## Migrating an existing handler to use buildcheck
-This requires the definition added to buildcheck and any differences resolved.
-
-1. Add your new handler to [data/build.ts](data/build.ts)
-1. Run `pnpm snapshot:assert <handler-name>` to see any differences
-1. Edit the buildcheck data (and existing files) to resolve any differences
-1. retest until you are happy
-1. Run `pnpm snapshot:assert` to ensure no other handler has been affected
-1. Optionally run `pnpm snapshot:update` to apply any intentional differences across the repo.
-1. Push and test your changes.
+### ...migrate an existing handler to use buildcheck
+1. add your new handler to [data/build.ts](data/build.ts)
+1. run `pnpm snapshot:update` to overwrite the existing files
+1. review the git diff (if necessary update the build definition and run snapshot:update again)
+1. commit and push
 
 ## Pros and cons of buildcheck
 The benefits and drawbacks of buildcheck are similar to CDK or SBT:


### PR DESCRIPTION
Just a few tweaks as I noticed it wasn't all up to date.
The main update is to suggest using git diff rather than the tests to understand the differences when adding a new handler as it's easier to get a handle on what's going on