### PR TITLE
move metric-push-api to support stack and to SrCDK

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -130,6 +130,7 @@ const stacks: Array<new (app: App, stage: SrStageNames) => unknown> = [
 	ProductSwitchApi,
 	UpdateSupporterPlusAmount,
 	MParticleApi,
+	MetricPushApi,
 ];
 
 // generate all stacks for all stages
@@ -311,16 +312,7 @@ new DiscountExpiryNotifier(app, 'discount-expiry-notifier-PROD', {
 	stack: 'support',
 	stage: 'PROD',
 });
-new MetricPushApi(app, 'metric-push-api-CODE', {
-	stack: 'membership',
-	stage: 'CODE',
-	cloudFormationStackName: 'membership-CODE-metric-push-api',
-});
-new MetricPushApi(app, 'metric-push-api-PROD', {
-	stack: 'membership',
-	stage: 'PROD',
-	cloudFormationStackName: 'membership-PROD-metric-push-api',
-});
+
 new ObserverDataExport(app, 'observer-data-export-CODE', {
 	stack: 'support',
 	stage: 'CODE',

--- a/cdk/lib/__snapshots__/metric-push-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/metric-push-api.test.ts.snap
@@ -5,7 +5,6 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuApiLambda",
       "GuPutCloudwatchMetricsPolicy",
       "GuAlarm",
     ],
@@ -83,6 +82,10 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "App",
+            "Value": "metric-push-api",
+          },
+          {
             "Key": "DiagnosticLinks",
             "Value": {
               "Fn::Join": [
@@ -106,7 +109,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -181,6 +184,10 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "App",
+            "Value": "metric-push-api",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -190,7 +197,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -218,8 +225,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
     },
     "MetricPushDNSRecord": {
       "Properties": {
-        "Comment": "CNAME for metric-push-api API CODE",
-        "HostedZoneName": "support.guardianapis.com.",
+        "HostedZoneId": "Z3KO35ELNWZMSX",
         "Name": "metric-push-api-code.support.guardianapis.com",
         "ResourceRecords": [
           {
@@ -246,11 +252,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           "Fn::Join": [
             "",
             [
-              "arn:aws:acm:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
+              "arn:aws:acm:eu-west-1:",
               {
                 "Ref": "AWS::AccountId",
               },
@@ -259,6 +261,10 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           ],
         },
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "metric-push-api",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -269,7 +275,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -289,16 +295,17 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "membership/CODE/metric-push-api/metric-push-api.zip",
+          "S3Key": "support/CODE/metric-push-api/metric-push-api.zip",
         },
         "Description": "API triggered lambda to push a metric to cloudwatch so we can alarm on errors",
         "Environment": {
           "Variables": {
             "APP": "metric-push-api",
             "App": "metric-push-api",
-            "STACK": "membership",
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STACK": "support",
             "STAGE": "CODE",
-            "Stack": "membership",
+            "Stack": "support",
             "Stage": "CODE",
           },
         },
@@ -307,7 +314,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
         "LoggingConfig": {
           "LogFormat": "Text",
         },
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
             "metricpushapilambdaServiceRole910E7F90",
@@ -330,7 +337,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -384,7 +391,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -433,7 +440,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/membership/CODE/metric-push-api/metric-push-api.zip",
+                      "/support/CODE/metric-push-api/metric-push-api.zip",
                     ],
                   ],
                 },
@@ -454,7 +461,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/CODE/membership/metric-push-api",
+                    ":parameter/CODE/support/metric-push-api",
                   ],
                 ],
               },
