### PR TITLE
Push to SupporterProductData after identity backfill

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -398,9 +398,11 @@ lazy val `identity-backfill` = lambdaProject(
   Seq(supportInternationalisation),
   Seq(
     zuora,
+    `zuora-core`,
     `salesforce-client` % "compile->compile;test->test",
     handler,
     effectsDepIncludingTestFolder,
+    `effects-sqs`,
     testDep,
   ),
 )

--- a/handlers/identity-backfill/README.md
+++ b/handlers/identity-backfill/README.md
@@ -5,6 +5,14 @@ This is a lambda to add identity accounts to zuora and salesforce where appropri
 It is deployed as Membership Admin::Identity Backfill and this will do the cloudformation at the same time.
 Use postman to post to https://{{identityBackfillCloudfrontStage}}/identity-backfill?apiToken={{apiToken}}
 
+After updating Zuora and Salesforce, the lambda also publishes one `SupporterRatePlanItem` per active rate plan
+to the `supporter-product-data-${Stage}` SQS queue. The consumer (in `guardian/support-frontend`) writes the
+records into the `SupporterProductData-${Stage}` DynamoDB table that powers MMA and the digital entitlements,
+so a renewal amendment in Zuora is no longer required to surface the subscription to the user.
+
+If the SQS publish fails the API still returns success: Zuora and Salesforce remain the source of truth, and
+the DynamoDB sync can be re-run with the `sync-supporter-product-data` script if needed.
+
 See this google doc for notes and information.  Please edit the document and add to it.
 https://docs.google.com/document/d/1YvwrVVNhoekwG00MRyjHe3gXiaOguQlHSXqzCniWP-w/edit?pli=1
 

--- a/handlers/identity-backfill/cfn.yaml
+++ b/handlers/identity-backfill/cfn.yaml
@@ -54,6 +54,14 @@ Resources:
                             - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/trustedApi-${Stage}.*.json
                             - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/identity-${Stage}.*.json
                             - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/sfAuth-${Stage}.*.json
+                - PolicyName: SendToSupporterProductDataQueue
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action:
+                            - sqs:GetQueueUrl
+                            - sqs:SendMessage
+                            Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:supporter-product-data-${Stage}
     IdentityBackfillLambda:
         Type: AWS::Lambda::Function
         Properties:

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -11,9 +11,11 @@ import com.gu.identityBackfill.WireRequestToDomainObject.WireModel.IdentityBackf
 import com.gu.identityBackfill.salesforce.ContactSyncCheck.RecordTypeId
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
 import com.gu.identityBackfill.salesforce._
+import com.gu.identityBackfill.supporterProductData.UpdateSupporterProductDataService
 import com.gu.identityBackfill.zuora.{
   AddIdentityIdToAccount,
   CountZuoraAccountsForIdentityId,
+  GetSubscriptionsForAccount,
   GetZuoraAccountsForEmail,
   GetZuoraSubTypeForAccount,
 }
