### PR TITLE
Remove duplication in the `createSubscriptionWithExistingPaymentMethod` module

### DIFF
--- a/modules/zuora/src/createSubscription/clonePaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/clonePaymentMethod.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { ExistingPaymentMethodInput } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
 import {
 	type BankTransferPaymentMethod,
 	type CreditCardReferenceTransactionPaymentMethod,
@@ -9,14 +10,6 @@ import type {
 	ExistingPaymentMethod,
 } from '@modules/zuora/orders/paymentMethods';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-
-// Represents a Zuora payment method ID provided by the caller.
-// requiresCloning: false — the PM exists but is not yet attached to any account;
-// requiresCloning: true — the PM is attached to an existing account and must be cloned before use.
-export type ExistingPaymentMethodInput = {
-	id: string;
-	requiresCloning: boolean;
-};
 
 // The clonePaymentMethod function will return either an inline payment method
 // object which can be passed to Zuora or an id of an existing orphan payment

--- a/modules/zuora/src/createSubscription/clonePaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/clonePaymentMethod.ts
@@ -4,29 +4,25 @@ import {
 	type CreditCardReferenceTransactionPaymentMethod,
 	getPaymentMethodObjectById,
 } from '@modules/zuora/getPaymentMethodObjectById';
-import type { ClonedCreditCardReferenceTransaction } from '@modules/zuora/orders/paymentMethods';
+import type {
+	ClonedCreditCardReferenceTransaction,
+	ExistingPaymentMethod,
+} from '@modules/zuora/orders/paymentMethods';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 
 // Represents a Zuora payment method ID provided by the caller.
 // requiresCloning: false — the PM exists but is not yet attached to any account;
 // requiresCloning: true — the PM is attached to an existing account and must be cloned before use.
-export type ExistingPaymentMethod = {
+export type ExistingPaymentMethodInput = {
 	id: string;
 	requiresCloning: boolean;
 };
 
 // The clonePaymentMethod function will return either an inline payment method
 // object which can be passed to Zuora or an id of an existing orphan payment
-// method but never both.
 export type ClonedPaymentMethod =
-	| {
-			hpmCreditCardPaymentMethodId: string;
-			paymentMethod?: never;
-	  }
-	| {
-			paymentMethod: ClonedCreditCardReferenceTransaction;
-			hpmCreditCardPaymentMethodId?: never;
-	  };
+	| ClonedCreditCardReferenceTransaction
+	| ExistingPaymentMethod;
 
 const createPaymentMethodResponseSchema = z.object({
 	Id: z.string(),
@@ -35,7 +31,7 @@ const createPaymentMethodResponseSchema = z.object({
 async function cloneBankTransfer(
 	zuoraClient: ZuoraClient,
 	bankTransfer: BankTransferPaymentMethod,
-) {
+): Promise<ExistingPaymentMethod> {
 	const body = JSON.stringify({
 		ExistingMandate: 'Yes',
 		Type: bankTransfer.Type,
@@ -52,18 +48,19 @@ async function cloneBankTransfer(
 		body,
 		createPaymentMethodResponseSchema,
 	);
-	return { hpmCreditCardPaymentMethodId: response.Id };
+	return {
+		type: 'ExistingPaymentMethod',
+		hpmCreditCardPaymentMethodId: response.Id,
+	};
 }
 
 function cloneCreditCardReferenceTransaction(
 	zuoraPaymentMethod: CreditCardReferenceTransactionPaymentMethod,
-): { paymentMethod: ClonedCreditCardReferenceTransaction } {
+): ClonedCreditCardReferenceTransaction {
 	return {
-		paymentMethod: {
-			type: zuoraPaymentMethod.Type,
-			tokenId: zuoraPaymentMethod.TokenId,
-			secondTokenId: zuoraPaymentMethod.SecondTokenId,
-		},
+		type: zuoraPaymentMethod.Type,
+		tokenId: zuoraPaymentMethod.TokenId,
+		secondTokenId: zuoraPaymentMethod.SecondTokenId,
 	};
 }
 
@@ -74,10 +71,13 @@ function cloneCreditCardReferenceTransaction(
 // - requiresCloning: true, CreditCard/PayPal — not supported; throws an error.
 export async function clonePaymentMethod(
 	zuoraClient: ZuoraClient,
-	existingPaymentMethod: ExistingPaymentMethod,
+	existingPaymentMethod: ExistingPaymentMethodInput,
 ): Promise<ClonedPaymentMethod> {
 	if (!existingPaymentMethod.requiresCloning) {
-		return { hpmCreditCardPaymentMethodId: existingPaymentMethod.id };
+		return {
+			type: 'ExistingPaymentMethod',
+			hpmCreditCardPaymentMethodId: existingPaymentMethod.id,
+		};
 	}
 
 	const zuoraPaymentMethod = await getPaymentMethodObjectById(

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -208,10 +208,7 @@ function getDeliveryFields(productPurchase: ProductPurchase): DeliveryFields {
 
 export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 	productCatalog: ProductCatalog,
-	input: CreateSubscriptionInputFields<T>,
-	promotion: Promo | undefined,
-): CreateOrderRequest {
-	const {
+	{
 		accountName,
 		createdRequestId,
 		salesforceAccountId,
@@ -226,11 +223,12 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 		appliedPromotion,
 		runBilling,
 		collectPayment,
+		createdByCSR,
 		acquisitionCase,
 		acquisitionSource,
-		createdByCSR,
-	} = input;
-
+	}: CreateSubscriptionInputFields<T>,
+	promotion: Promo | undefined,
+): CreateOrderRequest {
 	const { deliveryContact, deliveryAgent, deliveryInstructions } =
 		getDeliveryFields(productPurchase);
 
@@ -245,16 +243,16 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 			: { paymentMethod };
 
 	const newAccount = buildNewAccountObject<AnyPaymentMethod>({
-		accountName,
-		createdRequestId,
-		salesforceAccountId,
-		salesforceContactId,
-		identityId,
-		currency,
-		paymentGateway,
-		billToContact,
+		accountName: accountName,
+		createdRequestId: createdRequestId,
+		salesforceAccountId: salesforceAccountId,
+		salesforceContactId: salesforceContactId,
+		identityId: identityId,
+		currency: currency,
+		paymentGateway: paymentGateway,
+		billToContact: billToContact,
 		soldToContact: deliveryContact,
-		deliveryInstructions,
+		deliveryInstructions: deliveryInstructions,
 		...paymentFields,
 	});
 

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -67,7 +67,7 @@ export type CreateSubscriptionInputFields<T extends PaymentMethod> = {
 	createdByCSR?: string;
 };
 
-export type CreateSubscriptionInputFieldsWithExistingPaymentMethod = Omit<
+export type CreateSubscriptionWithExistingPaymentMethodInputFields = Omit<
 	CreateSubscriptionInputFields<PaymentMethod>,
 	'paymentMethod'
 > & {
@@ -217,7 +217,7 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 	productCatalog: ProductCatalog,
 	input:
 		| CreateSubscriptionInputFields<T>
-		| CreateSubscriptionInputFieldsWithExistingPaymentMethod,
+		| CreateSubscriptionWithExistingPaymentMethodInputFields,
 	promotion: Promo | undefined,
 ): CreateOrderRequest {
 	const {

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -228,6 +228,7 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 		identityId,
 		currency,
 		paymentGateway,
+		paymentMethod,
 		billToContact,
 		productPurchase,
 		giftRecipient,
@@ -243,14 +244,12 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 		getDeliveryFields(productPurchase);
 
 	const paymentFields =
-		input.paymentMethod.type === 'ExistingPaymentMethod'
+		paymentMethod.type === 'ExistingPaymentMethod'
 			? {
 					hpmCreditCardPaymentMethodId:
-						input.paymentMethod.hpmCreditCardPaymentMethodId,
+						paymentMethod.hpmCreditCardPaymentMethodId,
 				}
-			: {
-					paymentMethod: input.paymentMethod,
-				};
+			: { paymentMethod };
 
 	const newAccount = buildNewAccountObject<AnyPaymentMethod>({
 		accountName,

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -13,6 +13,7 @@ import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 import { z } from 'zod';
 import { getChargeOverride } from '@modules/zuora/createSubscription/chargeOverride';
+import type { ClonedPaymentMethod } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import { getProductRatePlan } from '@modules/zuora/createSubscription/getProductRatePlan';
 import type { GiftRecipient } from '@modules/zuora/createSubscription/giftRecipient';
 import { ReaderType } from '@modules/zuora/createSubscription/readerType';
@@ -26,7 +27,10 @@ import {
 import type { CreateOrderRequest } from '@modules/zuora/orders/orderRequests';
 import { executeOrderRequest } from '@modules/zuora/orders/orderRequests';
 import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
-import type { PaymentMethod } from '@modules/zuora/orders/paymentMethods';
+import type {
+	AnyPaymentMethod,
+	PaymentMethod,
+} from '@modules/zuora/orders/paymentMethods';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 
@@ -61,6 +65,13 @@ export type CreateSubscriptionInputFields<T extends PaymentMethod> = {
 	acquisitionCase?: string;
 	acquisitionSource?: string;
 	createdByCSR?: string;
+};
+
+export type CreateSubscriptionInputFieldsWithClonedPaymentMethod = Omit<
+	CreateSubscriptionInputFields<PaymentMethod>,
+	'paymentMethod'
+> & {
+	paymentMethod: ClonedPaymentMethod;
 };
 
 export type PromotionInputFields = {
@@ -204,7 +215,12 @@ function getDeliveryFields(productPurchase: ProductPurchase): DeliveryFields {
 
 export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 	productCatalog: ProductCatalog,
-	{
+	input:
+		| CreateSubscriptionInputFields<T>
+		| CreateSubscriptionInputFieldsWithClonedPaymentMethod,
+	promotion: Promo | undefined,
+): CreateOrderRequest {
+	const {
 		accountName,
 		createdRequestId,
 		salesforceAccountId,
@@ -212,31 +228,42 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 		identityId,
 		currency,
 		paymentGateway,
-		paymentMethod,
 		billToContact,
 		productPurchase,
 		giftRecipient,
 		appliedPromotion,
 		runBilling,
 		collectPayment,
-	}: CreateSubscriptionInputFields<T>,
-	promotion: Promo | undefined,
-): CreateOrderRequest {
+		acquisitionCase,
+		acquisitionSource,
+		createdByCSR,
+	} = input;
+
 	const { deliveryContact, deliveryAgent, deliveryInstructions } =
 		getDeliveryFields(productPurchase);
 
-	const newAccount = buildNewAccountObject({
-		accountName: accountName,
-		createdRequestId: createdRequestId,
-		salesforceAccountId: salesforceAccountId,
-		salesforceContactId: salesforceContactId,
-		identityId: identityId,
-		currency: currency,
-		paymentGateway: paymentGateway,
-		paymentMethod: paymentMethod,
-		billToContact: billToContact,
+	const paymentFields =
+		input.paymentMethod.type === 'ExistingPaymentMethod'
+			? {
+					hpmCreditCardPaymentMethodId:
+						input.paymentMethod.hpmCreditCardPaymentMethodId,
+				}
+			: {
+					paymentMethod: input.paymentMethod,
+				};
+
+	const newAccount = buildNewAccountObject<AnyPaymentMethod>({
+		accountName,
+		createdRequestId,
+		salesforceAccountId,
+		salesforceContactId,
+		identityId,
+		currency,
+		paymentGateway,
+		billToContact,
 		soldToContact: deliveryContact,
-		deliveryInstructions: deliveryInstructions,
+		deliveryInstructions,
+		...paymentFields,
 	});
 
 	const { contractEffectiveDate, createSubscriptionOrderAction } =
@@ -255,6 +282,9 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 		InitialPromotionCode__c: appliedPromotion?.promoCode,
 		PromotionCode__c: appliedPromotion?.promoCode,
 		CreatedRequestId__c: createdRequestId,
+		AcquisitionCase__c: acquisitionCase,
+		AcquisitionSource__c: acquisitionSource,
+		CreatedByCSR__c: createdByCSR,
 	};
 	return {
 		newAccount: newAccount,
@@ -272,6 +302,7 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 		},
 	};
 }
+
 export const createSubscription = async <T extends PaymentMethod>(
 	zuoraClient: ZuoraClient,
 	productCatalog: ProductCatalog,

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -55,7 +55,7 @@ export type CreateSubscriptionInputFields<T extends PaymentMethod> = {
 	identityId: string;
 	currency: IsoCurrency;
 	paymentGateway: PaymentGateway<T>;
-	paymentMethod: T;
+	paymentMethod: T | ClonedPaymentMethod;
 	billToContact: Contact;
 	productPurchase: ProductPurchase;
 	giftRecipient?: GiftRecipient;
@@ -67,12 +67,6 @@ export type CreateSubscriptionInputFields<T extends PaymentMethod> = {
 	createdByCSR?: string;
 };
 
-export type CreateSubscriptionWithExistingPaymentMethodInputFields = Omit<
-	CreateSubscriptionInputFields<PaymentMethod>,
-	'paymentMethod'
-> & {
-	paymentMethod: ClonedPaymentMethod;
-};
 
 export type PromotionInputFields = {
 	validatedPromotion: ValidatedPromotion;
@@ -215,9 +209,7 @@ function getDeliveryFields(productPurchase: ProductPurchase): DeliveryFields {
 
 export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 	productCatalog: ProductCatalog,
-	input:
-		| CreateSubscriptionInputFields<T>
-		| CreateSubscriptionWithExistingPaymentMethodInputFields,
+	input: CreateSubscriptionInputFields<T>,
 	promotion: Promo | undefined,
 ): CreateOrderRequest {
 	const {

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -67,7 +67,7 @@ export type CreateSubscriptionInputFields<T extends PaymentMethod> = {
 	createdByCSR?: string;
 };
 
-export type CreateSubscriptionInputFieldsWithClonedPaymentMethod = Omit<
+export type CreateSubscriptionInputFieldsWithExistingPaymentMethod = Omit<
 	CreateSubscriptionInputFields<PaymentMethod>,
 	'paymentMethod'
 > & {
@@ -217,7 +217,7 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 	productCatalog: ProductCatalog,
 	input:
 		| CreateSubscriptionInputFields<T>
-		| CreateSubscriptionInputFieldsWithClonedPaymentMethod,
+		| CreateSubscriptionInputFieldsWithExistingPaymentMethod,
 	promotion: Promo | undefined,
 ): CreateOrderRequest {
 	const {

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -67,7 +67,6 @@ export type CreateSubscriptionInputFields<T extends PaymentMethod> = {
 	createdByCSR?: string;
 };
 
-
 export type PromotionInputFields = {
 	validatedPromotion: ValidatedPromotion;
 	discountProductRatePlanId: string;

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -246,6 +246,8 @@ export function buildCreateSubscriptionRequest<T extends PaymentMethod>(
 	const paymentFields =
 		paymentMethod.type === 'ExistingPaymentMethod'
 			? {
+					// The hpmCreditCardPaymentMethodId parameter is passed in at the same level as
+					// the paymentMethod parameter not nested underneath
 					hpmCreditCardPaymentMethodId:
 						paymentMethod.hpmCreditCardPaymentMethodId,
 				}

--- a/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
@@ -1,9 +1,8 @@
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Promo } from '@modules/promotions/v2/schema';
-import type { ExistingPaymentMethodInput } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import { clonePaymentMethod } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import type {
-	CreateSubscriptionInputFieldsWithClonedPaymentMethod,
+	CreateSubscriptionInputFieldsWithExistingPaymentMethod,
 	CreateSubscriptionResponse,
 } from '@modules/zuora/createSubscription/createSubscription';
 import {
@@ -13,15 +12,20 @@ import {
 import { executeOrderRequest } from '@modules/zuora/orders/orderRequests';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 
-export type CreateSubscriptionWithExistingPaymentMethodInput = Omit<
-	CreateSubscriptionInputFieldsWithClonedPaymentMethod,
-	'paymentMethod'
-> & {
-	existingPaymentMethod: ExistingPaymentMethodInput;
+// Represents a Zuora payment method ID provided by the caller.
+// requiresCloning: false — the PM exists but is not yet attached to any account;
+// requiresCloning: true — the PM is attached to an existing account and must be cloned before use.
+export type ExistingPaymentMethodInput = {
+	id: string;
+	requiresCloning: boolean;
 };
 
+export type CreateSubscriptionWithExistingPaymentMethodInput =
+	CreateSubscriptionInputFieldsWithExistingPaymentMethod & {
+		existingPaymentMethodInput: ExistingPaymentMethodInput;
+	};
+
 // Creates a new Zuora account and subscription using a pre-existing Zuora payment method ID.
-//
 // If requiresCloning is false, the existing PM id is passed directly to Zuora in the hpmCreditCardPaymentMethodId
 // parameter - https://developer.zuora.com/v1-api-reference/api/orders/post_order#orders/post_order/t=request&path=newaccount/hpmcreditcardpaymentmethodid
 // If requiresCloning is true, the payment method is already attached to another account and must be re-created first:
@@ -35,16 +39,16 @@ export const createSubscriptionWithExistingPaymentMethod = async (
 	input: CreateSubscriptionWithExistingPaymentMethodInput,
 	promotion: Promo | undefined,
 ): Promise<CreateSubscriptionResponse> => {
-	const clonedPaymentMethod = await clonePaymentMethod(
+	const paymentMethod = await clonePaymentMethod(
 		zuoraClient,
-		input.existingPaymentMethod,
+		input.existingPaymentMethodInput,
 	);
 
 	return executeOrderRequest(
 		zuoraClient,
 		buildCreateSubscriptionRequest(
 			productCatalog,
-			{ ...input, paymentMethod: clonedPaymentMethod },
+			{ ...input, paymentMethod },
 			promotion,
 		),
 		createSubscriptionResponseSchema,

--- a/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
@@ -2,8 +2,8 @@ import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Promo } from '@modules/promotions/v2/schema';
 import { clonePaymentMethod } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import type {
-	CreateSubscriptionInputFieldsWithExistingPaymentMethod,
 	CreateSubscriptionResponse,
+	CreateSubscriptionWithExistingPaymentMethodInputFields,
 } from '@modules/zuora/createSubscription/createSubscription';
 import {
 	buildCreateSubscriptionRequest,
@@ -21,7 +21,7 @@ export type ExistingPaymentMethodInput = {
 };
 
 export type CreateSubscriptionWithExistingPaymentMethodInput =
-	CreateSubscriptionInputFieldsWithExistingPaymentMethod & {
+	CreateSubscriptionWithExistingPaymentMethodInputFields & {
 		existingPaymentMethodInput: ExistingPaymentMethodInput;
 	};
 

--- a/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
@@ -1,32 +1,23 @@
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Promo } from '@modules/promotions/v2/schema';
-import type { ExistingPaymentMethod } from '@modules/zuora/createSubscription/clonePaymentMethod';
+import type { ExistingPaymentMethodInput } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import { clonePaymentMethod } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import type {
-	CreateSubscriptionInputFields,
+	CreateSubscriptionInputFieldsWithClonedPaymentMethod,
 	CreateSubscriptionResponse,
 } from '@modules/zuora/createSubscription/createSubscription';
 import {
-	buildSubscriptionOrderAction,
+	buildCreateSubscriptionRequest,
 	createSubscriptionResponseSchema,
-	getReaderType,
 } from '@modules/zuora/createSubscription/createSubscription';
-import { buildNewAccountObject } from '@modules/zuora/orders/newAccount';
 import { executeOrderRequest } from '@modules/zuora/orders/orderRequests';
-import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
-import type {
-	AnyPaymentMethod,
-	PaymentMethod,
-} from '@modules/zuora/orders/paymentMethods';
-import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 
 export type CreateSubscriptionWithExistingPaymentMethodInput = Omit<
-	CreateSubscriptionInputFields<PaymentMethod>,
-	'paymentGateway' | 'paymentMethod'
+	CreateSubscriptionInputFieldsWithClonedPaymentMethod,
+	'paymentMethod'
 > & {
-	paymentGateway: PaymentGateway<PaymentMethod>;
-	existingPaymentMethod: ExistingPaymentMethod;
+	existingPaymentMethod: ExistingPaymentMethodInput;
 };
 
 // Creates a new Zuora account and subscription using a pre-existing Zuora payment method ID.
@@ -44,94 +35,19 @@ export const createSubscriptionWithExistingPaymentMethod = async (
 	input: CreateSubscriptionWithExistingPaymentMethodInput,
 	promotion: Promo | undefined,
 ): Promise<CreateSubscriptionResponse> => {
-	const {
-		existingPaymentMethod,
-		appliedPromotion,
-		runBilling,
-		collectPayment,
-		createdRequestId,
-		acquisitionCase,
-		acquisitionSource,
-		createdByCSR,
-		giftRecipient,
-		productPurchase,
-		currency,
-		accountName,
-		salesforceAccountId,
-		salesforceContactId,
-		identityId,
-		paymentGateway,
-		billToContact,
-	} = input;
-
-	const { contractEffectiveDate, createSubscriptionOrderAction } =
-		buildSubscriptionOrderAction(
-			productCatalog,
-			productPurchase,
-			currency,
-			appliedPromotion,
-			promotion,
-		);
-
-	const { deliveryContact, deliveryAgent, deliveryInstructions } = {
-		deliveryContact: undefined,
-		deliveryAgent: undefined,
-		deliveryInstructions: undefined,
-		...productPurchase,
-	};
-
-	const subscriptionCustomFields = {
-		DeliveryAgent__c: deliveryAgent?.toString(),
-		ReaderType__c: getReaderType(giftRecipient, appliedPromotion),
-		LastPlanAddedDate__c: zuoraDateFormat(contractEffectiveDate),
-		InitialPromotionCode__c: appliedPromotion?.promoCode,
-		PromotionCode__c: appliedPromotion?.promoCode,
-		CreatedRequestId__c: createdRequestId,
-		AcquisitionCase__c: acquisitionCase,
-		AcquisitionSource__c: acquisitionSource,
-		CreatedByCSR__c: createdByCSR,
-	};
-
-	const clonePaymentMethodResult = await clonePaymentMethod(
+	const clonedPaymentMethod = await clonePaymentMethod(
 		zuoraClient,
-		existingPaymentMethod,
+		input.existingPaymentMethod,
 	);
-
-	const newAccount = buildNewAccountObject<AnyPaymentMethod>({
-		accountName,
-		createdRequestId,
-		salesforceAccountId,
-		salesforceContactId,
-		identityId,
-		currency,
-		paymentGateway,
-		billToContact,
-		soldToContact: deliveryContact,
-		deliveryInstructions,
-		...clonePaymentMethodResult,
-	});
-
-	const orderRequest = {
-		newAccount,
-		orderDate: zuoraDateFormat(contractEffectiveDate),
-		description:
-			'Created by createSubscriptionWithExistingPaymentMethod.ts in support-service-lambdas',
-		subscriptions: [
-			{
-				orderActions: [createSubscriptionOrderAction],
-				customFields: subscriptionCustomFields,
-			},
-		],
-		processingOptions: {
-			runBilling: runBilling ?? true,
-			collectPayment: collectPayment ?? true,
-		},
-	};
 
 	return executeOrderRequest(
 		zuoraClient,
-		orderRequest,
+		buildCreateSubscriptionRequest(
+			productCatalog,
+			{ ...input, paymentMethod: clonedPaymentMethod },
+			promotion,
+		),
 		createSubscriptionResponseSchema,
-		createdRequestId,
+		input.createdRequestId,
 	);
 };

--- a/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
@@ -2,14 +2,15 @@ import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Promo } from '@modules/promotions/v2/schema';
 import { clonePaymentMethod } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import type {
+	CreateSubscriptionInputFields,
 	CreateSubscriptionResponse,
-	CreateSubscriptionWithExistingPaymentMethodInputFields,
 } from '@modules/zuora/createSubscription/createSubscription';
 import {
 	buildCreateSubscriptionRequest,
 	createSubscriptionResponseSchema,
 } from '@modules/zuora/createSubscription/createSubscription';
 import { executeOrderRequest } from '@modules/zuora/orders/orderRequests';
+import type { PaymentMethod } from '@modules/zuora/orders/paymentMethods';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 
 // Represents a Zuora payment method ID provided by the caller.
@@ -21,7 +22,7 @@ export type ExistingPaymentMethodInput = {
 };
 
 export type CreateSubscriptionWithExistingPaymentMethodInput = Omit<
-	CreateSubscriptionWithExistingPaymentMethodInputFields,
+	CreateSubscriptionInputFields<PaymentMethod>,
 	'paymentMethod'
 > & {
 	existingPaymentMethod: ExistingPaymentMethodInput;

--- a/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
@@ -20,10 +20,12 @@ export type ExistingPaymentMethodInput = {
 	requiresCloning: boolean;
 };
 
-export type CreateSubscriptionWithExistingPaymentMethodInput =
-	CreateSubscriptionWithExistingPaymentMethodInputFields & {
-		existingPaymentMethodInput: ExistingPaymentMethodInput;
-	};
+export type CreateSubscriptionWithExistingPaymentMethodInput = Omit<
+	CreateSubscriptionWithExistingPaymentMethodInputFields,
+	'paymentMethod'
+> & {
+	existingPaymentMethod: ExistingPaymentMethodInput;
+};
 
 // Creates a new Zuora account and subscription using a pre-existing Zuora payment method ID.
 // If requiresCloning is false, the existing PM id is passed directly to Zuora in the hpmCreditCardPaymentMethodId
@@ -41,7 +43,7 @@ export const createSubscriptionWithExistingPaymentMethod = async (
 ): Promise<CreateSubscriptionResponse> => {
 	const paymentMethod = await clonePaymentMethod(
 		zuoraClient,
-		input.existingPaymentMethodInput,
+		input.existingPaymentMethod,
 	);
 
 	return executeOrderRequest(

--- a/modules/zuora/src/orders/paymentGateways.ts
+++ b/modules/zuora/src/orders/paymentGateways.ts
@@ -33,6 +33,7 @@ type PaymentGatewayMap = {
 	Bacs: GoCardlessPaymentGateway;
 	PayPalNativeEC: PayPalPaymentGateway;
 	PayPalCP: PayPalCompletePaymentsPaymentGateway;
+	ExistingPaymentMethod: GoCardlessPaymentGateway;
 };
 
 export type PaymentGateway<T extends AnyPaymentMethod> =

--- a/modules/zuora/src/orders/paymentGateways.ts
+++ b/modules/zuora/src/orders/paymentGateways.ts
@@ -33,7 +33,7 @@ type PaymentGatewayMap = {
 	Bacs: GoCardlessPaymentGateway;
 	PayPalNativeEC: PayPalPaymentGateway;
 	PayPalCP: PayPalCompletePaymentsPaymentGateway;
-	ExistingPaymentMethod: GoCardlessPaymentGateway;
+	ExistingPaymentMethod: GoCardlessPaymentGateway | StripePaymentGateway;
 };
 
 export type PaymentGateway<T extends AnyPaymentMethod> =

--- a/modules/zuora/src/orders/paymentMethods.ts
+++ b/modules/zuora/src/orders/paymentMethods.ts
@@ -63,5 +63,4 @@ export type ExistingPaymentMethod = {
 
 export type AnyPaymentMethod =
 	| PaymentMethod
-	| ClonedCreditCardReferenceTransaction
-	| ExistingPaymentMethod;
+	| ClonedCreditCardReferenceTransaction;

--- a/modules/zuora/src/orders/paymentMethods.ts
+++ b/modules/zuora/src/orders/paymentMethods.ts
@@ -56,6 +56,9 @@ export type ClonedCreditCardReferenceTransaction = {
 
 // An existing payment method which is unattached to an account and can be added
 // to an account with the hpmCreditCardPaymentMethodId parameter in the Orders API.
+// Unfortunately it can't just be passed in the paymentMethod param in the same way
+// as all the other payment method types, it needs to sit as a single parameter at
+// the same level as paymentMethod.
 export type ExistingPaymentMethod = {
 	type: 'ExistingPaymentMethod';
 	hpmCreditCardPaymentMethodId: string;

--- a/modules/zuora/src/orders/paymentMethods.ts
+++ b/modules/zuora/src/orders/paymentMethods.ts
@@ -54,6 +54,14 @@ export type ClonedCreditCardReferenceTransaction = {
 	secondTokenId: string;
 };
 
+// An existing payment method which is unattached to an account and can be added
+// to an account with the hpmCreditCardPaymentMethodId parameter in the Orders API.
+export type ExistingPaymentMethod = {
+	type: 'ExistingPaymentMethod';
+	hpmCreditCardPaymentMethodId: string;
+};
+
 export type AnyPaymentMethod =
 	| PaymentMethod
-	| ClonedCreditCardReferenceTransaction;
+	| ClonedCreditCardReferenceTransaction
+	| ExistingPaymentMethod;

--- a/modules/zuora/test/__snapshots__/buildCreateSubscriptionRequest.test.ts.snap
+++ b/modules/zuora/test/__snapshots__/buildCreateSubscriptionRequest.test.ts.snap
@@ -40,6 +40,9 @@ exports[`the buildCreateSubscriptionRequest function builds request with applied
   "subscriptions": [
     {
       "customFields": {
+        "AcquisitionCase__c": "case_123",
+        "AcquisitionSource__c": "source_123",
+        "CreatedByCSR__c": "Jenny Wren",
         "CreatedRequestId__c": "request-123",
         "DeliveryAgent__c": undefined,
         "InitialPromotionCode__c": "PROMO10",
@@ -166,6 +169,9 @@ exports[`the buildCreateSubscriptionRequest function builds request with gift re
   "subscriptions": [
     {
       "customFields": {
+        "AcquisitionCase__c": "case_123",
+        "AcquisitionSource__c": "source_123",
+        "CreatedByCSR__c": "Jenny Wren",
         "CreatedRequestId__c": "request-123",
         "DeliveryAgent__c": undefined,
         "InitialPromotionCode__c": undefined,
@@ -256,6 +262,9 @@ exports[`the buildCreateSubscriptionRequest function builds request without prom
   "subscriptions": [
     {
       "customFields": {
+        "AcquisitionCase__c": "case_123",
+        "AcquisitionSource__c": "source_123",
+        "CreatedByCSR__c": "Jenny Wren",
         "CreatedRequestId__c": "request-123",
         "DeliveryAgent__c": undefined,
         "InitialPromotionCode__c": undefined,
@@ -364,6 +373,9 @@ exports[`the buildCreateSubscriptionRequest function sets delivery instructions 
   "subscriptions": [
     {
       "customFields": {
+        "AcquisitionCase__c": "case_123",
+        "AcquisitionSource__c": "source_123",
+        "CreatedByCSR__c": "Jenny Wren",
         "CreatedRequestId__c": "request-123",
         "DeliveryAgent__c": "42",
         "InitialPromotionCode__c": undefined,

--- a/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
+++ b/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
@@ -76,6 +76,9 @@ const baseStripeInput = {
 		workEmail: 'test@test.com',
 		country: 'GB',
 	},
+	acquisitionCase: 'case_123',
+	acquisitionSource: 'source_123',
+	createdByCSR: 'Jenny Wren',
 };
 
 const supporterPlusInput: CreateSubscriptionInputFields<CreditCardReferenceTransaction> =

--- a/modules/zuora/test/clonePaymentMethod.test.ts
+++ b/modules/zuora/test/clonePaymentMethod.test.ts
@@ -54,6 +54,7 @@ describe('clonePaymentMethod', () => {
 			});
 
 			expect(result).toEqual({
+				type: 'ExistingPaymentMethod',
 				hpmCreditCardPaymentMethodId: 'pm-existing-id',
 			});
 			expect(mockGet).not.toHaveBeenCalled();
@@ -71,11 +72,9 @@ describe('clonePaymentMethod', () => {
 			});
 
 			expect(result).toEqual({
-				paymentMethod: {
-					type: 'CreditCardReferenceTransaction',
-					tokenId: 'tok_stripe_123',
-					secondTokenId: 'cus_stripe_456',
-				},
+				type: 'CreditCardReferenceTransaction',
+				tokenId: 'tok_stripe_123',
+				secondTokenId: 'cus_stripe_456',
 			});
 		});
 
@@ -91,7 +90,10 @@ describe('clonePaymentMethod', () => {
 				requiresCloning: true,
 			});
 
-			expect(result).toEqual({ hpmCreditCardPaymentMethodId: 'new-pm-id' });
+			expect(result).toEqual({
+				type: 'ExistingPaymentMethod',
+				hpmCreditCardPaymentMethodId: 'new-pm-id',
+			});
 			const [path, body] = mockPost.mock.calls[0] as [string, string];
 			expect(path).toBe('/v1/object/payment-method');
 			const pm = JSON.parse(body) as Record<string, unknown>;

--- a/modules/zuora/test/createSubscriptionWithExistingPaymentMethodIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionWithExistingPaymentMethodIntegration.test.ts
@@ -151,7 +151,7 @@ describe('createSubscriptionWithExistingPaymentMethod integration', () => {
 		expect(response.accountNumber).toMatch(/^A\d+$/);
 		expect(response.subscriptionNumbers.length).toBe(1);
 
-		await deleteAccount(zuoraClient, response.accountNumber);
+		//await deleteAccount(zuoraClient, response.accountNumber);
 	}, 120000);
 
 	test('creates a NationalDelivery EverydayPlus subscription', async () => {

--- a/modules/zuora/test/createSubscriptionWithExistingPaymentMethodIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionWithExistingPaymentMethodIntegration.test.ts
@@ -151,7 +151,7 @@ describe('createSubscriptionWithExistingPaymentMethod integration', () => {
 		expect(response.accountNumber).toMatch(/^A\d+$/);
 		expect(response.subscriptionNumbers.length).toBe(1);
 
-		//await deleteAccount(zuoraClient, response.accountNumber);
+		await deleteAccount(zuoraClient, response.accountNumber);
 	}, 120000);
 
 	test('creates a NationalDelivery EverydayPlus subscription', async () => {


### PR DESCRIPTION
createSubscriptionWithExistingPaymentMethod

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
I noticed that we still had quite a bit chunk of duplicated code between the `createSubscription` function and the `createSubscriptionWithExistingPaymentMethod` function. Specifically this was the code in the function `buildCreateSubscriptionRequest` which was just duplicated in `createSubscriptionWithExistingPaymentMethod` meaning that any changes would need to be made in two places.

This PR fixes that, the main changes required to do this were:
- Make the `paymentMethod` field on the `CreateSubscriptionInputFields` type into  `T | ClonedPaymentMethod` instead of just T;
- Set the custom fields associated with CSR acquisitions in the `buildCreateSubscriptionRequest` function, it wasn't previously doing this because they are not sent by support-frontend.

## How has this change been tested?
All unit and integration tests still pass

