### PR TITLE
Fix new lambda template - add required routing

### DIFF
--- a/_templates/new-lambda/api-gateway/buildcheck-const.ejs.t
+++ b/_templates/new-lambda/api-gateway/buildcheck-const.ejs.t
@@ -14,7 +14,7 @@ const <%= h.changeCase.camel(lambdaName) %>: HandlerDefinition = {
 	<% if (includeOpenApiDoc === 'Y'){ %>
 		...devDeps['@redocly/cli'],
     },
-    moduleDependencies: [moduleLogger],
+    moduleDependencies: [moduleLogger, moduleRouting],
     extraScripts: {
         ...openApiScripts,
         package: `pnpm type-check && pnpm lint && pnpm openapi:lint && pnpm check-formatting && pnpm test && pnpm build && cd target && zip -qr <%= lambdaName %>.zip ./*.js.map ./*.js`,


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/support-service-lambdas/pull/3552 required all projects in this repo to declare their dependencies on other module projects using a moduleDependencies setting in the build.ts definition, to help with build time.

However the template which generates new api lambdas was not updated to include routing within this new setting so any lambdas created with the template fail the typescript compiler until it is added. 

This PR updates the template to ensure that routing is added on creation.
