### PR TITLE
switch on t2->t3 switch for non guardian users

### DIFF
--- a/handlers/product-switch-api/src/changePlan/prepare/switchInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/switchInformation.ts
@@ -1,5 +1,4 @@
 import type { GuardianSubscription } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
-import { userHasGuardianEmail } from '@modules/product-benefits/userBenefits';
 import type { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import type { ZuoraAccount } from '@modules/zuora/types';
 import type { ProductSwitchTargetBody } from '../schemas';
@@ -33,8 +32,6 @@ export async function getSwitchInformation(
 		accountInformation.currency,
 		subscriptionInformation.previousAmount,
 		subscriptionInformation.includesContribution,
-		userHasGuardianEmail(account.billToContact.workEmail) ||
-			account.billToContact.workEmail.endsWith('@thegulocal.com'),
 		productCatalogHelper,
 	);
 

--- a/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
@@ -38,7 +38,6 @@ export type TargetContribution = {
 export type SwitchActionData = {
 	mode: SwitchMode;
 	currency: IsoCurrency;
-	isGuardianEmail: boolean;
 } & (
 	| {
 			mode: 'switchToBasePrice' | 'save';
@@ -61,7 +60,6 @@ export const getTargetInformation = (
 	currency: IsoCurrency,
 	previousAmount: number,
 	includesContribution: boolean,
-	isGuardianEmail: boolean,
 	productCatalogHelper: ProductCatalogHelper,
 ): Promise<TargetInformation> => {
 	const targetProductKeys: GuardianCatalogKeys<typeof input.targetProduct> =
@@ -79,7 +77,6 @@ export const getTargetInformation = (
 				currency,
 				previousAmount,
 				includesContribution,
-				isGuardianEmail,
 			};
 			break;
 		case 'switchWithPriceOverride':
@@ -87,7 +84,6 @@ export const getTargetInformation = (
 				mode: input.mode,
 				currency,
 				userRequestedAmount: input.newAmount,
-				isGuardianEmail,
 			};
 			break;
 	}

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
@@ -18,10 +18,6 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 		>,
 		switchActionData: SwitchActionData,
 	): Promise<TargetInformation> => {
-		// to remove once this goes live
-		if (!switchActionData.isGuardianEmail) {
-			throw new ValidationError('this switch is only available internally');
-		}
 		if (switchActionData.mode === 'save') {
 			throw new ValidationError(
 				'you cannot currently get a discount on t2->3 switch',

--- a/handlers/product-switch-api/test/changePlan/action/pendingAmendments.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/pendingAmendments.test.ts
@@ -50,7 +50,6 @@ const getTestTargetInformation = async () =>
 			currency: 'GBP',
 			previousAmount: 10,
 			includesContribution: false,
-			isGuardianEmail: false,
 		},
 	);
 

--- a/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
@@ -53,7 +53,6 @@ describe('getTargetInformation', () => {
 			'EUR',
 			previousAmount,
 			false,
-			false,
 			productCatalogHelper,
 		);
 
@@ -94,7 +93,6 @@ describe('getTargetInformation', () => {
 			'EUR',
 			discountEligiblePreviousAmount,
 			false,
-			false,
 			productCatalogHelper,
 		);
 
@@ -118,7 +116,6 @@ describe('getTargetInformation', () => {
 				subscription.ratePlan,
 				'EUR',
 				50,
-				false,
 				false,
 				productCatalogHelper,
 			),

--- a/handlers/product-switch-api/test/changePlan/switchDefinition/digitalSubscriptionTargetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/switchDefinition/digitalSubscriptionTargetInformation.test.ts
@@ -21,7 +21,6 @@ describe('digitalSubscriptionTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount: catalogPrice,
 			includesContribution: false,
-			isGuardianEmail: true,
 		};
 
 		const result =
@@ -35,18 +34,6 @@ describe('digitalSubscriptionTargetInformation', () => {
 		expect(result.ratePlanName).toBe('Digital Pack Annual');
 		expect(result.contributionCharge).toBeUndefined();
 		expect(result.discount).toBeUndefined();
-
-		const nonGuardianSwitchActionData: SwitchActionData = {
-			...switchActionData,
-			isGuardianEmail: false,
-		};
-
-		expect(() =>
-			digitalSubscriptionTargetInformation.fromUserInformation(
-				annualDigitalSubscriptionRatePlan,
-				nonGuardianSwitchActionData,
-			),
-		).toThrow(ValidationError);
 	});
 
 	test('throws ValidationError when previous amount does include a contribution', () => {
@@ -57,7 +44,6 @@ describe('digitalSubscriptionTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount: catalogPrice + 5,
 			includesContribution: true,
-			isGuardianEmail: true,
 		};
 
 		expect(() =>
@@ -76,7 +62,6 @@ describe('digitalSubscriptionTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount: catalogPrice,
 			includesContribution: false,
-			isGuardianEmail: true,
 		};
 
 		const result =
@@ -96,7 +81,6 @@ describe('digitalSubscriptionTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount: catalogPrice,
 			includesContribution: false,
-			isGuardianEmail: true,
 		};
 
 		expect(() =>
@@ -114,7 +98,6 @@ describe('digitalSubscriptionTargetInformation', () => {
 			mode: 'switchWithPriceOverride',
 			currency: 'GBP',
 			userRequestedAmount: catalogPrice,
-			isGuardianEmail: true,
 		};
 
 		expect(() =>

--- a/handlers/product-switch-api/test/changePlan/switchDefinition/supporterPlusTargetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/switchDefinition/supporterPlusTargetInformation.test.ts
@@ -22,7 +22,6 @@ describe('getSupporterPlusTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount,
 			includesContribution: true,
-			isGuardianEmail: false,
 		};
 
 		const result = await supporterPlusTargetInformation.fromUserInformation(
@@ -46,7 +45,6 @@ describe('getSupporterPlusTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount,
 			includesContribution: true,
-			isGuardianEmail: false,
 		};
 
 		const result = await supporterPlusTargetInformation.fromUserInformation(
@@ -66,7 +64,6 @@ describe('getSupporterPlusTargetInformation', () => {
 			mode: 'switchWithPriceOverride',
 			currency: 'GBP',
 			userRequestedAmount,
-			isGuardianEmail: false,
 		};
 
 		const result = await supporterPlusTargetInformation.fromUserInformation(
@@ -86,7 +83,6 @@ describe('getSupporterPlusTargetInformation', () => {
 			mode: 'switchWithPriceOverride',
 			currency: 'GBP',
 			userRequestedAmount,
-			isGuardianEmail: false,
 		};
 
 		expect(() =>
@@ -107,7 +103,6 @@ describe('getSupporterPlusTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount,
 			includesContribution: true,
-			isGuardianEmail: false,
 		};
 
 		const result = await supporterPlusTargetInformation.fromUserInformation(
@@ -135,7 +130,6 @@ describe('getSupporterPlusTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount,
 			includesContribution: true,
-			isGuardianEmail: false,
 		};
 
 		expect(() =>
@@ -160,7 +154,6 @@ describe('getSupporterPlusTargetInformation', () => {
 			currency: 'GBP',
 			previousAmount,
 			includesContribution: true,
-			isGuardianEmail: false,
 		};
 
 		const result = await supporterPlusTargetInformation.fromUserInformation(


### PR DESCRIPTION
This PR is to actually turn on S+ -> D+ eligibility for non guardian email address.  Do not ship until the go live date.

original PR  with the main work: #3323 