### PR TITLE
Update supporter product data writes to include primarySubscriptionName

### DIFF
--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -73,7 +73,7 @@ export const acceptInvitationEndpoint = async (
 		const secondarySubscriptionName = `${invitation.subscriptionName}-${invitation.secondaryIdentityId}`;
 		const supporterProductDataRecord: SupporterRatePlanItem = {
 			subscriptionName: secondarySubscriptionName,
-			primarySubscriptionName: invitation.subscriptionName, // TODO Not being written currently
+			primarySubscriptionName: invitation.subscriptionName,
 			identityId: invitation.secondaryIdentityId,
 			productRatePlanId: parentSupporterProductDataRecord.productRatePlanId,
 			productRatePlanName: 'Digital Plus Secondary User',

--- a/handlers/supporter-product-data-lambdas/src/services/dynamoService.ts
+++ b/handlers/supporter-product-data-lambdas/src/services/dynamoService.ts
@@ -55,6 +55,10 @@ export class DynamoService {
 		let updateExpression =
 			'SET productRatePlanId = :productRatePlanId, productRatePlanName = :productRatePlanName, termEndDate = :termEndDate, contractEffectiveDate = :contractEffectiveDate, expiryDate = :expiryDate';
 
+		// This is to prevent stale data in the data store if for instance the first
+		// version of a record contains optional fields but a later version does not
+		const fieldsToRemove: string[] = [];
+
 		if (item.contributionAmount && item.contributionCurrency) {
 			expressionValues[':contributionAmount'] = {
 				N: item.contributionAmount.toString(),
@@ -64,6 +68,8 @@ export class DynamoService {
 			};
 			updateExpression +=
 				', contributionAmount = :contributionAmount, contributionCurrency = :contributionCurrency';
+		} else {
+			fieldsToRemove.push('contributionAmount', 'contributionCurrency');
 		}
 
 		if (item.primarySubscriptionName) {
@@ -72,6 +78,12 @@ export class DynamoService {
 			};
 			updateExpression +=
 				', primarySubscriptionName = :primarySubscriptionName';
+		} else {
+			fieldsToRemove.push('primarySubscriptionName');
+		}
+
+		if (fieldsToRemove.length > 0) {
+			updateExpression += ` REMOVE ${fieldsToRemove.join(', ')}`;
 		}
 
 		try {

--- a/handlers/supporter-product-data-lambdas/src/services/dynamoService.ts
+++ b/handlers/supporter-product-data-lambdas/src/services/dynamoService.ts
@@ -1,7 +1,7 @@
 import {
+	type AttributeValue,
 	DynamoDBClient,
 	UpdateItemCommand,
-	type UpdateItemCommandInput,
 } from '@aws-sdk/client-dynamodb';
 import { awsConfig } from '@modules/aws/config';
 import { logger } from '@modules/logger/logger';
@@ -40,51 +40,52 @@ export class DynamoService {
 			productRatePlanName: item.productRatePlanName,
 		});
 
-		const expressionValues: NonNullable<
-			UpdateItemCommandInput['ExpressionAttributeValues']
-		> = {
-			':productRatePlanId': { S: item.productRatePlanId },
-			':productRatePlanName': { S: item.productRatePlanName },
-			':termEndDate': { S: zuoraDateFormat(item.termEndDate) },
-			':contractEffectiveDate': {
-				S: zuoraDateFormat(item.contractEffectiveDate),
+		const setFields: Array<{ name: string; value: AttributeValue }> = [
+			{ name: 'productRatePlanId', value: { S: item.productRatePlanId } },
+			{ name: 'productRatePlanName', value: { S: item.productRatePlanName } },
+			{ name: 'termEndDate', value: { S: zuoraDateFormat(item.termEndDate) } },
+			{
+				name: 'contractEffectiveDate',
+				value: { S: zuoraDateFormat(item.contractEffectiveDate) },
 			},
-			':expiryDate': { N: this.formatAsTTL(item.termEndDate) },
-		};
-
-		let updateExpression =
-			'SET productRatePlanId = :productRatePlanId, productRatePlanName = :productRatePlanName, termEndDate = :termEndDate, contractEffectiveDate = :contractEffectiveDate, expiryDate = :expiryDate';
+			{ name: 'expiryDate', value: { N: this.formatAsTTL(item.termEndDate) } },
+		];
 
 		// This is to prevent stale data in the data store if for instance the first
 		// version of a record contains optional fields but a later version does not
 		const fieldsToRemove: string[] = [];
 
 		if (item.contributionAmount && item.contributionCurrency) {
-			expressionValues[':contributionAmount'] = {
-				N: item.contributionAmount.toString(),
-			};
-			expressionValues[':contributionCurrency'] = {
-				S: item.contributionCurrency,
-			};
-			updateExpression +=
-				', contributionAmount = :contributionAmount, contributionCurrency = :contributionCurrency';
+			setFields.push(
+				{
+					name: 'contributionAmount',
+					value: { N: item.contributionAmount.toString() },
+				},
+				{
+					name: 'contributionCurrency',
+					value: { S: item.contributionCurrency },
+				},
+			);
 		} else {
 			fieldsToRemove.push('contributionAmount', 'contributionCurrency');
 		}
 
 		if (item.primarySubscriptionName) {
-			expressionValues[':primarySubscriptionName'] = {
-				S: item.primarySubscriptionName,
-			};
-			updateExpression +=
-				', primarySubscriptionName = :primarySubscriptionName';
+			setFields.push({
+				name: 'primarySubscriptionName',
+				value: { S: item.primarySubscriptionName },
+			});
 		} else {
 			fieldsToRemove.push('primarySubscriptionName');
 		}
 
-		if (fieldsToRemove.length > 0) {
-			updateExpression += ` REMOVE ${fieldsToRemove.join(', ')}`;
-		}
+		const expressionValues = Object.fromEntries(
+			setFields.map(({ name, value }) => [`:${name}`, value]),
+		);
+		const setClause = `SET ${setFields.map(({ name }) => `${name} = :${name}`).join(', ')}`;
+		const removeClause =
+			fieldsToRemove.length > 0 ? ` REMOVE ${fieldsToRemove.join(', ')}` : '';
+		const updateExpression = setClause + removeClause;
 
 		try {
 			await this.client.send(

--- a/handlers/supporter-product-data-lambdas/src/services/dynamoService.ts
+++ b/handlers/supporter-product-data-lambdas/src/services/dynamoService.ts
@@ -66,6 +66,14 @@ export class DynamoService {
 				', contributionAmount = :contributionAmount, contributionCurrency = :contributionCurrency';
 		}
 
+		if (item.primarySubscriptionName) {
+			expressionValues[':primarySubscriptionName'] = {
+				S: item.primarySubscriptionName,
+			};
+			updateExpression +=
+				', primarySubscriptionName = :primarySubscriptionName';
+		}
+
 		try {
 			await this.client.send(
 				new UpdateItemCommand({

--- a/handlers/supporter-product-data-lambdas/test/dynamoService.it.test.ts
+++ b/handlers/supporter-product-data-lambdas/test/dynamoService.it.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @group integration
+ */
+
+import {
+	DeleteItemCommand,
+	DynamoDBClient,
+	GetItemCommand,
+} from '@aws-sdk/client-dynamodb';
+import { getAwsConfig } from '@modules/aws/config';
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
+import dayjs from 'dayjs';
+import { DynamoService } from '../src/services/dynamoService';
+
+const stage = 'CODE';
+const tableName = `SupporterProductData-${stage}`;
+const awsConfig = getAwsConfig('membership');
+const client = new DynamoDBClient(awsConfig);
+
+const baseItem = {
+	identityId: 'integration-test-identity-id',
+	productRatePlanId: 'rate-plan-id-123',
+	productRatePlanName: 'Supporter Plus Monthly',
+	termEndDate: dayjs('2027-01-01'),
+	contractEffectiveDate: dayjs('2026-01-01'),
+};
+
+const primarySubscriptionTestItem: SupporterRatePlanItem = {
+	...baseItem,
+	subscriptionName: 'A-S00000001',
+	primarySubscriptionName: 'A-S00009999',
+};
+
+const contributionTestItem: SupporterRatePlanItem = {
+	...baseItem,
+	subscriptionName: 'A-S00000002',
+	contributionAmount: 5.0,
+	contributionCurrency: 'GBP',
+};
+
+const missingCurrencyTestItem: SupporterRatePlanItem = {
+	...baseItem,
+	subscriptionName: 'A-S00000003',
+	contributionAmount: 5.0,
+};
+
+const missingAmountTestItem: SupporterRatePlanItem = {
+	...baseItem,
+	subscriptionName: 'A-S00000004',
+	contributionCurrency: 'GBP',
+};
+
+const staleFieldTestItem: SupporterRatePlanItem = {
+	...baseItem,
+	subscriptionName: 'A-S00000005',
+	primarySubscriptionName: 'A-S00009999',
+};
+
+async function deleteItem(item: SupporterRatePlanItem) {
+	await client.send(
+		new DeleteItemCommand({
+			TableName: tableName,
+			Key: {
+				identityId: { S: item.identityId },
+				subscriptionName: { S: item.subscriptionName },
+			},
+		}),
+	);
+}
+
+describe('DynamoService integration', () => {
+	const service = new DynamoService(stage);
+
+	afterEach(async () => {
+		await deleteItem(primarySubscriptionTestItem);
+		await deleteItem(contributionTestItem);
+		await deleteItem(missingCurrencyTestItem);
+		await deleteItem(missingAmountTestItem);
+		await deleteItem(staleFieldTestItem);
+	});
+
+	test('writes primarySubscriptionName to DynamoDB', async () => {
+		await service.writeItem(primarySubscriptionTestItem);
+
+		const result = await client.send(
+			new GetItemCommand({
+				TableName: tableName,
+				Key: {
+					identityId: { S: primarySubscriptionTestItem.identityId },
+					subscriptionName: { S: primarySubscriptionTestItem.subscriptionName },
+				},
+			}),
+		);
+
+		expect(result.Item).toBeDefined();
+		expect(result.Item?.primarySubscriptionName).toEqual({
+			S: primarySubscriptionTestItem.primarySubscriptionName,
+		});
+	});
+
+	test('writes contributionAmount and contributionCurrency to DynamoDB', async () => {
+		await service.writeItem(contributionTestItem);
+
+		const result = await client.send(
+			new GetItemCommand({
+				TableName: tableName,
+				Key: {
+					identityId: { S: contributionTestItem.identityId },
+					subscriptionName: { S: contributionTestItem.subscriptionName },
+				},
+			}),
+		);
+
+		expect(result.Item).toBeDefined();
+		expect(result.Item?.contributionAmount).toEqual({
+			N: contributionTestItem.contributionAmount?.toString(),
+		});
+		expect(result.Item?.contributionCurrency).toEqual({
+			S: contributionTestItem.contributionCurrency,
+		});
+	});
+
+	test('does not write contributionAmount or contributionCurrency when currency is missing', async () => {
+		await service.writeItem(missingCurrencyTestItem);
+
+		const result = await client.send(
+			new GetItemCommand({
+				TableName: tableName,
+				Key: {
+					identityId: { S: missingCurrencyTestItem.identityId },
+					subscriptionName: { S: missingCurrencyTestItem.subscriptionName },
+				},
+			}),
+		);
+
+		expect(result.Item).toBeDefined();
+		expect(result.Item?.contributionAmount).toBeUndefined();
+		expect(result.Item?.contributionCurrency).toBeUndefined();
+	});
+
+	test('does not write contributionAmount or contributionCurrency when amount is missing', async () => {
+		await service.writeItem(missingAmountTestItem);
+
+		const result = await client.send(
+			new GetItemCommand({
+				TableName: tableName,
+				Key: {
+					identityId: { S: missingAmountTestItem.identityId },
+					subscriptionName: { S: missingAmountTestItem.subscriptionName },
+				},
+			}),
+		);
+
+		expect(result.Item).toBeDefined();
+		expect(result.Item?.contributionAmount).toBeUndefined();
+		expect(result.Item?.contributionCurrency).toBeUndefined();
+	});
+
+	test('does not clear optional fields from a previous write when they are absent in an update', async () => {
+		// First write includes primarySubscriptionName
+		await service.writeItem(staleFieldTestItem);
+
+		// Second write for the same item omits primarySubscriptionName
+		await service.writeItem({
+			...staleFieldTestItem,
+			primarySubscriptionName: undefined,
+		});
+
+		const result = await client.send(
+			new GetItemCommand({
+				TableName: tableName,
+				Key: {
+					identityId: { S: staleFieldTestItem.identityId },
+					subscriptionName: { S: staleFieldTestItem.subscriptionName },
+				},
+			}),
+		);
+
+		// The field is NOT removed by a subsequent write that omits it — DynamoDB
+		// UpdateItemCommand only sets the fields included in the expression, leaving
+		// all others untouched. This test documents that behaviour so it is not
+		// accidentally relied upon to clear values.
+		expect(result.Item?.primarySubscriptionName).toEqual({
+			S: staleFieldTestItem.primarySubscriptionName,
+		});
+	});
+});

--- a/handlers/supporter-product-data-lambdas/test/dynamoService.it.test.ts
+++ b/handlers/supporter-product-data-lambdas/test/dynamoService.it.test.ts
@@ -156,7 +156,7 @@ describe('DynamoService integration', () => {
 		expect(result.Item?.contributionCurrency).toBeUndefined();
 	});
 
-	test('does not clear optional fields from a previous write when they are absent in an update', async () => {
+	test('removes optional fields from a previous write when they are absent in an update', async () => {
 		// First write includes primarySubscriptionName
 		await service.writeItem(staleFieldTestItem);
 
@@ -176,12 +176,6 @@ describe('DynamoService integration', () => {
 			}),
 		);
 
-		// The field is NOT removed by a subsequent write that omits it — DynamoDB
-		// UpdateItemCommand only sets the fields included in the expression, leaving
-		// all others untouched. This test documents that behaviour so it is not
-		// accidentally relied upon to clear values.
-		expect(result.Item?.primarySubscriptionName).toEqual({
-			S: staleFieldTestItem.primarySubscriptionName,
-		});
+		expect(result.Item?.primarySubscriptionName).toBeUndefined();
 	});
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
As part of the multiple accounts work described in [this doc](https://docs.google.com/document/d/1eqMn9zkg-iRK3Gi9ecmgGh8WWUYpLX6B3cOasTRYpns/edit?tab=t.0#heading=h.anbq3pjpq22s) a new field has been added to the SupporterProductData Dynamo DB table. This field `primarySubscriptionName` links a secondary subscription record to the original subscription which grants access for the secondary user.

As all writes to the SupporterProductData table are done via the `processSupporterRatePlanItemLambda` this needs to be updated to be aware of the new field. This PR makes that change and also adds some integration tests for the Dynamo write logic.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214265189400430