### PR TITLE
fix(stripe-disputes): salesforece base url for prod

### DIFF
--- a/handlers/stripe-disputes/src/services/salesforceAuth.ts
+++ b/handlers/stripe-disputes/src/services/salesforceAuth.ts
@@ -19,7 +19,10 @@ export async function authenticateWithSalesforce(
 			body: buildClientCredentialsBody(credentials),
 		};
 
-		const salesforceUrl = `${getSalesForceApiBaseUrl(credentials.sandbox)}/services/oauth2/token`;
+		const credentialsSandboxString = credentials.sandbox.toString();
+		logger.log('Salesforce sandbox mode:', credentialsSandboxString);
+
+		const salesforceUrl = `${getSalesForceApiBaseUrl(credentials.sandbox.toString() === 'true')}/services/oauth2/token`;
 
 		logger.log('Salesforce URL:', salesforceUrl);
 

--- a/handlers/stripe-disputes/src/services/upsertSalesforceObject.ts
+++ b/handlers/stripe-disputes/src/services/upsertSalesforceObject.ts
@@ -27,9 +27,10 @@ export const upsertSalesforceObject = async (
 ): Promise<SalesforceUpsertResponse> => {
 	logger.log('Starting upsertSalesforceObject process');
 
-	const salesforceCredentials = await getSecretValue<SalesforceCredentials>(
-		`${stageFromEnvironment()}/Salesforce/ConnectedApp/StripeDisputeWebhooks`,
-	);
+	const salesforceCredentials: SalesforceCredentials =
+		await getSecretValue<SalesforceCredentials>(
+			`${stageFromEnvironment()}/Salesforce/ConnectedApp/StripeDisputeWebhooks`,
+		);
 
 	const salesforceAuth: SalesforceAuthResponse =
 		await authenticateWithSalesforce(logger, salesforceCredentials);


### PR DESCRIPTION
 ## What does this change?

  Fixes Salesforce URL construction for production environment in the stripe-disputes service.

  The `credentials.sandbox` field was being passed directly to `getSalesForceApiBaseUrl()` without proper type conversion, which could cause the function to incorrectly
  determine whether to use the sandbox or production Salesforce URL. This change:
  - Explicitly converts `credentials.sandbox` to a string before comparison
  - Adds logging to track which Salesforce environment mode is being used
  - Ensures the correct Salesforce base URL is used based on the environment

  ## How to test

  **On CODE:**
  1. Trigger a test dispute webhook event
  2. Check CloudWatch logs for "Salesforce sandbox mode: true"
  3. Verify the Salesforce URL uses the sandbox domain

  **On PROD:**
  1. Monitor real dispute webhook processing
  2. Check CloudWatch logs for "Salesforce sandbox mode: false"
  3. Verify the Salesforce URL uses the production domain
  4. Confirm Salesforce Case records are created/updated successfully

  ## How can we measure success?

  - Salesforce authentication succeeds consistently in both CODE and PROD environments
  - No authentication errors in CloudWatch logs
  - Salesforce Case records are correctly created/updated when disputes are processed