### PR TITLE
Add `multipleAccounts` benefit to product benefit mappings

### DIFF
--- a/modules/product-benefits/src/productBenefit.ts
+++ b/modules/product-benefits/src/productBenefit.ts
@@ -19,6 +19,7 @@ export const digitalSubscriptionBenefits = supporterPlusBenefits.concat([
 	'newspaperEdition',
 	'guardianWeeklyEdition',
 	'newspaperArchive',
+	'multipleAccounts',
 ]);
 
 export const productBenefitMapping: Record<

--- a/modules/product-benefits/src/schemas.ts
+++ b/modules/product-benefits/src/schemas.ts
@@ -10,6 +10,7 @@ export const productBenefitListSchema = z.enum([
 	'hideSupportMessaging',
 	'allowRejectAll',
 	'liveEvents',
+	'multipleAccounts',
 ]);
 
 export type ProductBenefit = z.infer<typeof productBenefitListSchema>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a new product benefit 'multipleAccounts' which will be avalailable to any subscriber who holds a Digital Plus subscription or equivalent benefit mix.

### [Asana Ticket](https://app.asana.com/1/1210045093164357/project/1213124578809504/task/1214708000202789)