### PR TITLE
Create accept invitation endpoint

### DIFF
--- a/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
@@ -1084,10 +1084,6 @@ exports[`The Multiple account api stack matches the snapshot 1`] = `
             "Value": "CODE",
           },
         ],
-        "TimeToLiveSpecification": {
-          "AttributeName": "expiryDate",
-          "Enabled": true,
-        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Delete",
@@ -2292,10 +2288,6 @@ exports[`The Multiple account api stack matches the snapshot 2`] = `
             "Value": "PROD",
           },
         ],
-        "TimeToLiveSpecification": {
-          "AttributeName": "expiryDate",
-          "Enabled": true,
-        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",

--- a/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
@@ -1017,6 +1017,45 @@ exports[`The Multiple account api stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "SQSsendpolicy967EA932": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:SendMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sqs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":supporter-product-data-CODE",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SQSsendpolicy967EA932",
+        "Roles": [
+          {
+            "Ref": "LambdaServiceRoleA8ED4D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "SecondaryUserTable22C9D3B4": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -2239,6 +2278,45 @@ exports[`The Multiple account api stack matches the snapshot 2`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "S3catalogreadpolicyE18911B4",
+        "Roles": [
+          {
+            "Ref": "LambdaServiceRoleA8ED4D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SQSsendpolicy967EA932": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:SendMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sqs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":supporter-product-data-PROD",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SQSsendpolicy967EA932",
         "Roles": [
           {
             "Ref": "LambdaServiceRoleA8ED4D3B",

--- a/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
@@ -1088,6 +1088,29 @@ exports[`The Multiple account api stack matches the snapshot 1`] = `
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Delete",
     },
+    "SupporterProductDataTablequeryaccess7665F484": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "dynamodb:Query",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "supporter-product-data-tables-CODE-SupporterProductDataTable",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SupporterProductDataTablequeryaccess7665F484",
+        "Roles": [
+          {
+            "Ref": "LambdaServiceRoleA8ED4D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "ZuoraOAuthSecretsManagerpolicy5448D99B": {
       "Properties": {
         "PolicyDocument": {
@@ -2291,6 +2314,29 @@ exports[`The Multiple account api stack matches the snapshot 2`] = `
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
+    },
+    "SupporterProductDataTablequeryaccess7665F484": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "dynamodb:Query",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "supporter-product-data-tables-PROD-SupporterProductDataTable",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SupporterProductDataTablequeryaccess7665F484",
+        "Roles": [
+          {
+            "Ref": "LambdaServiceRoleA8ED4D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "ZuoraOAuthSecretsManagerpolicy5448D99B": {
       "Properties": {

--- a/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
@@ -1093,7 +1093,10 @@ exports[`The Multiple account api stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "dynamodb:Query",
+              "Action": [
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+              ],
               "Effect": "Allow",
               "Resource": {
                 "Fn::ImportValue": "supporter-product-data-tables-CODE-SupporterProductDataTable",
@@ -2320,7 +2323,10 @@ exports[`The Multiple account api stack matches the snapshot 2`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "dynamodb:Query",
+              "Action": [
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+              ],
               "Effect": "Allow",
               "Resource": {
                 "Fn::ImportValue": "supporter-product-data-tables-PROD-SupporterProductDataTable",

--- a/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
+++ b/cdk/lib/__snapshots__/press-reader-entitlements.test.ts.snap
@@ -308,7 +308,10 @@ exports[`The Press reader entitlements stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "dynamodb:Query",
+              "Action": [
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+              ],
               "Effect": "Allow",
               "Resource": {
                 "Fn::ImportValue": "supporter-product-data-tables-CODE-SupporterProductDataTable",
@@ -1350,7 +1353,10 @@ exports[`The Press reader entitlements stack matches the snapshot 2`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "dynamodb:Query",
+              "Action": [
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+              ],
               "Effect": "Allow",
               "Resource": {
                 "Fn::ImportValue": "supporter-product-data-tables-PROD-SupporterProductDataTable",

--- a/cdk/lib/cdk/policies.ts
+++ b/cdk/lib/cdk/policies.ts
@@ -83,7 +83,7 @@ export class AllowZuoraOAuthSecretsPolicy extends AllowGetSecretValuePolicy {
 export class AllowSupporterProductDataQueryPolicy extends GuAllowPolicy {
 	constructor(scope: GuStack) {
 		super(scope, 'SupporterProductDataTable query access', {
-			actions: ['dynamodb:Query'],
+			actions: ['dynamodb:Query', 'dynamodb:GetItem'],
 			resources: [
 				Fn.importValue(
 					`supporter-product-data-tables-${scope.stage}-SupporterProductDataTable`,

--- a/cdk/lib/multiple-account-api.ts
+++ b/cdk/lib/multiple-account-api.ts
@@ -10,6 +10,7 @@ import {
 } from 'aws-cdk-lib/aws-dynamodb';
 import {
 	AllowS3CatalogReadPolicy,
+	AllowSupporterProductDataQueryPolicy,
 	AllowZuoraOAuthSecretsPolicy,
 } from './cdk/policies';
 import { SrApiLambda } from './cdk/SrApiLambda';
@@ -43,6 +44,7 @@ export class MultipleAccountApi extends SrStack {
 
 		lambda.addPolicies(new AllowZuoraOAuthSecretsPolicy(this));
 		lambda.addPolicies(new AllowS3CatalogReadPolicy(this));
+		lambda.addPolicies(new AllowSupporterProductDataQueryPolicy(this));
 
 		const invitationTable = new Table(this, 'InvitationTable', {
 			tableName: `${app}-invitation-${this.stage}`,

--- a/cdk/lib/multiple-account-api.ts
+++ b/cdk/lib/multiple-account-api.ts
@@ -68,7 +68,6 @@ export class MultipleAccountApi extends SrStack {
 			billingMode: BillingMode.PAY_PER_REQUEST,
 			partitionKey: { name: 'subscriptionName', type: AttributeType.STRING },
 			sortKey: { name: 'secondaryIdentityId', type: AttributeType.STRING },
-			timeToLiveAttribute: 'expiryDate',
 			encryption: TableEncryption.AWS_MANAGED,
 			stream: StreamViewType.NEW_AND_OLD_IMAGES,
 			removalPolicy:

--- a/cdk/lib/multiple-account-api.ts
+++ b/cdk/lib/multiple-account-api.ts
@@ -10,6 +10,7 @@ import {
 } from 'aws-cdk-lib/aws-dynamodb';
 import {
 	AllowS3CatalogReadPolicy,
+	AllowSqsSendPolicy,
 	AllowSupporterProductDataQueryPolicy,
 	AllowZuoraOAuthSecretsPolicy,
 } from './cdk/policies';
@@ -45,6 +46,9 @@ export class MultipleAccountApi extends SrStack {
 		lambda.addPolicies(new AllowZuoraOAuthSecretsPolicy(this));
 		lambda.addPolicies(new AllowS3CatalogReadPolicy(this));
 		lambda.addPolicies(new AllowSupporterProductDataQueryPolicy(this));
+		lambda.addPolicies(
+			AllowSqsSendPolicy.create(this, 'supporter-product-data'),
+		);
 
 		const invitationTable = new Table(this, 'InvitationTable', {
 			tableName: `${app}-invitation-${this.stage}`,

--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -104,6 +104,82 @@ paths:
               schema:
                 type: string
                 example: Internal server error
+  /invitation/{invitationCode}/accept:
+    post:
+      operationId: acceptInvitation
+      summary: Accept invitation
+      description: Accepts an invitation for the signed-in secondary user, linking them to the subscription.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: invitationCode
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 12
+            maxLength: 12
+            pattern: '^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{12}$'
+          description: 12-character Base58 invitation code.
+          example: RpwR62kMnAxe
+      responses:
+        '200':
+          description: Invitation accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+        '400':
+          description: Invalid request or the signed-in user does not match the invited user.
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                incorrectUser:
+                  value: Incorrect user
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParserError'
+        '401':
+          description: Missing, expired, or invalid Okta token.
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                noToken:
+                  value: No Authorization header provided
+                expired:
+                  value: Token has expired
+                invalid:
+                  value: Token is invalid
+                signingKey:
+                  value: Unable to find a signing key for the token
+        '403':
+          description: Token does not have the required scopes.
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                invalidScopes:
+                  value: Token does not have the required scopes
+        '404':
+          description: Route not found.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Not Found
+        '500':
+          description: Internal server error.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
 components:
   securitySchemes:
     identityId:
@@ -114,6 +190,11 @@ components:
       type: apiKey
       in: header
       name: x-api-key
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Okta JWT token passed in the Authorization header.
   schemas:
     CreateInvitationRequest:
       type: object

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -38,7 +38,6 @@ export const acceptInvitationEndpoint = async (
 			secondaryIdentityId: invitation.secondaryIdentityId,
 			primaryIdentityId: invitation.primaryIdentityId,
 			acceptedDate: zuoraDateFormat(today),
-			expiryDate: today.add(1, 'year').unix(),
 		};
 		await secondaryUserRepository.save(secondaryUserRecord);
 

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -87,6 +87,7 @@ export const acceptInvitationEndpoint = async (
 
 		// TODO: email?
 		return ok({
+			identityId: invitation.secondaryIdentityId,
 			secondarySubscriptionName,
 		});
 	} catch (error) {

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -1,0 +1,28 @@
+import {
+	badRequest,
+	buildErrorResponse,
+	ok,
+} from '@modules/routing/apiGatewayResponses';
+import { z } from 'zod';
+import type { InvitationRepository } from './invitationRepository';
+
+export const acceptInvitationBodySchema = z.object({
+	invitationCode: z.string(),
+});
+
+export const acceptInvitationEndpoint = async (
+	signedInUserId: string,
+	invitationCode: string,
+	invitationRepository: InvitationRepository,
+) => {
+	try {
+		const invitation = await invitationRepository.get(invitationCode);
+		if (signedInUserId !== invitation?.secondaryIdentityId) {
+			return badRequest('Incorrect user');
+		}
+
+		return ok({});
+	} catch (error) {
+		return buildErrorResponse(error);
+	}
+};

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -45,7 +45,7 @@ export const acceptInvitationEndpoint = async (
 			`Supporter rate plan record not found for ${invitation.subscriptionName} and identity ${invitation.primaryIdentityId}`,
 		);
 		const today = dayjs();
-		
+
 		const secondaryUserRecord = {
 			subscriptionName: invitation.subscriptionName,
 			secondaryIdentityId: invitation.secondaryIdentityId,

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
 import type { InvitationRepository } from './invitationRepository';
 import type { SecondaryUserRepository } from './secondaryUserRepository';
 
-export const acceptInvitationBodySchema = z.object({
+export const acceptInvitationPathSchema = z.object({
 	invitationCode: z.string(),
 });
 

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -70,8 +70,9 @@ export const acceptInvitationEndpoint = async (
 			}),
 		);
 
+		const secondarySubscriptionName = `${invitation.subscriptionName}-${invitation.secondaryIdentityId}`;
 		const supporterProductDataRecord: SupporterRatePlanItem = {
-			subscriptionName: `${invitation.subscriptionName}-${invitation.secondaryIdentityId}`,
+			subscriptionName: secondarySubscriptionName,
 			primarySubscriptionName: invitation.subscriptionName, // TODO Not being written currently
 			identityId: invitation.secondaryIdentityId,
 			productRatePlanId: parentSupporterProductDataRecord.productRatePlanId,
@@ -85,7 +86,9 @@ export const acceptInvitationEndpoint = async (
 		await sendToSupporterProductData(stage, supporterProductDataRecord);
 
 		// TODO: email?
-		return ok({});
+		return ok({
+			secondarySubscriptionName,
+		});
 	} catch (error) {
 		return buildErrorResponse(error);
 	}

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -1,3 +1,5 @@
+import { TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
+import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import {
 	badRequest,
@@ -27,6 +29,7 @@ export const acceptInvitationEndpoint = async (
 	invitationCode: string,
 	invitationRepository: InvitationRepository,
 	secondaryUserRepository: SecondaryUserRepository,
+	dynamoClient: DynamoDBClient,
 ) => {
 	try {
 		const invitation = await invitationRepository.get(invitationCode);
@@ -52,7 +55,20 @@ export const acceptInvitationEndpoint = async (
 			primaryIdentityId: invitation.primaryIdentityId,
 			acceptedDate: zuoraDateFormat(today),
 		};
-		await secondaryUserRepository.save(secondaryUserRecord);
+
+		// Carry out the secondary user creation and deletion of the invitation
+		// in a transaction to keep them atomic
+		await dynamoClient.send(
+			new TransactWriteItemsCommand({
+				TransactItems: [
+					secondaryUserRepository.getPutTransaction(secondaryUserRecord),
+					invitationRepository.getDeleteTransaction(
+						invitation.subscriptionName,
+						invitationCode,
+					),
+				],
+			}),
+		);
 
 		const supporterProductDataRecord: SupporterRatePlanItem = {
 			subscriptionName: `${invitation.subscriptionName}-${invitation.secondaryIdentityId}`,
@@ -63,12 +79,10 @@ export const acceptInvitationEndpoint = async (
 			contractEffectiveDate: today,
 			termEndDate: parentSupporterProductDataRecord.termEndDate,
 		};
-		await sendToSupporterProductData(stage, supporterProductDataRecord);
 
-		await invitationRepository.delete(
-			invitation.subscriptionName,
-			invitationCode,
-		);
+		// This record is not part of the transaction because it is sent via an SQS queue
+		// If there is an issue with it it will be debugged and retried there
+		await sendToSupporterProductData(stage, supporterProductDataRecord);
 
 		// TODO: email?
 		return ok({});

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -36,15 +36,6 @@ export const acceptInvitationEndpoint = async (
 		if (signedInUserId !== invitation.secondaryIdentityId) {
 			return badRequest('Incorrect user');
 		}
-		const today = dayjs();
-		const secondaryUserRecord = {
-			subscriptionName: invitation.subscriptionName,
-			secondaryIdentityId: invitation.secondaryIdentityId,
-			primaryIdentityId: invitation.primaryIdentityId,
-			acceptedDate: zuoraDateFormat(today),
-		};
-		await secondaryUserRepository.save(secondaryUserRecord);
-
 		const parentSupporterProductDataRecord = getIfDefined(
 			await getSupporterRatePlan(
 				stage,
@@ -53,6 +44,16 @@ export const acceptInvitationEndpoint = async (
 			),
 			`Supporter rate plan record not found for ${invitation.subscriptionName} and identity ${invitation.primaryIdentityId}`,
 		);
+		const today = dayjs();
+		
+		const secondaryUserRecord = {
+			subscriptionName: invitation.subscriptionName,
+			secondaryIdentityId: invitation.secondaryIdentityId,
+			primaryIdentityId: invitation.primaryIdentityId,
+			acceptedDate: zuoraDateFormat(today),
+		};
+		await secondaryUserRepository.save(secondaryUserRecord);
+
 		const supporterProductDataRecord: SupporterRatePlanItem = {
 			subscriptionName: `${invitation.subscriptionName}-${invitation.secondaryIdentityId}`,
 			primarySubscriptionName: invitation.subscriptionName, // TODO Not being written currently

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -2,6 +2,7 @@ import { getIfDefined } from '@modules/nullAndUndefined';
 import {
 	badRequest,
 	buildErrorResponse,
+	notFound,
 	ok,
 } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
@@ -29,7 +30,10 @@ export const acceptInvitationEndpoint = async (
 ) => {
 	try {
 		const invitation = await invitationRepository.get(invitationCode);
-		if (signedInUserId !== invitation?.secondaryIdentityId) {
+		if (!invitation) {
+			return notFound();
+		}
+		if (signedInUserId !== invitation.secondaryIdentityId) {
 			return badRequest('Incorrect user');
 		}
 		const today = dayjs();

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -52,7 +52,7 @@ export const acceptInvitationEndpoint = async (
 		);
 		const supporterProductDataRecord: SupporterRatePlanItem = {
 			subscriptionName: `${invitation.subscriptionName}-${invitation.secondaryIdentityId}`,
-			parentSubscriptionName: invitation.subscriptionName, // TODO Not being written currently
+			primarySubscriptionName: invitation.subscriptionName, // TODO Not being written currently
 			identityId: invitation.secondaryIdentityId,
 			productRatePlanId: parentSupporterProductDataRecord.productRatePlanId,
 			productRatePlanName: 'Digital Plus Secondary User',
@@ -66,6 +66,7 @@ export const acceptInvitationEndpoint = async (
 			invitationCode,
 		);
 
+		// TODO: email?
 		return ok({});
 	} catch (error) {
 		return buildErrorResponse(error);

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -1,25 +1,70 @@
+import { getIfDefined } from '@modules/nullAndUndefined';
 import {
 	badRequest,
 	buildErrorResponse,
 	ok,
 } from '@modules/routing/apiGatewayResponses';
+import type { Stage } from '@modules/stage';
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
+import {
+	getSupporterRatePlan,
+	sendToSupporterProductData,
+} from '@modules/supporter-product-data/supporterProductData';
+import { zuoraDateFormat } from '@modules/zuora/utils';
+import dayjs from 'dayjs';
 import { z } from 'zod';
 import type { InvitationRepository } from './invitationRepository';
+import type { SecondaryUserRepository } from './secondaryUserRepository';
 
 export const acceptInvitationBodySchema = z.object({
 	invitationCode: z.string(),
 });
 
 export const acceptInvitationEndpoint = async (
+	stage: Stage,
 	signedInUserId: string,
 	invitationCode: string,
 	invitationRepository: InvitationRepository,
+	secondaryUserRepository: SecondaryUserRepository,
 ) => {
 	try {
 		const invitation = await invitationRepository.get(invitationCode);
 		if (signedInUserId !== invitation?.secondaryIdentityId) {
 			return badRequest('Incorrect user');
 		}
+		const today = dayjs();
+		const secondaryUserRecord = {
+			subscriptionName: invitation.subscriptionName,
+			secondaryIdentityId: invitation.secondaryIdentityId,
+			primaryIdentityId: invitation.primaryIdentityId,
+			acceptedDate: zuoraDateFormat(today),
+			expiryDate: today.add(1, 'year').unix(),
+		};
+		await secondaryUserRepository.save(secondaryUserRecord);
+
+		const parentSupporterProductDataRecord = getIfDefined(
+			await getSupporterRatePlan(
+				stage,
+				invitation.primaryIdentityId,
+				invitation.subscriptionName,
+			),
+			`Supporter rate plan record not found for ${invitation.subscriptionName} and identity ${invitation.primaryIdentityId}`,
+		);
+		const supporterProductDataRecord: SupporterRatePlanItem = {
+			subscriptionName: `${invitation.subscriptionName}-secondary-${invitation.secondaryIdentityId}`,
+			parentSubscriptionName: invitation.subscriptionName,
+			identityId: invitation.secondaryIdentityId,
+			productRatePlanId: parentSupporterProductDataRecord.productRatePlanId,
+			productRatePlanName: 'Digital Plus Secondary User',
+			contractEffectiveDate: today,
+			termEndDate: parentSupporterProductDataRecord.termEndDate,
+		};
+		await sendToSupporterProductData(stage, supporterProductDataRecord);
+
+		await invitationRepository.delete(
+			invitation.subscriptionName,
+			invitationCode,
+		);
 
 		return ok({});
 	} catch (error) {

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -51,8 +51,8 @@ export const acceptInvitationEndpoint = async (
 			`Supporter rate plan record not found for ${invitation.subscriptionName} and identity ${invitation.primaryIdentityId}`,
 		);
 		const supporterProductDataRecord: SupporterRatePlanItem = {
-			subscriptionName: `${invitation.subscriptionName}-secondary-${invitation.secondaryIdentityId}`,
-			parentSubscriptionName: invitation.subscriptionName,
+			subscriptionName: `${invitation.subscriptionName}-${invitation.secondaryIdentityId}`,
+			parentSubscriptionName: invitation.subscriptionName, // TODO Not being written currently
 			identityId: invitation.secondaryIdentityId,
 			productRatePlanId: parentSupporterProductDataRecord.productRatePlanId,
 			productRatePlanName: 'Digital Plus Secondary User',

--- a/handlers/multiple-account-api/src/createInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/createInvitationEndpoint.ts
@@ -24,8 +24,11 @@ export const createInvitationBodySchema = z.object({
 	subscriptionName: z.string(),
 	secondaryUserEmail: z.string().email(),
 });
-
 export type CreateInvitationBody = z.infer<typeof createInvitationBodySchema>;
+
+export const createInvitationResponseBodySchema = z.object({
+	invitationCode: z.string(),
+});
 
 const generateInvitationCode = customAlphabet(
 	'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz',
@@ -79,5 +82,8 @@ export const createInvitationEndpoint =
 
 		// TODO: trigger the invite email
 
-		return created({ invitationCode });
+		return created(
+			{ invitationCode },
+			{ schema: createInvitationResponseBodySchema },
+		);
 	};

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -69,7 +69,7 @@ export const handler: Handler = Router([
 		),
 	},
 	{
-		httpMethod: 'PUT',
+		httpMethod: 'POST',
 		path: '/invitation/{invitationCode}',
 		handler: withPathParser(acceptInvitationPathSchema, async (event, path) => {
 			const maybeAuthenticatedEvent = await authenticate(event);

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -70,7 +70,7 @@ export const handler: Handler = Router([
 	},
 	{
 		httpMethod: 'POST',
-		path: '/invitation/{invitationCode}',
+		path: '/invitation/{invitationCode}/accept',
 		handler: withPathParser(acceptInvitationPathSchema, async (event, path) => {
 			const maybeAuthenticatedEvent = await authenticate(event);
 

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -1,3 +1,4 @@
+import { buildAuthenticate } from '@modules/identity/apiGateway';
 import { IdentityClient } from '@modules/identity/identityClient';
 import { Lazy } from '@modules/lazy';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
@@ -7,6 +8,10 @@ import { withBodyParser, withPathParser } from '@modules/routing/withParsers';
 import { stageFromEnvironment } from '@modules/stage';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
 import type { Handler } from 'aws-lambda';
+import {
+	acceptInvitationBodySchema,
+	acceptInvitationEndpoint,
+} from './acceptInvitationEndpoint';
 import {
 	createInvitationBodySchema,
 	createInvitationEndpoint,
@@ -18,6 +23,7 @@ import {
 import { InvitationRepository } from './invitationRepository';
 
 const stage = stageFromEnvironment();
+const authenticate = buildAuthenticate(stage, []);
 const invitationRepository = InvitationRepository.create(stage);
 const identityClientPromise = IdentityClient.create(
 	stage,
@@ -58,6 +64,26 @@ export const handler: Handler = Router([
 		path: '/invitation/{invitationCode}',
 		handler: withPathParser(deleteInvitationPathSchema, async (_event, path) =>
 			deleteInvitationEndpoint(invitationRepository)(path),
+		),
+	},
+	{
+		httpMethod: 'PUT',
+		path: '/invitation',
+		handler: withBodyParser(
+			acceptInvitationBodySchema,
+			async (event, path, body) => {
+				const maybeAuthenticatedEvent = await authenticate(event);
+
+				if (maybeAuthenticatedEvent.type === 'failure') {
+					return maybeAuthenticatedEvent.response;
+				}
+
+				return acceptInvitationEndpoint(
+					maybeAuthenticatedEvent.userDetails.identityId,
+					body.invitationCode,
+					invitationRepository,
+				);
+			},
 		),
 	},
 ]);

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -21,10 +21,12 @@ import {
 	deleteInvitationPathSchema,
 } from './deleteInvitationEndpoint';
 import { InvitationRepository } from './invitationRepository';
+import { SecondaryUserRepository } from './secondaryUserRepository';
 
 const stage = stageFromEnvironment();
 const authenticate = buildAuthenticate(stage, []);
 const invitationRepository = InvitationRepository.create(stage);
+const secondaryUserRepository = SecondaryUserRepository.create(stage);
 const identityClientPromise = IdentityClient.create(
 	stage,
 	`/${stage}/support/multiple-account-api/identity-client-access-token`,
@@ -82,6 +84,7 @@ export const handler: Handler = Router([
 					maybeAuthenticatedEvent.userDetails.identityId,
 					body.invitationCode,
 					invitationRepository,
+					secondaryUserRepository,
 				);
 			},
 		),

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -1,3 +1,5 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { awsConfig } from '@modules/aws/config';
 import { buildAuthenticate } from '@modules/identity/apiGateway';
 import { IdentityClient } from '@modules/identity/identityClient';
 import { Lazy } from '@modules/lazy';
@@ -25,6 +27,7 @@ import { SecondaryUserRepository } from './secondaryUserRepository';
 
 const stage = stageFromEnvironment();
 const authenticate = buildAuthenticate(stage, []);
+const dynamoClient = new DynamoDBClient(awsConfig);
 const invitationRepository = InvitationRepository.create(stage);
 const secondaryUserRepository = SecondaryUserRepository.create(stage);
 const identityClientPromise = IdentityClient.create(
@@ -84,6 +87,7 @@ export const handler: Handler = Router([
 				path.invitationCode,
 				invitationRepository,
 				secondaryUserRepository,
+				dynamoClient,
 			);
 		}),
 	},

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -9,8 +9,8 @@ import { stageFromEnvironment } from '@modules/stage';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
 import type { Handler } from 'aws-lambda';
 import {
-	acceptInvitationPathSchema,
 	acceptInvitationEndpoint,
+	acceptInvitationPathSchema,
 } from './acceptInvitationEndpoint';
 import {
 	createInvitationBodySchema,

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -9,7 +9,7 @@ import { stageFromEnvironment } from '@modules/stage';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
 import type { Handler } from 'aws-lambda';
 import {
-	acceptInvitationBodySchema,
+	acceptInvitationPathSchema,
 	acceptInvitationEndpoint,
 } from './acceptInvitationEndpoint';
 import {
@@ -70,23 +70,21 @@ export const handler: Handler = Router([
 	},
 	{
 		httpMethod: 'PUT',
-		path: '/invitation',
-		handler: withBodyParser(
-			acceptInvitationBodySchema,
-			async (event, path, body) => {
-				const maybeAuthenticatedEvent = await authenticate(event);
+		path: '/invitation/{invitationCode}',
+		handler: withPathParser(acceptInvitationPathSchema, async (event, path) => {
+			const maybeAuthenticatedEvent = await authenticate(event);
 
-				if (maybeAuthenticatedEvent.type === 'failure') {
-					return maybeAuthenticatedEvent.response;
-				}
+			if (maybeAuthenticatedEvent.type === 'failure') {
+				return maybeAuthenticatedEvent.response;
+			}
 
-				return acceptInvitationEndpoint(
-					maybeAuthenticatedEvent.userDetails.identityId,
-					body.invitationCode,
-					invitationRepository,
-					secondaryUserRepository,
-				);
-			},
-		),
+			return acceptInvitationEndpoint(
+				stage,
+				maybeAuthenticatedEvent.userDetails.identityId,
+				path.invitationCode,
+				invitationRepository,
+				secondaryUserRepository,
+			);
+		}),
 	},
 ]);

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -3,6 +3,7 @@ import {
 	DynamoDBClient,
 	PutItemCommand,
 	QueryCommand,
+	type TransactWriteItem,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { getMaybeSingleOrThrow } from '@modules/arrayFunctions';
@@ -95,5 +96,20 @@ export class InvitationRepository {
 				},
 			}),
 		);
+	}
+
+	getDeleteTransaction(
+		subscriptionName: string,
+		invitationCode: string,
+	): TransactWriteItem {
+		return {
+			Delete: {
+				TableName: this.tableName,
+				Key: {
+					subscriptionName: { S: subscriptionName },
+					invitationCode: { S: invitationCode },
+				},
+			},
+		};
 	}
 }

--- a/handlers/multiple-account-api/src/secondaryUserRepository.ts
+++ b/handlers/multiple-account-api/src/secondaryUserRepository.ts
@@ -5,35 +5,33 @@ import {
 	QueryCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import { getMaybeSingleOrThrow } from '@modules/arrayFunctions';
 import type { Stage } from '@modules/stage';
 import { z } from 'zod';
 
-const invitationRecordSchema = z.object({
+const secondaryUserRecordSchema = z.object({
 	subscriptionName: z.string(),
-	invitationCode: z.string(),
-	primaryIdentityId: z.string(),
 	secondaryIdentityId: z.string(),
-	invitedDate: z.string(),
+	primaryIdentityId: z.string(),
+	acceptedDate: z.string(),
 	expiryDate: z.number(),
 });
 
-export type InvitationRecord = z.infer<typeof invitationRecordSchema>;
+export type SecondaryUserRecord = z.infer<typeof secondaryUserRecordSchema>;
 
-export class InvitationRepository {
+export class SecondaryUserRepository {
 	constructor(
 		private readonly client: DynamoDBClient,
 		private readonly tableName: string,
 	) {}
 
-	static create(stage: Stage): InvitationRepository {
-		return new InvitationRepository(
+	static create(stage: Stage): SecondaryUserRepository {
+		return new SecondaryUserRepository(
 			new DynamoDBClient({}),
-			`multiple-account-invitation-${stage}`,
+			`multiple-account-secondary-user-${stage}`,
 		);
 	}
 
-	async save(record: InvitationRecord): Promise<void> {
+	async save(record: SecondaryUserRecord): Promise<void> {
 		await this.client.send(
 			new PutItemCommand({
 				TableName: this.tableName,
@@ -42,32 +40,23 @@ export class InvitationRepository {
 		);
 	}
 
-	async get(invitationCode: string): Promise<InvitationRecord | undefined> {
+	async get(secondaryIdentityId: string): Promise<SecondaryUserRecord[]> {
 		const result = await this.client.send(
 			new QueryCommand({
 				TableName: this.tableName,
-				IndexName: 'invitationCode-index',
-				KeyConditionExpression: 'invitationCode = :invitationCode',
+				IndexName: 'secondaryIdentityId-index',
+				KeyConditionExpression: 'secondaryIdentityId = :secondaryIdentityId',
 				ExpressionAttributeValues: {
-					':invitationCode': { S: invitationCode },
+					':secondaryIdentityId': { S: secondaryIdentityId },
 				},
 			}),
 		);
-
-		const item = getMaybeSingleOrThrow(
-			result.Items ?? [],
-			() =>
-				new Error(
-					`Multiple invitations found with the invitationCode ${invitationCode}`,
-				),
+		return (result.Items ?? []).map((item) =>
+			secondaryUserRecordSchema.parse(unmarshall(item)),
 		);
-		if (!item) {
-			return undefined;
-		}
-		return invitationRecordSchema.parse(unmarshall(item));
 	}
 
-	async list(subscriptionName: string): Promise<InvitationRecord[]> {
+	async list(subscriptionName: string): Promise<SecondaryUserRecord[]> {
 		const result = await this.client.send(
 			new QueryCommand({
 				TableName: this.tableName,
@@ -78,22 +67,23 @@ export class InvitationRepository {
 			}),
 		);
 		return (result.Items ?? []).map((item) =>
-			invitationRecordSchema.parse(unmarshall(item)),
+			secondaryUserRecordSchema.parse(unmarshall(item)),
 		);
 	}
 
 	async delete(
 		subscriptionName: string,
-		invitationCode: string,
+		secondaryIdentityId: string,
 	): Promise<void> {
 		await this.client.send(
 			new DeleteItemCommand({
 				TableName: this.tableName,
 				Key: {
 					subscriptionName: { S: subscriptionName },
-					invitationCode: { S: invitationCode },
+					secondaryIdentityId: { S: secondaryIdentityId },
 				},
 			}),
 		);
 	}
 }
+

--- a/handlers/multiple-account-api/src/secondaryUserRepository.ts
+++ b/handlers/multiple-account-api/src/secondaryUserRepository.ts
@@ -3,6 +3,7 @@ import {
 	DynamoDBClient,
 	PutItemCommand,
 	QueryCommand,
+	type TransactWriteItem,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import type { Stage } from '@modules/stage';
@@ -83,5 +84,14 @@ export class SecondaryUserRepository {
 				},
 			}),
 		);
+	}
+
+	getPutTransaction(record: SecondaryUserRecord): TransactWriteItem {
+		return {
+			Put: {
+				TableName: this.tableName,
+				Item: marshall(record),
+			},
+		};
 	}
 }

--- a/handlers/multiple-account-api/src/secondaryUserRepository.ts
+++ b/handlers/multiple-account-api/src/secondaryUserRepository.ts
@@ -86,4 +86,3 @@ export class SecondaryUserRepository {
 		);
 	}
 }
-

--- a/handlers/multiple-account-api/src/secondaryUserRepository.ts
+++ b/handlers/multiple-account-api/src/secondaryUserRepository.ts
@@ -13,7 +13,6 @@ const secondaryUserRecordSchema = z.object({
 	secondaryIdentityId: z.string(),
 	primaryIdentityId: z.string(),
 	acceptedDate: z.string(),
-	expiryDate: z.number(),
 });
 
 export type SecondaryUserRecord = z.infer<typeof secondaryUserRecordSchema>;

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -4,6 +4,7 @@
  *
  * @group integration
  */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { IdentityClient } from '@modules/identity/identityClient';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import {
@@ -28,6 +29,7 @@ let secondaryIdentityId: string;
 
 const invitationRepository = InvitationRepository.create(stage);
 const secondaryUserRepository = SecondaryUserRepository.create(stage);
+const dynamoClient = new DynamoDBClient({});
 
 beforeEach(async () => {
 	const zuoraClient = await ZuoraClient.create(stage);
@@ -91,6 +93,7 @@ test('acceptInvitationEndpoint accepts an invitation and creates a secondary use
 		invitationCode,
 		invitationRepository,
 		secondaryUserRepository,
+		dynamoClient,
 	);
 
 	expect(result.statusCode).toBe(200);

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -14,6 +14,7 @@ import { acceptInvitationEndpoint } from '../src/acceptInvitationEndpoint';
 import { createInvitationEndpoint } from '../src/createInvitationEndpoint';
 import { InvitationRepository } from '../src/invitationRepository';
 import { SecondaryUserRepository } from '../src/secondaryUserRepository';
+import { getSupporterRatePlans } from '@modules/supporter-product-data/supporterProductData';
 
 const stage = 'CODE';
 const subscriptionName = 'A-S00974337';
@@ -96,4 +97,21 @@ test('acceptInvitationEndpoint accepts an invitation and creates a secondary use
 	expect(secondaryUsers).toHaveLength(1);
 	expect(secondaryUsers[0]?.subscriptionName).toBe(subscriptionName);
 	expect(secondaryUsers[0]?.secondaryIdentityId).toBe(secondaryIdentityId);
+
+	// A secondary subscription record should have been created
+	const supporterProductDataRecords =
+		(await getSupporterRatePlans(stage, secondaryIdentityId)) ?? [];
+	expect(supporterProductDataRecords.length).toBeGreaterThan(0);
+	// Won't work until supporter product data lambdas are updated
+	// expect(supporterProductDataRecords[0]?.primarySubscriptionName).toBe(
+	// 	subscriptionName,
+	// );
+	expect(supporterProductDataRecords[0]?.identityId).toBe(secondaryIdentityId);
+	expect(supporterProductDataRecords[0]?.productRatePlanName).toBe(
+		'Digital Plus Secondary User',
+	);
+	expect(supporterProductDataRecords[0]?.subscriptionName).toBe(
+		`${subscriptionName}-${secondaryIdentityId}`,
+	);
+
 });

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
+ * command and will not be run during continuous integration.
+ *
+ * @group integration
+ */
+import { IdentityClient } from '@modules/identity/identityClient';
+import { getProductCatalogFromApi } from '@modules/product-catalog/api';
+import { getAccount } from '@modules/zuora/account';
+import { getSubscription } from '@modules/zuora/subscription';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
+import { acceptInvitationEndpoint } from '../src/acceptInvitationEndpoint';
+import { createInvitationEndpoint } from '../src/createInvitationEndpoint';
+import { InvitationRepository } from '../src/invitationRepository';
+import { SecondaryUserRepository } from '../src/secondaryUserRepository';
+
+const stage = 'CODE';
+const subscriptionName = 'A-S00974337';
+const secondaryUserEmail = 'integration-test2+multiple-account@theguardian.com';
+
+let invitationCode: string;
+let secondaryIdentityId: string;
+
+const invitationRepository = InvitationRepository.create(stage);
+const secondaryUserRepository = SecondaryUserRepository.create(stage);
+
+beforeEach(async () => {
+	const zuoraClient = await ZuoraClient.create(stage);
+	const zuoraCatalog = await getZuoraCatalogFromS3(stage);
+	const productCatalog = await getProductCatalogFromApi(stage);
+	const identityClient = await IdentityClient.create(
+		stage,
+		`/${stage}/support/multiple-account-api/identity-client-access-token`,
+	);
+
+	const endpoint = createInvitationEndpoint(
+		invitationRepository,
+		identityClient,
+		zuoraCatalog,
+		productCatalog,
+	);
+
+	const subscription = await getSubscription(zuoraClient, subscriptionName);
+	const account = await getAccount(zuoraClient, subscription.accountNumber);
+
+	const createResult = await endpoint(
+		{ subscriptionName, secondaryUserEmail },
+		undefined as never,
+		subscription,
+		account,
+	);
+
+	expect(createResult.statusCode).toBe(201);
+
+	const body = JSON.parse(createResult.body) as { invitationCode: string };
+	invitationCode = body.invitationCode;
+
+	const invitation = await invitationRepository.get(invitationCode);
+	expect(invitation).toBeDefined();
+	secondaryIdentityId = invitation!.secondaryIdentityId;
+});
+
+afterEach(async () => {
+	// Clean up the invitation if it still exists (e.g. if acceptInvitation failed)
+	const invitation = await invitationRepository.get(invitationCode);
+	if (invitation) {
+		await invitationRepository.delete(
+			invitation.subscriptionName,
+			invitationCode,
+		);
+	}
+
+	// Clean up the secondary user record created by acceptInvitationEndpoint
+	await secondaryUserRepository.delete(subscriptionName, secondaryIdentityId);
+	// TODO: delete supporter product data child record
+});
+
+test('acceptInvitationEndpoint accepts an invitation and creates a secondary user record', async () => {
+	const result = await acceptInvitationEndpoint(
+		stage,
+		secondaryIdentityId,
+		invitationCode,
+		invitationRepository,
+		secondaryUserRepository,
+	);
+
+	expect(result.statusCode).toBe(200);
+
+	// The invitation should have been deleted as part of accepting
+	const invitation = await invitationRepository.get(invitationCode);
+	expect(invitation).toBeUndefined();
+
+	// A secondary user record should have been created
+	const secondaryUsers = await secondaryUserRepository.get(secondaryIdentityId);
+	expect(secondaryUsers).toHaveLength(1);
+	expect(secondaryUsers[0]?.subscriptionName).toBe(subscriptionName);
+	expect(secondaryUsers[0]?.secondaryIdentityId).toBe(secondaryIdentityId);
+});

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -14,7 +14,10 @@ import { acceptInvitationEndpoint } from '../src/acceptInvitationEndpoint';
 import { createInvitationEndpoint } from '../src/createInvitationEndpoint';
 import { InvitationRepository } from '../src/invitationRepository';
 import { SecondaryUserRepository } from '../src/secondaryUserRepository';
-import { getSupporterRatePlans } from '@modules/supporter-product-data/supporterProductData';
+import {
+	deleteSupporterRatePlan,
+	getSupporterRatePlans,
+} from '@modules/supporter-product-data/supporterProductData';
 
 const stage = 'CODE';
 const subscriptionName = 'A-S00974337';
@@ -74,7 +77,11 @@ afterEach(async () => {
 
 	// Clean up the secondary user record created by acceptInvitationEndpoint
 	await secondaryUserRepository.delete(subscriptionName, secondaryIdentityId);
-	// TODO: delete supporter product data child record
+	await deleteSupporterRatePlan(
+		stage,
+		secondaryIdentityId,
+		`${subscriptionName}-${secondaryIdentityId}`,
+	);
 });
 
 test('acceptInvitationEndpoint accepts an invitation and creates a secondary user record', async () => {
@@ -87,6 +94,10 @@ test('acceptInvitationEndpoint accepts an invitation and creates a secondary use
 	);
 
 	expect(result.statusCode).toBe(200);
+
+	// Wait for a second to allow the async creation of the supporter product
+	// data record to complete
+	await new Promise((resolve) => setTimeout(resolve, 10000));
 
 	// The invitation should have been deleted as part of accepting
 	const invitation = await invitationRepository.get(invitationCode);
@@ -113,5 +124,4 @@ test('acceptInvitationEndpoint accepts an invitation and creates a secondary use
 	expect(supporterProductDataRecords[0]?.subscriptionName).toBe(
 		`${subscriptionName}-${secondaryIdentityId}`,
 	);
-
-});
+}, 15000);

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -6,6 +6,10 @@
  */
 import { IdentityClient } from '@modules/identity/identityClient';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
+import {
+	deleteSupporterRatePlan,
+	getSupporterRatePlans,
+} from '@modules/supporter-product-data/supporterProductData';
 import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
@@ -14,10 +18,6 @@ import { acceptInvitationEndpoint } from '../src/acceptInvitationEndpoint';
 import { createInvitationEndpoint } from '../src/createInvitationEndpoint';
 import { InvitationRepository } from '../src/invitationRepository';
 import { SecondaryUserRepository } from '../src/secondaryUserRepository';
-import {
-	deleteSupporterRatePlan,
-	getSupporterRatePlans,
-} from '@modules/supporter-product-data/supporterProductData';
 
 const stage = 'CODE';
 const subscriptionName = 'A-S00974337';

--- a/handlers/multiple-account-api/test/createInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/createInvitationIntegration.test.ts
@@ -11,7 +11,10 @@ import { getSubscription } from '@modules/zuora/subscription';
 import { zuoraSubscriptionSchema } from '@modules/zuora/types';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
-import { createInvitationEndpoint } from '../src/createInvitationEndpoint';
+import {
+	createInvitationEndpoint,
+	createInvitationResponseBodySchema,
+} from '../src/createInvitationEndpoint';
 import { InvitationRepository } from '../src/invitationRepository';
 import weekendSub from './fixtures/weekend-subscription.json';
 
@@ -26,6 +29,7 @@ test('createInvitationEndpoint saves invitation data and returns invitation code
 		stage,
 		`/${stage}/support/multiple-account-api/identity-client-access-token`,
 	);
+	const subscriptionName = 'A-S00974337';
 
 	const endpoint = createInvitationEndpoint(
 		invitationRepository,
@@ -40,7 +44,7 @@ test('createInvitationEndpoint saves invitation data and returns invitation code
 
 	const result = await endpoint(
 		{
-			subscriptionName: 'A-S00974337',
+			subscriptionName,
 			secondaryUserEmail: 'integration-test2+multiple-account@theguardian.com',
 		},
 		undefined as never,
@@ -49,4 +53,12 @@ test('createInvitationEndpoint saves invitation data and returns invitation code
 	);
 
 	expect(result.statusCode).toBe(201);
+	const resultBody = createInvitationResponseBodySchema.parse(
+		JSON.parse(result.body),
+	);
+	expect(resultBody.invitationCode).toBeDefined();
+	await invitationRepository.delete(
+		subscriptionName,
+		resultBody.invitationCode,
+	);
 });

--- a/handlers/multiple-account-api/test/secondaryUserRepositoryIntegration.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserRepositoryIntegration.test.ts
@@ -1,0 +1,40 @@
+/**
+ * This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
+ * command and will not be run during continuous integration.
+ * This makes it useful for testing things that require credentials which are available locally but not on the CI server.
+ *
+ * @group integration
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { getAwsConfig } from '@modules/aws/config';
+import type { Stage } from '@modules/stage';
+import dayjs from 'dayjs';
+import { SecondaryUserRepository } from '../src/secondaryUserRepository';
+
+const stage: Stage = 'CODE';
+
+const testRecord = {
+	subscriptionName: 'A-S00099999',
+	secondaryIdentityId: 'it-test-secondary-identity-id',
+	primaryIdentityId: '12345678',
+	acceptedDate: new Date().toISOString(),
+	expiryDate: dayjs().add(10, 'seconds').toDate().getTime(),
+};
+
+const repo = new SecondaryUserRepository(
+	new DynamoDBClient(getAwsConfig('membership')),
+	`multiple-account-secondary-user-${stage}`,
+);
+
+afterEach(async () => {
+	await repo.delete(testRecord.subscriptionName, testRecord.secondaryIdentityId);
+});
+
+test('SecondaryUserRepository saves and retrieves a record from DynamoDB', async () => {
+	await repo.save(testRecord);
+
+	const saved = await repo.get(testRecord.secondaryIdentityId);
+
+	expect(saved).toEqual([testRecord]);
+});
+

--- a/handlers/multiple-account-api/test/secondaryUserRepositoryIntegration.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserRepositoryIntegration.test.ts
@@ -27,7 +27,10 @@ const repo = new SecondaryUserRepository(
 );
 
 afterEach(async () => {
-	await repo.delete(testRecord.subscriptionName, testRecord.secondaryIdentityId);
+	await repo.delete(
+		testRecord.subscriptionName,
+		testRecord.secondaryIdentityId,
+	);
 });
 
 test('SecondaryUserRepository saves and retrieves a record from DynamoDB', async () => {
@@ -37,4 +40,3 @@ test('SecondaryUserRepository saves and retrieves a record from DynamoDB', async
 
 	expect(saved).toEqual([testRecord]);
 });
-

--- a/handlers/press-reader-entitlements/src/supporterProductData.ts
+++ b/handlers/press-reader-entitlements/src/supporterProductData.ts
@@ -4,7 +4,7 @@ import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
-import { getSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
+import { getSupporterRatePlans } from '@modules/supporter-product-data/supporterProductData';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 
 export async function getLatestSubscription(
@@ -12,7 +12,7 @@ export async function getLatestSubscription(
 	identityId: string,
 	productCatalog: ProductCatalog,
 ): Promise<SupporterRatePlanItem | undefined> {
-	const supporterProductDataItems = await getSupporterProductData(
+	const supporterProductDataItems = await getSupporterRatePlans(
 		stage,
 		identityId,
 	);

--- a/handlers/stripe-disputes/test/producer.test.ts
+++ b/handlers/stripe-disputes/test/producer.test.ts
@@ -202,6 +202,7 @@ describe('Producer Handler', () => {
 				'Missing Stripe-Signature header',
 			);
 			expect(result).toEqual({
+				headers: { 'Content-Type': 'application/json' },
 				statusCode: 400,
 				body: JSON.stringify({ message: 'Missing Stripe-Signature header' }),
 			});
@@ -220,6 +221,7 @@ describe('Producer Handler', () => {
 
 			expect(mockLogger.error).toHaveBeenCalledWith('Missing request body');
 			expect(result).toEqual({
+				headers: { 'Content-Type': 'application/json' },
 				statusCode: 400,
 				body: JSON.stringify({ message: 'Missing request body' }),
 			});

--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -6,7 +6,7 @@ import type {
 } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
-import { getSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
+import { getSupporterRatePlans } from '@modules/supporter-product-data/supporterProductData';
 import dayjs from 'dayjs';
 import {
 	inAppPurchaseProductKey,
@@ -25,7 +25,7 @@ export const getUserProducts = async (
 	productCatalogHelper: ProductCatalogHelper,
 	identityId: string,
 ): Promise<Array<ProductKey | InAppPurchaseProductKey>> => {
-	const supporterProductDataItems = await getSupporterProductData(
+	const supporterProductDataItems = await getSupporterRatePlans(
 		stage,
 		identityId,
 	);

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -15,13 +15,6 @@ export function badRequest(message: string): APIGatewayProxyResult {
 	return jsonResponse(message, 400);
 }
 
-export function notFound(): APIGatewayProxyResult {
-	return {
-		body: JSON.stringify({ message: 'Not Found' }),
-		statusCode: 404,
-	};
-}
-
 export function internalServerError(): APIGatewayProxyResult {
 	return jsonResponse('Internal server error', 500);
 }

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -25,6 +25,13 @@ export function internalServerError(): APIGatewayProxyResult {
 	};
 }
 
+export function notFound() {
+	return {
+		body: JSON.stringify({ message: 'Not Found' }),
+		statusCode: 404,
+	};
+}
+
 /**
  * Return a 200 OK response with the provided body.
  * @param body

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -4,11 +4,15 @@ import { stringify } from '@modules/stringify';
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { z } from 'zod';
 
-export function badRequest(message: string): APIGatewayProxyResult {
+function jsonResponse(message: string, statusCode: number) {
 	return {
+		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ message }),
-		statusCode: 400,
+		statusCode,
 	};
+}
+export function badRequest(message: string): APIGatewayProxyResult {
+	return jsonResponse(message, 400);
 }
 
 export function notFound(): APIGatewayProxyResult {
@@ -19,17 +23,11 @@ export function notFound(): APIGatewayProxyResult {
 }
 
 export function internalServerError(): APIGatewayProxyResult {
-	return {
-		body: JSON.stringify({ message: 'Internal server error' }),
-		statusCode: 500,
-	};
+	return jsonResponse('Internal server error', 500);
 }
 
-export function notFound() {
-	return {
-		body: JSON.stringify({ message: 'Not Found' }),
-		statusCode: 404,
-	};
+export function notFound(): APIGatewayProxyResult {
+	return jsonResponse('Not Found', 404);
 }
 
 /**

--- a/modules/routing/src/router.ts
+++ b/modules/routing/src/router.ts
@@ -119,6 +119,7 @@ export function Router(
 					);
 				}
 			}
+			logger.log(`No route found for ${event.httpMethod} ${event.path}`);
 			return NotFoundResponse;
 		} catch (error) {
 			return buildErrorResponse(error);

--- a/modules/supporter-product-data/src/supporterProductData.ts
+++ b/modules/supporter-product-data/src/supporterProductData.ts
@@ -1,5 +1,8 @@
-import * as console from 'node:console';
-import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import {
+	DynamoDBClient,
+	GetItemCommand,
+	QueryCommand,
+} from '@aws-sdk/client-dynamodb';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { awsConfig } from '@modules/aws/config';
 import { sendMessageToQueue } from '@modules/aws/sqs';
@@ -19,10 +22,44 @@ const supporterRatePlanItemSchema = z.object({
 	productRatePlanName: z.string(), // Name of the product in this rate plan
 	termEndDate: z.string().transform((arg) => dayjs(arg)), // Date that this subscription term ends
 	contractEffectiveDate: z.string().transform((arg) => dayjs(arg)), // Date that this subscription started
+	parentSubscriptionName: z.string().optional(), // Set for child subscriptions granted through the multiple accounts feature
 });
 export type SupporterRatePlanItem = z.infer<typeof supporterRatePlanItemSchema>;
 
-export const getSupporterProductData = async (
+export const getSupporterRatePlan = async (
+	stage: Stage,
+	identityId: string,
+	subscriptionName: string,
+): Promise<SupporterRatePlanItem | undefined> => {
+	const tableName = `SupporterProductData-${stage}`;
+	logger.log(
+		`Querying ${tableName} for identityId ${identityId} and subscriptionName ${subscriptionName}`,
+	);
+	const data = await dynamoClient.send(
+		new GetItemCommand({
+			TableName: tableName,
+			Key: {
+				identityId: { S: identityId },
+				subscriptionName: { S: subscriptionName },
+			},
+		}),
+	);
+	logger.log(`GetItem returned ${JSON.stringify(data)}`);
+	if (!data.Item) {
+		return undefined;
+	}
+	const unmarshalled = unmarshall(data.Item);
+	const parseResult = supporterRatePlanItemSchema.safeParse(unmarshalled);
+	if (!parseResult.success) {
+		logger.log(
+			`Failed to parse supporter product data: ${prettyPrint(unmarshalled)} because of error: ${prettyPrint(parseResult.error)}`,
+		);
+		throw new Error('Failed to parse supporter product data');
+	}
+	return parseResult.data;
+};
+
+export const getSupporterRatePlans = async (
 	stage: Stage,
 	identityId: string,
 ): Promise<SupporterRatePlanItem[] | undefined> => {
@@ -36,18 +73,18 @@ export const getSupporterProductData = async (
 		KeyConditionExpression: 'identityId = :v1',
 		TableName: tableName,
 	};
-	console.log(`Querying ${tableName} for identityId ${identityId}`);
+	logger.log(`Querying ${tableName} for identityId ${identityId}`);
 	const data = await dynamoClient.send(new QueryCommand(input));
-	console.log(`Query returned ${JSON.stringify(data)}`);
+	logger.log(`Query returned ${JSON.stringify(data)}`);
 
 	return data.Items?.map((item) => {
 		const unmarshalled = unmarshall(item);
 		const parseResult = supporterRatePlanItemSchema.safeParse(unmarshalled);
 		if (!parseResult.success) {
-			console.error(
+			logger.log(
 				`Failed to parse supporter product data: ${prettyPrint(unmarshalled)} because of error:`,
-				parseResult.error,
 			);
+			logger.log(prettyPrint(parseResult.error));
 			throw new Error('Failed to parse supporter product data');
 		}
 		return parseResult.data;

--- a/modules/supporter-product-data/src/supporterProductData.ts
+++ b/modules/supporter-product-data/src/supporterProductData.ts
@@ -22,7 +22,7 @@ const supporterRatePlanItemSchema = z.object({
 	productRatePlanName: z.string(), // Name of the product in this rate plan
 	termEndDate: z.string().transform((arg) => dayjs(arg)), // Date that this subscription term ends
 	contractEffectiveDate: z.string().transform((arg) => dayjs(arg)), // Date that this subscription started
-	parentSubscriptionName: z.string().optional(), // Set for child subscriptions granted through the multiple accounts feature
+	primarySubscriptionName: z.string().optional(), // Set for secondary subscriptions granted through the multiple accounts feature
 });
 export type SupporterRatePlanItem = z.infer<typeof supporterRatePlanItemSchema>;
 

--- a/modules/supporter-product-data/src/supporterProductData.ts
+++ b/modules/supporter-product-data/src/supporterProductData.ts
@@ -1,4 +1,5 @@
 import {
+	DeleteItemCommand,
 	DynamoDBClient,
 	GetItemCommand,
 	QueryCommand,
@@ -102,7 +103,28 @@ const supporterRatePlanDateReplacer = (key: string, value: unknown) => {
 	return value;
 };
 
-// We insert into the SupporterProductData table via an SQS queue to keep all the logic around formatting and TTLs in one place
+export const deleteSupporterRatePlan = async (
+	stage: Stage,
+	identityId: string,
+	subscriptionName: string,
+): Promise<void> => {
+	const tableName = `SupporterProductData-${stage}`;
+	logger.log(
+		`Deleting from ${tableName} for identityId ${identityId} and subscriptionName ${subscriptionName}`,
+	);
+	const response = await dynamoClient.send(
+		new DeleteItemCommand({
+			TableName: tableName,
+			Key: {
+				identityId: { S: identityId },
+				subscriptionName: { S: subscriptionName },
+			},
+		}),
+	);
+	logger.log(`DeleteItem returned ${JSON.stringify(response)}`);
+};
+
+// We insert into the SupporterProductData table via an SQS queue
 // This is the lambda that ultimately does the writing:
 // https://github.com/guardian/support-frontend/blob/main/supporter-product-data/src/main/scala/com/gu/lambdas/ProcessSupporterRatePlanItemLambda.scala#L24
 export const sendToSupporterProductData = async (

--- a/modules/supporter-product-data/test/supporterProductDataIntegration.test.ts
+++ b/modules/supporter-product-data/test/supporterProductDataIntegration.test.ts
@@ -4,12 +4,12 @@
 
 import dayjs from 'dayjs';
 import {
-	getSupporterProductData,
+	getSupporterRatePlans,
 	sendToSupporterProductData,
 } from '@modules/supporter-product-data/supporterProductData';
 
 test('Dynamo Integration', async () => {
-	const supporterData = await getSupporterProductData('CODE', '110001137');
+	const supporterData = await getSupporterRatePlans('CODE', '110001137');
 	expect(supporterData?.length).toEqual(4);
 	expect(supporterData?.[0]?.contractEffectiveDate.year()).toEqual(2024);
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR is part of the API work for the multiple accounts feature. It is described in more detail [in this doc](https://docs.google.com/document/d/1eqMn9zkg-iRK3Gi9ecmgGh8WWUYpLX6B3cOasTRYpns/edit?tab=t.0)

## Details
This adds one new endpoint which allows a user to accept an invitation to become a secondary user
`POST /invitation/[invitationCode]/accept`

Validation is done via an Okta token in the `Authorization` header - this is the standard way to identify signed in users.

The endpoint validates that the invitation exists and was sent to the currently signed in user

On successful acceptance, the endpoint creates a new record in the `multiple-account-secondary-user-[STAGE]` users Dynamo table, a new secondary subscription record in the `SupporterProductData-[STAGE]` Dynamo table, and then deletes the invitation record from the `multiple-account-invitation-[STAGE]` Dynamo table.

## Testing
Testing this endpoint is a little more complicated than the create invitation endpoint because it requires an Okta Authorization header. 

1. First you can create an invitation either via Postman/Hopscotch or using the following cURL command:
```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/invitation' \
--header 'x-api-key: [GET_API_KEY_FROM_AWS]' \
--header 'x-identity-id: 112809589' \
--header 'Content-Type: application/json' \
--header 'Authorization: ••••••' \
--data-raw '{
  "subscriptionName": "A-S00974337",
  "secondaryUserEmail": "your.email@guardian.co.uk"
}'
```
This will return an invitation code you can use in your acceptance request:
```json
{
    "invitationCode": "8hpLZeTwHZj5"
}
```
2. You will then need to get an Okta authorisation header for your accept request. Follow the steps in [this README](https://github.com/guardian/identity/tree/main/docs/generating_tokens_locally) to generate a header in Postman or Hopscotch. 
3. Then you can finally make your accept request. In cURL this would look like:
```shell
curl --location --request POST 'https://multiple-account-api-code.support.guardianapis.com/invitation/8hpLZeTwHZj5/accept' \
--header 'x-api-key: [GET_API_KEY_FROM_AWS]' \
--header 'Authorization: Bearer [MY_GENERATED_OKTA_TOKEN]'
```