### PR TITLE
Align Braze acquisition mappings with bigQuery field values

### DIFF
--- a/handlers/braze-acquisition-events-sync/src/acquisitionEvent.ts
+++ b/handlers/braze-acquisition-events-sync/src/acquisitionEvent.ts
@@ -23,6 +23,7 @@ export const paymentFrequencyValues = [
 	'QUARTERLY',
 	'SIX_MONTHLY',
 	'ANNUALLY',
+	'ANNUAL',
 ] as const;
 
 export type PaymentFrequency = (typeof paymentFrequencyValues)[number];
@@ -30,6 +31,7 @@ export type PaymentFrequency = (typeof paymentFrequencyValues)[number];
 export const acquisitionDataRowSchema = z.object({
 	eventTimeStamp: z.string(),
 	product: z.enum(acquisitionProductValues),
+	printProduct: z.string().nullable().optional(),
 	amount: z.number().nullable().optional(),
 	currency: z.string(),
 	paymentFrequency: z.enum(paymentFrequencyValues),
@@ -46,6 +48,7 @@ export const acquisitionsEventSchema = z
 export interface AcquisitionDataRow {
 	eventTimeStamp: string;
 	product: AcquisitionProduct;
+	printProduct?: string | null;
 	currency: Currency;
 	paymentFrequency: PaymentFrequency;
 	identityId?: string | null;

--- a/handlers/braze-acquisition-events-sync/src/transform.ts
+++ b/handlers/braze-acquisition-events-sync/src/transform.ts
@@ -1,6 +1,63 @@
 import type { AcquisitionDataRow } from './acquisitionEvent';
 import type { BrazeTrackPayload } from './brazeClient';
 
+function mapProductName(event: AcquisitionDataRow): string {
+	switch (event.product) {
+		case 'CONTRIBUTION':
+			return 'Single Contribution';
+		case 'RECURRING_CONTRIBUTION':
+			return 'Recurring Contribution';
+		case 'SUPPORTER_PLUS':
+			return 'Supporter Plus';
+		case 'DIGITAL_SUBSCRIPTION':
+			return 'Digital Subscription';
+		case 'PRINT_SUBSCRIPTION': {
+			if (
+				event.printProduct === 'HOME_DELIVERY_SUNDAY' ||
+				event.printProduct === 'VOUCHER_SUNDAY'
+			) {
+				return 'Newspaper - Subscription';
+			}
+
+			if (event.printProduct !== 'GUARDIAN_WEEKLY') {
+				return 'Newspaper - Subscription';
+			}
+
+			return 'Guardian Weekly - Digital';
+		}
+		case 'TIER_THREE':
+			return 'Tier Three';
+		case 'GUARDIAN_AD_LITE':
+			return 'Guardian Ad-Lite';
+		case 'APP_PREMIUM_TIER':
+			return 'Premium App';
+		case 'FEAST_APP':
+			return 'Feast App';
+		default:
+			return event.product;
+	}
+}
+
+function mapPaymentFrequency(
+	paymentFrequency: AcquisitionDataRow['paymentFrequency'],
+): string {
+	switch (paymentFrequency) {
+		case 'ONE_OFF':
+			return 'One-off payment';
+		case 'MONTHLY':
+			return 'Month';
+		case 'QUARTERLY':
+			return 'Quarter';
+		case 'SIX_MONTHLY':
+			return 'Semi-Annual';
+		case 'ANNUALLY':
+		case 'ANNUAL':
+			return 'Annual';
+		default:
+			return paymentFrequency;
+	}
+}
+
 export function transformEventForBrazePayload(
 	event: AcquisitionDataRow,
 	externalId: string,
@@ -13,10 +70,10 @@ export function transformEventForBrazePayload(
 				time: event.eventTimeStamp,
 				_update_existing_only: true,
 				properties: {
-					product_name: event.product,
+					product_name: mapProductName(event),
 					currency: event.currency,
 					promo_code: event.promoCode,
-					payment_frequency: event.paymentFrequency,
+					payment_frequency: mapPaymentFrequency(event.paymentFrequency),
 					transaction_value: event.amount,
 				},
 			},

--- a/handlers/braze-acquisition-events-sync/src/transform.ts
+++ b/handlers/braze-acquisition-events-sync/src/transform.ts
@@ -1,61 +1,51 @@
 import type { AcquisitionDataRow } from './acquisitionEvent';
 import type { BrazeTrackPayload } from './brazeClient';
 
+const productNameMap: Partial<Record<AcquisitionDataRow['product'], string>> = {
+	CONTRIBUTION: 'Single Contribution',
+	RECURRING_CONTRIBUTION: 'Recurring Contribution',
+	SUPPORTER_PLUS: 'Supporter Plus',
+	DIGITAL_SUBSCRIPTION: 'Digital Subscription',
+	TIER_THREE: 'Tier Three',
+	GUARDIAN_AD_LITE: 'Guardian Ad-Lite',
+	APP_PREMIUM_TIER: 'Premium App',
+	FEAST_APP: 'Feast App',
+};
+
+const paymentFrequencyMap: Partial<
+	Record<AcquisitionDataRow['paymentFrequency'], string>
+> = {
+	ONE_OFF: 'One-off payment',
+	MONTHLY: 'Month',
+	QUARTERLY: 'Quarter',
+	SIX_MONTHLY: 'Semi-Annual',
+	ANNUALLY: 'Annual',
+	ANNUAL: 'Annual',
+};
+
 function mapProductName(event: AcquisitionDataRow): string {
-	switch (event.product) {
-		case 'CONTRIBUTION':
-			return 'Single Contribution';
-		case 'RECURRING_CONTRIBUTION':
-			return 'Recurring Contribution';
-		case 'SUPPORTER_PLUS':
-			return 'Supporter Plus';
-		case 'DIGITAL_SUBSCRIPTION':
-			return 'Digital Subscription';
-		case 'PRINT_SUBSCRIPTION': {
-			if (
-				event.printProduct === 'HOME_DELIVERY_SUNDAY' ||
-				event.printProduct === 'VOUCHER_SUNDAY'
-			) {
-				return 'Newspaper - Subscription';
-			}
-
-			if (event.printProduct !== 'GUARDIAN_WEEKLY') {
-				return 'Newspaper - Subscription';
-			}
-
-			return 'Guardian Weekly - Digital';
+	if (event.product === 'PRINT_SUBSCRIPTION') {
+		if (
+			event.printProduct === 'HOME_DELIVERY_SUNDAY' ||
+			event.printProduct === 'VOUCHER_SUNDAY'
+		) {
+			return 'Newspaper - Subscription';
 		}
-		case 'TIER_THREE':
-			return 'Tier Three';
-		case 'GUARDIAN_AD_LITE':
-			return 'Guardian Ad-Lite';
-		case 'APP_PREMIUM_TIER':
-			return 'Premium App';
-		case 'FEAST_APP':
-			return 'Feast App';
-		default:
-			return event.product;
+
+		if (event.printProduct !== 'GUARDIAN_WEEKLY') {
+			return 'Newspaper - Subscription';
+		}
+
+		return 'Guardian Weekly - Digital';
 	}
+
+	return productNameMap[event.product] ?? event.product;
 }
 
 function mapPaymentFrequency(
 	paymentFrequency: AcquisitionDataRow['paymentFrequency'],
 ): string {
-	switch (paymentFrequency) {
-		case 'ONE_OFF':
-			return 'One-off payment';
-		case 'MONTHLY':
-			return 'Month';
-		case 'QUARTERLY':
-			return 'Quarter';
-		case 'SIX_MONTHLY':
-			return 'Semi-Annual';
-		case 'ANNUALLY':
-		case 'ANNUAL':
-			return 'Annual';
-		default:
-			return paymentFrequency;
-	}
+	return paymentFrequencyMap[paymentFrequency] ?? paymentFrequency;
 }
 
 export function transformEventForBrazePayload(

--- a/handlers/braze-acquisition-events-sync/test/processAcquisitionEvent.test.ts
+++ b/handlers/braze-acquisition-events-sync/test/processAcquisitionEvent.test.ts
@@ -96,7 +96,7 @@ describe('processAcquisitionEvent', () => {
 					time: '2026-06-03T12:00:00Z',
 					_update_existing_only: true,
 					properties: {
-						product_name: 'Contribution',
+						product_name: 'Single Contribution',
 						currency: 'GBP',
 						promo_code: 'PROMO123',
 						payment_frequency: 'One-off payment',
@@ -108,17 +108,17 @@ describe('processAcquisitionEvent', () => {
 	});
 
 	it.each([
-		['RECURRING_CONTRIBUTION', undefined, 'Contribution'],
+		['RECURRING_CONTRIBUTION', undefined, 'Recurring Contribution'],
 		['SUPPORTER_PLUS', undefined, 'Supporter Plus'],
 		['TIER_THREE', undefined, 'Tier Three'],
-		['DIGITAL_SUBSCRIPTION', undefined, 'Digital Pack'],
+		['DIGITAL_SUBSCRIPTION', undefined, 'Digital Subscription'],
 		['GUARDIAN_AD_LITE', undefined, 'Guardian Ad-Lite'],
-		['PRINT_SUBSCRIPTION', 'GUARDIAN_WEEKLY', 'Guardian Weekly'],
-		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_SUNDAY', 'Newspaper - Observer only'],
-		['PRINT_SUBSCRIPTION', 'VOUCHER_SUNDAY', 'Newspaper - Observer only'],
-		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_EVERYDAY', 'newspaper'],
-		['PRINT_SUBSCRIPTION', 'VOUCHER_SIXDAY', 'newspaper'],
-		['APP_PREMIUM_TIER', undefined, 'APP_PREMIUM_TIER'],
+		['PRINT_SUBSCRIPTION', 'GUARDIAN_WEEKLY', 'Guardian Weekly - Digital'],
+		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_SUNDAY', 'Newspaper - Subscription'],
+		['PRINT_SUBSCRIPTION', 'VOUCHER_SUNDAY', 'Newspaper - Subscription'],
+		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_EVERYDAY', 'Newspaper - Subscription'],
+		['PRINT_SUBSCRIPTION', 'VOUCHER_SIXDAY', 'Newspaper - Subscription'],
+		['APP_PREMIUM_TIER', undefined, 'Premium App'],
 	] as const)(
 		'maps product %s with printProduct %s to %s',
 		(product, printProduct, expectedProductName) => {

--- a/handlers/braze-acquisition-events-sync/test/processAcquisitionEvent.test.ts
+++ b/handlers/braze-acquisition-events-sync/test/processAcquisitionEvent.test.ts
@@ -78,8 +78,8 @@ describe('processAcquisitionEvent', () => {
 
 	it('creates Braze payload with expected event properties', () => {
 		const event = buildEvent({
-			product: 'SUPPORTER_PLUS',
-			paymentFrequency: 'MONTHLY',
+			product: 'CONTRIBUTION',
+			paymentFrequency: 'ONE_OFF',
 			currency: 'GBP',
 			eventTimeStamp: '2026-06-03T12:00:00Z',
 			promoCode: 'PROMO123',
@@ -96,14 +96,68 @@ describe('processAcquisitionEvent', () => {
 					time: '2026-06-03T12:00:00Z',
 					_update_existing_only: true,
 					properties: {
-						product_name: 'SUPPORTER_PLUS',
+						product_name: 'Contribution',
 						currency: 'GBP',
 						promo_code: 'PROMO123',
-						payment_frequency: 'MONTHLY',
+						payment_frequency: 'One-off payment',
 						transaction_value: 15,
 					},
 				},
 			],
 		});
 	});
+
+	it.each([
+		['RECURRING_CONTRIBUTION', undefined, 'Contribution'],
+		['SUPPORTER_PLUS', undefined, 'Supporter Plus'],
+		['TIER_THREE', undefined, 'Tier Three'],
+		['DIGITAL_SUBSCRIPTION', undefined, 'Digital Pack'],
+		['GUARDIAN_AD_LITE', undefined, 'Guardian Ad-Lite'],
+		['PRINT_SUBSCRIPTION', 'GUARDIAN_WEEKLY', 'Guardian Weekly'],
+		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_SUNDAY', 'Newspaper - Observer only'],
+		['PRINT_SUBSCRIPTION', 'VOUCHER_SUNDAY', 'Newspaper - Observer only'],
+		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_EVERYDAY', 'newspaper'],
+		['PRINT_SUBSCRIPTION', 'VOUCHER_SIXDAY', 'newspaper'],
+		['MEMBERSHIP_SUPPORTER', undefined, 'MEMBERSHIP_SUPPORTER'],
+		['MEMBERSHIP_PARTNER', undefined, 'MEMBERSHIP_PARTNER'],
+		['APP_PREMIUM_TIER', undefined, 'APP_PREMIUM_TIER'],
+	] as const)(
+		'maps product %s with printProduct %s to %s',
+		(product, printProduct, expectedProductName) => {
+			const event = buildEvent({
+				product,
+				printProduct,
+			});
+
+			const payload = transformEventForBrazePayload(
+				event.detail,
+				'external-user-123',
+			);
+			expect(payload.events?.[0]?.properties?.product_name).toEqual(
+				expectedProductName,
+			);
+		},
+	);
+
+	it.each([
+		['ONE_OFF', 'One-off payment'],
+		['MONTHLY', 'Month'],
+		['QUARTERLY', 'Quarter'],
+		['SIX_MONTHLY', 'Semi-Annual'],
+		['ANNUALLY', 'Annual'],
+		['ANNUAL', 'Annual'],
+	] as const)(
+		'maps payment frequency %s to %s',
+		(paymentFrequency, expected) => {
+			const event = buildEvent({ paymentFrequency });
+
+			const payload = transformEventForBrazePayload(
+				event.detail,
+				'external-user-123',
+			);
+			expect(payload.events?.[0]?.properties?.payment_frequency).toEqual(
+				expected,
+			);
+		},
+	);
 });

--- a/handlers/braze-acquisition-events-sync/test/processAcquisitionEvent.test.ts
+++ b/handlers/braze-acquisition-events-sync/test/processAcquisitionEvent.test.ts
@@ -116,7 +116,11 @@ describe('processAcquisitionEvent', () => {
 		['PRINT_SUBSCRIPTION', 'GUARDIAN_WEEKLY', 'Guardian Weekly - Digital'],
 		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_SUNDAY', 'Newspaper - Subscription'],
 		['PRINT_SUBSCRIPTION', 'VOUCHER_SUNDAY', 'Newspaper - Subscription'],
-		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_EVERYDAY', 'Newspaper - Subscription'],
+		[
+			'PRINT_SUBSCRIPTION',
+			'HOME_DELIVERY_EVERYDAY',
+			'Newspaper - Subscription',
+		],
 		['PRINT_SUBSCRIPTION', 'VOUCHER_SIXDAY', 'Newspaper - Subscription'],
 		['APP_PREMIUM_TIER', undefined, 'Premium App'],
 	] as const)(

--- a/handlers/braze-acquisition-events-sync/test/processAcquisitionEvent.test.ts
+++ b/handlers/braze-acquisition-events-sync/test/processAcquisitionEvent.test.ts
@@ -118,8 +118,6 @@ describe('processAcquisitionEvent', () => {
 		['PRINT_SUBSCRIPTION', 'VOUCHER_SUNDAY', 'Newspaper - Observer only'],
 		['PRINT_SUBSCRIPTION', 'HOME_DELIVERY_EVERYDAY', 'newspaper'],
 		['PRINT_SUBSCRIPTION', 'VOUCHER_SIXDAY', 'newspaper'],
-		['MEMBERSHIP_SUPPORTER', undefined, 'MEMBERSHIP_SUPPORTER'],
-		['MEMBERSHIP_PARTNER', undefined, 'MEMBERSHIP_PARTNER'],
 		['APP_PREMIUM_TIER', undefined, 'APP_PREMIUM_TIER'],
 	] as const)(
 		'maps product %s with printProduct %s to %s',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1214545137038302)
## What does this change?
This change maps product and billing period field values that come from acquisition event to the fields in bigQuery and mParticle
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
