### PR TITLE
tighten zuora object query schema

### DIFF
--- a/modules/zuora/src/objectQuery/expandSchemas/ratePlanItemSchema.ts
+++ b/modules/zuora/src/objectQuery/expandSchemas/ratePlanItemSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import z from 'zod';
 import { ratePlanChargeItemSchema } from '@modules/zuora/objectQuery/expandSchemas/ratePlanChargeItemSchema';
 
 export const ratePlanItemSchema = z.object({
@@ -18,17 +18,7 @@ export const ratePlanItemSchema = z.object({
 	amendmentId: z.string().nullable(),
 	/** The type of amendment associated with the rate plan. */
 	amendmentType: z
-		.enum([
-			'Cancellation',
-			'NewProduct',
-			'Composite',
-			'RemoveProduct',
-			'Renewal',
-			'UpdateProduct',
-			'TermsAndConditions',
-			'SuspendSubscription',
-			'ResumeSubscription',
-		])
+		.enum(['NewProduct', 'RemoveProduct', 'UpdateProduct'])
 		.nullable(),
 	/** The name of the rate plan. */
 	name: z.string(),

--- a/modules/zuora/src/objectQuery/expandSchemas/subscriptionItemSchema.ts
+++ b/modules/zuora/src/objectQuery/expandSchemas/subscriptionItemSchema.ts
@@ -84,9 +84,9 @@ export const subscriptionItemSchema = z.object({
 	subscriptionVersionAmendmentId: z.string().nullable(),
 	/**
 	 * The date the subscription term ends.
-	 * Null if the subscription is evergreen and no cancellation date has been set.
+	 * would only be Null if the subscription is evergreen and no cancellation date has been set.
 	 */
-	termEndDate: z.coerce.date().nullable(),
+	termEndDate: z.coerce.date(),
 	/** The date the subscription term begins. */
 	termStartDate: z.coerce.date(),
 	/** The type of the subscription term. */


### PR DESCRIPTION
Object query is a new functionality added in https://github.com/guardian/support-service-lambdas/pull/3621

The first use will be for the account overview lambda.

As part of setting it up I noticed some improvements needed to the schema.

This PR tightens up the schema accordingly.

See inline comments.