### PR TITLE
Add a lint exhaustiveness check for switch statements

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,4 +31,9 @@ export default [
 			],
 		},
 	},
+	{
+		rules: {
+			'@typescript-eslint/switch-exhaustiveness-check': 'error',
+		},
+	},
 ];

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -208,6 +208,7 @@ async function getDiscountToApply(
 			);
 			break;
 		case 'NoCheck':
+		case undefined:
 			break;
 	}
 

--- a/handlers/product-switch-api/src/changePlan/prepare/subscriptionInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/subscriptionInformation.ts
@@ -75,6 +75,25 @@ function getNextPaymentDate(ratePlanCharges: RatePlanCharge[]) {
 	);
 }
 
+function ratePlanIncludesContribution(ratePlan: GuardianRatePlan) {
+	if (ratePlan.productKey === 'Contribution') {
+		return true;
+	}
+	if (
+		ratePlan.productKey === 'SupporterPlus' &&
+		(ratePlan.productRatePlanKey == 'Annual' ||
+			ratePlan.productRatePlanKey == 'Monthly')
+	) {
+		return (
+			getIfDefined(
+				ratePlan.ratePlanCharges.Contribution.price,
+				'missing contribution price',
+			) > 0
+		);
+	}
+	return false;
+}
+
 export function getSubscriptionInformation(
 	subscription: GuardianSubscription,
 ): SubscriptionInformation {
@@ -88,22 +107,7 @@ export function getSubscriptionInformation(
 		),
 		'missing charges',
 	);
-	let includesContribution = false;
-	switch (ratePlan.productKey) {
-		case 'Contribution':
-			includesContribution = true;
-			break;
-		case 'SupporterPlus':
-			switch (ratePlan.productRatePlanKey) {
-				case 'Annual':
-				case 'Monthly':
-					includesContribution =
-						getIfDefined(
-							ratePlan.ratePlanCharges.Contribution.price,
-							'missing contribution price',
-						) > 0;
-			}
-	}
+	const includesContribution = ratePlanIncludesContribution(ratePlan);
 
 	return {
 		accountNumber: subscription.accountNumber,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR switches on the ESLint `switch-exhaustiveness-check` rule at an error level. This rule can be really useful for picking up unhandled options when we for instance add a new product or rate plan to ensure that we are treating it correctly throughout the codebase.

I have also fixed the two places where we had inexhaustive switches.