### PR TITLE
Zod schemas for payment gateways

### DIFF
--- a/modules/zuora/src/account.ts
+++ b/modules/zuora/src/account.ts
@@ -1,7 +1,5 @@
-import type {
-	PaymentGateway,
-	PaymentMethod,
-} from '@modules/zuora/orders/paymentMethods';
+import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
+import type { PaymentMethod } from '@modules/zuora/orders/paymentMethods';
 import type { ZuoraAccount } from './types';
 import { voidSchema, zuoraAccountSchema } from './types';
 import type { ZuoraClient } from './zuoraClient';

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -25,10 +25,8 @@ import {
 } from '@modules/zuora/orders/orderActions';
 import type { CreateOrderRequest } from '@modules/zuora/orders/orderRequests';
 import { executeOrderRequest } from '@modules/zuora/orders/orderRequests';
-import type {
-	PaymentGateway,
-	PaymentMethod,
-} from '@modules/zuora/orders/paymentMethods';
+import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
+import type { PaymentMethod } from '@modules/zuora/orders/paymentMethods';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 

--- a/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
@@ -13,9 +13,9 @@ import {
 } from '@modules/zuora/createSubscription/createSubscription';
 import { buildNewAccountObject } from '@modules/zuora/orders/newAccount';
 import { executeOrderRequest } from '@modules/zuora/orders/orderRequests';
+import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
 import type {
 	AnyPaymentMethod,
-	PaymentGateway,
 	PaymentMethod,
 } from '@modules/zuora/orders/paymentMethods';
 import { zuoraDateFormat } from '@modules/zuora/utils';

--- a/modules/zuora/src/orders/newAccount.ts
+++ b/modules/zuora/src/orders/newAccount.ts
@@ -1,8 +1,6 @@
 import type { IsoCurrency } from '@modules/internationalisation/currency';
-import type {
-	AnyPaymentMethod,
-	PaymentGateway,
-} from '@modules/zuora/orders/paymentMethods';
+import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
+import type { AnyPaymentMethod } from '@modules/zuora/orders/paymentMethods';
 
 // This file contains types for creating a new account via the Orders API.
 

--- a/modules/zuora/src/orders/paymentGateways.ts
+++ b/modules/zuora/src/orders/paymentGateways.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import type { AnyPaymentMethod } from '@modules/zuora/orders/paymentMethods';
+
+//Gateway names need to match to those set in Zuora
+//See: https://apisandbox.zuora.com/apps/NewGatewaySetting.do?method=list
+export const stripePaymentGatewaySchema = z.enum([
+	'Stripe PaymentIntents GNM Membership',
+	'Stripe PaymentIntents GNM Membership AUS',
+	'Stripe - Observer - Tortoise Media',
+]);
+export type StripePaymentGateway = z.infer<typeof stripePaymentGatewaySchema>;
+
+export const payPalPaymentGatewaySchema = z.enum(['PayPal Express']);
+export type PayPalPaymentGateway = z.infer<typeof payPalPaymentGatewaySchema>;
+
+export const payPalCompletePaymentsPaymentGatewaySchema = z.enum([
+	'PayPal Complete Payments',
+]);
+export type PayPalCompletePaymentsPaymentGateway = z.infer<
+	typeof payPalCompletePaymentsPaymentGatewaySchema
+>;
+
+export const goCardlessPaymentGatewaySchema = z.enum([
+	'GoCardless',
+	'GoCardless - Observer - Tortoise Media',
+]);
+export type GoCardlessPaymentGateway = z.infer<
+	typeof goCardlessPaymentGatewaySchema
+>;
+
+type PaymentGatewayMap = {
+	CreditCardReferenceTransaction: StripePaymentGateway;
+	Bacs: GoCardlessPaymentGateway;
+	PayPalNativeEC: PayPalPaymentGateway;
+	PayPalCP: PayPalCompletePaymentsPaymentGateway;
+};
+
+export type PaymentGateway<T extends AnyPaymentMethod> =
+	T['type'] extends keyof PaymentGatewayMap
+		? PaymentGatewayMap[T['type']]
+		: never;

