### PR TITLE
Route supporter-product-data-lambdas alarms to Portfolio

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -77,6 +77,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'press-reader-entitlements',
 		'user-benefits',
 		'mobile-purchases-to-supporter-product-data',
+		'supporter-product-data-lambdas',
 	],
 	PLATFORM: [
 		// fulfilment


### PR DESCRIPTION
## What does this change?

Route alarms for `supporter-product-data-lambdas` to Portfolio team.