### PR TITLE
enable source maps in CDK and add reusable SrApiLambda construct

### DIFF
--- a/cdk/lib/__snapshots__/discount-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/discount-api.test.ts.snap
@@ -5,7 +5,6 @@ exports[`The Discount API stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuApiLambda",
       "GuGetDistributablePolicy",
     ],
     "gu:cdk:version": "TEST",
@@ -342,6 +341,7 @@ exports[`The Discount API stack matches the snapshot 1`] = `
           "Variables": {
             "APP": "discount-api",
             "App": "discount-api",
+            "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "CODE",
             "Stack": "support",
@@ -1048,7 +1048,6 @@ exports[`The Discount API stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuApiLambda",
       "GuGetDistributablePolicy",
     ],
     "gu:cdk:version": "TEST",
@@ -1385,6 +1384,7 @@ exports[`The Discount API stack matches the snapshot 2`] = `
           "Variables": {
             "APP": "discount-api",
             "App": "discount-api",
+            "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "PROD",
             "Stack": "support",

--- a/cdk/lib/__snapshots__/mparticle-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/mparticle-api.test.ts.snap
@@ -533,6 +533,7 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "mparticle-api",
+            "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "CODE",
           },
@@ -776,6 +777,7 @@ exports[`The mParticle API stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "mparticle-api",
+            "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "CODE",
           },
@@ -1770,6 +1772,7 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "mparticle-api",
+            "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "PROD",
           },
@@ -2013,6 +2016,7 @@ exports[`The mParticle API stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "mparticle-api",
+            "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "PROD",
           },

--- a/cdk/lib/__snapshots__/product-switch-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/product-switch-api.test.ts.snap
@@ -5,7 +5,6 @@ exports[`The Product switch api stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuApiLambda",
       "GuGetDistributablePolicy",
     ],
     "gu:cdk:version": "TEST",
@@ -280,6 +279,7 @@ exports[`The Product switch api stack matches the snapshot 1`] = `
           "Variables": {
             "APP": "product-switch-api",
             "App": "product-switch-api",
+            "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "CODE",
             "Stack": "support",
@@ -986,7 +986,6 @@ exports[`The Product switch api stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuApiLambda",
       "GuGetDistributablePolicy",
     ],
     "gu:cdk:version": "TEST",
@@ -1413,6 +1412,7 @@ exports[`The Product switch api stack matches the snapshot 2`] = `
           "Variables": {
             "APP": "product-switch-api",
             "App": "product-switch-api",
+            "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "PROD",
             "Stack": "support",

--- a/cdk/lib/cdk/sr-api-lambda.ts
+++ b/cdk/lib/cdk/sr-api-lambda.ts
@@ -11,7 +11,7 @@ function getApiLambdaDefaultProps(scope: Identity, props: SrApiLambdaProps) {
 		...getLambdaDefaultProps(scope, props.nameSuffix),
 		timeout: Duration.seconds(300),
 		monitoringConfiguration: {
-			noMonitoring: true, // There is a threshold alarm defined below
+			noMonitoring: true, // we don't use the standard GuCDK alarms due to low traffic
 		} as const,
 		api: {
 			id: getNameWithStage(scope, props.nameSuffix),

--- a/cdk/lib/cdk/sr-api-lambda.ts
+++ b/cdk/lib/cdk/sr-api-lambda.ts
@@ -1,0 +1,64 @@
+import { GuApiLambda, type GuApiLambdaProps } from '@guardian/cdk';
+import type { Identity } from '@guardian/cdk/lib/constructs/core';
+import { Duration } from 'aws-cdk-lib';
+import { ApiKeySourceType } from 'aws-cdk-lib/aws-apigateway';
+import type { SrLambdaProps } from './sr-lambda';
+import { getLambdaDefaultProps, getNameWithStage } from './sr-lambda';
+import type { SrStack } from './sr-stack';
+
+function getApiLambdaDefaultProps(scope: Identity, props: SrApiLambdaProps) {
+	return {
+		...getLambdaDefaultProps(scope, props.nameSuffix),
+		timeout: Duration.seconds(300),
+		monitoringConfiguration: {
+			noMonitoring: true, // There is a threshold alarm defined below
+		} as const,
+		api: {
+			id: getNameWithStage(scope, props.nameSuffix),
+			restApiName: getNameWithStage(scope, props.nameSuffix),
+			description: props.apiDescriptionOverride ?? 'API Gateway created by CDK',
+			proxy: true,
+			deployOptions: {
+				stageName: scope.stage,
+			},
+			apiKeySourceType: ApiKeySourceType.HEADER,
+			defaultMethodOptions: {
+				apiKeyRequired: true,
+			},
+		},
+	};
+}
+
+type ApiDefaultProps = ReturnType<typeof getApiLambdaDefaultProps>;
+type SrApiLambdaOverrides = Omit<GuApiLambdaProps, keyof ApiDefaultProps> &
+	Partial<ApiDefaultProps>;
+type SrApiLambdaProps = SrLambdaProps & { apiDescriptionOverride?: string };
+
+export class SrApiLambda extends GuApiLambda {
+	constructor(
+		scope: SrStack,
+		id: string,
+		lambdaOverrides: SrApiLambdaOverrides,
+		props: SrApiLambdaProps,
+	) {
+		const defaultProps = getApiLambdaDefaultProps(scope, props);
+		const deprecatedVars = {
+			// for some reason we often use these instead of the upper case STACK/STAGE/APP added by GuCDK
+			// https://github.com/guardian/cdk/blob/5569c749211b518001666cffb558fe403ff0539c/src/constructs/lambda/lambda.ts#L134-L138
+			App: scope.app,
+			Stack: scope.stack,
+			Stage: scope.stage,
+		};
+		const finalProps = {
+			...defaultProps,
+			...lambdaOverrides,
+			environment: {
+				...defaultProps.environment,
+				...deprecatedVars,
+				...lambdaOverrides.environment,
+			},
+		};
+
+		super(scope, id, finalProps);
+	}
+}

--- a/cdk/lib/discount-api.ts
+++ b/cdk/lib/discount-api.ts
@@ -1,20 +1,17 @@
-import { GuApiLambda } from '@guardian/cdk';
 import { GuGetDistributablePolicy } from '@guardian/cdk/lib/constructs/iam';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
-import { ApiKeySourceType } from 'aws-cdk-lib/aws-apigateway';
 import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
-import { LoggingFormat } from 'aws-cdk-lib/aws-lambda';
 import {
 	AllowS3CatalogReadPolicy,
 	AllowSqsSendPolicy,
 	AllowZuoraOAuthSecretsPolicy,
 } from './cdk/policies';
+import { SrApiLambda } from './cdk/sr-api-lambda';
 import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
 import { SrRestDomain } from './cdk/sr-rest-domain';
 import type { SrStageNames } from './cdk/sr-stack';
 import { SrStack } from './cdk/sr-stack';
-import { nodeVersion } from './node-version';
 
 export class DiscountApi extends SrStack {
 	constructor(scope: App, stage: SrStageNames) {
@@ -23,42 +20,16 @@ export class DiscountApi extends SrStack {
 		const app = this.app;
 		const nameWithStage = `${app}-${this.stage}`;
 
-		const commonEnvironmentVariables = {
-			App: app,
-			Stack: this.stack,
-			Stage: this.stage,
-		};
-
 		// ---- API-triggered lambda functions ---- //
-		const lambda = new GuApiLambda(this, `${app}-lambda`, {
-			description:
-				'A lambda that enables the addition of discounts to existing subscriptions',
-			functionName: nameWithStage,
-			loggingFormat: LoggingFormat.TEXT,
-			fileName: `${app}.zip`,
-			handler: 'index.handler',
-			runtime: nodeVersion,
-			memorySize: 1024,
-			timeout: Duration.seconds(300),
-			environment: commonEnvironmentVariables,
-			monitoringConfiguration: {
-				noMonitoring: true, // There is a threshold alarm defined below
+		const lambda = new SrApiLambda(
+			this,
+			`${app}-lambda`,
+			{
+				description:
+					'A lambda that enables the addition of discounts to existing subscriptions',
 			},
-			app: app,
-			api: {
-				id: nameWithStage,
-				restApiName: nameWithStage,
-				description: 'API Gateway created by CDK',
-				proxy: true,
-				deployOptions: {
-					stageName: this.stage,
-				},
-				apiKeySourceType: ApiKeySourceType.HEADER,
-				defaultMethodOptions: {
-					apiKeyRequired: true,
-				},
-			},
-		});
+			{},
+		);
 
 		const usagePlan = lambda.api.addUsagePlan('UsagePlan', {
 			name: nameWithStage,

--- a/handlers/discount-api/src/index.ts
+++ b/handlers/discount-api/src/index.ts
@@ -1,4 +1,3 @@
-import 'source-map-support/register';
 import { sendEmail } from '@modules/email/email';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { logger } from '@modules/routing/logger';

--- a/handlers/product-switch-api/src/index.ts
+++ b/handlers/product-switch-api/src/index.ts
@@ -1,4 +1,3 @@
-import 'source-map-support/register';
 import { createRoute, Router } from '@modules/routing/router';
 import type { Stage } from '@modules/stage';
 import type { Handler } from 'aws-lambda';


### PR DESCRIPTION
(supersedes/part of https://github.com/guardian/support-service-lambdas/pull/3101 )

I did some work to make two TS lambdas use source maps in https://github.com/guardian/support-service-lambdas/pull/3062
It is very useful to have correct line numbers on the log statements and stack traces
<img width="1234" height="230" alt="image" src="https://github.com/user-attachments/assets/072bd214-d79b-48b2-9916-e059bdaa70d2" />
and there doesn't seem to be any obious performance hit.

I decided to roll it out to more lambdas, and it turns out we can enable it using an environment variable
NODE_OPTIONS set to [--enable-source-maps](https://nodejs.org/api/cli.html#--enable-source-maps)
passed to the lambda rather than having to add an import in the index.ts of each lambda.

It would be better to set it in CDK as it can apply across the board rather than relying on it being added in each place.

As part of the CDK deduplication I have added a SrApiLambda construct.  This is just to stop us having to duplicate the same ~15-20 lines in every cdk file and make it easier to maintain.

As part of this change I have made source maps switched on in node automatically in order to get better stack traces and logging tags.
