### PR TITLE
increase time for DD refund attempts to 14 days

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -380,7 +380,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       VisibilityTimeout: 43200 # 12 hours
-      MessageRetentionPeriod: 865800 # 10 days +30 minutes
+      MessageRetentionPeriod: 1209600 # 14 days - is the max
       QueueName:
         Fn::Sub: product-switch-refund-${Stage}
       RedrivePolicy:


### PR DESCRIPTION
When someone starts a DD, it can take 10+ days for the payment to go through and be refundable ("settled" rather than "submitted" in zuora.)

When people take out supporter plus, we automatically refund them if they cancel within 14 days of taking it out.

This means that if someone takes one out with DD, and cancels soon after, we retry for around 10 days to give them their money back.

Unfortunatelly we still end up with a trickle of cases on the DLQ, which we then have to manually redrive to make sure they get their refund.

If there were genuine failures (which seem to be rare in my experience), we'd have to wait 10 days to find out, which wouldn't provide a good service to customers with credit card.

This PR increases the 10 day to 14 day.

