### PR TITLE
upload cfn file to riffraff bucket

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -135,6 +135,8 @@ jobs:
           contentDirectories: |
             ${{ matrix.subproject }}:
               - /tmp/${{ matrix.subproject }}.jar
+            cfn:
+              - handlers/${{ matrix.subproject }}/cfn.yaml
 
 
   zuora-callout-apis:

--- a/build.sbt
+++ b/build.sbt
@@ -352,7 +352,6 @@ def lambdaProject(
     projectDependencies: Seq[ClasspathDependency] = Nil,
     scalaSettings: SettingsDefinition = scala2Settings,
 ) = {
-  val cfName = "cfn.yaml"
   Project(projectName, file(s"handlers/$projectName"))
     .configs(EffectsTest, HealthCheckTest)
     .dependsOn(projectDependencies *)


### PR DESCRIPTION
following on from https://github.com/guardian/support-service-lambdas/pull/3587

we didn't make sure the new riff raff action uploaded the existing expected cfn.yaml

this means it's failing https://riffraff.gutools.co.uk/deployment/view/bacb9fec-aa60-42b0-b6f6-3b2bf957ae1a
`Unable to locate cloudformation template s3://riffraff-artifact/support-service-lambdas::holiday-stop-api/14234/cfn/cfn.yaml`

Used to happen here:
https://github.com/guardian/support-service-lambdas/pull/3587/changes#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91L371

This PR adds the correct file copy to make it work again.

Tested and working in CODE
https://riffraff.gutools.co.uk/deployment/view/ed55b5e2-9e1c-4f1b-806f-dc2d54c35049
