### PR TITLE
stop zuora module depending on discount-api

### DIFF
--- a/handlers/discount-api/src/productToDiscountMapping.ts
+++ b/handlers/discount-api/src/productToDiscountMapping.ts
@@ -86,13 +86,6 @@ export const catalog = {
 	},
 };
 
-export const sandboxProductRatePlanChargeIds = {
-	recurringContribution: {
-		Month: '2c92c0f85a6b1352015a7fcf35ab397c',
-		Annual: '2c92c0f85e2d19af015e3896e84d092e',
-	},
-};
-
 const Discounts = (stage: Stage) => {
 	const getCancellationFree2Mo = (
 		eligibilityCheckForRatePlan: EligibilityCheck,

--- a/modules/zuora/test/fixtures/request-bodies/contribution-subscribe-body.ts
+++ b/modules/zuora/test/fixtures/request-bodies/contribution-subscribe-body.ts
@@ -1,13 +1,11 @@
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Dayjs } from 'dayjs';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import {
-	catalog,
-	sandboxProductRatePlanChargeIds,
-} from '../../../../../handlers/discount-api/src/productToDiscountMapping';
 import type { ContributionTestAdditionalOptions } from '../../it-helpers/createGuardianSubscription';
 
 export const contributionSubscribeBody = (
 	subscriptionDate: Dayjs,
+	productCatalog: ProductCatalog,
 	additionOptions?: ContributionTestAdditionalOptions,
 ) => {
 	const paymentOptions = {
@@ -68,16 +66,18 @@ export const contributionSubscribeBody = (
 						{
 							RatePlan: {
 								ProductRatePlanId:
-									catalog.CODE.recurringContribution[billingPeriod],
+									productCatalog.Contribution.ratePlans[
+										billingPeriod === 'Month' ? 'Monthly' : billingPeriod
+									].id,
 							},
 							RatePlanChargeData: [
 								{
 									RatePlanCharge: {
 										Price: additionOptions?.price ?? 100,
 										ProductRatePlanChargeId:
-											sandboxProductRatePlanChargeIds.recurringContribution[
-												billingPeriod
-											],
+											productCatalog.Contribution.ratePlans[
+												billingPeriod === 'Month' ? 'Monthly' : billingPeriod
+											].charges.Contribution.id,
 										EndDateCondition: 'SubscriptionEnd',
 									},
 								},

--- a/modules/zuora/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
+++ b/modules/zuora/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
@@ -1,10 +1,11 @@
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Dayjs } from 'dayjs';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import { catalog } from '../../../../../handlers/discount-api/src/productToDiscountMapping';
 
 export const digiSubSubscribeBody = (
 	subscriptionDate: Dayjs,
 	createWithOldPrice: boolean,
+	productCatalog: ProductCatalog,
 ) => {
 	const chargeOverride = createWithOldPrice
 		? {
@@ -57,7 +58,8 @@ export const digiSubSubscribeBody = (
 					RatePlanData: [
 						{
 							RatePlan: {
-								ProductRatePlanId: catalog.CODE.digiSub.Month,
+								ProductRatePlanId:
+									productCatalog.DigitalSubscription.ratePlans.Monthly.id,
 							},
 							...chargeOverride,
 							SubscriptionProductFeatureList: [],

--- a/modules/zuora/test/fixtures/request-bodies/supporterplus-subscribe-body-tier2.ts
+++ b/modules/zuora/test/fixtures/request-bodies/supporterplus-subscribe-body-tier2.ts
@@ -1,8 +1,11 @@
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Dayjs } from 'dayjs';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import { catalog } from '../../../../../handlers/discount-api/src/productToDiscountMapping';
 
-export const supporterPlusSubscribeBody = (subscriptionDate: Dayjs) => {
+export const supporterPlusSubscribeBody = (
+	subscriptionDate: Dayjs,
+	productCatalog: ProductCatalog,
+) => {
 	return {
 		subscribes: [
 			{
@@ -41,7 +44,8 @@ export const supporterPlusSubscribeBody = (subscriptionDate: Dayjs) => {
 					RatePlanData: [
 						{
 							RatePlan: {
-								ProductRatePlanId: catalog.CODE.supporterPlus.Month,
+								ProductRatePlanId:
+									productCatalog.SupporterPlus.ratePlans.Monthly.id,
 							},
 							SubscriptionProductFeatureList: [],
 						},

--- a/modules/zuora/test/it-helpers/createGuardianSubscription.ts
+++ b/modules/zuora/test/it-helpers/createGuardianSubscription.ts
@@ -1,11 +1,19 @@
 import { getIfDefined } from '@modules/nullAndUndefined';
+import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import dayjs from 'dayjs';
 import { zuoraSubscribeResponseSchema } from '@modules/zuora/types';
 import type { ZuoraSubscribeResponse } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import code from '../../../zuora-catalog/test/fixtures/catalog-code.json';
 import { contributionSubscribeBody } from '../fixtures/request-bodies/contribution-subscribe-body';
 import { digiSubSubscribeBody } from '../fixtures/request-bodies/digitalSub-subscribe-body-old-price';
 import { supporterPlusSubscribeBody } from '../fixtures/request-bodies/supporterplus-subscribe-body-tier2';
+
+const productCatalog: ProductCatalog = generateProductCatalog(
+	zuoraCatalogSchema.parse(code),
+);
 
 export const createDigitalSubscription = async (
 	zuoraClient: ZuoraClient,
@@ -13,7 +21,7 @@ export const createDigitalSubscription = async (
 ): Promise<string> => {
 	const subscribeResponse = await subscribe(
 		zuoraClient,
-		digiSubSubscribeBody(dayjs(), createWithOldPrice),
+		digiSubSubscribeBody(dayjs(), createWithOldPrice, productCatalog),
 	);
 	return getIfDefined(
 		subscribeResponse[0]?.SubscriptionNumber,
@@ -26,7 +34,7 @@ export const createSupporterPlusSubscription = async (
 ): Promise<string> => {
 	const subscribeResponse = await subscribe(
 		zuoraClient,
-		supporterPlusSubscribeBody(dayjs()),
+		supporterPlusSubscribeBody(dayjs(), productCatalog),
 	);
 
 	return getIfDefined(
@@ -55,7 +63,7 @@ export const createContribution = async (
 ): Promise<string> => {
 	const subscribeResponse = await subscribe(
 		zuoraClient,
-		contributionSubscribeBody(startDate, additionOptions),
+		contributionSubscribeBody(startDate, productCatalog, additionOptions),
 	);
 	return getIfDefined(
 		subscribeResponse[0]?.SubscriptionNumber,


### PR DESCRIPTION
zuora module tests depends on discount-api

No module should depend on a handler

This is only needed for IDs of things from sandbox catalog.

This PR makes it use productCatalog instead