### PR TITLE
fix conflicts caused by new getUserByIdentityId vs restclient changes

### DIFF
--- a/modules/identity/src/idapi.ts
+++ b/modules/identity/src/idapi.ts
@@ -67,11 +67,7 @@ export const getUserByIdentityId = async (
 	identityId: string,
 ): Promise<IdentityUserWithPrivateFields | undefined> => {
 	try {
-		const response = await client.get<
-			z.input<typeof userByIdentityIdResponseSchema>,
-			z.output<typeof userByIdentityIdResponseSchema>,
-			typeof userByIdentityIdResponseSchema
-		>(
+		const response = await client.get(
 			`/user/${encodeURIComponent(identityId)}`,
 			userByIdentityIdResponseSchema,
 		);


### PR DESCRIPTION
fix conflicts not spotted by git or the build

between the new method `getUserByIdentityId` added in https://github.com/guardian/support-service-lambdas/pull/3598

It was added with type parameters to match the other functions there, as the rest client needed them.

and the improvements to type inference in the zuoraclient in https://github.com/guardian/support-service-lambdas/pull/3621

This means the type parameters aren't needed as the return type is inferred

cc @AnastasiiaBalenko for your information in case you noticed it was broken by my pr and then changed