### PR TITLE
List invitations and Secondary users

### DIFF
--- a/handlers/multiple-account-api/README.md
+++ b/handlers/multiple-account-api/README.md
@@ -57,3 +57,51 @@ Headers: 'x-identity-id' - the identity id of the user creating the invitation
 - The subscription must be an active subscription with the `multipleAccounts` benefit (eg. Digital Plus, Newspaper etc.) and must belong to the user creating the invitation
 - The number of existing invitations for the subscription must be less than the maximum allowed (currently 5)
 - There must not be an existing invitation for the same secondary user email and subscription
+
+### List invitations for a primary subscription
+
+#### Request:
+
+GET /subscriptions/{subscriptionName}/invitations
+
+Headers: 'x-identity-id' - the identity id of the primary user
+
+#### Response:
+
+```JSON
+{
+  "invitations": [
+    {
+      "subscriptionName": "A-S00974337",
+      "invitationCode": "RpwR62kMnAxe",
+      "primaryIdentityId": "20012345",
+      "secondaryIdentityId": "30067890",
+      "invitedDate": "2026-06-12",
+      "expiryDate": 1781222400000
+    }
+  ]
+}
+```
+
+### List secondary users for a primary subscription
+
+#### Request:
+
+GET /subscriptions/{subscriptionName}/secondary-users
+
+Headers: 'x-identity-id' - the identity id of the primary user
+
+#### Response:
+
+```JSON
+{
+  "secondaryUsers": [
+    {
+      "subscriptionName": "A-S00974337",
+      "secondaryIdentityId": "30067890",
+      "primaryIdentityId": "20012345",
+      "acceptedDate": "2026-06-12"
+    }
+  ]
+}
+```

--- a/handlers/multiple-account-api/README.md
+++ b/handlers/multiple-account-api/README.md
@@ -62,7 +62,7 @@ Headers: 'x-identity-id' - the identity id of the user creating the invitation
 
 #### Request:
 
-GET /subscriptions/{subscriptionName}/invitations
+GET /invitations
 
 Headers: 'x-identity-id' - the identity id of the primary user
 
@@ -87,7 +87,7 @@ Headers: 'x-identity-id' - the identity id of the primary user
 
 #### Request:
 
-GET /subscriptions/{subscriptionName}/secondary-users
+GET /secondary-users
 
 Headers: 'x-identity-id' - the identity id of the primary user
 

--- a/handlers/multiple-account-api/README.md
+++ b/handlers/multiple-account-api/README.md
@@ -62,9 +62,11 @@ Headers: 'x-identity-id' - the identity id of the user creating the invitation
 
 #### Request:
 
-GET /invitations
+GET /subscriptions/{subscriptionName}/invitations
 
 Headers: 'x-identity-id' - the identity id of the primary user
+
+Example path: /subscriptions/A-S00974337/invitations
 
 #### Response:
 
@@ -87,9 +89,11 @@ Headers: 'x-identity-id' - the identity id of the primary user
 
 #### Request:
 
-GET /secondary-users
+GET /subscriptions/{subscriptionName}/secondary-users
 
 Headers: 'x-identity-id' - the identity id of the primary user
+
+Example path: /subscriptions/A-S00974337/secondary-users
 
 #### Response:
 

--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -65,6 +65,98 @@ paths:
               schema:
                 type: string
                 example: Internal server error
+  /subscriptions/{subscriptionName}/invitations:
+    get:
+      operationId: listInvitations
+      summary: List invitations
+      description: Lists all invitations for a given primary subscription.
+      security:
+        - identityId: []
+        - apiKey: []
+      parameters:
+        - name: subscriptionName
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Zuora subscription number for the primary user.
+          example: A-S00974337
+      responses:
+        '200':
+          description: Invitations listed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListInvitationsResponse'
+        '400':
+          description: Invalid request or validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParserError'
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Route not found.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Not Found
+        '500':
+          description: Internal server error.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
+  /subscriptions/{subscriptionName}/secondary-users:
+    get:
+      operationId: listSecondaryUsers
+      summary: List secondary users
+      description: Lists all secondary users associated with a primary subscription.
+      security:
+        - identityId: []
+        - apiKey: []
+      parameters:
+        - name: subscriptionName
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Zuora subscription number for the primary user.
+          example: A-S00974337
+      responses:
+        '200':
+          description: Secondary users listed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSecondaryUsersResponse'
+        '400':
+          description: Invalid request or validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParserError'
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Route not found.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Not Found
+        '500':
+          description: Internal server error.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
   /invitation/{invitationCode}:
     delete:
       operationId: deleteInvitation