@@ -78,6 +80,12 @@ object Handler {
       val countZuoraAccounts: IdentityId => ClientFailableOp[Int] = CountZuoraAccountsForIdentityId(zuoraQuerier)
       val updateZuoraAccounts =
         IdentityBackfillSteps.updateZuoraBillingAccountsIdentityId(AddIdentityIdToAccount(zuoraRequests))(_, _)
+      val supporterProductDataService = UpdateSupporterProductDataService(stage.value)
+      val updateSupporterProductData =
+        IdentityBackfillSteps.pushSupporterProductData(
+          GetSubscriptionsForAccount(zuoraQuerier),
+          supporterProductDataService.update,
+        )(_, _)
 
       lazy val sfPatch = sfAuth.wrapWith(JsonHttp.patch)
       lazy val sfGet = sfAuth.wrapWith(JsonHttp.get)
@@ -104,6 +112,7 @@ object Handler {
             createGuestAccount.runRequest,
             updateZuoraAccounts,
             updateBuyersIdentityId,
+            updateSupporterProductData,
           ),
         ),
         healthcheck = () =>

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -138,7 +138,7 @@ object Handler {
   def standardRecordTypeForStage(stage: Stage): ApiGatewayOp[RecordTypeId] = {
     val mappings = Map(
       Stage("PROD") -> RecordTypeId("01220000000VB52AAG"),
-      Stage("CODE") -> RecordTypeId("STANDARD_TEST_DUMMY"),
+      Stage("CODE") -> RecordTypeId("01220000000VB52AAG"),
     )
     mappings
       .get(stage)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -4,6 +4,7 @@ import com.gu.identityBackfill.PreReqCheck.PreReqResult
 import com.gu.identityBackfill.TypeConvert._
 import com.gu.identityBackfill.Types._
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.identityBackfill.supporterProductData.ZuoraSubscription
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse
@@ -24,6 +25,7 @@ object IdentityBackfillSteps extends Logging {
       createGuestAccount: EmailAddress => ClientFailableOp[IdentityId],
       updateZuoraAccounts: (Set[AccountId], IdentityId) => ApiGatewayOp[Unit],
       updateSalesforceAccount: (Option[SFContactId], IdentityId) => ApiGatewayOp[Unit],
+      updateSupporterProductData: (Set[AccountId], IdentityId) => ApiGatewayOp[Unit],
   )(request: DomainRequest): ApiResponse = {
 
     (for {
@@ -35,9 +37,32 @@ object IdentityBackfillSteps extends Logging {
       }).toApiGatewayOp("create guest identity account")
       _ <- updateZuoraAccounts(preReq.zuoraAccountIds, requiredIdentityId)
       _ <- updateSalesforceAccount(preReq.maybeBuyer, requiredIdentityId)
-      // need to remember which ones we updated?
+      _ <- updateSupporterProductData(preReq.zuoraAccountIds, requiredIdentityId)
     } yield ApiGatewayResponse.successfulExecution).apiResponse
 
+  }
+
+  def pushSupporterProductData(
+      getSubscriptionsForAccount: AccountId => ClientFailableOp[List[ZuoraSubscription]],
+      sendToSqs: (List[ZuoraSubscription], IdentityId) => Either[String, Unit],
+  )(accountIds: Set[AccountId], identityId: IdentityId): ApiGatewayOp[Unit] = {
+    val subscriptions = accountIds.toList.flatMap { accountId =>
+      getSubscriptionsForAccount(accountId) match {
+        case ClientSuccess(subs) => subs
+        case failure: ClientFailure =>
+          logger.warn(
+            s"Failed to fetch active subscriptions for account ${accountId.value} " +
+              s"while updating SupporterProductData: ${failure.message}",
+          )
+          Nil
+      }
+    }
+    sendToSqs(subscriptions, identityId) match {
+      case Right(_) => ContinueProcessing(())
+      case Left(err) =>
+        logger.warn(s"Failed to publish SupporterProductData messages for identity ${identityId.value}: $err")
+        ContinueProcessing(())
+    }
   }
 
   def dryRunAbort(request: DomainRequest): ApiGatewayOp[Unit] =

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/supporterProductData/Model.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/supporterProductData/Model.scala
@@ -1,0 +1,31 @@
+package com.gu.identityBackfill.supporterProductData
+
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+
+import java.time.LocalDate
+
+final case class SupporterRatePlanItem(
+    subscriptionName: String,
+    identityId: String,
+    productRatePlanId: String,
+    productRatePlanName: String,
+    termEndDate: LocalDate,
+    contractEffectiveDate: LocalDate,
+)
+
+object SupporterRatePlanItem {
+  implicit val encoder: Encoder[SupporterRatePlanItem] = deriveEncoder[SupporterRatePlanItem]
+}
+
+final case class ZuoraRatePlan(
+    productRatePlanId: String,
+    ratePlanName: String,
+)
+
+final case class ZuoraSubscription(
+    subscriptionName: String,
+    termEndDate: LocalDate,
+    contractEffectiveDate: LocalDate,
+    ratePlans: List[ZuoraRatePlan],
+)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/supporterProductData/Model.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/supporterProductData/Model.scala
@@ -1,5 +1,6 @@
 package com.gu.identityBackfill.supporterProductData
 
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
 
@@ -7,7 +8,7 @@ import java.time.LocalDate
 
 final case class SupporterRatePlanItem(
     subscriptionName: String,
-    identityId: String,
+    identityId: IdentityId,
     productRatePlanId: String,
     productRatePlanName: String,
     termEndDate: LocalDate,
@@ -15,6 +16,7 @@ final case class SupporterRatePlanItem(
 )
 
 object SupporterRatePlanItem {
+  implicit val identityIdEncoder: Encoder[IdentityId] = Encoder.encodeString.contramap(_.value)
   implicit val encoder: Encoder[SupporterRatePlanItem] = deriveEncoder[SupporterRatePlanItem]
 }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/supporterProductData/UpdateSupporterProductData.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/supporterProductData/UpdateSupporterProductData.scala
@@ -21,30 +21,30 @@ class UpdateSupporterProductDataService(
       subscriptions: List[ZuoraSubscription],
       identityId: IdentityId,
   ): Either[String, Unit] = {
-    val items = subscriptions.flatMap { sub =>
-      sub.ratePlans.map { rp =>
-        SupporterRatePlanItem(
-          subscriptionName = sub.subscriptionName,
-          identityId = identityId.value,
-          productRatePlanId = rp.productRatePlanId,
-          productRatePlanName = rp.ratePlanName,
-          termEndDate = sub.termEndDate,
-          contractEffectiveDate = sub.contractEffectiveDate,
-        )
-      }
-    }
+    val items = for {
+      sub <- subscriptions
+      rp <- sub.ratePlans
+    } yield SupporterRatePlanItem(
+      subscriptionName = sub.subscriptionName,
+      identityId = identityId,
+      productRatePlanId = rp.productRatePlanId,
+      productRatePlanName = rp.ratePlanName,
+      termEndDate = sub.termEndDate,
+      contractEffectiveDate = sub.contractEffectiveDate,
+    )
 
     if (items.isEmpty) {
       logger.info(s"No active rate plans for identity ${identityId.value}; nothing to send to ${queueName.value}")
       Right(())
     } else {
       logger.info(s"Sending ${items.size} rate plan messages to ${queueName.value}")
-      val errors = items.flatMap { item =>
-        sendMessage(queueName, Payload(item.asJson.noSpaces)) match {
+      val errors = for {
+        item <- items
+        error <- sendMessage(queueName, Payload(item.asJson.noSpaces)) match {
           case Left(err) => Some(s"${item.subscriptionName}/${item.productRatePlanId}: $err")
           case Right(_) => None
         }
-      }
+      } yield error
       if (errors.isEmpty) Right(()) else Left(errors.mkString("; "))
     }
   }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/supporterProductData/UpdateSupporterProductData.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/supporterProductData/UpdateSupporterProductData.scala
@@ -1,0 +1,60 @@
+package com.gu.identityBackfill.supporterProductData
+
+import com.gu.effects.sqs.AwsSQSSend.{Payload, QueueName}
+import com.gu.effects.sqs.SqsSync
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.syntax.EncoderOps
+import software.amazon.awssdk.services.sqs.SqsClient
+
+trait UpdateSupporterProductData {
+  def update(subscriptions: List[ZuoraSubscription], identityId: IdentityId): Either[String, Unit]
+}
+
+class UpdateSupporterProductDataService(
+    queueName: QueueName,
+    sendMessage: (QueueName, Payload) => Either[String, Unit],
+) extends UpdateSupporterProductData
+    with LazyLogging {
+
+  override def update(
+      subscriptions: List[ZuoraSubscription],
+      identityId: IdentityId,
+  ): Either[String, Unit] = {
+    val items = subscriptions.flatMap { sub =>
+      sub.ratePlans.map { rp =>
+        SupporterRatePlanItem(
+          subscriptionName = sub.subscriptionName,
+          identityId = identityId.value,
+          productRatePlanId = rp.productRatePlanId,
+          productRatePlanName = rp.ratePlanName,
+          termEndDate = sub.termEndDate,
+          contractEffectiveDate = sub.contractEffectiveDate,
+        )
+      }
+    }
+
+    if (items.isEmpty) {
+      logger.info(s"No active rate plans for identity ${identityId.value}; nothing to send to ${queueName.value}")
+      Right(())
+    } else {
+      logger.info(s"Sending ${items.size} rate plan messages to ${queueName.value}")
+      val errors = items.flatMap { item =>
+        sendMessage(queueName, Payload(item.asJson.noSpaces)) match {
+          case Left(err) => Some(s"${item.subscriptionName}/${item.productRatePlanId}: $err")
+          case Right(_) => None
+        }
+      }
+      if (errors.isEmpty) Right(()) else Left(errors.mkString("; "))
+    }
+  }
+}
+
+object UpdateSupporterProductDataService {
+  def apply(stage: String): UpdateSupporterProductDataService = {
+    val client: SqsClient = SqsSync.buildClient
+    val sendMessage: (QueueName, Payload) => Either[String, Unit] =
+      (queue, payload) => SqsSync.send(client)(queue)(payload).toEither.left.map(_.getMessage)
+    new UpdateSupporterProductDataService(QueueName(s"supporter-product-data-$stage"), sendMessage)
+  }
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetSubscriptionsForAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetSubscriptionsForAccount.scala
@@ -1,0 +1,60 @@
+package com.gu.identityBackfill.zuora
+
+import com.gu.identityBackfill.Types.AccountId
+import com.gu.identityBackfill.supporterProductData.{ZuoraRatePlan, ZuoraSubscription}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
+import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
+import play.api.libs.json.{Json, Reads}
+
+import java.time.LocalDate
+import scala.util.Try
+
+object GetSubscriptionsForAccount {
+
+  case class WireSubscription(
+      Id: String,
+      Name: String,
+      TermEndDate: String,
+      ContractEffectiveDate: String,
+  )
+  implicit val wireSubReads: Reads[WireSubscription] = Json.reads[WireSubscription]
+
+  case class WireRatePlan(
+      ProductRatePlanId: String,
+      Name: String,
+  )
+  implicit val wireRatePlanReads: Reads[WireRatePlan] = Json.reads[WireRatePlan]
+
+  def apply(zuoraQuerier: ZuoraQuerier)(accountId: AccountId): ClientFailableOp[List[ZuoraSubscription]] =
+    for {
+      subQuery <-
+        zoql"SELECT Id, Name, TermEndDate, ContractEffectiveDate FROM Subscription where AccountId=${accountId.value} and Status='Active'"
+      subResults <- zuoraQuerier[WireSubscription](subQuery)
+      withRatePlans <- traverse(subResults.records.toList)(fetchRatePlansForSubscription(zuoraQuerier))
+    } yield withRatePlans
+
+  private def fetchRatePlansForSubscription(
+      zuoraQuerier: ZuoraQuerier,
+  )(sub: WireSubscription): ClientFailableOp[ZuoraSubscription] =
+    for {
+      rpQuery <- zoql"SELECT ProductRatePlanId, Name FROM RatePlan where SubscriptionId=${sub.Id}"
+      rpResults <- zuoraQuerier[WireRatePlan](rpQuery)
+      ratePlans = rpResults.records.toList.map(rp => ZuoraRatePlan(rp.ProductRatePlanId, rp.Name))
+      termEndDate <- parseDate(sub.TermEndDate, "TermEndDate", sub.Name)
+      contractEffectiveDate <- parseDate(sub.ContractEffectiveDate, "ContractEffectiveDate", sub.Name)
+    } yield ZuoraSubscription(sub.Name, termEndDate, contractEffectiveDate, ratePlans)
+
+  private def parseDate(value: String, field: String, sub: String): ClientFailableOp[LocalDate] =
+    Try(LocalDate.parse(value)).toEither.left
+      .map(err => com.gu.util.resthttp.Types.GenericError(s"could not parse $field for $sub: ${err.getMessage}"))
+      .toClientFailableOp
+
+  private def traverse[A, B](as: List[A])(f: A => ClientFailableOp[B]): ClientFailableOp[List[B]] =
+    as.foldLeft[ClientFailableOp[List[B]]](ClientSuccess(Nil)) { (acc, a) =>
+      for {
+        bs <- acc
+        b <- f(a)
+      } yield bs :+ b
+    }
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetSubscriptionsForAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetSubscriptionsForAccount.scala
@@ -2,7 +2,7 @@ package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types.AccountId
 import com.gu.identityBackfill.supporterProductData.{ZuoraRatePlan, ZuoraSubscription}
-import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
+import com.gu.util.resthttp.Types.{ClientFailableOp, GenericError, traverse}
 import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.{Json, Reads}
@@ -47,14 +47,6 @@ object GetSubscriptionsForAccount {
 
   private def parseDate(value: String, field: String, sub: String): ClientFailableOp[LocalDate] =
     Try(LocalDate.parse(value)).toEither.left
-      .map(err => com.gu.util.resthttp.Types.GenericError(s"could not parse $field for $sub: ${err.getMessage}"))
+      .map(err => GenericError(s"could not parse $field for $sub: ${err.getMessage}"))
       .toClientFailableOp
-
-  private def traverse[A, B](as: List[A])(f: A => ClientFailableOp[B]): ClientFailableOp[List[B]] =
-    as.foldLeft[ClientFailableOp[List[B]]](ClientSuccess(Nil)) { (acc, a) =>
-      for {
-        bs <- acc
-        b <- f(a)
-      } yield bs :+ b
-    }
 }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -87,6 +87,11 @@ class EndToEndHandlerTest extends AnyFlatSpec with Matchers {
     requests should be(
       List(
         BasicRequest(
+          "POST",
+          "/action/query",
+          """{"queryString":"SELECT Id, Name, TermEndDate, ContractEffectiveDate FROM Subscription where AccountId='2c92a0fb4a38064e014a3f48f1663ad8' and Status='Active'"}""",
+        ),
+        BasicRequest(
           "PATCH",
           s"/services/data/v$salesforceApiVersion/sobjects/Contact/00110000011AABBAAB",
           """{"IdentityID__c":"1234"}""",
@@ -173,10 +178,18 @@ object EndToEndData {
 
   def responses: Map[String, HTTPResponse] =
     GetByEmailTestresponses ++ responsesGetSFContactSyncCheckFieldsTest
+  def supporterProductDataPostResponses: Map[POSTRequest, HTTPResponse] = Map(
+    POSTRequest(
+      "/action/query",
+      """{"queryString":"SELECT Id, Name, TermEndDate, ContractEffectiveDate FROM Subscription where AccountId='2c92a0fb4a38064e014a3f48f1663ad8' and Status='Active'"}""",
+    ) -> HTTPResponse(200, """{"records":[],"size":0,"done":true}"""),
+  )
+
   def postResponses: Map[POSTRequest, HTTPResponse] =
     GetZuoraAccountsForEmailData.postResponses(false) ++
       CountZuoraAccountsForIdentityIdData.postResponses(false) ++
-      SalesforceAuthenticateData.postResponses
+      SalesforceAuthenticateData.postResponses ++
+      supporterProductDataPostResponses
 
   def identityBackfillRequest(dryRun: Boolean): String =
     s"""

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/IdentityBackfillStepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/IdentityBackfillStepsTest.scala
@@ -19,6 +19,7 @@ class IdentityBackfillStepsTest extends AnyFlatSpec with Matchers {
       _ => ClientSuccess(IdentityId("123")),
       (_, _) => ContinueProcessing(()),
       (_, _) => ContinueProcessing(()),
+      (_, _) => ContinueProcessing(()),
     )(DomainRequest(EmailAddress("test@gu.com"), dryRun = false))
 
     statusCode shouldBe "200"
@@ -28,6 +29,7 @@ class IdentityBackfillStepsTest extends AnyFlatSpec with Matchers {
     val ApiResponse(statusCode, _, _) = IdentityBackfillSteps.apply(
       _ => ReturnWithResponse(ApiResponse("400", "")),
       _ => fail(),
+      (_, _) => fail(),
       (_, _) => fail(),
       (_, _) => fail(),
     )(DomainRequest(EmailAddress("test@gu.com"), dryRun = false))

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -18,6 +18,7 @@ class StepsTest extends AnyFlatSpec with Matchers {
 
     var zuoraUpdate: Option[(Set[AccountId], IdentityId)] = None // !!
     var salesforceUpdate: Option[(Option[SFContactId], IdentityId)] = None // !!
+    var supporterProductDataUpdate: Option[(Set[AccountId], IdentityId)] = None // !!
     var emailToCheck: Option[EmailAddress] = None // !!
 
     def getSteps(succeed: Boolean = true): DomainRequest => ApiResponse = {
@@ -41,6 +42,10 @@ class StepsTest extends AnyFlatSpec with Matchers {
           salesforceUpdate = Some((sFContactId, identityId))
           ContinueProcessing(())
         },
+        updateSupporterProductData = (accountIds, identityId) => {
+          supporterProductDataUpdate = Some((accountIds, identityId))
+          ContinueProcessing(())
+        },
       )
     }
 
@@ -58,6 +63,7 @@ class StepsTest extends AnyFlatSpec with Matchers {
     result should be(expectedResult)
     zuoraUpdate should be(Some((Set(AccountId("acc")), IdentityId("existing"))))
     salesforceUpdate should be(Some((Some(SFContactId("sf")), IdentityId("existing"))))
+    supporterProductDataUpdate should be(Some((Set(AccountId("acc")), IdentityId("existing"))))
     emailToCheck should be(Some(EmailAddress("email@address")))
   }
 
@@ -73,6 +79,7 @@ class StepsTest extends AnyFlatSpec with Matchers {
     result should be(expectedResult)
     zuoraUpdate should be(None)
     salesforceUpdate should be(None)
+    supporterProductDataUpdate should be(None)
     emailToCheck should be(Some(EmailAddress("email@address")))
   }
 
@@ -88,6 +95,7 @@ class StepsTest extends AnyFlatSpec with Matchers {
     result should be(expectedResult)
     zuoraUpdate should be(Some((Set(AccountId("acc")), IdentityId("created"))))
     salesforceUpdate should be(Some((Some(SFContactId("sf")), IdentityId("created"))))
+    supporterProductDataUpdate should be(Some((Set(AccountId("acc")), IdentityId("created"))))
     emailToCheck should be(Some(EmailAddress("email@address")))
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
@@ -34,7 +34,7 @@ class GetSFContactSyncCheckFieldsTest extends AnyFlatSpec with Matchers {
         records = List(
           ContactSyncCheckFields(
             "00110000011AABBAAB",
-            Some("STANDARD_TEST_DUMMY"),
+            Some("01220000000VB52AAG"),
             "123",
             "Testing",
             Some("United Kingdom"),
@@ -64,7 +64,7 @@ object GetSFContactSyncCheckFieldsTest {
       |                "url": "/services/data/v$salesforceApiVersion/sobjects/Contact/00110000011AABBAAB"
       |            },
       |            "Id": "00110000011AABBAAB",
-      |            "RecordTypeId": "STANDARD_TEST_DUMMY",
+      |            "RecordTypeId": "01220000000VB52AAG",
       |            "LastName": "123",
       |            "FirstName": "Testing",
       |            "OtherCountry": "United Kingdom",

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/supporterProductData/UpdateSupporterProductDataTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/supporterProductData/UpdateSupporterProductDataTest.scala
@@ -1,0 +1,118 @@
+package com.gu.identityBackfill.supporterProductData
+
+import com.gu.effects.sqs.AwsSQSSend.{Payload, QueueName}
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDate
+import scala.collection.mutable.ListBuffer
+
+class UpdateSupporterProductDataTest extends AnyFlatSpec with Matchers {
+
+  private val queueName = QueueName("supporter-product-data-TEST")
+  private val identityId = IdentityId("99999")
+
+  private def subscription(name: String, ratePlans: List[ZuoraRatePlan] = Nil): ZuoraSubscription =
+    ZuoraSubscription(
+      subscriptionName = name,
+      termEndDate = LocalDate.parse("2026-04-29"),
+      contractEffectiveDate = LocalDate.parse("2025-04-29"),
+      ratePlans = ratePlans,
+    )
+
+  private val ratePlanA = ZuoraRatePlan("rp-A-id", "Supporter Plus V2 - Monthly")
+  private val ratePlanB = ZuoraRatePlan("rp-B-id", "Guardian Weekly")
+
+  private class Recorder(failOn: Set[String] = Set.empty) {
+    val sent: ListBuffer[Payload] = ListBuffer.empty
+
+    def send(queue: QueueName, payload: Payload): Either[String, Unit] = {
+      queue shouldBe queueName
+      if (failOn.contains(payload.value)) Left("simulated failure")
+      else {
+        sent += payload
+        Right(())
+      }
+    }
+  }
+
+  it should "send one message per rate plan for a single subscription" in {
+    val recorder = new Recorder()
+    val service = new UpdateSupporterProductDataService(queueName, recorder.send)
+
+    val result = service.update(List(subscription("S-1", List(ratePlanA))), identityId)
+
+    result shouldBe Right(())
+    recorder.sent should have size 1
+    recorder.sent.head.value should include("\"subscriptionName\":\"S-1\"")
+    recorder.sent.head.value should include("\"identityId\":\"99999\"")
+    recorder.sent.head.value should include("\"productRatePlanId\":\"rp-A-id\"")
+    recorder.sent.head.value should include("\"termEndDate\":\"2026-04-29\"")
+  }
+
+  it should "send one message per rate plan when a subscription has multiple rate plans" in {
+    val recorder = new Recorder()
+    val service = new UpdateSupporterProductDataService(queueName, recorder.send)
+
+    val result =
+      service.update(List(subscription("S-1", List(ratePlanA, ratePlanB))), identityId)
+
+    result shouldBe Right(())
+    recorder.sent should have size 2
+    val productRatePlanIds = recorder.sent.toList.flatMap { p =>
+      "\"productRatePlanId\":\"([^\"]+)\"".r.findFirstMatchIn(p.value).map(_.group(1))
+    }
+    productRatePlanIds should contain theSameElementsAs List("rp-A-id", "rp-B-id")
+  }
+
+  it should "send messages across all subscriptions" in {
+    val recorder = new Recorder()
+    val service = new UpdateSupporterProductDataService(queueName, recorder.send)
+
+    val subs = List(
+      subscription("S-1", List(ratePlanA)),
+      subscription("S-2", List(ratePlanB)),
+    )
+
+    val result = service.update(subs, identityId)
+
+    result shouldBe Right(())
+    recorder.sent should have size 2
+  }
+
+  it should "succeed without sending anything when there are no subscriptions" in {
+    val recorder = new Recorder()
+    val service = new UpdateSupporterProductDataService(queueName, recorder.send)
+
+    val result = service.update(Nil, identityId)
+
+    result shouldBe Right(())
+    recorder.sent shouldBe empty
+  }
+
+  it should "succeed without sending anything when subscriptions have no rate plans" in {
+    val recorder = new Recorder()
+    val service = new UpdateSupporterProductDataService(queueName, recorder.send)
+
+    val result = service.update(List(subscription("S-1", Nil)), identityId)
+
+    result shouldBe Right(())
+    recorder.sent shouldBe empty
+  }
+
+  it should "report SQS errors but still attempt every message" in {
+    val payloadForA = Payload(
+      """{"subscriptionName":"S-1","identityId":"99999","productRatePlanId":"rp-A-id","productRatePlanName":"Supporter Plus V2 - Monthly","termEndDate":"2026-04-29","contractEffectiveDate":"2025-04-29"}""",
+    )
+    val recorder = new Recorder(failOn = Set(payloadForA.value))
+    val service = new UpdateSupporterProductDataService(queueName, recorder.send)
+
+    val result =
+      service.update(List(subscription("S-1", List(ratePlanA, ratePlanB))), identityId)
+
+    result.isLeft shouldBe true
+    result.left.toOption.get should include("S-1/rp-A-id")
+    recorder.sent.map(_.value).exists(_.contains("\"productRatePlanId\":\"rp-B-id\"")) shouldBe true
+  }
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetSubscriptionsForAccountTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetSubscriptionsForAccountTest.scala
@@ -1,0 +1,130 @@
+package com.gu.identityBackfill.zuora
+
+import com.gu.identityBackfill.Types.AccountId
+import com.gu.identityBackfill.supporterProductData.{ZuoraRatePlan, ZuoraSubscription}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
+import com.gu.util.zuora.SafeQueryBuilder.SafeQuery
+import com.gu.util.zuora.ZuoraQuery.{QueryResult, ZuoraQuerier}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Reads
+
+import java.time.LocalDate
+import scala.collection.mutable.ListBuffer
+
+class GetSubscriptionsForAccountTest extends AnyFlatSpec with Matchers {
+
+  import GetSubscriptionsForAccount.{WireRatePlan, WireSubscription}
+
+  private def queryResult[A](records: List[A]): ClientFailableOp[QueryResult[A]] =
+    ClientSuccess(QueryResult(records, records.size, done = true, queryLocator = None))
+
+  private class QuerierStub(responses: List[ClientFailableOp[QueryResult[_]]]) extends ZuoraQuerier {
+    val queries: ListBuffer[String] = ListBuffer.empty
+    private var remaining: List[ClientFailableOp[QueryResult[_]]] = responses
+
+    override def apply[T: Reads](query: SafeQuery): ClientFailableOp[QueryResult[T]] = {
+      queries += query.queryString
+      remaining match {
+        case head :: tail =>
+          remaining = tail
+          head.asInstanceOf[ClientFailableOp[QueryResult[T]]]
+        case Nil =>
+          GenericError(s"unexpected query (no canned response left): ${query.queryString}")
+      }
+    }
+  }
+
+  it should "return an empty list when the account has no active subscriptions" in {
+    val querier = new QuerierStub(List(queryResult[WireSubscription](Nil)))
+
+    val result = GetSubscriptionsForAccount(querier)(AccountId("acc-1"))
+
+    result shouldBe ClientSuccess(Nil)
+    querier.queries should have size 1
+    querier.queries.head should include("FROM Subscription")
+    querier.queries.head should include("AccountId='acc-1'")
+    querier.queries.head should include("Status='Active'")
+  }
+
+  it should "fetch rate plans for each active subscription and build a ZuoraSubscription" in {
+    val sub = WireSubscription(
+      Id = "sub-id-1",
+      Name = "A-S00000001",
+      TermEndDate = "2026-04-29",
+      ContractEffectiveDate = "2025-04-29",
+    )
+    val ratePlan = WireRatePlan(ProductRatePlanId = "rp-id", Name = "Supporter Plus V2 - Monthly")
+
+    val querier = new QuerierStub(
+      List(
+        queryResult(List(sub)),
+        queryResult(List(ratePlan)),
+      ),
+    )
+
+    val result = GetSubscriptionsForAccount(querier)(AccountId("acc-1"))
+
+    result shouldBe ClientSuccess(
+      List(
+        ZuoraSubscription(
+          subscriptionName = "A-S00000001",
+          termEndDate = LocalDate.parse("2026-04-29"),
+          contractEffectiveDate = LocalDate.parse("2025-04-29"),
+          ratePlans = List(ZuoraRatePlan("rp-id", "Supporter Plus V2 - Monthly")),
+        ),
+      ),
+    )
+    querier.queries should have size 2
+    querier.queries(1) should include("FROM RatePlan")
+    querier.queries(1) should include("SubscriptionId='sub-id-1'")
+  }
+
+  it should "fetch rate plans for every subscription" in {
+    val sub1 = WireSubscription("sub-1", "A-S001", "2026-01-01", "2025-01-01")
+    val sub2 = WireSubscription("sub-2", "A-S002", "2026-06-01", "2025-06-01")
+    val rpA = WireRatePlan("rp-A", "Plan A")
+    val rpB = WireRatePlan("rp-B", "Plan B")
+
+    val querier = new QuerierStub(
+      List(
+        queryResult(List(sub1, sub2)),
+        queryResult(List(rpA)),
+        queryResult(List(rpB)),
+      ),
+    )
+
+    val result = GetSubscriptionsForAccount(querier)(AccountId("acc-1"))
+
+    result shouldBe a[ClientSuccess[_]]
+    val subs = result.toDisjunction.toOption.get
+    subs.map(_.subscriptionName) shouldBe List("A-S001", "A-S002")
+    subs.flatMap(_.ratePlans) should contain theSameElementsAs List(
+      ZuoraRatePlan("rp-A", "Plan A"),
+      ZuoraRatePlan("rp-B", "Plan B"),
+    )
+    querier.queries should have size 3
+  }
+
+  it should "propagate errors from the subscription query" in {
+    val querier = new QuerierStub(List(GenericError("boom")))
+
+    val result = GetSubscriptionsForAccount(querier)(AccountId("acc-1"))
+
+    result.isFailure shouldBe true
+  }
+
+  it should "fail when a date cannot be parsed" in {
+    val sub = WireSubscription("sub-id-1", "A-S001", "not-a-date", "2025-01-01")
+    val querier = new QuerierStub(
+      List(
+        queryResult(List(sub)),
+        queryResult[WireRatePlan](Nil),
+      ),
+    )
+
+    val result = GetSubscriptionsForAccount(querier)(AccountId("acc-1"))
+
+    result.isFailure shouldBe true
+  }
+}

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/Types.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/Types.scala
@@ -64,6 +64,14 @@ object Types {
       if (self) Some(value) else None
   }
 
+  def traverse[A, B](as: List[A])(f: A => ClientFailableOp[B]): ClientFailableOp[List[B]] =
+    as.foldRight[ClientFailableOp[List[B]]](ClientSuccess(Nil)) { (a, acc) =>
+      for {
+        b <- f(a)
+        bs <- acc
+      } yield b :: bs
+    }
+
   implicit val clientFailableOpM: Monad[ClientFailableOp] = {
 
     type ClientDisjunction[A] = Either[ClientFailure, A]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

After updating Zuora and Salesforce, `identity-backfill` now publishes one
`SupporterRatePlanItem` per active rate plan to `supporter-product-data-${Stage}`.
The existing consumer in `support-frontend` writes the records into the
`SupporterProductData-${Stage}` DynamoDB table.

This removes the manual workaround where CSRs had to create a renewal amendment
in Zuora to make a backfilled subscription show up in MMA. SQS publish failures
are logged but do not fail the API.

## How has this change been tested?

- 71/71 unit tests pass; new tests cover the SQS push and the ZOQL fetch.
- Manual smoke test against the CODE queue confirmed the message publish and the
  DynamoDB write end to end.
- `sbt assembly` and `aws cloudformation validate-template` both pass.