### PR TITLE
Fix CVE-2026-33871

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,8 @@
 import Dependencies.*
 
+// CVE-2026-33871: force patched Netty across all subprojects
+ThisBuild / dependencyOverrides ++= nettyOverrides
+
 val scala2Settings = Seq(
   ThisBuild / scalaVersion := "2.13.18",
   version := "0.0.1",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,19 @@ object Dependencies {
 
   val awsSdkVersion = "2.42.24"
 
+  // CVE-2026-33871: Netty HTTP/2 CONTINUATION frame flood DoS; patched in 4.1.132.Final
+  val nettyVersion = "4.1.132.Final"
+  val nettyOverrides: Seq[ModuleID] = Seq(
+    "io.netty" % "netty-codec-http2" % nettyVersion,
+    "io.netty" % "netty-codec-http" % nettyVersion,
+    "io.netty" % "netty-codec" % nettyVersion,
+    "io.netty" % "netty-transport" % nettyVersion,
+    "io.netty" % "netty-common" % nettyVersion,
+    "io.netty" % "netty-buffer" % nettyVersion,
+    "io.netty" % "netty-handler" % nettyVersion,
+    "io.netty" % "netty-transport-classes-epoll" % nettyVersion,
+  )
+
   val circeVersion = "0.14.13"
   val sttpVersion = "3.11.0"
   val http4sVersion = "0.22.15" // keep version 0.22.15, later versions pull in cats effect 3 which is not compatible


### PR DESCRIPTION
## What does this change?

Pins all `io.netty` modules to **4.1.132.Final** across the entire build to remediate CVE-2026-33871 (Netty HTTP/2 CONTINUATION Frame Flood DoS via Zero-Byte Frame Bypass, GHSA-w9fj-cfpg-grvv).

**The vulnerability:** A remote user can trigger a Denial of Service against a Netty HTTP/2 server by flooding it with CONTINUATION frames carrying zero-byte payloads. Because `DefaultHttp2FrameReader.verifyContinuationFrame()` has no frame-count limit, and the existing `maxHeaderListSize` byte check is never triggered when `len=0`, the server can be forced to process an unbounded number of frames, exhausting CPU with minimal bandwidth.

**Why this repo is affected:** AWS SDK v2 (`2.42.24`) transitively pulls in `io.netty:netty-codec-http2` **4.1.130.Final** via `software.amazon.awssdk:netty-nio-client`. This client is used directly in `product-move-api` (SQS.scala imports `NettyNioAsyncHttpClient`), and indirectly in several other subprojects via `effects-sqs`. The patched version is **4.1.132.Final**.

**Fix:** Added a `nettyOverrides` sequence in Dependencies.scala covering all core Netty modules, and applied it build-wide via `ThisBuild / dependencyOverrides` in build.sbt.

**Note on `grpc-netty-shaded`:** The `google-cloud-bigquery` dependency uses `io.grpc:grpc-netty-shaded` (1.80.0), which shades Netty under a relocated namespace. It cannot be patched via `dependencyOverrides` and is not exploitable here as it is used purely as a gRPC client, not a server.

## How has this change been tested?

Dependency override correctness can be verified by running `sbt dependencyTree` and confirming all `io.netty` artefacts resolve to `4.1.132.Final`. No functional behaviour changes, so unit tests are sufficient to confirm nothing is broken.

## How can we measure success?

Dependabot alert #44 for CVE-2026-33871 should be dismissed automatically once the patched version is detected in the resolved dependency graph after merging.

## Have we considered potential risks?

Netty patch releases are backwards compatible within the 4.1.x line. The override only affects unshaded `io.netty` artefacts; shaded copies (e.g. inside `grpc-netty-shaded`) are unaffected. Risk of regression is low, as the bump is two patch versions (4.1.130 to 4.1.132). No alarm changes required; this is a dependency version pin with no user-facing behaviour change.

## Images

N/A

## Accessibility

N/A