### PR TITLE
Update alarms handler for MarTech and Lifecycle teams

### DIFF
--- a/handlers/alarms-handler/README.md
+++ b/handlers/alarms-handler/README.md
@@ -6,10 +6,10 @@ First you need to create a webhook for the channel that you want the alarms to g
 
 The important thing is that the name of the Parameter Store key follows a strong convention. 
 
-For instance for the Value Alarms channel, there is a team `VALUE` defined in the alarmMappings.ts file. The parameter store key must then be 
+For instance for the Value Alarms channel, there is a team `LIFECYCLE` defined in the alarmMappings.ts file. The parameter store key must then be 
 
 ```
-/PROD/support/alarms-handler/webhookUrls/VALUE
+/PROD/support/alarms-handler/webhookUrls/LIFECYCLE
 ```
 That key contains the webhook for the Value Alarms channel.
 

--- a/handlers/alarms-handler/runManual/runHandlerDEV.ts
+++ b/handlers/alarms-handler/runManual/runHandlerDEV.ts
@@ -38,8 +38,8 @@ const services: Services = {
 			DiagnosticLinks: 'lambda:product-switch-api-CODE',
 		}),
 	webhookUrls: {
-		VALUE: testWebhook,
-		GROWTH: testWebhook,
+		LIFECYCLE: testWebhook,
+		MARTECH: testWebhook,
 		SRE: testWebhook,
 		PORTFOLIO: testWebhook,
 		PLATFORM: testWebhook,

--- a/handlers/alarms-handler/runManual/runHandlerScheduledDEV.ts
+++ b/handlers/alarms-handler/runManual/runHandlerScheduledDEV.ts
@@ -15,8 +15,8 @@ loadConfig('CODE', 'support', 'alarms-handler', ConfigSchema)
 			now: () => dayjs(),
 			config: {
 				webhookUrls: {
-					VALUE: testWebhook,
-					GROWTH: testWebhook,
+					LIFECYCLE: testWebhook,
+					MARTECH: testWebhook,
 					SRE: testWebhook,
 					PORTFOLIO: testWebhook,
 					PLATFORM: testWebhook,

--- a/handlers/alarms-handler/runManual/triggerProdAlarms.sh
+++ b/handlers/alarms-handler/runManual/triggerProdAlarms.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # This is a handy script to test an alarm in PROD
-# Just run it with arguments value/growth/etc or all
+# Just run it with arguments lifecycle/martech/etc or all
 
 set -e
 
 # from alarm mappings file - SRE is not possible to test as it's only for unallocated alarms
-TEAM_KEYS=("growth" "value" "portfolio" "platform" "email")
+TEAM_KEYS=("martech" "lifecycle" "portfolio" "platform" "email")
 TEAM_EXAMPLE_APPS=("support-reminders" "apps-metering-events" "workers" "stripe-disputes" "alarms-handler")
 
 if [[ $# -lt 1 ]]; then

--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -1,8 +1,8 @@
 import { objectEntries } from '@modules/objectFunctions';
 
 export type Team =
-	| 'VALUE'
-	| 'GROWTH'
+	| 'LIFECYCLE'
+	| 'MARTECH'
 	| 'PORTFOLIO'
 	| 'PLATFORM'
 	| 'SRE'
@@ -10,7 +10,7 @@ export type Team =
 	| 'PUZZLES';
 
 const teamToAppMappings: Record<Team, string[]> = {
-	GROWTH: [
+	MARTECH: [
 		'acquisition-events-api',
 		'admin-console',
 		'apps-metering',
@@ -26,9 +26,10 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'support-reminders',
 		'ticker-calculator',
 		'bandit',
-	],
-	VALUE: [
 		'apps-metering-events',
+		'publishing-alarm-stack-cdk',
+	],
+	LIFECYCLE: [
 		'cancellation-sf-cases-api',
 		'comms-sqs', // membership-workflow queues
 		'contact-us-api',
@@ -41,7 +42,6 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'mobile-purchases-soft-opt-in-acquisitions',
 		'mobile-purchases-soft-opt-in-acquisitions-dlq-processor',
 		'payment-failure-comms',
-		'publishing-alarm-stack-cdk',
 		'salesforce-case-raiser',
 		'product-switch-api',
 		'update-supporter-plus-amount',

--- a/handlers/alarms-handler/src/configSchema.ts
+++ b/handlers/alarms-handler/src/configSchema.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const WebhookUrlsSchema = z.object({
-	VALUE: z.string(),
-	GROWTH: z.string(),
+	LIFECYCLE: z.string(),
+	MARTECH: z.string(),
 	SRE: z.string(),
 	PORTFOLIO: z.string(),
 	PLATFORM: z.string(),

--- a/handlers/alarms-handler/src/indexSummary.ts
+++ b/handlers/alarms-handler/src/indexSummary.ts
@@ -16,7 +16,7 @@ import type { WebhookUrls } from './configSchema';
 import { ConfigSchema } from './configSchema';
 
 // only teams that have opted in will get the weekly summary
-const weeklySummaryTeams: Team[] = ['VALUE'];
+const weeklySummaryTeams: Team[] = ['LIFECYCLE'];
 
 // called by AWS
 export const handler = LambdaHandler(ConfigSchema, handlerWithStage);

--- a/handlers/alarms-handler/test/alarmMappings.test.ts
+++ b/handlers/alarms-handler/test/alarmMappings.test.ts
@@ -6,7 +6,7 @@ describe('getTeam', () => {
 
 		const team = prodAppToTeams(app);
 
-		expect(team).toEqual(['GROWTH']);
+		expect(team).toEqual(['MARTECH']);
 	});
 
 	it('returns SRE if the app does not have a team owner', () => {

--- a/handlers/alarms-handler/test/index.test.ts
+++ b/handlers/alarms-handler/test/index.test.ts
@@ -6,8 +6,8 @@ import type { WebhookUrls } from '../src/configSchema';
 
 describe('Handler', () => {
 	const mockWebhookUrls: WebhookUrls = {
-		VALUE: 'value-webhook-url',
-		GROWTH: 'growth-webhook-url',
+		LIFECYCLE: 'lifecycle-webhook-url',
+		MARTECH: 'martech-webhook-url',
 		SRE: 'sre-webhook-url',
 		PORTFOLIO: 'portfolio-webhook-url',
 		PLATFORM: 'platform-webhook-url',

--- a/handlers/alarms-handler/test/indexScheduled.test.ts
+++ b/handlers/alarms-handler/test/indexScheduled.test.ts
@@ -8,8 +8,8 @@ import { getChatMessages } from '../src/indexScheduled';
 
 it('should convert some alarms into a chat message', async () => {
 	const webhookUrls: WebhookUrls = {
-		VALUE: 'http://thegulocal.com/VALUE_WEBHOOK',
-		GROWTH: 'http://thegulocal.com/GROWTH_WEBHOOK',
+		LIFECYCLE: 'http://thegulocal.com/LIFECYCLE_WEBHOOK',
+		MARTECH: 'http://thegulocal.com/MARTECH_WEBHOOK',
 		SRE: '',
 		PORTFOLIO: '',
 		PLATFORM: '',
@@ -75,7 +75,7 @@ const expected = [
 				},
 			],
 		},
-		webhookUrl: 'http://thegulocal.com/VALUE_WEBHOOK',
+		webhookUrl: 'http://thegulocal.com/LIFECYCLE_WEBHOOK',
 	},
 	{
 		body: {
@@ -108,7 +108,7 @@ const expected = [
 				},
 			],
 		},
-		webhookUrl: 'http://thegulocal.com/GROWTH_WEBHOOK',
+		webhookUrl: 'http://thegulocal.com/MARTECH_WEBHOOK',
 	},
 ];
 

--- a/handlers/alarms-handler/test/indexSummary.test.ts
+++ b/handlers/alarms-handler/test/indexSummary.test.ts
@@ -10,18 +10,18 @@ import type { WebhookUrls } from '../src/configSchema';
 import { getChatMessages } from '../src/indexSummary';
 
 const testAppToTeams: AppToTeams = (app) => {
-	const mapping: Record<string, Array<'VALUE' | 'GROWTH'>> = {
-		'product-move-api': ['VALUE'],
-		'soft-opt-in-consent-setter': ['VALUE'],
-		'support-reminders': ['GROWTH'],
+	const mapping: Record<string, Array<'LIFECYCLE' | 'MARTECH'>> = {
+		'product-move-api': ['LIFECYCLE'],
+		'soft-opt-in-consent-setter': ['LIFECYCLE'],
+		'support-reminders': ['MARTECH'],
 	};
 	return mapping[app ?? ''] ?? [];
 };
 
 it('should convert alarm history into summary chat messages', async () => {
 	const webhookUrls: WebhookUrls = {
-		VALUE: 'http://thegulocal.com/VALUE_WEBHOOK',
-		GROWTH: 'http://thegulocal.com/GROWTH_WEBHOOK',
+		LIFECYCLE: 'http://thegulocal.com/LIFECYCLE_WEBHOOK',
+		MARTECH: 'http://thegulocal.com/MARTECH_WEBHOOK',
 		SRE: '',
 		PORTFOLIO: '',
 		PLATFORM: '',
@@ -42,8 +42,8 @@ it('should convert alarm history into summary chat messages', async () => {
 
 const expected = [
 	{
-		team: 'VALUE',
-		webhookUrl: 'http://thegulocal.com/VALUE_WEBHOOK',
+		team: 'LIFECYCLE',
+		webhookUrl: 'http://thegulocal.com/LIFECYCLE_WEBHOOK',
 		payload: {
 			cardsV2: [
 				{
@@ -130,8 +130,8 @@ const expected = [
 		},
 	},
 	{
-		team: 'GROWTH',
-		webhookUrl: 'http://thegulocal.com/GROWTH_WEBHOOK',
+		team: 'MARTECH',
+		webhookUrl: 'http://thegulocal.com/MARTECH_WEBHOOK',
 		payload: {
 			cardsV2: [
 				{


### PR DESCRIPTION
## What does this change?

This PR updates the alarms-handler config to replace the `Growth` and `Value` teams with `MarTech` and `Lifecycle`.

As part of this, the `apps-metering-events` and `publishing-alarm-stack-cdk` (Braze publishing) apps are moved from Value MarTech.

The following parameters have been created in Parameter Store with the same values as the corresponding existing ones had:
- `/CODE/support/alarms-handler/webhookUrls/MARTECH`
- `/CODE/support/alarms-handler/webhookUrls/LIFECYCLE`
- `/PROD/support/alarms-handler/webhookUrls/MARTECH`
- `/PROD/support/alarms-handler/webhookUrls/LIFECYCLE`   


## How has this change been tested?

Tested in CODE: invoked the alarms-handler lambda with alarm payloads for the apps-metering-events (which has moved teams) and holiday-stop-api. And the logs show it correctly assigned these to the MarTech and Lifecycle teams (respectively).
