### PR TITLE
make sure to run tests when not using riffRaffUpload

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -117,11 +117,8 @@ jobs:
       - name: Setup SBT
         uses: sbt/setup-sbt@v1.2.0
 
-      - name: Build
-        run: |
-          LAST_TEAMCITY_BUILD=6410
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project ${{ matrix.subproject }}" test assembly
+      - name: run tests and Build jar
+        run: sbt "project ${{ matrix.subproject }}" test assembly
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v4.3.3

--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=6410
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project ${{ matrix.subproject }}" assembly
+          sbt "project ${{ matrix.subproject }}" test assembly
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v4.3.3


### PR DESCRIPTION
the old riffRaffUpload plugin used to automatically run tests before building and uploading the jar.

When we moved to the modern GHA way to do the upload in https://github.com/guardian/support-service-lambdas/pull/3587 , we forgot to explicitly run the tests

This PR adds the test task back in so they run again.

I also cleaned up some env vars that aren't needed any more.