### PR TITLE
add user-subscriptions-api to value team

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -49,6 +49,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'workflow',
 		'consent-autolapse',
 		'mparticle-api',
+		'user-subscriptions-api',
 	],
 	SRE: ['alarms-handler', 'gchat-test-app'],
 	PORTFOLIO: [


### PR DESCRIPTION
assigning the new lambda in https://github.com/guardian/support-service-lambdas/pull/3567 to "value" (aka lifecycle) team.