### PR TITLE
Fix CVE-2026-33870

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -367,6 +367,7 @@ def lambdaProject(
       riffRaffManifestProjectName := s"support-service-lambdas::$projectName",
       riffRaffArtifactResources += (file(s"handlers/$projectName/$cfName"), s"cfn/$cfName"),
       dependencyOverrides ++= jacksonDependencies,
+      dependencyOverrides ++= nettyOverrides,
       libraryDependencies ++= externalDependencies ++ logging,
       Test / test := ((Test / test) dependsOn (projectDependencies.map(_.project / Test / test) *)).value,
       Test / testOnly := ((Test / testOnly) dependsOn (projectDependencies.map(_.project / Test / test) *)).evaluated,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -100,6 +100,23 @@ object Dependencies {
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.18.1" % Test
   val scalaMock = "org.scalamock" %% "scalamock" % "7.3.2" % Test
   val mockito = "org.mockito" % "mockito-core" % "5.23.0" % Test
+  // CVE-2026-33870: Netty HTTP Request Smuggling via Chunked Extension Quoted-String Parsing
+  // Affects io.netty:netty-codec-http < 4.1.132.Final, pulled in transitively by async-http-client and aws-sdk netty-nio-client
+  val nettyVersion = "4.1.132.Final"
+  val nettyOverrides: Seq[ModuleID] = Seq(
+    "io.netty" % "netty-buffer" % nettyVersion,
+    "io.netty" % "netty-codec" % nettyVersion,
+    "io.netty" % "netty-codec-http" % nettyVersion,
+    "io.netty" % "netty-codec-http2" % nettyVersion,
+    "io.netty" % "netty-common" % nettyVersion,
+    "io.netty" % "netty-handler" % nettyVersion,
+    "io.netty" % "netty-resolver" % nettyVersion,
+    "io.netty" % "netty-transport" % nettyVersion,
+    "io.netty" % "netty-transport-classes-epoll" % nettyVersion,
+    "io.netty" % "netty-transport-native-epoll" % nettyVersion,
+    "io.netty" % "netty-transport-native-unix-common" % nettyVersion,
+  )
+
   // play-json still uses an old version of jackson-core which has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538
   val jacksonVersion = "2.18.6"
 


### PR DESCRIPTION
## What does this change?

Fixes CVE-2026-33870, a high-severity HTTP request smuggling vulnerability in Netty (`io.netty:netty-codec-http`) affecting versions below `4.1.132.Final`.

Netty incorrectly parses quoted strings in HTTP/1.1 chunked transfer encoding extension values, terminating chunk header parsing at `\r\n` inside a quoted string instead of rejecting the request as malformed. This creates a parsing differential that can be exploited for request smuggling, cache poisoning, and access control bypass.

In this repo, the vulnerable artifact is pulled in transitively via:
- `async-http-client` (through `sttpAsyncHttpClientBackendCats`), used at runtime in several lambdas including `delivery-problem-credit-processor`, `sf-move-subscriptions-api`, `delivery-records-api`, `digital-voucher-api`, `digital-voucher-cancellation-processor`, and `digital-voucher-suspension-processor`
- AWS SDK v2 `netty-nio-client` (through `product-move-api` via `NettyNioAsyncHttpClient`)

The fix adds a `nettyOverrides` block in `project/Dependencies.scala` pinning all commonly pulled-in Netty artifacts to `4.1.132.Final`, and applies it via `dependencyOverrides` in the shared `lambdaProject` function in `build.sbt` so all lambda projects are covered.

References: https://github.com/advisories/GHSA-pwqr-wmgm-9rr8

## How has this change been tested?

The lambdas in this repo use Netty purely as an HTTP client (outbound requests), not as an HTTP server, so the attack surface is minimal. No functional behaviour changes. Unit tests remain sufficient to validate correctness.

After merging, a `sbt dependencyTree` check against any affected subproject (e.g. `delivery-problem-credit-processor`) can confirm `io.netty:netty-codec-http:4.1.132.Final` is resolved.

## How can we measure success?

The 41 Dependabot alerts for `io.netty:netty-codec-http` should be automatically resolved once the patched version is resolved by the build.

## Have we considered potential risks?

Netty `4.1.132.Final` is a patch release within the `4.1.x` line and is intended to be backwards compatible. The risk of a regression is low. These lambdas use Netty only as an outbound HTTP transport layer, not as a server, so the vulnerable code path is not directly reachable in production. Upgrading is still the correct action to resolve the Dependabot alerts and follow defence in depth.

## Images

N/A, no UI changes.

## Accessibility

N/A, no UI changes.