### PR TITLE
run buildcheck on modules

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -33,7 +33,7 @@ jobs:
       - run: pnpm --filter "./buildcheck" type-check
       - run: pnpm --filter "./buildcheck" check-formatting
       - run: pnpm --filter "./buildcheck" lint
-      - run: pnpm --filter "./buildcheck" snapshot:assert ROOT
+      - run: pnpm --filter "./buildcheck" snapshot:assert 'ROOT|modules'
       - run: pnpm --filter "./modules/**" check-formatting
       - run: pnpm --filter "./modules/**" build
       - run: pnpm --filter "./modules/**" lint


### PR DESCRIPTION
When we added modules to buildcheck in https://github.com/guardian/support-service-lambdas/pull/3292 and related PRs, we didn't make it actually check them in the build.

This PR adds the required check to the common build.

It still takes a tiny amount of time to run 
<img width="1277" height="178" alt="image" src="https://github.com/user-attachments/assets/87488ff1-3ce8-41d5-aaf6-d350bde8e156" />
And see the output so we can see the result
https://github.com/guardian/support-service-lambdas/actions/runs/25912532753/job/76161006573?pr=3553#step:10:23
