### PR TITLE
Remove X-Ephemeral-Salesforce-Access-Token session forking from holiday-stop-api

### DIFF
--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -27,9 +27,11 @@ creates a new all holiday stop, example body:
 {
     "startDate": "2023-06-10", 
     "endDate": "2024-06-14", 
-    "subscriptionName": "A-S00071783"
+    "subscriptionName": "A-S00071783",
+    "userId": "005XXXXXXXXXXXXXXX"
  }
 ```
+The optional `userId` field is a Salesforce User ID. When present, it is written to the `Last_Modified_By__c` field on the Holiday Stop Request so the CSR who made the change can be tracked.
 
 ### `POST` `/{STAGE}/bulk-hsr`
 creates a new holiday stop where it has been imposed because we are unable to fulfil the subscription.  
@@ -39,16 +41,17 @@ In this case, the `reason` field will hold the reason for the suspension:
     "startDate": "2023-06-10", 
     "endDate": "2024-06-14", 
     "subscriptionName": "A-S00071783",
-    "reason": "someReason"
+    "reason": "someReason",
+    "userId": "005XXXXXXXXXXXXXXX"
  }
 ```
-The reason has to be one from a closed set configured in Salesforce.
+The reason has to be one from a closed set configured in Salesforce. `userId` behaves as for POST /hsr.
 
 ### `PATCH` `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}`
-with the same body as create endpoint above, amends the holiday stop request (where holiday stop request `Id` matches `{SF_ID}`) to the newly specified dates and adds/removes the underlying detail records where appropriate.
+with the same body as create endpoint above, amends the holiday stop request (where holiday stop request `Id` matches `{SF_ID}`) to the newly specified dates and adds/removes the underlying detail records where appropriate. The optional `userId` field is written to `Last_Modified_By__c` as for POST.
 
-### `DELETE` `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}`
-marks the holiday stop request as 'withdrawn' in SalesForce (by placing timestamp in `Withdrawn_Time__c` field), where holiday stop request `Id` matches `{SF_ID}`.
+### `DELETE` `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/{SF_ID}?userId={SF_USER_ID}`
+marks the holiday stop request as 'withdrawn' in SalesForce (by placing timestamp in `Withdrawn_Time__c` field), where holiday stop request `Id` matches `{SF_ID}`. The optional `userId` query string parameter is a Salesforce User ID written to `Last_Modified_By__c`.
 
 ### `POST` `/{STAGE}/hsr/{SUBSCRIPTION_NAME}/cancel?effectiveCancellationDate=yyyy-MM-dd`
 handles processing of holiday stops when a subscription is cancelled, unprocessed holiday stops before the effectiveCancellationDate will be marked with a charge code "ManualRefund_Cancellation" for reporting purposes.  This should only be called if the customer was refunded for holiday stops that fall in the cancellation period, otherwise no changes should be made to existing holiday stops.

--- a/handlers/holiday-stop-api/README.md
+++ b/handlers/holiday-stop-api/README.md
@@ -6,8 +6,6 @@ All endpoints require...
   - `x-identity-id` header which specifies the identityID of the user to request data for _(sent in the `manage-frontend` use-case)_
   - `x-salesforce-contact-id` header which specifies the Salesforce contact ID of the user to request data for _(sent in the CSR UI (in Salesforce) use-case)_
 
