### PR TITLE
feat(stripe-disputes): improved zuora data in stripe disputes

### DIFF
--- a/cdk/lib/__snapshots__/stripe-disputes.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-disputes.test.ts.snap
@@ -153,7 +153,10 @@ exports[`The stripe disputes webhook API stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "sqs:sendmessage",
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueUrl",
+              ],
               "Effect": "Allow",
               "Resource": {
                 "Fn::Join": [
@@ -1918,7 +1921,10 @@ exports[`The stripe disputes webhook API stack matches the snapshot 2`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "sqs:sendmessage",
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueUrl",
+              ],
               "Effect": "Allow",
               "Resource": {
                 "Fn::Join": [

--- a/cdk/lib/stripe-disputes.ts
+++ b/cdk/lib/stripe-disputes.ts
@@ -195,7 +195,7 @@ export class StripeDisputes extends GuStack {
 			[
 				new PolicyStatement({
 					effect: Effect.ALLOW,
-					actions: ['sqs:sendmessage'],
+					actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
 					resources: [
 						`arn:aws:sqs:${this.region}:${this.account}:braze-emails-${this.stage}`,
 					],

--- a/handlers/stripe-disputes/src/services/cancelSubscriptionService.ts
+++ b/handlers/stripe-disputes/src/services/cancelSubscriptionService.ts
@@ -51,7 +51,7 @@ export async function cancelSubscriptionService(
 			zuoraClient,
 			subscription.subscriptionNumber,
 			{
-				Reason_for_Cancellation__c: 'Disputed Payment',
+				CancellationReason__c: 'Disputed Payment',
 			},
 		);
 		logger.log(

--- a/modules/zuora/src/errors/zuoraErrorHandler.ts
+++ b/modules/zuora/src/errors/zuoraErrorHandler.ts
@@ -3,7 +3,7 @@ import {
 	faultCodeAndMessageSchema,
 	lowerCaseZuoraErrorSchema,
 	upperCaseZuoraErrorSchema,
-} from '@modules/zuora/types/httpResponse';
+} from '../types/httpResponse';
 import type { ZuoraErrorDetail } from './zuoraError';
 import { ZuoraError } from './zuoraError';
 

--- a/modules/zuora/src/subscription.ts
+++ b/modules/zuora/src/subscription.ts
@@ -61,3 +61,13 @@ export const getSubscriptionsByAccountNumber = async (
 	);
 	return response.subscriptions ?? [];
 };
+
+export const updateSubscription = async (
+	zuoraClient: ZuoraClient,
+	subscriptionNumber: string,
+	fields: Record<string, any>,
+): Promise<ZuoraResponse> => {
+	const path = `v1/subscriptions/${subscriptionNumber}`;
+	const body = JSON.stringify(fields);
+	return zuoraClient.put(path, body, zuoraResponseSchema);
+};


### PR DESCRIPTION
What does this change?

  This PR addresses three issues identified during testing in CODE environment related to the Stripe disputes webhook service:

  1. Fixes QueueDoesNotExist error for email queue - The Lambda consumer was missing the sqs:GetQueueUrl permission needed to access the braze-emails queue when sending
  cancellation emails to customers.
  2. Adds cancellation reason field update - When a subscription is cancelled due to a dispute, we now update the Reason_for_Cancellation__c field in Zuora to "Disputed
  Payment" for better tracking and reporting.
  3. Adds Zuora invoice data to Salesforce records - When a dispute.created event is processed, we now fetch the related invoice data from Zuora and include it in the
  Salesforce Case record, providing customer service with better visibility into the disputed transaction.

  How to test

  In CODE:
  1. Trigger a test dispute webhook from Stripe's dashboard
  2. Verify in CloudWatch logs that:
    - No QueueDoesNotExist errors appear when sending emails
    - Zuora invoice data is successfully fetched (log: "Zuora invoice data retrieved")
    - The cancellation reason is updated (log: "Subscription cancellation reason update response")
  3. Check the created Salesforce Case contains the Zuora invoice information
  4. Verify the cancelled subscription in Zuora has Reason_for_Cancellation__c = "Disputed Payment"

  How can we measure success?

  - Error reduction: CloudWatch logs should show zero QueueDoesNotExist errors for the stripe-disputes-consumer Lambda
  - Data completeness: All new Salesforce Cases created from disputes should contain Zuora invoice data (when available)
  - Improved reporting: Zuora subscriptions cancelled due to disputes can be filtered using the Reason_for_Cancellation__c field
  - Customer communication: Successful email delivery can be verified through the braze-emails queue metrics

  Have we considered potential risks?

  - Zuora API failures: If Zuora is unavailable when fetching invoice data, the handler continues processing without it (non-blocking failure) to ensure Salesforce records are
   still created
  - Email delivery failures: Email sending failures are logged but don't block the cancellation process
  - Backward compatibility: All changes are additive and won't affect existing dispute records
  - Monitoring: Existing CloudWatch alarms will alert on any Lambda errors or DLQ messages