### PR TITLE
aggregate build for simpler branch protection

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -189,3 +189,20 @@ jobs:
               - ./cdk/cdk.out/zuora-auto-cancel-PROD.template.json
             zuora-callout-apis:
               - /tmp/zuora-callout-apis.jar
+
+  # for branch protection - only passes if all builds pass
+  ci-scala-all:
+    name: ci-scala-all
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - gu-cdk-build
+      - build
+      - zuora-callout-apis
+    steps:
+      - name: Fail unless all Scala CI jobs succeeded
+        run: |
+          [ "${{ needs.gu-cdk-build.result }}" = "success" ]
+          [ "${{ needs.build.result }}" = "success" ]
+          [ "${{ needs.zuora-callout-apis.result }}" = "success" ]
+

--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -194,6 +194,7 @@ jobs:
   ci-scala-all:
     name: ci-scala-all
     runs-on: ubuntu-latest
+    permissions: {}
     if: ${{ always() }}
     needs:
       - gu-cdk-build

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -94,6 +94,7 @@ jobs:
   ci-typescript-all:
     name: ci-typescript-all
     runs-on: ubuntu-latest
+    permissions: {}
     if: ${{ always() }}
     needs:
       - gu-cdk-build

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -89,3 +89,16 @@ jobs:
               - ./cdk/cdk.out/${{ matrix.subproject }}-PROD.template.json
             ${{ matrix.subproject }}:
               - ./handlers/${{ matrix.subproject }}/target/${{ matrix.subproject }}.zip
+
+  # for branch protection - only passes if all builds pass
+  ci-typescript-all:
+    name: ci-typescript-all
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - gu-cdk-build
+    steps:
+      - name: Fail unless all matrix jobs succeeded
+        run: |
+          [ "${{ needs.gu-cdk-build.result }}" = "success" ]
+


### PR DESCRIPTION
We don't want people to merge things unless all handlers have passed and are deployable.

At the moment we do that by adding every single handler to to branch protection which ends up with an unmaintainable list
<img width="305" height="1124" alt="image" src="https://github.com/user-attachments/assets/9db989aa-e0d8-44d4-8126-1cf12000509e" />

It also means we have to add them manually, and we keep forgetting to add them, meaning we could break lambdas and not notice as quickly.
<img width="888" height="292" alt="image" src="https://github.com/user-attachments/assets/dc6a0079-89cd-4c43-9859-23f8b4e572bd" />

This PR changes it so that there is a single "all" build for each action, that only passes when all contained builds fail.

scala in progress
<img width="663" height="477" alt="image" src="https://github.com/user-attachments/assets/78c9c4a4-4514-4992-b86f-2aa3996fbdb7" />

ts in progress
<img width="665" height="231" alt="image" src="https://github.com/user-attachments/assets/10ba0f1f-b4c3-4506-be68-81e6c6527156" />

scala complete 
<img width="670" height="480" alt="image" src="https://github.com/user-attachments/assets/102d5a96-5013-472b-a106-aac0cf1815fd" />


TODO once merged: we can change it so only the two "all" builds are required.