@@ -477,7 +484,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/CODE/membership/metric-push-api/*",
+                    ":parameter/CODE/support/metric-push-api/*",
                   ],
                 ],
               },
@@ -513,7 +520,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -704,7 +711,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -715,7 +722,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "metricpushapilambdametricpushapiCODEDeployment9B65369Cbfd935d3e15ba02166d0d2a3efbb3b26": {
+    "metricpushapilambdametricpushapiCODEDeployment9B65369C9b8e195f5ba5aaa1cc9e4b269b959bd9": {
       "DependsOn": [
         "metricpushapilambdametricpushapiCODEproxyANYC000D577",
         "metricpushapilambdametricpushapiCODEproxyBBD345B3",
@@ -735,7 +742,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "metricpushapilambdametricpushapiCODEDeployment9B65369Cbfd935d3e15ba02166d0d2a3efbb3b26",
+          "Ref": "metricpushapilambdametricpushapiCODEDeployment9B65369C9b8e195f5ba5aaa1cc9e4b269b959bd9",
         },
         "RestApiId": {
           "Ref": "metricpushapilambdametricpushapiCODE87B70A97",
@@ -756,7 +763,7 @@ exports[`The MetricPushApi stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -908,7 +915,6 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuApiLambda",
       "GuPutCloudwatchMetricsPolicy",
       "GuAlarm",
     ],
@@ -986,6 +992,10 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "App",
+            "Value": "metric-push-api",
+          },
+          {
             "Key": "DiagnosticLinks",
             "Value": {
               "Fn::Join": [
@@ -1009,7 +1019,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1084,6 +1094,10 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "App",
+            "Value": "metric-push-api",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1093,7 +1107,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1121,8 +1135,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
     },
     "MetricPushDNSRecord": {
       "Properties": {
-        "Comment": "CNAME for metric-push-api API PROD",
-        "HostedZoneName": "support.guardianapis.com.",
+        "HostedZoneId": "Z3KO35ELNWZMSX",
         "Name": "metric-push-api-prod.support.guardianapis.com",
         "ResourceRecords": [
           {
@@ -1149,11 +1162,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           "Fn::Join": [
             "",
             [
-              "arn:aws:acm:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
+              "arn:aws:acm:eu-west-1:",
               {
                 "Ref": "AWS::AccountId",
               },
@@ -1162,6 +1171,10 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           ],
         },
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "metric-push-api",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1172,7 +1185,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1192,16 +1205,17 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "membership/PROD/metric-push-api/metric-push-api.zip",
+          "S3Key": "support/PROD/metric-push-api/metric-push-api.zip",
         },
         "Description": "API triggered lambda to push a metric to cloudwatch so we can alarm on errors",
         "Environment": {
           "Variables": {
             "APP": "metric-push-api",
             "App": "metric-push-api",
-            "STACK": "membership",
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STACK": "support",
             "STAGE": "PROD",
-            "Stack": "membership",
+            "Stack": "support",
             "Stage": "PROD",
           },
         },
@@ -1210,7 +1224,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
         "LoggingConfig": {
           "LogFormat": "Text",
         },
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
             "metricpushapilambdaServiceRole910E7F90",
@@ -1233,7 +1247,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1287,7 +1301,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1336,7 +1350,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/membership/PROD/metric-push-api/metric-push-api.zip",
+                      "/support/PROD/metric-push-api/metric-push-api.zip",
                     ],
                   ],
                 },
@@ -1357,7 +1371,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/membership/metric-push-api",
+                    ":parameter/PROD/support/metric-push-api",
                   ],
                 ],
               },
@@ -1380,7 +1394,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/membership/metric-push-api/*",
+                    ":parameter/PROD/support/metric-push-api/*",
                   ],
                 ],
               },
@@ -1578,7 +1592,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1589,7 +1603,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "metricpushapilambdametricpushapiPRODDeployment353B728D2f7424849f61ebeb3f6f6ef9013cc2f9": {
+    "metricpushapilambdametricpushapiPRODDeployment353B728D6547e0ff38f2b7521e3f3f15b14f585f": {
       "DependsOn": [
         "metricpushapilambdametricpushapiPRODproxyANY9737E265",
         "metricpushapilambdametricpushapiPRODproxy1154D5C4",
@@ -1609,7 +1623,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "metricpushapilambdametricpushapiPRODDeployment353B728D2f7424849f61ebeb3f6f6ef9013cc2f9",
+          "Ref": "metricpushapilambdametricpushapiPRODDeployment353B728D6547e0ff38f2b7521e3f3f15b14f585f",
         },
         "RestApiId": {
           "Ref": "metricpushapilambdametricpushapiPRODF582713E",
@@ -1630,7 +1644,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1659,7 +1673,7 @@ exports[`The MetricPushApi stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",

--- a/cdk/lib/cdk/sr-api-lambda.ts
+++ b/cdk/lib/cdk/sr-api-lambda.ts
@@ -21,10 +21,14 @@ function getApiLambdaDefaultProps(scope: Identity, props: SrApiLambdaProps) {
 			deployOptions: {
 				stageName: scope.stage,
 			},
-			apiKeySourceType: ApiKeySourceType.HEADER,
-			defaultMethodOptions: {
-				apiKeyRequired: true,
-			},
+			...(props.isPublic
+				? {}
+				: {
+						apiKeySourceType: ApiKeySourceType.HEADER,
+						defaultMethodOptions: {
+							apiKeyRequired: true,
+						},
+					}),
 		},
 	};
 }
@@ -32,7 +36,10 @@ function getApiLambdaDefaultProps(scope: Identity, props: SrApiLambdaProps) {
 type ApiDefaultProps = ReturnType<typeof getApiLambdaDefaultProps>;
 type SrApiLambdaOverrides = Omit<GuApiLambdaProps, keyof ApiDefaultProps> &
 	Partial<ApiDefaultProps>;
-type SrApiLambdaProps = SrLambdaProps & { apiDescriptionOverride?: string };
+type SrApiLambdaProps = SrLambdaProps & {
+	apiDescriptionOverride?: string;
+	isPublic?: boolean;
+};
 
 export class SrApiLambda extends GuApiLambda {
 	constructor(

--- a/cdk/lib/metric-push-api.test.ts
+++ b/cdk/lib/metric-push-api.test.ts
@@ -6,16 +6,8 @@ describe('The MetricPushApi stack', () => {
 	it('matches the snapshot', () => {
 		const app = new App();
 
-		const codeStack = new MetricPushApi(app, 'metric-push-api-CODE', {
-			stack: 'membership',
-			stage: 'CODE',
-			cloudFormationStackName: 'membership-CODE-metric-push-api',
-		});
-		const prodStack = new MetricPushApi(app, 'metric-push-api-PROD', {
-			stack: 'membership',
-			stage: 'PROD',
-			cloudFormationStackName: 'membership-PROD-metric-push-api',
-		});
+		const codeStack = new MetricPushApi(app, 'CODE');
+		const prodStack = new MetricPushApi(app, 'PROD');
 
 		expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
 		expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();

--- a/cdk/lib/metric-push-api.ts
+++ b/cdk/lib/metric-push-api.ts
@@ -1,87 +1,44 @@
-import { GuApiLambda } from '@guardian/cdk';
 import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuPutCloudwatchMetricsPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { type App, Duration } from 'aws-cdk-lib';
-import { CfnBasePathMapping, CfnDomainName } from 'aws-cdk-lib/aws-apigateway';
 import {
 	ComparisonOperator,
 	Metric,
 	TreatMissingData,
 } from 'aws-cdk-lib/aws-cloudwatch';
-import { LoggingFormat } from 'aws-cdk-lib/aws-lambda';
-import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
+import { SrApiLambda } from './cdk/sr-api-lambda';
 import { SrLambdaAlarm } from './cdk/sr-lambda-alarm';
-import { nodeVersion } from './node-version';
+import { SrRestDomain } from './cdk/sr-rest-domain';
+import type { SrStageNames } from './cdk/sr-stack';
+import { SrStack } from './cdk/sr-stack';
 
-export class MetricPushApi extends GuStack {
-	constructor(scope: App, id: string, props: GuStackProps) {
-		super(scope, id, props);
-		const app = 'metric-push-api';
+export class MetricPushApi extends SrStack {
+	constructor(scope: App, stage: SrStageNames) {
+		super(scope, { stage, app: 'metric-push-api' });
+		const app = this.app;
 		const nameWithStage = `${app}-${this.stage}`;
 
-		// Lambda & API Gateway
-		const commonEnvironmentVariables = {
-			App: app,
-			Stack: this.stack,
-			Stage: this.stage,
-		};
-
-		const lambda = new GuApiLambda(this, `${app}-lambda`, {
-			description:
-				'API triggered lambda to push a metric to cloudwatch so we can alarm on errors',
-			functionName: nameWithStage,
-			loggingFormat: LoggingFormat.TEXT,
-			fileName: `${app}.zip`,
-			handler: 'index.handler',
-			runtime: nodeVersion,
-			memorySize: 512,
-			timeout: Duration.seconds(60),
-			environment: commonEnvironmentVariables,
-			// Create an alarm
-			monitoringConfiguration: {
-				noMonitoring: true,
+		const lambda = new SrApiLambda(
+			this,
+			`${app}-lambda`,
+			{
+				description:
+					'API triggered lambda to push a metric to cloudwatch so we can alarm on errors',
+				timeout: Duration.seconds(60),
 			},
-			app: app,
-			api: {
-				id: nameWithStage,
-				restApiName: nameWithStage,
-				description: `API Gateway endpoint for the ${nameWithStage} lambda`,
-				proxy: true,
-				deployOptions: {
-					stageName: this.stage,
-				},
+			{
+				apiDescriptionOverride: `API Gateway endpoint for the ${nameWithStage} lambda`,
+				isPublic: true,
 			},
-		});
+		);
 
 		const cloudwatchPutMetricPolicy = new GuPutCloudwatchMetricsPolicy(this);
 		lambda.role?.attachInlinePolicy(cloudwatchPutMetricPolicy);
 
-		// DNS
-		const domainName = new CfnDomainName(this, 'MetricPushDomainName', {
-			regionalCertificateArn: `arn:aws:acm:${this.region}:${this.account}:certificate/b384a6a0-2f54-4874-b99b-96eeff96c009`,
-			domainName: `metric-push-api-${this.stage.toLowerCase()}.support.guardianapis.com`,
-			endpointConfiguration: {
-				types: ['REGIONAL'],
-			},
-		});
-
-		new CfnBasePathMapping(this, 'MetricPushBasePathMapping', {
-			restApiId: lambda.api.restApiId,
-			domainName: domainName.ref,
-			stage: lambda.api.deploymentStage.stageName,
-		});
-
-		const dnsRecord = new CfnRecordSet(this, 'MetricPushDNSRecord', {
-			name: `metric-push-api-${this.stage.toLowerCase()}.support.guardianapis.com`,
-			type: 'CNAME',
-			comment: `CNAME for metric-push-api API ${this.stage}`,
-			hostedZoneName: 'support.guardianapis.com.',
-			ttl: '120',
-			resourceRecords: [domainName.attrRegionalDomainName],
-		});
-		dnsRecord.overrideLogicalId('MetricPushDNSRecord');
+		const domain = new SrRestDomain(this, lambda.api, true);
+		domain.dnsRecord.overrideLogicalId('MetricPushDNSRecord');
+		domain.basePathMapping.overrideLogicalId(`MetricPushBasePathMapping`);
+		domain.cfnDomainName.overrideLogicalId(`MetricPushDomainName`);
 
 		// Alarms
 		new SrLambdaAlarm(this, '5xxApiAlarm', {

--- a/handlers/metric-push-api/riff-raff.yaml
+++ b/handlers/metric-push-api/riff-raff.yaml
@@ -1,5 +1,5 @@
 stacks:
-  - membership
+  - support
 regions:
   - eu-west-1
 allowedStages:


### PR DESCRIPTION
(Following various SrCDK PRs such as https://github.com/guardian/support-service-lambdas/pull/3121 )

I noticed that metric-push-api stack is membership but its domain is support.  

This PR updates metric-push-api to use SrCDK
It also makes it wholly a support rather than part membership/part support stacks.

This will also gain better logging/stack traces due to the source maps being enabled by default in SrCDK

## Note 
 because the stack name changes to `support-CODE-metric-push-api` it's necessary to drop the old stack and then deploy.  I had an issue dropping the CODE stack so I had to delete the APIGateway stage manually, with "Failed retrieving identifier ownership" error from CFN.


## Tested in CODE:

I think the alarm will still work fine as it goes off the app tag which is present
https://github.com/guardian/support-service-lambdas/blob/cb9507cfb7f6f7fb65996e46adba10ec59046154/handlers/alarms-handler/src/alarmMappings.ts#L81

<img width="371" height="75" alt="image" src="https://github.com/user-attachments/assets/d29a12e9-c7b6-4969-93ad-5afda7d36571" />

Looks good in the logs (although I didn't send a referrer header so it didn't log the metric)
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fmetric-push-api-CODE/log-events/2025$252F10$252F06$252F$255B$2524LATEST$255D2bdbbb3ba7cd4c36b7a3895f0cb07967