### PR TITLE
Use a simple error message with Zuora errors, not a concatenated one

### DIFF
--- a/handlers/discount-expiry-notifier/jest.config.js
+++ b/handlers/discount-expiry-notifier/jest.config.js
@@ -4,8 +4,7 @@ module.exports = {
 	testEnvironment: 'node',
 	runner: 'groups',
 	moduleNameMapper: {
-		'@modules/(.*)/(.*)/(.*)$': '<rootDir>/../../modules/$1/$2/$3',
-		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
+		'@modules/([^/]*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
 		'@modules/(.*)$': '<rootDir>/../../modules/$1',
 	},
 };

--- a/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getExpiringDiscounts.ts
@@ -1,5 +1,5 @@
 import { getSSMParam } from '@modules/aws/ssm';
-import { buildAuthClient, runQuery } from '@modules/bigquery/src/bigquery';
+import { buildAuthClient, runQuery } from '@modules/bigquery/bigquery';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { stageFromEnvironment } from '@modules/stage';
 import { functionalTestQueryResponse } from '../../test/handlers/data/functionalTestQueryResponse';

--- a/handlers/discount-expiry-notifier/test/handlers/getExpiringDiscounts.test.ts
+++ b/handlers/discount-expiry-notifier/test/handlers/getExpiringDiscounts.test.ts
@@ -1,10 +1,10 @@
 import { getSSMParam } from '@modules/aws/ssm';
-import { buildAuthClient, runQuery } from '@modules/bigquery/src/bigquery';
+import { buildAuthClient, runQuery } from '@modules/bigquery/bigquery';
 import { stageFromEnvironment } from '@modules/stage';
 import { addDays, handler } from '../../src/handlers/getExpiringDiscounts';
 import { testQueryResponse } from './data/getExpiringDiscounts/testQueryResponse';
 
-jest.mock('@modules/bigquery/src/bigquery');
+jest.mock('@modules/bigquery/bigquery');
 jest.mock('@modules/stage');
 jest.mock('@modules/aws/ssm');
 

--- a/handlers/negative-invoices-processor/src/handlers/getInvoices.ts
+++ b/handlers/negative-invoices-processor/src/handlers/getInvoices.ts
@@ -1,5 +1,5 @@
 import { getSSMParam } from '@modules/aws/ssm';
-import { buildAuthClient, runQuery } from '@modules/bigquery/src/bigquery';
+import { buildAuthClient, runQuery } from '@modules/bigquery/bigquery';
 import { stageFromEnvironment } from '@modules/stage';
 import { CODEDataMockQueryResponse } from '../../test/handlers/data/CODEDataMockQueryResponse';
 import { InvoiceRecordsArraySchema } from '../types';

