### PR TITLE
migrate press-reader-entitlements to SrCDK

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -131,6 +131,7 @@ const stacks: Array<new (app: App, stage: SrStageNames) => unknown> = [
 	UpdateSupporterPlusAmount,
 	MParticleApi,
 	MetricPushApi,
+	PressReaderEntitlements,
 ];
 
 // generate all stacks for all stages
@@ -264,26 +265,7 @@ new TicketTailorWebhook(app, 'ticket-tailor-webhook-PROD', {
 	stack: 'support',
 	stage: 'PROD',
 });
-new PressReaderEntitlements(app, 'press-reader-entitlements-CODE', {
-	stack: 'support',
-	stage: 'CODE',
-	internalDomainName: `press-reader-entitlements-code.${supportApisDomain}`,
-	publicDomainName: 'press-reader-entitlements.code.dev-guardianapis.com',
-	hostedZoneId: supportHostedZoneId,
-	certificateId: supportCertificateId,
-	supporterProductDataTable:
-		'supporter-product-data-tables-CODE-SupporterProductDataTable',
-});
-new PressReaderEntitlements(app, 'press-reader-entitlements-PROD', {
-	stack: 'support',
-	stage: 'PROD',
-	internalDomainName: `press-reader-entitlements.${supportApisDomain}`,
-	publicDomainName: 'press-reader-entitlements.guardianapis.com',
-	hostedZoneId: supportHostedZoneId,
-	certificateId: supportCertificateId,
-	supporterProductDataTable:
-		'supporter-product-data-tables-PROD-SupporterProductDataTable',
-});
+
 new UserBenefits(app, 'user-benefits-CODE', {
 	stack: 'support',
 	stage: 'CODE',

--- a/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
+++ b/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
@@ -5,9 +5,9 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuApiLambda",
       "GuApiGateway5xxPercentageAlarm",
       "GuCname",
+      "GuGetDistributablePolicy",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -84,6 +84,10 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
             "Key": "DiagnosticLinks",
             "Value": {
               "Fn::Join": [
@@ -107,7 +111,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -188,6 +192,10 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
         ],
         "Tags": [
           {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -197,7 +205,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -226,7 +234,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
     "DNSRecord": {
       "Properties": {
         "HostedZoneId": "Z3KO35ELNWZMSX",
-        "Name": "product-switch-api.code.support.guardianapis.com",
+        "Name": "press-reader-entitlements-code.support.guardianapis.com",
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
@@ -242,7 +250,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
     },
     "DomainName": {
       "Properties": {
-        "DomainName": "product-switch-api.code.support.guardianapis.com",
+        "DomainName": "press-reader-entitlements-code.support.guardianapis.com",
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL",
@@ -262,6 +270,10 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
         },
         "Tags": [
           {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -271,7 +283,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -280,6 +292,38 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "GetDistributablePolicyPressreaderentitlements64111028": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/support/CODE/press-reader-entitlements/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyPressreaderentitlements64111028",
+        "Roles": [
+          {
+            "Ref": "pressreaderentitlementslambdaServiceRole94C17F23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "NS1DNSentryforpressreaderentitlementscodedevguardianapiscom": {
       "Properties": {
@@ -293,27 +337,6 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
       },
       "Type": "Guardian::DNS::RecordSet",
     },
-    "S3inlinepolicy3B07399A": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Resource": "arn:aws:s3::*:membership-dist/membership/CODE/press-reader-entitlements/",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "S3inlinepolicy3B07399A",
-        "Roles": [
-          {
-            "Ref": "pressreaderentitlementslambdaServiceRole94C17F23",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "pressreaderentitlementslambda849A2923": {
       "DependsOn": [
         "pressreaderentitlementslambdaServiceRoleDefaultPolicyE75EB370",
@@ -324,16 +347,17 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "membership/CODE/press-reader-entitlements/press-reader-entitlements.zip",
+          "S3Key": "support/CODE/press-reader-entitlements/press-reader-entitlements.zip",
         },
         "Description": "An API Gateway triggered lambda generated in the support-service-lambdas repo",
         "Environment": {
           "Variables": {
             "APP": "press-reader-entitlements",
             "App": "press-reader-entitlements",
-            "STACK": "membership",
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STACK": "support",
             "STAGE": "CODE",
-            "Stack": "membership",
+            "Stack": "support",
             "Stage": "CODE",
           },
         },
@@ -365,7 +389,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -419,7 +443,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -475,7 +499,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/membership/CODE/press-reader-entitlements/press-reader-entitlements.zip",
+                      "/support/CODE/press-reader-entitlements/press-reader-entitlements.zip",
                     ],
                   ],
                 },
@@ -496,7 +520,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/CODE/membership/press-reader-entitlements",
+                    ":parameter/CODE/support/press-reader-entitlements",
                   ],
                 ],
               },
@@ -519,7 +543,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/CODE/membership/press-reader-entitlements/*",
+                    ":parameter/CODE/support/press-reader-entitlements/*",
                   ],
                 ],
               },
@@ -556,7 +580,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -748,7 +772,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -759,7 +783,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentAF63E253dcc78fbadae79b72e926c362765ad40f": {
+    "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentAF63E253d4c9f2ae469a8e1ea64845d04c7ca59b": {
       "DependsOn": [
         "pressreaderentitlementslambdapressreaderentitlementsCODEproxyANY94DA2830",
         "pressreaderentitlementslambdapressreaderentitlementsCODEproxyC7B8C5A6",
@@ -779,7 +803,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentAF63E253dcc78fbadae79b72e926c362765ad40f",
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODEDeploymentAF63E253d4c9f2ae469a8e1ea64845d04c7ca59b",
         },
         "RestApiId": {
           "Ref": "pressreaderentitlementslambdapressreaderentitlementsCODE7DEC1320",
@@ -800,7 +824,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -839,7 +863,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -891,7 +915,7 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1044,9 +1068,9 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuApiLambda",
       "GuApiGateway5xxPercentageAlarm",
       "GuCname",
+      "GuGetDistributablePolicy",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1123,6 +1147,10 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
         "Statistic": "Sum",
         "Tags": [
           {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
             "Key": "DiagnosticLinks",
             "Value": {
               "Fn::Join": [
@@ -1146,7 +1174,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1227,6 +1255,10 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
         ],
         "Tags": [
           {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1236,7 +1268,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1265,7 +1297,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
     "DNSRecord": {
       "Properties": {
         "HostedZoneId": "Z3KO35ELNWZMSX",
-        "Name": "product-switch-api.support.guardianapis.com",
+        "Name": "press-reader-entitlements.support.guardianapis.com",
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
@@ -1281,7 +1313,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
     },
     "DomainName": {
       "Properties": {
-        "DomainName": "product-switch-api.support.guardianapis.com",
+        "DomainName": "press-reader-entitlements.support.guardianapis.com",
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL",
@@ -1301,6 +1333,10 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
         },
         "Tags": [
           {
+            "Key": "App",
+            "Value": "press-reader-entitlements",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1310,7 +1346,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1319,6 +1355,38 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "GetDistributablePolicyPressreaderentitlements64111028": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/support/PROD/press-reader-entitlements/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyPressreaderentitlements64111028",
+        "Roles": [
+          {
+            "Ref": "pressreaderentitlementslambdaServiceRole94C17F23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "NS1DNSentryforpressreaderentitlementsguardianapiscom": {
       "Properties": {
@@ -1332,27 +1400,6 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
       },
       "Type": "Guardian::DNS::RecordSet",
     },
-    "S3inlinepolicy3B07399A": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Resource": "arn:aws:s3::*:membership-dist/membership/PROD/press-reader-entitlements/",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "S3inlinepolicy3B07399A",
-        "Roles": [
-          {
-            "Ref": "pressreaderentitlementslambdaServiceRole94C17F23",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "pressreaderentitlementslambda849A2923": {
       "DependsOn": [
         "pressreaderentitlementslambdaServiceRoleDefaultPolicyE75EB370",
@@ -1363,16 +1410,17 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "membership/PROD/press-reader-entitlements/press-reader-entitlements.zip",
+          "S3Key": "support/PROD/press-reader-entitlements/press-reader-entitlements.zip",
         },
         "Description": "An API Gateway triggered lambda generated in the support-service-lambdas repo",
         "Environment": {
           "Variables": {
             "APP": "press-reader-entitlements",
             "App": "press-reader-entitlements",
-            "STACK": "membership",
+            "NODE_OPTIONS": "--enable-source-maps",
+            "STACK": "support",
             "STAGE": "PROD",
-            "Stack": "membership",
+            "Stack": "support",
             "Stage": "PROD",
           },
         },
@@ -1404,7 +1452,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1458,7 +1506,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1514,7 +1562,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/membership/PROD/press-reader-entitlements/press-reader-entitlements.zip",
+                      "/support/PROD/press-reader-entitlements/press-reader-entitlements.zip",
                     ],
                   ],
                 },
@@ -1535,7 +1583,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/membership/press-reader-entitlements",
+                    ":parameter/PROD/support/press-reader-entitlements",
                   ],
                 ],
               },
@@ -1558,7 +1606,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/membership/press-reader-entitlements/*",
+                    ":parameter/PROD/support/press-reader-entitlements/*",
                   ],
                 ],
               },
@@ -1757,7 +1805,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1788,7 +1836,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1798,7 +1846,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentD4B7367101f9305c35ee5681d8ac6f33855b3e0f": {
+    "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentD4B736714318e1b97b03f9c6682b90368e7ee55c": {
       "DependsOn": [
         "pressreaderentitlementslambdapressreaderentitlementsPRODproxyANY3A6E2187",
         "pressreaderentitlementslambdapressreaderentitlementsPRODproxyA619485E",
@@ -1818,7 +1866,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentD4B7367101f9305c35ee5681d8ac6f33855b3e0f",
+          "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDeploymentD4B736714318e1b97b03f9c6682b90368e7ee55c",
         },
         "RestApiId": {
           "Ref": "pressreaderentitlementslambdapressreaderentitlementsPRODDEDF38DA",
@@ -1839,7 +1887,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1878,7 +1926,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",
@@ -1930,7 +1978,7 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
           },
           {
             "Key": "Stack",
-            "Value": "membership",
+            "Value": "support",
           },
           {
             "Key": "Stage",

--- a/cdk/lib/cdk/sr-api-lambda.ts
+++ b/cdk/lib/cdk/sr-api-lambda.ts
@@ -12,7 +12,7 @@ function getApiLambdaDefaultProps(scope: Identity, props: SrApiLambdaProps) {
 		timeout: Duration.seconds(300),
 		monitoringConfiguration: {
 			noMonitoring: true, // we don't use the standard GuCDK alarms due to low traffic
-		} as const,
+		} as GuApiLambdaProps['monitoringConfiguration'],
 		api: {
 			id: getNameWithStage(scope, props.nameSuffix),
 			restApiName: getNameWithStage(scope, props.nameSuffix),

--- a/cdk/lib/press-reader-entitlements.test.ts
+++ b/cdk/lib/press-reader-entitlements.test.ts
@@ -1,43 +1,12 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import {
-	supportApisDomain,
-	supportCertificateId,
-	supportHostedZoneId,
-} from './constants';
 import { PressReaderEntitlements } from './press-reader-entitlements';
 
 describe('The Press reader entitlements stack', () => {
 	it('matches the snapshot', () => {
 		const app = new App();
-		const codeStack = new PressReaderEntitlements(
-			app,
-			'press-reader-entitlements-CODE',
-			{
-				stack: 'membership',
-				stage: 'CODE',
-				internalDomainName: `product-switch-api.code.${supportApisDomain}`,
-				publicDomainName: 'press-reader-entitlements.code.dev-guardianapis.com',
-				certificateId: supportCertificateId,
-				hostedZoneId: supportHostedZoneId,
-				supporterProductDataTable:
-					'supporter-product-data-tables-CODE-SupporterProductDataTable',
-			},
-		);
-		const prodStack = new PressReaderEntitlements(
-			app,
-			'press-reader-entitlements-PROD',
-			{
-				stack: 'membership',
-				stage: 'PROD',
-				internalDomainName: `product-switch-api.${supportApisDomain}`,
-				publicDomainName: `press-reader-entitlements.guardianapis.com`,
-				certificateId: supportCertificateId,
-				hostedZoneId: supportHostedZoneId,
-				supporterProductDataTable:
-					'supporter-product-data-tables-PROD-SupporterProductDataTable',
-			},
-		);
+		const codeStack = new PressReaderEntitlements(app, 'CODE');
+		const prodStack = new PressReaderEntitlements(app, 'PROD');
 
 		expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
 		expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();


### PR DESCRIPTION
This migrates the above lambda to use the relevant SrCDK constructs.

See inline comments.

Here is the changeset for CODE
Tested in CODE
via `curl -v 'https://press-reader-entitlements.code.dev-guardianapis.com/user-entitlements?userId=1234' -H 'x-api-key: .....'`
logs:
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fpress-reader-entitlements-CODE/log-events/2025$252F10$252F06$252F$255B$2524LATEST$255D414521109ba24325ad3d1454caa51841