### PR TITLE
add required zuora oauth permission

### DIFF
--- a/cdk/lib/__snapshots__/user-subscriptions-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/user-subscriptions-api.test.ts.snap
@@ -836,6 +836,42 @@ exports[`The User subscription api stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "ZuoraOAuthSecretsManagerpolicy5448D99B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ZuoraOAuthSecretsManagerpolicy5448D99B",
+        "Roles": [
+          {
+            "Ref": "LambdaServiceRoleA8ED4D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
   },
 }
 `;
@@ -1744,6 +1780,42 @@ exports[`The User subscription api stack matches the snapshot 2`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "LambdaServiceRoleDefaultPolicyDAE46E21",
+        "Roles": [
+          {
+            "Ref": "LambdaServiceRoleA8ED4D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ZuoraOAuthSecretsManagerpolicy5448D99B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ZuoraOAuthSecretsManagerpolicy5448D99B",
         "Roles": [
           {
             "Ref": "LambdaServiceRoleA8ED4D3B",

--- a/cdk/lib/user-subscriptions-api.ts
+++ b/cdk/lib/user-subscriptions-api.ts
@@ -1,4 +1,5 @@
 import type { App } from 'aws-cdk-lib';
+import { AllowZuoraOAuthSecretsPolicy } from './cdk/policies';
 import { SrApiLambda } from './cdk/SrApiLambda';
 import type { SrStageNames } from './cdk/SrStack';
 import { SrStack } from './cdk/SrStack';
@@ -7,7 +8,7 @@ export class UserSubscriptionsApi extends SrStack {
 	constructor(scope: App, stage: SrStageNames) {
 		super(scope, { stage, app: 'user-subscriptions-api' });
 
-		new SrApiLambda(this, 'Lambda', {
+		const lambda = new SrApiLambda(this, 'Lambda', {
 			lambdaOverrides: {
 				description:
 					'A lambda that efficiently returns detailed user subscription information for account overview',
@@ -21,5 +22,7 @@ export class UserSubscriptionsApi extends SrStack {
 				burstLimit: 10,
 			},
 		});
+
+		lambda.addPolicies(new AllowZuoraOAuthSecretsPolicy(this));
 	}
 }


### PR DESCRIPTION
following on from https://github.com/guardian/support-service-lambdas/pull/3621 and waiting for the fixes in https://github.com/guardian/support-service-lambdas/pull/3635

I missed a CDK permission for the handler to access zuora auth.

This PR adds the necessary policy.