--- a/handlers/negative-invoices-processor/test/handlers/getInvoices.test.ts
+++ b/handlers/negative-invoices-processor/test/handlers/getInvoices.test.ts
@@ -32,7 +32,7 @@ describe('getCODEData', () => {
 jest.mock('@modules/aws/ssm', () => ({
 	getSSMParam: jest.fn().mockResolvedValue('mock-gcp-config'),
 }));
-jest.mock('@modules/bigquery/src/bigquery', () => ({
+jest.mock('@modules/bigquery/bigquery', () => ({
 	buildAuthClient: jest.fn().mockResolvedValue('mock-auth-client'),
 	runQuery: jest.fn().mockResolvedValue([
 		[

--- a/handlers/salesforce-disaster-recovery/jest.config.js
+++ b/handlers/salesforce-disaster-recovery/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
 	testEnvironment: 'node',
 	runner: 'groups',
 	moduleNameMapper: {
-		'@modules/(.*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
+		'@modules/([^/]*)/(.*)$': '<rootDir>/../../modules/$1/src/$2',
 		'@modules/(.*)$': '<rootDir>/../../modules/$1',
 	},
 };

--- a/handlers/write-off-unpaid-invoices/src/handlers/getUnpaidInvoices.ts
+++ b/handlers/write-off-unpaid-invoices/src/handlers/getUnpaidInvoices.ts
@@ -1,6 +1,6 @@
 import { uploadFileToS3 } from '@modules/aws/s3';
 import { getSSMParam } from '@modules/aws/ssm';
-import { buildAuthClient, runQuery } from '@modules/bigquery/src/bigquery';
+import { buildAuthClient, runQuery } from '@modules/bigquery/bigquery';
 
 export const handler = async ({ filePath }: { filePath: string }) => {
 	const gcpConfig = await getSSMParam(

--- a/modules/zuora/src/zuoraClient.ts
+++ b/modules/zuora/src/zuoraClient.ts
@@ -104,7 +104,9 @@ export class ZuoraClient {
 		} else {
 			// When Zuora returns a 429 status, the response headers typically contain important rate limiting information
 			if (response.status === 429) {
-				logger.log(response.headers);
+				logger.log(
+					`Received a 429 rate limit response with response headers ${response.headers}`,
+				);
 			}
 
 			throw generateZuoraError(json, response);

--- a/modules/zuora/test/zuoraClient.test.ts
+++ b/modules/zuora/test/zuoraClient.test.ts
@@ -42,6 +42,8 @@ describe('ZuoraClient fetch method error handling', () => {
 
 	describe('HTTP 400 errors with different response formats', () => {
 		test('should handle /v1/object/* error format with Errors array', async () => {
+			const errorMessage =
+				'You cannot transfer an amount greater than the invoice balance. Please update and try again.';
 			const mockResponse = {
 				ok: false,
 				status: 400,
@@ -49,8 +51,7 @@ describe('ZuoraClient fetch method error handling', () => {
 				json: jest.fn().mockResolvedValue({
 					Errors: [
 						{
-							Message:
-								'You cannot transfer an amount greater than the invoice balance. Please update and try again.',
+							Message: errorMessage,
 							Code: 'INVALID_VALUE',
 						},
 					],
@@ -76,21 +77,19 @@ describe('ZuoraClient fetch method error handling', () => {
 				);
 			} catch (error) {
 				expect(error).toBeInstanceOf(ZuoraError);
-				expect((error as ZuoraError).message).toContain(
-					'You cannot transfer an amount greater than the invoice balance',
-				);
-				expect((error as ZuoraError).message).toContain('INVALID_VALUE');
+				expect((error as ZuoraError).message).toBe(errorMessage);
 			}
 		});
 
 		test('should handle query action error format with FaultCode/FaultMessage', async () => {
+			const errorMessage = 'invalid field for query: Invoice.accountid1';
 			const mockResponse = {
 				ok: false,
 				status: 400,
 				statusText: 'Bad Request',
 				json: jest.fn().mockResolvedValue({
 					FaultCode: 'INVALID_FIELD',
-					FaultMessage: 'invalid field for query: Invoice.accountid1',
+					FaultMessage: errorMessage,
 				}),
 			};
 
@@ -104,21 +103,19 @@ describe('ZuoraClient fetch method error handling', () => {
 				await zuoraClient.fetch()('v1/action/query', 'POST', testSchema);
 			} catch (error) {
 				expect(error).toBeInstanceOf(ZuoraError);
-				expect((error as ZuoraError).message).toContain(
-					'invalid field for query: Invoice.accountid1',
-				);
-				expect((error as ZuoraError).message).toContain('INVALID_FIELD');
+				expect((error as ZuoraError).message).toBe(errorMessage);
 			}
 		});
 
 		test('should handle invalid action error format with code/message', async () => {
+			const errorMessage = "Invalid action 'query1'";
 			const mockResponse = {
 				ok: false,
 				status: 400,
 				statusText: 'Bad Request',
 				json: jest.fn().mockResolvedValue({
 					code: 'ClientError',
-					message: "Invalid action 'query1'",
+					message: errorMessage,
 				}),
 			};
 
@@ -132,16 +129,14 @@ describe('ZuoraClient fetch method error handling', () => {
 				await zuoraClient.fetch()('v1/action/query1', 'POST', testSchema);
 			} catch (error) {
 				expect(error).toBeInstanceOf(ZuoraError);
-				expect((error as ZuoraError).message).toContain(
-					"Invalid action 'query1'",
-				);
-				expect((error as ZuoraError).message).toContain('ClientError');
+				expect((error as ZuoraError).message).toBe(errorMessage);
 			}
 		});
 	});
 
 	describe('HTTP 401 errors', () => {
 		test('should handle authentication error with reasons array', async () => {
+			const errorMessage = 'Authentication error';
 			const mockResponse = {
 				ok: false,
 				status: 401,
@@ -151,7 +146,7 @@ describe('ZuoraClient fetch method error handling', () => {
 					reasons: [
 						{
 							code: '90000011',
-							message: 'Authentication error',
+							message: errorMessage,
 						},
 					],
 				}),
@@ -175,8 +170,7 @@ describe('ZuoraClient fetch method error handling', () => {
 				);
 			} catch (error) {
 				expect(error).toBeInstanceOf(ZuoraError);
-				expect((error as ZuoraError).message).toContain('Authentication error');
-				expect((error as ZuoraError).message).toContain('90000011');
+				expect((error as ZuoraError).message).toBe(errorMessage);
 			}
 		});
 	});
@@ -243,6 +237,7 @@ describe('ZuoraClient fetch method error handling', () => {
 
 	describe('Rate limiting (HTTP 429)', () => {
 		test('should handle rate limiting with enhanced error information', async () => {
+			const errorMessage = 'Rate limit exceeded';
 			const mockResponse = {
 				ok: false,
 				status: 429,
@@ -255,7 +250,7 @@ describe('ZuoraClient fetch method error handling', () => {
 				json: jest.fn().mockResolvedValue({
 					success: false,
 					code: 'RATE_LIMIT_EXCEEDED',
-					message: 'Rate limit exceeded',
+					message: errorMessage,
 				}),
 			};
 
@@ -278,7 +273,7 @@ describe('ZuoraClient fetch method error handling', () => {
 			} catch (error) {
 				expect(error).toBeInstanceOf(ZuoraError);
 				expect((error as ZuoraError).code).toBe(429);
-				expect((error as ZuoraError).message).toContain('Rate limit exceeded');
+				expect((error as ZuoraError).message).toContain(errorMessage);
 			}
 		});
 	});

--- a/modules/zuora/test/zuoraErrorHandler.test.ts
+++ b/modules/zuora/test/zuoraErrorHandler.test.ts
@@ -1,0 +1,85 @@
+import { generateZuoraError } from '@modules/zuora/errors/zuoraErrorHandler';
+import { ZuoraError } from '@modules/zuora/errors';
+
+function mockResponse(status: number, body: unknown): Response {
+	return {
+		status,
+		statusText: typeof body === 'string' ? body : JSON.stringify(body),
+	} as Response;
+}
+
+describe('generateZuoraError', () => {
+	it('parses lowerCaseZuoraErrorSchema format', () => {
+		const errorMessage = 'Authentication error';
+		const body = {
+			success: false,
+			reasons: [
+				{
+					code: '90000011',
+					message: errorMessage,
+				},
+			],
+		};
+		const response = mockResponse(401, body);
+		const error = generateZuoraError(body, response);
+
+		expect(error).toBeInstanceOf(ZuoraError);
+
+		expect(error.message).toBe(errorMessage);
+		expect(error.zuoraErrorDetails).toHaveLength(1);
+	});
+
+	it('parses upperCaseZuoraErrorSchema format', () => {
+		const errorMessage =
+			'You cannot transfer an amount greater than the invoice balance. Please update and try again.';
+		const body = {
+			Errors: [
+				{
+					Message: errorMessage,
+					Code: 'INVALID_VALUE',
+				},
+			],
+			Success: false,
+		};
+		const response = mockResponse(400, body);
+		const error = generateZuoraError(body, response);
+
+		expect(error.message).toBe(errorMessage);
+		expect(error.zuoraErrorDetails[0]?.code).toBe('INVALID_VALUE');
+	});
+
+	it('parses faultCodeAndMessageSchema format', () => {
+		const errorMessage = 'invalid field for query: Invoice.accountid1';
+		const body = {
+			FaultCode: 'INVALID_FIELD',
+			FaultMessage: errorMessage,
+		};
+		const response = mockResponse(400, body);
+		const error = generateZuoraError(body, response);
+
+		expect(error.message).toBe(errorMessage);
+		expect(error.zuoraErrorDetails[0]?.code).toBe('INVALID_FIELD');
+	});
+
+	it('parses codeAndMessageSchema format', () => {
+		const errorMessage = "Invalid action 'query1'";
+		const body = {
+			code: 'ClientError',
+			message: errorMessage,
+		};
+		const response = mockResponse(400, body);
+		const error = generateZuoraError(body, response);
+
+		expect(error.message).toBe(errorMessage);
+		expect(error.zuoraErrorDetails[0]?.code).toBe('ClientError');
+	});
+
+	it('returns default error if no schema matches', () => {
+		const json = { unexpected: 'data' };
+		const response = mockResponse(418, "I'm a teapot");
+		const error = generateZuoraError(json, response);
+
+		expect(error.message).toBe("I'm a teapot");
+		expect(error.zuoraErrorDetails).toEqual([]);
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "paths": {
       "@modules/aws/*": ["./modules/aws/src/*"],
       "@modules/zuora/*": ["./modules/zuora/src/*"],
+      "@modules/bigquery/*": ["./modules/bigquery/src/*"],
       "@modules/zuora-catalog/*": ["./modules/zuora-catalog/src/*"],
       "@modules/product-benefits/*": ["./modules/product-benefits/src/*"],
       "@modules/product-catalog/*": ["./modules/product-catalog/src/*"],


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

It is useful to be able to access the raw error message returned by Zuora as easily as possible, but since some refactoring work was carried out on the Zuora client, we have been concatenating the status code and various other things onto the message which makes it hard to work with.

This PR removes the concatenation and adds some tests.

I have checked the codebase for any code which relies on the old structure and there is none. The only code I know of which checks the exact error message is in support-workers and that is currently broken, this change will fix it.