-**If being used in the CSR UI (in Salesforce) use-case**, then one should also pass the CSR's Session ID via the `X-Ephemeral-Salesforce-Access-Token` header (can be obtained in Apex with `UserInfo.getSessionId()`) so that the actions can be attributed correctly to the CSR (rather than the configured API user for this repo).
-
 #### Handling Multiple Environments
 The CSR UI (in Salesforce) is one consumer of this API and so each Salesforce environment is configured to speak the corresponding instance of the lambda.
 

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -388,6 +388,7 @@ object Handler extends Logging {
         issuesData,
         matchingSfSub,
         requestBody.bulkSuspensionReason,
+        requestBody.userId,
       )
       sfErrorExposer = new SFErrorExposer(
         s"create new Holiday Stop Request for subscription ${requestBody.subscriptionName} (contact $contact)",
@@ -519,6 +520,7 @@ object Handler extends Logging {
           requestBody.endDate,
           issuesData,
           existingPublicationsThatWereToBeStopped,
+          requestBody.userId,
         )
         .toApiGatewayOp(message => badRequest(s"build body for holiday stop request: $message"))
       sfErrorExposer = new SFErrorExposer(
@@ -556,6 +558,8 @@ object Handler extends Logging {
       backend: SttpBackend[Identity, Any],
   )(): Either[ApiFailure, AccessToken] = Zuora.accessTokenGetResponse(config.zuoraConfig, backend)
 
+  case class WithdrawHolidayStopQueryParams(userId: Option[String])
+
   def stepsToWithdraw(now: () => ZonedDateTime)(req: ApiGatewayRequest, sfClient: SfClient): ApiResponse = {
 
     val lookupOp =
@@ -567,6 +571,9 @@ object Handler extends Logging {
     (for {
       contact <- extractContactFromHeaders(req.headers)
       pathParams <- req.pathParamsAsCaseClass[SpecificHolidayStopRequestPathParams]()
+      queryParams <- req.queryParamsAsCaseClass[WithdrawHolidayStopQueryParams]()(
+        Json.reads[WithdrawHolidayStopQueryParams],
+      )
       existingForUser <- lookupOp
         .run(contact, None, None)
         .toDisjunction
@@ -581,7 +588,7 @@ object Handler extends Logging {
         None,
       )
       _ <- withdrawOp
-        .run(now(), pathParams.holidayStopRequestId)
+        .run(now(), pathParams.holidayStopRequestId, queryParams.userId)
         .toDisjunction
         .toApiGatewayOp(sfErrorExposer.parseFailureTo500ApiResponse _)
     } yield ApiGatewayResponse.successfulExecution).apiResponse

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/Handler.scala
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.{Context, LambdaRuntime}
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.fulfilmentdates.FulfilmentDatesFetcher
 import com.gu.holiday_stops.WireHolidayStopRequest.toHolidayStopRequestDetail
-import com.gu.salesforce.SalesforceClient.withAlternateAccessTokenIfPresentInHeaderList
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequest._
 import com.gu.salesforce.holiday_stops.SalesforceHolidayStopRequestsDetail.HolidayStopRequestId
 import com.gu.salesforce.holiday_stops.{SalesforceHolidayStopRequest, SalesforceSFSubscription}
@@ -124,7 +123,7 @@ object Handler extends Logging {
           now,
         )(
           request,
-          sfClient.setupRequest(withAlternateAccessTokenIfPresentInHeaderList(request.headers)),
+          sfClient,
         ),
     )
 

--- a/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
+++ b/handlers/holiday-stop-api/src/main/scala/com/gu/holiday_stops/WireHolidayStopRequest.scala
@@ -87,12 +87,14 @@ trait HolidayStopRequestPartialTrait {
   val endDate: LocalDate
   val subscriptionName: SubscriptionName
   val bulkSuspensionReason: Option[BulkSuspensionReason]
+  val userId: Option[String]
 }
 
 case class HolidayStopRequestPartial(
     startDate: LocalDate,
     endDate: LocalDate,
     subscriptionName: SubscriptionName,
+    userId: Option[String] = None,
 ) extends HolidayStopRequestPartialTrait {
   val bulkSuspensionReason = None
 }
@@ -106,6 +108,7 @@ case class BulkHolidayStopRequestPartial(
     endDate: LocalDate,
     subscriptionName: SubscriptionName,
     reason: BulkSuspensionReason,
+    userId: Option[String] = None,
 ) extends HolidayStopRequestPartialTrait {
   val bulkSuspensionReason = Some(reason)
 }

--- a/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
+++ b/lib/holiday-stops/src/main/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequest.scala
@@ -165,6 +165,7 @@ object SalesforceHolidayStopRequest extends Logging {
       End_Date__c: HolidayStopRequestEndDate,
       SF_Subscription__c: SFSubscriptionId, // TODO attempt to reinstate the __r with SubscriptionNameLookup approach (so it can be reused in back-fill without sep. lookup call first
       Bulk_Suspension_Reason__c: Option[BulkSuspensionReason],
+      Last_Modified_By__c: Option[String],
       Holiday_Stop_Request_Detail__r: RecordsWrapperCaseClass[CompositeTreeHolidayStopRequestsDetail],
       attributes: CompositeAttributes =
         CompositeAttributes(holidayStopRequestSfObjectRef, holidayStopRequestSfObjectRef),
@@ -205,6 +206,7 @@ object SalesforceHolidayStopRequest extends Logging {
         issuesData: List[IssueData],
         sfSubscription: MatchingSubscription,
         bulkSuspensionReason: Option[BulkSuspensionReason],
+        userId: Option[String],
     ) = {
       RecordsWrapperCaseClass(
         List(
@@ -213,6 +215,7 @@ object SalesforceHolidayStopRequest extends Logging {
             End_Date__c = HolidayStopRequestEndDate(endDate),
             SF_Subscription__c = sfSubscription.Id,
             Bulk_Suspension_Reason__c = bulkSuspensionReason,
+            Last_Modified_By__c = userId,
             Holiday_Stop_Request_Detail__r = RecordsWrapperCaseClass(
               issuesData.map { issuesData =>
                 CompositeTreeHolidayStopRequestsDetail(
@@ -273,6 +276,7 @@ object SalesforceHolidayStopRequest extends Logging {
     case class AmendHolidayStopRequestItselfBody(
         Start_Date__c: HolidayStopRequestStartDate,
         End_Date__c: HolidayStopRequestEndDate,
+        Last_Modified_By__c: Option[String],
     )
 
     case class AddHolidayStopRequestDetailBody(
@@ -288,6 +292,7 @@ object SalesforceHolidayStopRequest extends Logging {
         endDate: LocalDate,
         issuesData: List[IssueData],
         existingPublicationsThatWereToBeStopped: List[HolidayStopRequestsDetail],
+        userId: Option[String],
     ): Either[String, CompositeRequest] = {
 
       val masterRecordToBePatched = CompositePart(
@@ -298,6 +303,7 @@ object SalesforceHolidayStopRequest extends Logging {
           AmendHolidayStopRequestItselfBody(
             Start_Date__c = HolidayStopRequestStartDate(startDate),
             End_Date__c = HolidayStopRequestEndDate(endDate),
+            Last_Modified_By__c = userId,
           ),
         )(Json.writes[AmendHolidayStopRequestItselfBody]),
       )
@@ -388,16 +394,20 @@ object SalesforceHolidayStopRequest extends Logging {
   }
 
   object WithdrawHolidayStopRequest {
-    case class WithdrawnTimePatch(Withdrawn_Time__c: ZonedDateTime)
+    case class WithdrawnTimePatch(Withdrawn_Time__c: ZonedDateTime, Last_Modified_By__c: Option[String])
 
     implicit val writes = Json.writes[WithdrawnTimePatch]
   }
 
   class WithdrawHolidayStopRequest(sfPatch: HttpOp[RestRequestMaker.PatchRequest, Unit]) {
-    def run(withdrawlTime: ZonedDateTime, holidayStopRequestId: HolidayStopRequestId): ClientFailableOp[Unit] =
+    def run(
+        withdrawlTime: ZonedDateTime,
+        holidayStopRequestId: HolidayStopRequestId,
+        userId: Option[String],
+    ): ClientFailableOp[Unit] =
       sfPatch.runRequest(
         PatchRequest(
-          WithdrawnTimePatch(withdrawlTime),
+          WithdrawnTimePatch(withdrawlTime, userId),
           RelativePath(s"$holidayStopRequestSfObjectsBaseUrl/${holidayStopRequestId.value}"),
         ),
       )

--- a/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
+++ b/lib/holiday-stops/src/test/scala/com/gu/salesforce/holiday_stops/SalesforceHolidayStopRequestEndToEndEffectsTest.scala
@@ -59,6 +59,7 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends AnyFlatSpec with M
             publicationDatesToBeStopped,
             maybeMatchingSubscription.get,
             None,
+            None,
           ),
         )
         .toDisjunction
@@ -97,7 +98,7 @@ class SalesforceHolidayStopRequestEndToEndEffectsTest extends AnyFlatSpec with M
       ).toDisjunction
 
       deleteOp = new SalesforceHolidayStopRequest.WithdrawHolidayStopRequest(sfAuth.wrapWith(JsonHttp.patch))
-      _ <- deleteOp.run(withdrawTime, createResult).toDisjunction
+      _ <- deleteOp.run(withdrawTime, createResult, None).toDisjunction
 
     } yield EndToEndResults(createResult, preProcessingFetchResult, postProcessingFetchResult)
 

--- a/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/client/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -49,22 +49,6 @@ object SalesforceClient extends LazyLogging {
     builderWithHeaders.url(url).build()
   }
 
-  def withAlternateAccessTokenIfPresentInHeaderList(
-      headers: Option[Map[String, String]],
-  ): StringHttpRequest => StringHttpRequest =
-    withMaybeAlternateAccessToken(headers.flatMap(_.get("X-Ephemeral-Salesforce-Access-Token")))
-
-  def withMaybeAlternateAccessToken(
-      maybeAlternateAccessToken: Option[String],
-  )(requestInfo: StringHttpRequest): StringHttpRequest =
-    maybeAlternateAccessToken
-      .map { alternateAccessToken =>
-        val nonAuthHeaders =
-          requestInfo.headers.filterNot(header => AuthHeaderNames.map(_.toLowerCase).contains(header.name.toLowerCase))
-        requestInfo.copy(headers = nonAuthHeaders ++ getAuthHeaders(alternateAccessToken))
-      }
-      .getOrElse(requestInfo)
-
   case class SalesforceErrorResponseBody(message: String, errorCode: String) {
     override def toString = s"${errorCode} : ${message}"
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Server-side work for the Salesforce security story: enable the "Lock sessions to the domain in which they were first used" setting without losing CSR attribution on Holiday Stop Requests.

Two related changes in this PR:

1. **Remove the `X-Ephemeral-Salesforce-Access-Token` session forking mechanism.** The holiday-stop-api lambda now authenticates to Salesforce exclusively as the configured API user, for both manage-frontend and Salesforce UI (CSR) use cases. The forking relied on calling `/secur/frontdoor.jsp` with a user's session id to obtain a forked session id; when the security setting is enabled, that endpoint stops returning a usable session id and the forking breaks. This aligns with option 4 from the investigation (don't fork sessions at all).

2. **Add an optional `userId` to POST/PATCH/DELETE, written to `Last_Modified_By__c` on the Holiday Stop Request in Salesforce.** Preserves CSR-level attribution that was previously carried implicitly by the session forking. `userId` is a Salesforce User ID (lookup to User on the SF side).
    - `POST /hsr` and `POST /bulk-hsr`: new optional field in the request body.
    - `PATCH /hsr/{sub}/{id}`: new optional field in the request body.
    - `DELETE /hsr/{sub}/{id}?userId=...`: new optional query string parameter.

The `Last_Modified_By__c` field has already been added in the Salesforce sandbox by Graham.

Once this is deployed, the Salesforce side can stop sending the `X-Ephemeral-Salesforce-Access-Token` header, start sending `userId`, and the security setting can be enabled.

Note on PATCH/DELETE semantics: when `userId` is not provided, `Last_Modified_By__c` is sent as `null`, which clears the field on update. Acceptable behaviour: if no modifier is identified, there is no last modifier to record. Can be revisited if preserving the previous value is preferred.

## How has this change been tested?

Changes are small and mechanical:
- Two helper functions and a single call site removed.
- One optional field threaded through the existing request bodies and `buildBody` helpers.
- The effects test for the lib was updated to pass `None` through.

## How can we measure success?

- No functional regression for manage-frontend requests (they never used the ephemeral header and will continue sending no `userId`).
- CSR UI requests continue to work once the Salesforce-side follow-up is deployed (stops sending the ephemeral header, starts sending `userId`, enables the security setting).
- `Last_Modified_By__c` is populated on Holiday Stop Requests created/edited/withdrawn by CSRs.
- Salesforce security setting "Lock sessions to the domain in which they were first used" can be enabled without breaking holiday stop flows.

## Have we considered potential risks?

- Deploy order matters: this lambda change must be deployed *before* Salesforce stops sending the ephemeral header and *before* the security setting is enabled. Sending the ephemeral header after this change is a no-op (it is simply ignored), so there is no hard coupling.
- `Last_Modified_By__c` must exist on the Holiday Stop Request object in each Salesforce environment before the corresponding lambda stage is deployed. Already in sandbox; production needs the same.
- `userId` is trusted input from the Salesforce UI - the lambda does not validate the Salesforce User ID; Salesforce itself will reject invalid lookup references on write.
- No sensitive data is touched; the removed code path was not relied on by manage-frontend.

## Images

N/A

## Accessibility

N/A (no UI changes)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214110088337109