### PR TITLE
Rename the supporter-product-data-lambdas execution failure alarm

### DIFF
--- a/cdk/lib/__snapshots__/supporter-product-data-lambdas.test.ts.snap
+++ b/cdk/lib/__snapshots__/supporter-product-data-lambdas.test.ts.snap
@@ -308,7 +308,7 @@ exports[`The supporter-product-data-lambdas stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "The supporter-product-data-lambdas-CODE step function has failed. Check the Step Functions console for details.",
-        "AlarmName": "Supporter Product Data step function Failure in CODE",
+        "AlarmName": "Supporter Product Data lambdas step function Failure in CODE",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
@@ -1990,7 +1990,7 @@ exports[`The supporter-product-data-lambdas stack matches the snapshot 2`] = `
           },
         ],
         "AlarmDescription": "The supporter-product-data-lambdas-PROD step function has failed. Check the Step Functions console for details.",
-        "AlarmName": "Supporter Product Data step function Failure in PROD",
+        "AlarmName": "Supporter Product Data lambdas step function Failure in PROD",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [

--- a/cdk/lib/supporter-product-data-lambdas.ts
+++ b/cdk/lib/supporter-product-data-lambdas.ts
@@ -253,7 +253,7 @@ export class SupporterProductDataLambdas extends SrStack {
 		});
 
 		new GuAlarm(this, 'ExecutionFailureAlarm', {
-			alarmName: `Supporter Product Data step function Failure in ${this.stage}`,
+			alarmName: `Supporter Product Data lambdas step function Failure in ${this.stage}`,
 			alarmDescription: `The ${app}-${this.stage} step function has failed. Check the Step Functions console for details.`,
 			// Suppress alarms between 00:00-06:00 UTC when Zuora is slow and failures are expected
 			metric: new MathExpression({


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
https://github.com/guardian/support-service-lambdas/pull/3498 migrated the supporter product data state machine to this repo, however it failed to deploy in PROD because one of the alarms in the new stack had the same name as an alarm in the old stack. This PR changes the name of the new alarm so there is no collision