### PR TITLE
update it-test command 

### DIFF
--- a/buildcheck/data/snippets/buildPackageJson.ts
+++ b/buildcheck/data/snippets/buildPackageJson.ts
@@ -30,7 +30,9 @@ export function buildPackageJson(
 		name: `${pkg.name}`,
 		scripts: {
 			test: 'jest --group=-integration',
-			'it-test': 'jest --group=integration',
+			'it-test':
+				'NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" jest --group=integration',
+
 			'type-check': 'tsc --noEmit',
 			lint: "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
 			'check-formatting': 'prettier --check "**/*.ts"',

--- a/handlers/alarms-handler/package.json
+++ b/handlers/alarms-handler/package.json
@@ -2,7 +2,7 @@
   "name": "alarms-handler",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/contributions-only-countries-api/package.json
+++ b/handlers/contributions-only-countries-api/package.json
@@ -2,7 +2,7 @@
   "name": "contributions-only-countries-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/discount-api/package.json
+++ b/handlers/discount-api/package.json
@@ -2,7 +2,7 @@
   "name": "discount-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/discount-expiry-notifier/package.json
+++ b/handlers/discount-expiry-notifier/package.json
@@ -2,7 +2,7 @@
   "name": "discount-expiry-notifier",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/generate-product-catalog/package.json
+++ b/handlers/generate-product-catalog/package.json
@@ -2,7 +2,7 @@
   "name": "generate-product-catalog",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/imovo-voucher-api/package.json
+++ b/handlers/imovo-voucher-api/package.json
@@ -2,7 +2,7 @@
   "name": "imovo-voucher-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/metric-push-api/package.json
+++ b/handlers/metric-push-api/package.json
@@ -2,7 +2,7 @@
   "name": "metric-push-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/mobile-purchases-to-supporter-product-data/package.json
+++ b/handlers/mobile-purchases-to-supporter-product-data/package.json
@@ -2,7 +2,7 @@
   "name": "mobile-purchases-to-supporter-product-data",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/mparticle-api/package.json
+++ b/handlers/mparticle-api/package.json
@@ -2,7 +2,7 @@
   "name": "mparticle-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/multiple-account-api/package.json
+++ b/handlers/multiple-account-api/package.json
@@ -2,7 +2,7 @@
   "name": "multiple-account-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/negative-invoices-processor/package.json
+++ b/handlers/negative-invoices-processor/package.json
@@ -2,7 +2,7 @@
   "name": "negative-invoices-processor",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/new-subscription-api/package.json
+++ b/handlers/new-subscription-api/package.json
@@ -2,7 +2,7 @@
   "name": "new-subscription-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/newsletter-acquisition/package.json
+++ b/handlers/newsletter-acquisition/package.json
@@ -2,7 +2,7 @@
   "name": "newsletter-acquisition",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/observer-data-export/package.json
+++ b/handlers/observer-data-export/package.json
@@ -2,7 +2,7 @@
   "name": "observer-data-export",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/press-reader-entitlements/package.json
+++ b/handlers/press-reader-entitlements/package.json
@@ -2,7 +2,7 @@
   "name": "press-reader-entitlements",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/product-switch-api/package.json
+++ b/handlers/product-switch-api/package.json
@@ -2,7 +2,7 @@
   "name": "product-switch-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/promotions-lambdas/package.json
+++ b/handlers/promotions-lambdas/package.json
@@ -2,7 +2,7 @@
   "name": "promotions-lambdas",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/salesforce-disaster-recovery-health-check/package.json
+++ b/handlers/salesforce-disaster-recovery-health-check/package.json
@@ -2,7 +2,7 @@
   "name": "salesforce-disaster-recovery-health-check",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/salesforce-disaster-recovery/package.json
+++ b/handlers/salesforce-disaster-recovery/package.json
@@ -2,7 +2,7 @@
   "name": "salesforce-disaster-recovery",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/stripe-disputes/package.json
+++ b/handlers/stripe-disputes/package.json
@@ -2,7 +2,7 @@
   "name": "stripe-disputes",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/ticket-tailor-webhook/package.json
+++ b/handlers/ticket-tailor-webhook/package.json
@@ -2,7 +2,7 @@
   "name": "ticket-tailor-webhook",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/update-supporter-plus-amount/package.json
+++ b/handlers/update-supporter-plus-amount/package.json
@@ -2,7 +2,7 @@
   "name": "update-supporter-plus-amount",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/user-benefits/package.json
+++ b/handlers/user-benefits/package.json
@@ -2,7 +2,7 @@
   "name": "user-benefits",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/user-subscriptions-api/package.json
+++ b/handlers/user-subscriptions-api/package.json
@@ -2,7 +2,7 @@
   "name": "user-subscriptions-api",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/write-off-unpaid-invoices/package.json
+++ b/handlers/write-off-unpaid-invoices/package.json
@@ -2,7 +2,7 @@
   "name": "write-off-unpaid-invoices",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/handlers/zuora-salesforce-link-remover/package.json
+++ b/handlers/zuora-salesforce-link-remover/package.json
@@ -2,7 +2,7 @@
   "name": "zuora-salesforce-link-remover",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/aws/package.json
+++ b/modules/aws/package.json
@@ -2,7 +2,7 @@
   "name": "aws",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/bigquery/package.json
+++ b/modules/bigquery/package.json
@@ -2,7 +2,7 @@
   "name": "bigquery",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/email/package.json
+++ b/modules/email/package.json
@@ -2,7 +2,7 @@
   "name": "email",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/guardian-subscription/package.json
+++ b/modules/guardian-subscription/package.json
@@ -2,7 +2,7 @@
   "name": "guardian-subscription",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/identity/package.json
+++ b/modules/identity/package.json
@@ -2,7 +2,7 @@
   "name": "identity",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/internationalisation/package.json
+++ b/modules/internationalisation/package.json
@@ -2,7 +2,7 @@
   "name": "internationalisation",
   "scripts": {
     "test": "jest --group=-integration --passWithNoTests",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/logger/package.json
+++ b/modules/logger/package.json
@@ -2,7 +2,7 @@
   "name": "logger",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/product-benefits/package.json
+++ b/modules/product-benefits/package.json
@@ -2,7 +2,7 @@
   "name": "product-benefits",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/product-catalog/package.json
+++ b/modules/product-catalog/package.json
@@ -2,7 +2,7 @@
   "name": "product-catalog",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/promotions/package.json
+++ b/modules/promotions/package.json
@@ -2,7 +2,7 @@
   "name": "promotions",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/routing/package.json
+++ b/modules/routing/package.json
@@ -2,7 +2,7 @@
   "name": "routing",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/salesforce/package.json
+++ b/modules/salesforce/package.json
@@ -2,7 +2,7 @@
   "name": "salesforce",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/secrets-manager/package.json
+++ b/modules/secrets-manager/package.json
@@ -2,7 +2,7 @@
   "name": "secrets-manager",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/supporter-product-data/package.json
+++ b/modules/supporter-product-data/package.json
@@ -2,7 +2,7 @@
   "name": "supporter-product-data",
   "scripts": {
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/sync-supporter-product-data/package.json
+++ b/modules/sync-supporter-product-data/package.json
@@ -2,7 +2,7 @@
   "name": "sync-supporter-product-data",
   "scripts": {
     "test": "jest --group=-integration --passWithNoTests",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/test-users/package.json
+++ b/modules/test-users/package.json
@@ -2,7 +2,7 @@
   "name": "test-users",
   "scripts": {
     "test": "jest --group=-integration --passWithNoTests",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/zuora-catalog/package.json
+++ b/modules/zuora-catalog/package.json
@@ -2,7 +2,7 @@
   "name": "zuora-catalog",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",

--- a/modules/zuora/package.json
+++ b/modules/zuora/package.json
@@ -2,7 +2,7 @@
   "name": "zuora",
   "scripts": {
     "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
+    "it-test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --group=integration",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache --cache-location /tmp/eslintcache/ 'src/**/*.ts' 'test/**/*.ts'",
     "check-formatting": "prettier --check \"**/*.ts\"",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
update the build package.json generator `it-test` command to include a `--experimental-vm-modules` node flag. 

## Why
If `--experimental-vm-modules` flag is not present, tests that use dynamic imports will fail.
Dynamic import of modules fails if flag is not passed because the node api jest uses to enable ESM support is still not stable as of node 18.x.
- https://nodejs.org/api/vm.html#when-importmoduledynamically-is-a-function
- https://jestjs.io/docs/ecmascript-modules

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->


