### PR TITLE
Sales Tax Api: Canadian state tax rate alignment with Zuora tax rates

### DIFF
--- a/handlers/sales-tax-api/src/taxRatesEndpoint.ts
+++ b/handlers/sales-tax-api/src/taxRatesEndpoint.ts
@@ -14,7 +14,7 @@ export const cadStates: TaxRatesResponse = {
 	MB: 0.12,
 	NB: 0.15,
 	NL: 0.15,
-	NT: 0.15,
+	NT: 0.05,
 	NS: 0.15,
 	NU: 0.05,
 	ON: 0.13,


### PR DESCRIPTION
## What does this change?
Rate correction to the sales-tax-api / get-rates endpoint from the [sales tax endpoint setup PR](https://github.com/guardian/support-service-lambdas/pull/3606)

Aligns the following (incorrect) Canadian State tax rate with Zuora's tax rate ->
|From|To|
|----|----|
|NT:0.15|NT:0.05|