@@ -233,6 +325,76 @@ components:
         message:
           type: string
           example: Deleted
+    Invitation:
+      type: object
+      additionalProperties: false
+      required:
+        - subscriptionName
+        - invitationCode
+        - primaryIdentityId
+        - secondaryIdentityId
+        - invitedDate
+        - expiryDate
+      properties:
+        subscriptionName:
+          type: string
+          example: A-S00974337
+        invitationCode:
+          type: string
+          example: RpwR62kMnAxe
+        primaryIdentityId:
+          type: string
+          example: 20012345
+        secondaryIdentityId:
+          type: string
+          example: 30067890
+        invitedDate:
+          type: string
+          example: '2026-06-12'
+        expiryDate:
+          type: number
+          example: 1781222400000
+    ListInvitationsResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - invitations
+      properties:
+        invitations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Invitation'
+    SecondaryUser:
+      type: object
+      additionalProperties: false
+      required:
+        - subscriptionName
+        - secondaryIdentityId
+        - primaryIdentityId
+        - acceptedDate
+      properties:
+        subscriptionName:
+          type: string
+          example: A-S00974337
+        secondaryIdentityId:
+          type: string
+          example: 30067890
+        primaryIdentityId:
+          type: string
+          example: 20012345
+        acceptedDate:
+          type: string
+          example: '2026-06-12'
+    ListSecondaryUsersResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - secondaryUsers
+      properties:
+        secondaryUsers:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecondaryUser'
     ParserError:
       type: object
       additionalProperties: true

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -113,7 +113,7 @@ export const handler: Handler = Router([
 	},
 	{
 		httpMethod: 'GET',
-		path: '/secondaryUser',
+		path: '/secondary-users',
 		handler: withBodyParser(
 			listSecondaryUsersBodySchema,
 			withMMAIdentityCheck(

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -28,8 +28,8 @@ import {
 	listInvitationsEndpoint,
 } from './listInvitationsEndpoint';
 import {
-	listSecondaryUsersBodySchema,
 	listSecondaryUsersEndpoint,
+	listSecondaryUsersPathSchema,
 } from './listSecondaryUsersEndpoint';
 import { SecondaryUserRepository } from './secondaryUserRepository';
 
@@ -113,14 +113,16 @@ export const handler: Handler = Router([
 	},
 	{
 		httpMethod: 'GET',
-		path: '/secondary-users',
-		handler: withBodyParser(
-			listSecondaryUsersBodySchema,
+		path: '/subscriptions/{subscriptionName}/secondary-users',
+		handler: withPathParser(
+			listSecondaryUsersPathSchema,
 			withMMAIdentityCheck(
 				stage,
-				async (body) =>
-					listSecondaryUsersEndpoint(secondaryUserRepository)(body),
-				({ body }) => body.subscriptionName,
+				async (_body, _zuoraClient, subscription) =>
+					listSecondaryUsersEndpoint(secondaryUserRepository)({
+						subscriptionName: subscription.subscriptionNumber,
+					}),
+				({ path }) => path.subscriptionName,
 			),
 		),
 	},

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -23,6 +23,14 @@ import {
 	deleteInvitationPathSchema,
 } from './deleteInvitationEndpoint';
 import { InvitationRepository } from './invitationRepository';
+import {
+	listInvitationsBodySchema,
+	listInvitationsEndpoint,
+} from './listInvitationsEndpoint';
+import {
+	listSecondaryUsersBodySchema,
+	listSecondaryUsersEndpoint,
+} from './listSecondaryUsersEndpoint';
 import { SecondaryUserRepository } from './secondaryUserRepository';
 
 const stage = stageFromEnvironment();
@@ -44,6 +52,18 @@ const lazyZuoraCatalog = new Lazy(
 );
 
 export const handler: Handler = Router([
+	{
+		httpMethod: 'GET',
+		path: '/invitation',
+		handler: withBodyParser(
+			listInvitationsBodySchema,
+			withMMAIdentityCheck(
+				stage,
+				async (body) => listInvitationsEndpoint(invitationRepository)(body),
+				({ body }) => body.subscriptionName,
+			),
+		),
+	},
 	{
 		httpMethod: 'POST',
 		path: '/invitation',
@@ -90,5 +110,18 @@ export const handler: Handler = Router([
 				dynamoClient,
 			);
 		}),
+	},
+	{
+		httpMethod: 'GET',
+		path: '/secondaryUser',
+		handler: withBodyParser(
+			listSecondaryUsersBodySchema,
+			withMMAIdentityCheck(
+				stage,
+				async (body) =>
+					listSecondaryUsersEndpoint(secondaryUserRepository)(body),
+				({ body }) => body.subscriptionName,
+			),
+		),
 	},
 ]);

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -24,8 +24,8 @@ import {
 } from './deleteInvitationEndpoint';
 import { InvitationRepository } from './invitationRepository';
 import {
-	listInvitationsBodySchema,
 	listInvitationsEndpoint,
+	listInvitationsPathSchema,
 } from './listInvitationsEndpoint';
 import {
 	listSecondaryUsersEndpoint,
@@ -52,18 +52,6 @@ const lazyZuoraCatalog = new Lazy(
 );
 
 export const handler: Handler = Router([
-	{
-		httpMethod: 'GET',
-		path: '/invitation',
-		handler: withBodyParser(
-			listInvitationsBodySchema,
-			withMMAIdentityCheck(
-				stage,
-				async (body) => listInvitationsEndpoint(invitationRepository)(body),
-				({ body }) => body.subscriptionName,
-			),
-		),
-	},
 	{
 		httpMethod: 'POST',
 		path: '/invitation',
@@ -110,6 +98,21 @@ export const handler: Handler = Router([
 				dynamoClient,
 			);
 		}),
+	},
+	{
+		httpMethod: 'GET',
+		path: '/subscriptions/{subscriptionName}/invitations',
+		handler: withPathParser(
+			listInvitationsPathSchema,
+			withMMAIdentityCheck(
+				stage,
+				async (_body, _zuoraClient, subscription) =>
+					listInvitationsEndpoint(invitationRepository)({
+						subscriptionName: subscription.subscriptionNumber,
+					}),
+				({ path }) => path.subscriptionName,
+			),
+		),
 	},
 	{
 		httpMethod: 'GET',

--- a/handlers/multiple-account-api/src/listInvitationsEndpoint.ts
+++ b/handlers/multiple-account-api/src/listInvitationsEndpoint.ts
@@ -3,17 +3,16 @@ import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
 import { z } from 'zod';
 import type { InvitationRepository } from './invitationRepository';
 
-export const listInvitationsBodySchema = z.object({
+export const listInvitationsPathSchema = z.object({
 	subscriptionName: z.string(),
 });
 
-export type ListInvitationsBody = z.infer<typeof listInvitationsBodySchema>;
+export type ListInvitationsPath = z.infer<typeof listInvitationsPathSchema>;
 
 export const listInvitationsEndpoint =
 	(invitationRepository: InvitationRepository) =>
-	async (body: ListInvitationsBody) => {
+	async ({ subscriptionName }: ListInvitationsPath) => {
 		try {
-			const { subscriptionName } = body;
 			logger.mutableAddContext(subscriptionName);
 			const invitations = await invitationRepository.list(subscriptionName);
 			return ok({ invitations });

--- a/handlers/multiple-account-api/src/listInvitationsEndpoint.ts
+++ b/handlers/multiple-account-api/src/listInvitationsEndpoint.ts
@@ -1,0 +1,23 @@
+import { logger } from '@modules/logger/logger';
+import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
+import { z } from 'zod';
+import type { InvitationRepository } from './invitationRepository';
+
+export const listInvitationsBodySchema = z.object({
+	subscriptionName: z.string(),
+});
+
+export type ListInvitationsBody = z.infer<typeof listInvitationsBodySchema>;
+
+export const listInvitationsEndpoint =
+	(invitationRepository: InvitationRepository) =>
+	async (body: ListInvitationsBody) => {
+		try {
+			const { subscriptionName } = body;
+			logger.mutableAddContext(subscriptionName);
+			const invitations = await invitationRepository.list(subscriptionName);
+			return ok({ invitations });
+		} catch (error) {
+			return buildErrorResponse(error);
+		}
+	};

--- a/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
+++ b/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
@@ -3,19 +3,18 @@ import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
 import { z } from 'zod';
 import type { SecondaryUserRepository } from './secondaryUserRepository';
 
-export const listSecondaryUsersBodySchema = z.object({
+export const listSecondaryUsersPathSchema = z.object({
 	subscriptionName: z.string(),
 });
 
 export type ListSecondaryUsersBody = z.infer<
-	typeof listSecondaryUsersBodySchema
+	typeof listSecondaryUsersPathSchema
 >;
 
 export const listSecondaryUsersEndpoint =
 	(secondaryUserRepository: SecondaryUserRepository) =>
-	async (body: ListSecondaryUsersBody) => {
+	async ({ subscriptionName }: ListSecondaryUsersBody) => {
 		try {
-			const { subscriptionName } = body;
 			logger.mutableAddContext(subscriptionName);
 			const secondaryUsers =
 				await secondaryUserRepository.list(subscriptionName);

--- a/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
+++ b/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
@@ -1,0 +1,26 @@
+import { logger } from '@modules/logger/logger';
+import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
+import { z } from 'zod';
+import type { SecondaryUserRepository } from './secondaryUserRepository';
+
+export const listSecondaryUsersBodySchema = z.object({
+	subscriptionName: z.string(),
+});
+
+export type ListSecondaryUsersBody = z.infer<
+	typeof listSecondaryUsersBodySchema
+>;
+
+export const listSecondaryUsersEndpoint =
+	(secondaryUserRepository: SecondaryUserRepository) =>
+	async (body: ListSecondaryUsersBody) => {
+		try {
+			const { subscriptionName } = body;
+			logger.mutableAddContext(subscriptionName);
+			const secondaryUsers =
+				await secondaryUserRepository.list(subscriptionName);
+			return ok({ secondaryUsers });
+		} catch (error) {
+			return buildErrorResponse(error);
+		}
+	};

--- a/handlers/multiple-account-api/test/listInvitationsEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listInvitationsEndpoint.test.ts
@@ -1,0 +1,52 @@
+import type {
+	InvitationRecord,
+	InvitationRepository,
+} from '../src/invitationRepository';
+import { listInvitationsEndpoint } from '../src/listInvitationsEndpoint';
+
+describe('listInvitationsEndpoint', () => {
+	it('returns all invitations for the subscription', async () => {
+		const invitations: InvitationRecord[] = [
+			{
+				subscriptionName: 'A-S00974337',
+				invitationCode: 'RpwR62kMnAxe',
+				primaryIdentityId: 'primary-id',
+				secondaryIdentityId: 'secondary-id',
+				invitedDate: '2026-06-12',
+				expiryDate: 1781222400000,
+			},
+		];
+		const mockList = jest
+			.fn<Promise<InvitationRecord[]>, [string]>()
+			.mockResolvedValue(invitations);
+		const invitationRepository = {
+			list: mockList,
+		} as unknown as InvitationRepository;
+
+		const result = await listInvitationsEndpoint(invitationRepository)({
+			subscriptionName: 'A-S00974337',
+		});
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({ invitations });
+		expect(mockList).toHaveBeenCalledWith('A-S00974337');
+	});
+
+	it('returns a 500 response when listing fails', async () => {
+		const mockList = jest
+			.fn<Promise<InvitationRecord[]>, [string]>()
+			.mockRejectedValue(new Error('dynamodb error'));
+		const invitationRepository = {
+			list: mockList,
+		} as unknown as InvitationRepository;
+
+		const result = await listInvitationsEndpoint(invitationRepository)({
+			subscriptionName: 'A-S00974337',
+		});
+
+		expect(result.statusCode).toBe(500);
+		expect(JSON.parse(result.body)).toEqual({
+			message: 'Internal server error',
+		});
+	});
+});

--- a/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
@@ -1,0 +1,50 @@
+import { listSecondaryUsersEndpoint } from '../src/listSecondaryUsersEndpoint';
+import type {
+	SecondaryUserRecord,
+	SecondaryUserRepository,
+} from '../src/secondaryUserRepository';
+
+describe('listSecondaryUsersEndpoint', () => {
+	it('returns all secondary users for the subscription', async () => {
+		const secondaryUsers: SecondaryUserRecord[] = [
+			{
+				subscriptionName: 'A-S00974337',
+				secondaryIdentityId: 'secondary-id',
+				primaryIdentityId: 'primary-id',
+				acceptedDate: '2026-06-12',
+			},
+		];
+		const mockList = jest
+			.fn<Promise<SecondaryUserRecord[]>, [string]>()
+			.mockResolvedValue(secondaryUsers);
+		const secondaryUserRepository = {
+			list: mockList,
+		} as unknown as SecondaryUserRepository;
+
+		const result = await listSecondaryUsersEndpoint(secondaryUserRepository)({
+			subscriptionName: 'A-S00974337',
+		});
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({ secondaryUsers });
+		expect(mockList).toHaveBeenCalledWith('A-S00974337');
+	});
+
+	it('returns a 500 response when listing fails', async () => {
+		const mockList = jest
+			.fn<Promise<SecondaryUserRecord[]>, [string]>()
+			.mockRejectedValue(new Error('dynamodb error'));
+		const secondaryUserRepository = {
+			list: mockList,
+		} as unknown as SecondaryUserRepository;
+
+		const result = await listSecondaryUsersEndpoint(secondaryUserRepository)({
+			subscriptionName: 'A-S00974337',
+		});
+
+		expect(result.statusCode).toBe(500);
+		expect(JSON.parse(result.body)).toEqual({
+			message: 'Internal server error',
+		});
+	});
+});


### PR DESCRIPTION
## List invitations and secondary users for a primary subscription

## What does this change?

Adds two new read endpoints to the `multiple-account-api` lambda:

-  `GET /subscriptions/:subscriptionName/invitations` — lists all pending invitations associated with a primary subscription
- `GET /subscriptions/:subscriptionName/secondary-users` — lists all accepted secondary users associated with a primary subscription

Both endpoints are protected by the existing MMA identity check middleware and scoped to a `subscriptionName` provided in the request body.

### Why

These endpoints are needed to allow the primary user (and supporting tooling/admin surfaces) to view the current state of their shared access — both invitations that are pending acceptance and users who have already accepted.

---

### Request / Response

#### `GET /subscriptions/:subscriptionName/invitations`

**Request headers:**

```json
x-identity-id: <primary user identity id>
```


**Response 200 OK:**

```json
{
  "invitations": [
    {
      "subscriptionName": "A-S00974337",
      "invitationCode": "RpwR62kMnAxe",
      "primaryIdentityId": "20012345",
      "secondaryIdentityId": "30067890",
      "invitedDate": "2026-06-12",
      "expiryDate": 1781222400000
    }
  ]
}
```

#### `GET /subscriptions/:subscriptionName/secondary-users`

**Request headers:**

```json
x-identity-id: <primary user identity id>
```


**Response 200 OK:**

```json
{
  "secondaryUsers": [
    {
      "subscriptionName": "A-S00974337",
      "secondaryIdentityId": "30067890",
      "primaryIdentityId": "20012345",
      "acceptedDate": "2026-06-12"
    }
  ]
}
```

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
Deployed to Code and tested using Postman


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214265189400418