### PR TITLE
each handler check modules in parallel

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -51,10 +51,11 @@ jobs:
       - run: pnpm --filter "./buildcheck" check-formatting
       - run: pnpm --filter "./buildcheck" lint
       - run: pnpm --filter "./buildcheck" snapshot:assert 'ROOT|modules|handlers/${{ matrix.subproject }}'
-      - run: pnpm --filter cdk package ${{ matrix.subproject }}
-      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output '/^(type-check|lint|check-formatting)$/'
+      - run: pnpm --filter ${{ matrix.subproject }}... --filter cdk --parallel --aggregate-output '/^(type-check|lint|check-formatting)$/'
       - run: pnpm --filter ${{ matrix.subproject }}... test
+      - run: pnpm --filter cdk test ${{ matrix.subproject }}
       - run: pnpm --filter ${{ matrix.subproject }} packageQuick
+      - run: pnpm --filter cdk synth ${{ matrix.subproject }}
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v4.3.0

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -52,10 +52,8 @@ jobs:
       - run: pnpm --filter "./buildcheck" lint
       - run: pnpm --filter "./buildcheck" snapshot:assert 'ROOT|modules|handlers/${{ matrix.subproject }}'
       - run: pnpm --filter cdk package ${{ matrix.subproject }}
-      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output type-check
-      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output lint
-      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output check-formatting
-      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output test
+      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output '/^(type-check|lint|check-formatting)$/'
+      - run: pnpm --filter ${{ matrix.subproject }}... test
       - run: pnpm --filter ${{ matrix.subproject }} packageQuick
 
       - name: Upload to Riff-Raff

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -52,10 +52,10 @@ jobs:
       - run: pnpm --filter "./buildcheck" lint
       - run: pnpm --filter "./buildcheck" snapshot:assert 'ROOT|modules|handlers/${{ matrix.subproject }}'
       - run: pnpm --filter cdk package ${{ matrix.subproject }}
-      - run: pnpm --filter ${{ matrix.subproject }}... type-check
-      - run: pnpm --filter ${{ matrix.subproject }}... lint
-      - run: pnpm --filter ${{ matrix.subproject }}... check-formatting
-      - run: pnpm --filter ${{ matrix.subproject }}... test
+      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output type-check
+      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output lint
+      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output check-formatting
+      - run: pnpm --filter ${{ matrix.subproject }}... --parallel --aggregate-output test
       - run: pnpm --filter ${{ matrix.subproject }} packageQuick
 
       - name: Upload to Riff-Raff


### PR DESCRIPTION
At the moment the build time is slow, could be 4-5 minutes for a handler.

We run each of the lint/type-check etc one after the other on each dependency.

This changes it to lint (etc) all modules and handler at the same time.