### PR TITLE
Add logging to bearerTokenProvider.ts

### DIFF
--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -22,15 +22,31 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 	) {}
 
 	private tokenIsExpired = () => {
+		logger.log('Checking if Zuora bearer token is expired');
 		if (this.bearerToken === null) {
+			logger.log('No Zuora bearer token found, fetching a new one');
 			return true;
 		}
 		const now = new Date();
-		return (
-			this.lastFetchedTime === null ||
+		if (this.lastFetchedTime === null) {
+			logger.log(
+				'No last fetched time found, fetching a new Zuora bearer token',
+			);
+			return true;
+		}
+		if (
 			this.lastFetchedTime.getTime() + this.bearerToken.expires_in * 1000 <
-				now.getTime()
-		);
+			now.getTime()
+		) {
+			logger.log('Zuora bearer token is expired', {
+				lastFetchedTime: this.lastFetchedTime.getTime(),
+				expiresIn: this.bearerToken.expires_in * 1000,
+				now: now.getTime(),
+			});
+			return true;
+		}
+		logger.log('Zuora bearer token is still valid');
+		return false;
 	};
 	public async getBearerToken(): Promise<ZuoraBearerToken> {
 		if (this.bearerToken === null || this.tokenIsExpired()) {
@@ -60,8 +76,8 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 		const json = await response.json();
 
 		const parseResult = zuoraBearerTokenSchema.safeParse(json);
+		logger.log('Zuora bearer token response:', json);
 		if (!parseResult.success) {
-			logger.log('Zuora bearer token response:', json);
 			throw new Error(
 				`Failed to fetch Zuora bearer token: ${JSON.stringify(parseResult.error.issues)}`,
 			);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We have seen a number of Zuora authentication errors in the logs - [for instance here](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252FsupporterProductData-ProcessItem-PROD/log-events$3Fstart$3D1781669771000$26filterPattern$3D$26end$3D1781669820000)
The response from Zuora is 
```json
{
  code: 401,
  zuoraErrorDetails: [
    {
      code: "90000011",
      message: "Authentication error"
    }
  ],
  name: "ZuoraError"
}
```

This PR adds logging around the bearer token expiry logic to see if that could be the cause of this issue