### PR TITLE
Observer Digital Benefits Authorisation API - Add Public Domain

### DIFF
--- a/cdk/lib/__snapshots__/observer-benefits-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/observer-benefits-api.test.ts.snap
@@ -120,6 +120,18 @@ exports[`The Observer benefits api stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::DomainName",
     },
+    "FastlyCname": {
+      "Properties": {
+        "Name": "observer-benefits-api.code.dev-guardianapis.com",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          "dualstack.guardian.map.fastly.net",
+        ],
+        "Stage": "CODE",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
     "LambdaD247545B": {
       "DependsOn": [
         "LambdaServiceRoleDefaultPolicyDAE46E21",
@@ -1092,6 +1104,18 @@ exports[`The Observer benefits api stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "FastlyCname": {
+      "Properties": {
+        "Name": "observer-benefits-api.guardianapis.com",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          "dualstack.guardian.map.fastly.net",
+        ],
+        "Stage": "PROD",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "LambdaD247545B": {
       "DependsOn": [

--- a/cdk/lib/observer-benefits-api.ts
+++ b/cdk/lib/observer-benefits-api.ts
@@ -23,6 +23,9 @@ export class ObserverBenefitsApi extends SrStack {
 				rateLimit: 20,
 				burstLimit: 10,
 			},
+			srRestDomainProps: {
+				publicDomain: true,
+			},
 		});
 
 		lambda.addPolicies(


### PR DESCRIPTION
## What does this change?
Add's a public domain for use within fastly setup. snapshot re-generated
