### PR TITLE
Fix buildcheck repo root validation to support bare repository worktree paths

### DIFF
--- a/buildcheck/src/util/argsParser.ts
+++ b/buildcheck/src/util/argsParser.ts
@@ -30,12 +30,13 @@ export function parseArguments(argv: string[]): ParsedArgs {
 	}
 
 	const repoRoot = args[1];
+	const isSupportedRepoPath =
+		repoRoot.startsWith('/') &&
+		(repoRoot.endsWith('support-service-lambdas') ||
+			// This allows the path validation for bare repositories
+			/support-service-lambdas\.git\/[^/]+$/.test(repoRoot));
 
-	if (
-		!fs.existsSync(repoRoot) ||
-		!repoRoot.startsWith('/') ||
-		!repoRoot.endsWith('support-service-lambdas')
-	) {
+	if (!fs.existsSync(repoRoot) || !isSupportedRepoPath) {
 		throw new Error(`Invalid repository root: ${repoRoot}`);
 	}
 


### PR DESCRIPTION
### What

Updates `parseArguments` in `buildcheck/src/util/argsParser.ts` to accept repository root paths from bare Git repositories with worktrees.

Previously the validation only accepted paths ending exactly with `support-service-lambdas`, which rejected paths in the form `/support-service-lambdas.git/<worktreeName>` (e.g. `/support-service-lambdas.git/main`).

The updated check accepts:
- `/support-service-lambdas` — standard clone
- `/support-service-lambdas.git/<worktreeName>` — bare clone with a worktree

### Why

Running `buildcheck` from a bare repository worktree (a common local dev setup) caused a hard failure at argument parsing with `Invalid repository root`, making the tool unusable in that setup.
