### PR TITLE
make sure we try DD trial refunds for 10 days

### DIFF
--- a/handlers/product-move-api/cfn.yaml
+++ b/handlers/product-move-api/cfn.yaml
@@ -380,13 +380,13 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       VisibilityTimeout: 43200 # 12 hours
-      MessageRetentionPeriod: 1209600 # 14 days - is the max
+      MessageRetentionPeriod: 865800 # 10 days +30 minutes - keep in step with maxReceiveCount
       QueueName:
         Fn::Sub: product-switch-refund-${Stage}
       RedrivePolicy:
         deadLetterTargetArn:
           Fn::GetAtt: RefundDeadLetterQueue.Arn
-        maxReceiveCount: 14
+        maxReceiveCount: 20 # keep in step with MessageRetentionPeriod
   RefundLambdaRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
We have had issues with refunds not being tried for long enough when it's a direct debit, as they can take longer than a week to set up and take the payment, esepcially when it's a bank holiday period.

In previous PRs e.g. https://github.com/guardian/support-service-lambdas/pull/3604 I increased the time they will stay on the queue, to try to give more time to let them through without alarming.

Unfortunately I didn't notice that it was restricted to 14 retries, which meant it ended up on the DLQ regardless.

This PR changes the number of retries and retention period to match at 10 days, rather than having one still at 7 and the other all the way up at 14.

Tested in CODE, looks good.