--- a/modules/zuora/src/orders/paymentMethods.ts
+++ b/modules/zuora/src/orders/paymentMethods.ts
@@ -57,30 +57,3 @@ export type ClonedCreditCardReferenceTransaction = {
 export type AnyPaymentMethod =
 	| PaymentMethod
 	| ClonedCreditCardReferenceTransaction;
-
-//Gateway names need to match to those set in Zuora
-//See: https://apisandbox.zuora.com/apps/NewGatewaySetting.do?method=list
-type StripePaymentGateway =
-	| 'Stripe PaymentIntents GNM Membership'
-	| 'Stripe PaymentIntents GNM Membership AUS'
-	| 'Stripe - Observer - Tortoise Media';
-
-type PayPalPaymentGateway = 'PayPal Express';
-
-type PayPalCompletePaymentsPaymentGateway = 'PayPal Complete Payments';
-
-type GoCardlessPaymentGateway =
-	| 'GoCardless'
-	| 'GoCardless - Observer - Tortoise Media';
-
-type PaymentGatewayMap = {
-	CreditCardReferenceTransaction: StripePaymentGateway;
-	Bacs: GoCardlessPaymentGateway;
-	PayPalNativeEC: PayPalPaymentGateway;
-	PayPalCP: PayPalCompletePaymentsPaymentGateway;
-};
-
-export type PaymentGateway<T extends AnyPaymentMethod> =
-	T['type'] extends keyof PaymentGatewayMap
-		? PaymentGatewayMap[T['type']]
-		: never;

--- a/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
+++ b/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
@@ -8,10 +8,8 @@ import dayjs from 'dayjs';
 import { buildCreateSubscriptionRequest } from '@modules/zuora/createSubscription/createSubscription';
 import type { CreateSubscriptionInputFields } from '@modules/zuora/createSubscription/createSubscription';
 import type { CreateSubscriptionOrderAction } from '@modules/zuora/orders/orderActions';
-import type {
-	CreditCardReferenceTransaction,
-	PaymentGateway,
-} from '@modules/zuora/orders/paymentMethods';
+import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
+import type { CreditCardReferenceTransaction } from '@modules/zuora/orders/paymentMethods';
 import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 import { ReaderType } from '../src/createSubscription/readerType';
 

--- a/modules/zuora/test/createSubscriptionIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionIntegration.test.ts
@@ -19,10 +19,10 @@ import { createSubscription } from '@modules/zuora/createSubscription/createSubs
 import type { PreviewCreateSubscriptionInputFields } from '@modules/zuora/createSubscription/previewCreateSubscription';
 import { previewCreateSubscription } from '@modules/zuora/createSubscription/previewCreateSubscription';
 import { getInvoice } from '@modules/zuora/invoice';
+import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
 import type {
 	CreditCardReferenceTransaction,
 	DirectDebit,
-	PaymentGateway,
 } from '@modules/zuora/orders/paymentMethods';
 import { getSubscription } from '@modules/zuora/subscription';
 import { zuoraSubscriptionSchema } from '@modules/zuora/types/objects/subscription';

--- a/modules/zuora/test/createSubscriptionWithExistingPaymentMethodIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionWithExistingPaymentMethodIntegration.test.ts
@@ -12,10 +12,8 @@ import { z } from 'zod';
 import { deleteAccount } from '@modules/zuora/account';
 import type { CreateSubscriptionWithExistingPaymentMethodInput } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
 import { createSubscriptionWithExistingPaymentMethod } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
-import type {
-	PaymentGateway,
-	PaymentMethod,
-} from '@modules/zuora/orders/paymentMethods';
+import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
+import type { PaymentMethod } from '@modules/zuora/orders/paymentMethods';
 import { getSubscription } from '@modules/zuora/subscription';
 import { zuoraSubscriptionSchema } from '@modules/zuora/types/objects/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds Zod schemas for the Zuora payment gateway type. Up until now we have just had TS types defined but I am going to need Zod schemas to validate them in the new-subscription API which I am currently working on. 
To try to keep that PR manageable I am introducing this change in isolation. 

I have also moved them into their own file paymentGateways.ts - before this they were bundled in with payment methods in paymentMethod.ts.