### PR TITLE
readme update for braze-acquisition-events-sync

### DIFF
--- a/handlers/braze-acquisition-events-sync/README.md
+++ b/handlers/braze-acquisition-events-sync/README.md
@@ -1,29 +1,116 @@
-# braze-acquisition-events-sync API
+# braze-acquisition-events-sync
+
+## Overview
+
+An AWS Lambda that listens to acquisition events from an EventBridge event bus and syncs them to Braze as custom events via the [`/users/track`](https://www.braze.com/docs/api/endpoints/user_data/post_user_track/) endpoint.
+
+### Why this lambda exists
+
+Without it, Braze only learns about a new contribution or subscription when `diff-publisher` runs its nightly batch (once a day, overnight). Until that batch completes, Braze still treats the user as a non-supporter and continues to show them marketing surfaces — banners, epics, etc.
+
+This lambda closes that gap: it fires as soon as the acquisition event is published, so Braze is updated within seconds of the purchase and can immediately suppress marketing for that user.
+
+When a user completes a purchase (contribution, subscription, etc.), an `AcquisitionsEvent` is published to the `acquisitions-bus` EventBridge event bus. This lambda picks it up, looks up the user's Braze UUID from the Identity API (IDAPI), transforms the acquisition data into a Braze event payload (the fields are transformed to correspond to existing field values in big Query tables), and posts it to Braze.
+
+Events for **guest users** (no `identityId`) are silently skipped since they cannot be matched to a Braze profile.
+
+### Supported products
+
+| Internal value | Braze event `product_name` |
+|---|---|
+| `CONTRIBUTION` | Single Contribution |
+| `RECURRING_CONTRIBUTION` | Recurring Contribution |
+| `SUPPORTER_PLUS` | Supporter Plus |
+| `TIER_THREE` | Tier Three |
+| `DIGITAL_SUBSCRIPTION` | Digital Subscription |
+| `PRINT_SUBSCRIPTION` (Guardian Weekly) | Guardian Weekly - Digital |
+| `PRINT_SUBSCRIPTION` (other) | Newspaper - Subscription |
+| `APP_PREMIUM_TIER` | Premium App |
+| `GUARDIAN_AD_LITE` | Guardian Ad-Lite |
+| `FEAST_APP` | Feast App |
+
+## Event flow
+
+```
+acquisitions-bus (EventBridge)
+        │  AcquisitionsEvent
+        ▼
+braze-acquisition-events-sync (Lambda)
+        │
+        ├─ 1. Parse & validate event (zod)
+        ├─ 2. Skip if no identityId (guest)
+        ├─ 3. Look up Braze UUID via IDAPI (privateFields.brazeUuid)
+        ├─ 4. Skip if Braze UUID not found
+        ├─ 5. Transform event → Braze /users/track payload
+        └─ 6. POST to Braze /users/track
+```
+
+If EventBridge cannot invoke the lambda after 3 retries or within 2 hours, the event is sent to a dead-letter queue (DLQ) for manual inspection.
+
+## Infrastructure (CDK)
+
+Defined in [cdk/lib/braze-acquisition-events-sync.ts](../../cdk/lib/braze-acquisition-events-sync.ts).
+
+| Resource | Details |
+|---|---|
+| Lambda | `SrApiLambda` |
+| EventBridge rule | `braze-acquisition-events-sync-{stage}` on `acquisitions-bus-{stage}`, matches `detail-type: AcquisitionsEvent` |
+| EventBridge DLQ | `braze-acquisition-events-sync-eventbridge-dlq-{stage}` |
+| Lambda error alarm | Fires in PROD when ≥1 lambda error in a 5-minute window |
+| DLQ alarm | Fires in PROD when ≥1 message is visible in the DLQ in a 5-minute window |
 
 ## URLs
 
-#### CODE - https://braze-acquisition-events-sync-code.support.guardianapis.com/
+| Stage | URL |
+|---|---|
+| CODE | https://braze-acquisition-events-sync-code.support.guardianapis.com/ |
+| PROD | https://braze-acquisition-events-sync.support.guardianapis.com/ |
 
-#### PROD - https://braze-acquisition-events-sync.support.guardianapis.com/
+## Configuration
 
-## OpenAPI
+Loaded from SSM Parameter Store via `@modules/aws/appConfig`:
 
-The OpenAPI description for this handler is in `openapi.yaml`. The spec is linted automatically as part of `pnpm package`.
+| Key | Description |
+|---|---|
+| `braze.apiUrl` | Braze REST API base URL |
+| `braze.apiKey` | Braze REST API key (secret) |
 
-### Validate and preview locally
+The Identity client access token is read from:
+`/{stage}/support/braze-acquisition-events-sync/identity-client-access-token`
+
+## How to test
+
+Run unit tests:
 
 ```bash
-# Lint the OpenAPI spec
-pnpm --filter braze-acquisition-events-sync openapi:lint
+pnpm --filter braze-acquisition-events-sync test
+```
 
-# Open an interactive preview in the browser
+Run integration tests:
+
+```bash
+pnpm --filter braze-acquisition-events-sync test:integration
+```
+
+Lint the OpenAPI spec:
+
+```bash
+pnpm --filter braze-acquisition-events-sync openapi:lint
+```
+
+Preview the OpenAPI spec locally:
+
+```bash
 pnpm --filter braze-acquisition-events-sync openapi:preview
 ```
 
-### External documentation
+## Alerts and triage
 
-- OpenAPI specification: https://spec.openapis.org/oas/latest.html
-- Redocly CLI: https://redocly.com/docs/cli/
+**Lambda error alarm**
+Inspect lambda logs for error stack and `identityId` context. Check IDAPI lookup result for missing `brazeUuid`. Confirm Braze `/users/track` request and response payloads. Impact: eligible users may not have acquisition events applied to their Braze profile.
+
+**EventBridge DLQ alarm**
+Inspect DLQ message attributes for the invoke failure reason. Confirm the EventBridge rule event pattern matches the `AcquisitionsEvent` payload shape. Verify lambda permissions from EventBridge. Redrive once the root cause is fixed.
 
 
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This change updates the Readme of the braze-acquisition-events-sync lambda
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
