### PR TITLE
Target node 22 with ESBuild

### DIFF
--- a/buildcheck/data/templates/handler/package.json.ts
+++ b/buildcheck/data/templates/handler/package.json.ts
@@ -7,7 +7,7 @@ export default (pkg: HandlerDefinition) => {
 		: 'src/index.ts';
 	const handlerScripts = {
 		build:
-			'esbuild --bundle --platform=node --target=node20 --outdir=target/ ' +
+			'esbuild --bundle --platform=node --target=node22 --outdir=target/ ' +
 			entryPoints +
 			` --sourcemap --source-root=/support-service-lambdas/handlers/${pkg.name}/target/`,
 		package: `pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr ${pkg.name}.zip ./*.js.map ./*.js`,

--- a/handlers/alarms-handler/package.json
+++ b/handlers/alarms-handler/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts src/indexScheduled.ts src/indexSummary.ts --sourcemap --source-root=/support-service-lambdas/handlers/alarms-handler/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts src/indexScheduled.ts src/indexSummary.ts --sourcemap --source-root=/support-service-lambdas/handlers/alarms-handler/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr alarms-handler.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test alarms-handler",
     "cdk:test-update": "pnpm --filter cdk test-update alarms-handler",

--- a/handlers/discount-api/package.json
+++ b/handlers/discount-api/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/discount-api/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/discount-api/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr discount-api.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test discount-api",
     "cdk:test-update": "pnpm --filter cdk test-update discount-api",

--- a/handlers/discount-expiry-notifier/package.json
+++ b/handlers/discount-expiry-notifier/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/discount-expiry-notifier/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/discount-expiry-notifier/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr discount-expiry-notifier.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test discount-expiry-notifier",
     "cdk:test-update": "pnpm --filter cdk test-update discount-expiry-notifier",

--- a/handlers/generate-product-catalog/package.json
+++ b/handlers/generate-product-catalog/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/generate-product-catalog/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/generate-product-catalog/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr generate-product-catalog.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test generate-product-catalog",
     "cdk:test-update": "pnpm --filter cdk test-update generate-product-catalog",

--- a/handlers/imovo-voucher-api/package.json
+++ b/handlers/imovo-voucher-api/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/imovo-voucher-api/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/imovo-voucher-api/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr imovo-voucher-api.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test imovo-voucher-api",
     "cdk:test-update": "pnpm --filter cdk test-update imovo-voucher-api",

--- a/handlers/metric-push-api/package.json
+++ b/handlers/metric-push-api/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/metric-push-api/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/metric-push-api/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr metric-push-api.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test metric-push-api",
     "cdk:test-update": "pnpm --filter cdk test-update metric-push-api",

--- a/handlers/mobile-purchases-to-supporter-product-data/package.json
+++ b/handlers/mobile-purchases-to-supporter-product-data/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/mobile-purchases-to-supporter-product-data/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/mobile-purchases-to-supporter-product-data/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr mobile-purchases-to-supporter-product-data.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test mobile-purchases-to-supporter-product-data",
     "cdk:test-update": "pnpm --filter cdk test-update mobile-purchases-to-supporter-product-data",

--- a/handlers/mparticle-api/package.json
+++ b/handlers/mparticle-api/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/mparticle-api/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/mparticle-api/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr mparticle-api.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test mparticle-api",
     "cdk:test-update": "pnpm --filter cdk test-update mparticle-api",

--- a/handlers/negative-invoices-processor/package.json
+++ b/handlers/negative-invoices-processor/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/negative-invoices-processor/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/negative-invoices-processor/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr negative-invoices-processor.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test negative-invoices-processor",
     "cdk:test-update": "pnpm --filter cdk test-update negative-invoices-processor",

--- a/handlers/newsletter-acquisition/package.json
+++ b/handlers/newsletter-acquisition/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/newsletter-acquisition/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/newsletter-acquisition/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr newsletter-acquisition.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test newsletter-acquisition",
     "cdk:test-update": "pnpm --filter cdk test-update newsletter-acquisition",

--- a/handlers/observer-data-export/package.json
+++ b/handlers/observer-data-export/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/observer-data-export/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/observer-data-export/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr observer-data-export.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test observer-data-export",
     "cdk:test-update": "pnpm --filter cdk test-update observer-data-export",

--- a/handlers/press-reader-entitlements/package.json
+++ b/handlers/press-reader-entitlements/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/press-reader-entitlements/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/press-reader-entitlements/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr press-reader-entitlements.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test press-reader-entitlements",
     "cdk:test-update": "pnpm --filter cdk test-update press-reader-entitlements",

--- a/handlers/product-switch-api/package.json
+++ b/handlers/product-switch-api/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/product-switch-api/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/product-switch-api/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr product-switch-api.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test product-switch-api",
     "cdk:test-update": "pnpm --filter cdk test-update product-switch-api",

--- a/handlers/promotions-lambdas/package.json
+++ b/handlers/promotions-lambdas/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/promotions-lambdas/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/promotions-lambdas/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr promotions-lambdas.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test promotions-lambdas",
     "cdk:test-update": "pnpm --filter cdk test-update promotions-lambdas",

--- a/handlers/salesforce-disaster-recovery-health-check/package.json
+++ b/handlers/salesforce-disaster-recovery-health-check/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/salesforce-disaster-recovery-health-check/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/salesforce-disaster-recovery-health-check/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr salesforce-disaster-recovery-health-check.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test salesforce-disaster-recovery-health-check",
     "cdk:test-update": "pnpm --filter cdk test-update salesforce-disaster-recovery-health-check",

--- a/handlers/salesforce-disaster-recovery/package.json
+++ b/handlers/salesforce-disaster-recovery/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/salesforce-disaster-recovery/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/salesforce-disaster-recovery/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr salesforce-disaster-recovery.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test salesforce-disaster-recovery",
     "cdk:test-update": "pnpm --filter cdk test-update salesforce-disaster-recovery",

--- a/handlers/stripe-disputes/package.json
+++ b/handlers/stripe-disputes/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/producer.ts src/consumer.ts --sourcemap --source-root=/support-service-lambdas/handlers/stripe-disputes/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/producer.ts src/consumer.ts --sourcemap --source-root=/support-service-lambdas/handlers/stripe-disputes/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr stripe-disputes.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test stripe-disputes",
     "cdk:test-update": "pnpm --filter cdk test-update stripe-disputes",

--- a/handlers/ticket-tailor-webhook/package.json
+++ b/handlers/ticket-tailor-webhook/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/ticket-tailor-webhook/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/ticket-tailor-webhook/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr ticket-tailor-webhook.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test ticket-tailor-webhook",
     "cdk:test-update": "pnpm --filter cdk test-update ticket-tailor-webhook",

--- a/handlers/update-supporter-plus-amount/package.json
+++ b/handlers/update-supporter-plus-amount/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/update-supporter-plus-amount/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/update-supporter-plus-amount/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr update-supporter-plus-amount.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test update-supporter-plus-amount",
     "cdk:test-update": "pnpm --filter cdk test-update update-supporter-plus-amount",

--- a/handlers/user-benefits/package.json
+++ b/handlers/user-benefits/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/user-benefits/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/index.ts --sourcemap --source-root=/support-service-lambdas/handlers/user-benefits/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr user-benefits.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test user-benefits",
     "cdk:test-update": "pnpm --filter cdk test-update user-benefits",

--- a/handlers/write-off-unpaid-invoices/package.json
+++ b/handlers/write-off-unpaid-invoices/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/write-off-unpaid-invoices/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/write-off-unpaid-invoices/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr write-off-unpaid-invoices.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test write-off-unpaid-invoices",
     "cdk:test-update": "pnpm --filter cdk test-update write-off-unpaid-invoices",

--- a/handlers/zuora-salesforce-link-remover/package.json
+++ b/handlers/zuora-salesforce-link-remover/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",
     "fix-formatting": "prettier --write \"**/*.ts\"",
-    "build": "esbuild --bundle --platform=node --target=node20 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/zuora-salesforce-link-remover/target/",
+    "build": "esbuild --bundle --platform=node --target=node22 --outdir=target/ src/handlers/*.ts --sourcemap --source-root=/support-service-lambdas/handlers/zuora-salesforce-link-remover/target/",
     "package": "pnpm type-check && pnpm lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr zuora-salesforce-link-remover.zip ./*.js.map ./*.js",
     "cdk:test": "pnpm --filter cdk test zuora-salesforce-link-remover",
     "cdk:test-update": "pnpm --filter cdk test-update zuora-salesforce-link-remover",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We now use Node 22 as our lambda runtime, but our ESBuild package scripts still target Node 20. 

This PR updates the package.json template used by all TS lambdas to target Node 22 and then regenerates all the package.json files to pick this up.