### PR TITLE
Add a buffer to bearer token expiry check

### DIFF
--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -14,9 +14,9 @@ export interface BearerTokenProvider {
 
 export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 	private bearerToken: ZuoraBearerToken | null = null;
-	private lastFetchedTime: Date | null = null;
-	// avoid failures caused by millisecond timing issues
-	private bufferInMilliseconds = 1000;
+	private tokenExpiryTime: number | null = null;
+	// 5 minute buffer in case of early expiry
+	private bufferInMilliseconds = 5 * 60 * 1000;
 
 	constructor(
 		private stage: string,
@@ -25,39 +25,30 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 
 	private tokenIsExpired = () => {
 		logger.log('Checking if Zuora bearer token is expired');
-		if (this.bearerToken === null) {
-			logger.log('No Zuora bearer token found, fetching a new one');
-			return true;
-		}
-		const now = new Date();
-		if (this.lastFetchedTime === null) {
+		if (this.tokenExpiryTime === null) {
 			logger.log(
-				'No last fetched time found, fetching a new Zuora bearer token',
+				'No token expiry time found, fetching a new Zuora bearer token',
 			);
 			return true;
 		}
-		if (
-			this.lastFetchedTime.getTime() + this.bearerToken.expires_in * 1000 <
-			now.getTime() + this.bufferInMilliseconds
-		) {
+		const now = new Date();
+		if (this.tokenExpiryTime < now.getTime() + this.bufferInMilliseconds) {
 			logger.log('Zuora bearer token is expired', {
-				lastFetchedTime: this.lastFetchedTime.getTime(),
-				expiresIn: this.bearerToken.expires_in * 1000,
+				tokenExpiryTime: this.tokenExpiryTime,
 				now: now.getTime(),
 			});
 			return true;
 		}
 		logger.log('Zuora bearer token is still valid', {
-			lastFetchedTime: this.lastFetchedTime.getTime(),
-			expiresIn: this.bearerToken.expires_in * 1000,
+			tokenExpiryTime: this.tokenExpiryTime,
 			now: now.getTime(),
 		});
 		return false;
 	};
 	public async getBearerToken(): Promise<ZuoraBearerToken> {
 		if (this.bearerToken === null || this.tokenIsExpired()) {
-			this.lastFetchedTime = new Date();
 			this.bearerToken = await this.fetchZuoraBearerToken();
+			this.tokenExpiryTime = Date.now() + this.bearerToken.expires_in * 1000;
 		}
 		return this.bearerToken;
 	}

--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -1,5 +1,5 @@
 import { logger } from '@modules/logger/logger';
-import type { OAuthClientCredentials, ZuoraBearerToken } from '../types';
+import type { OAuthClientCredentials } from '../types';
 import { zuoraBearerTokenSchema } from '../types';
 import { zuoraServerUrl } from '../utils';
 
@@ -12,11 +12,15 @@ export interface BearerTokenProvider {
 	getAuthorisation(): Promise<Authorisation>;
 }
 
+type BearerToken = {
+	bearerToken: string;
+	tokenExpiryTime: number;
+};
+
 export class ZuoraBearerTokenProvider implements BearerTokenProvider {
-	private bearerToken: ZuoraBearerToken | null = null;
-	private tokenExpiryTime: number | null = null;
 	// 1 minute buffer in case of early expiry
 	private readonly bufferInMilliseconds = 60 * 1000;
+	private bearerToken: BearerToken | null = null;
 
 	constructor(
 		private stage: string,
@@ -24,36 +28,39 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 	) {}
 
 	private tokenIsExpired = () => {
-		logger.log('Checking if Zuora bearer token is expired');
-		if (this.tokenExpiryTime === null) {
+		logger.log('Checking for valid Zuora bearer token');
+		if (this.bearerToken === null) {
 			logger.log(
-				'No token expiry time found, fetching a new Zuora bearer token',
+				'No Zuora bearer token found, fetching a new Zuora bearer token',
 			);
 			return true;
 		}
 		const now = new Date();
-		if (this.tokenExpiryTime < now.getTime() + this.bufferInMilliseconds) {
+		if (
+			this.bearerToken.tokenExpiryTime <
+			now.getTime() + this.bufferInMilliseconds
+		) {
 			logger.log('Zuora bearer token is expired', {
-				tokenExpiryTime: this.tokenExpiryTime,
+				tokenExpiryTime: this.bearerToken.tokenExpiryTime,
 				now: now.getTime(),
 			});
 			return true;
 		}
 		logger.log('Zuora bearer token is still valid', {
-			tokenExpiryTime: this.tokenExpiryTime,
+			tokenExpiryTime: this.bearerToken.tokenExpiryTime,
 			now: now.getTime(),
 		});
 		return false;
 	};
-	public async getBearerToken(): Promise<ZuoraBearerToken> {
+
+	public async getBearerToken(): Promise<BearerToken> {
 		if (this.bearerToken === null || this.tokenIsExpired()) {
-			this.bearerToken = await this.fetchZuoraBearerToken();
-			this.tokenExpiryTime = Date.now() + this.bearerToken.expires_in * 1000;
+			this.bearerToken = await this.fetchBearerToken();
 		}
 		return this.bearerToken;
 	}
 
-	private fetchZuoraBearerToken = async (): Promise<ZuoraBearerToken> => {
+	private fetchBearerToken = async (): Promise<BearerToken> => {
 		logger.log(`fetching zuora bearer token for stage: ${this.stage}`);
 		const url = `${zuoraServerUrl(this.stage)}/oauth/token`;
 
@@ -79,7 +86,10 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 				`Failed to fetch Zuora bearer token: ${JSON.stringify(parseResult.error.issues)}`,
 			);
 		}
-		return parseResult.data;
+		return {
+			bearerToken: parseResult.data.access_token,
+			tokenExpiryTime: Date.now() + parseResult.data.expires_in * 1000,
+		};
 	};
 
 	public async getAuthorisation() {
@@ -87,7 +97,7 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 		return {
 			baseUrl: zuoraServerUrl(this.stage),
 			authHeaders: {
-				Authorization: `Bearer ${bearerToken.access_token}`,
+				Authorization: `Bearer ${bearerToken.bearerToken}`,
 			},
 		};
 	}

--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -16,7 +16,7 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 	private bearerToken: ZuoraBearerToken | null = null;
 	private tokenExpiryTime: number | null = null;
 	// 1 minute buffer in case of early expiry
-	private bufferInMilliseconds = 60 * 1000;
+	private readonly bufferInMilliseconds = 60 * 1000;
 
 	constructor(
 		private stage: string,

--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -15,6 +15,8 @@ export interface BearerTokenProvider {
 export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 	private bearerToken: ZuoraBearerToken | null = null;
 	private lastFetchedTime: Date | null = null;
+	// avoid failures caused by millisecond timing issues
+	private bufferInMilliseconds = 1000;
 
 	constructor(
 		private stage: string,
@@ -36,7 +38,7 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 		}
 		if (
 			this.lastFetchedTime.getTime() + this.bearerToken.expires_in * 1000 <
-			now.getTime()
+			now.getTime() + this.bufferInMilliseconds
 		) {
 			logger.log('Zuora bearer token is expired', {
 				lastFetchedTime: this.lastFetchedTime.getTime(),
@@ -45,7 +47,11 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 			});
 			return true;
 		}
-		logger.log('Zuora bearer token is still valid');
+		logger.log('Zuora bearer token is still valid', {
+			lastFetchedTime: this.lastFetchedTime.getTime(),
+			expiresIn: this.bearerToken.expires_in * 1000,
+			now: now.getTime(),
+		});
 		return false;
 	};
 	public async getBearerToken(): Promise<ZuoraBearerToken> {

--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -27,7 +27,7 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 		private credentials: OAuthClientCredentials,
 	) {}
 
-	private tokenIsExpired = () => {
+	private tokenIsNullOrExpired = () => {
 		logger.log('Checking for valid Zuora bearer token');
 		if (this.bearerToken === null) {
 			logger.log(
@@ -54,10 +54,10 @@ export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 	};
 
 	public async getBearerToken(): Promise<BearerToken> {
-		if (this.bearerToken === null || this.tokenIsExpired()) {
+		if (this.tokenIsNullOrExpired()) {
 			this.bearerToken = await this.fetchBearerToken();
 		}
-		return this.bearerToken;
+		return this.bearerToken!; //Checked in tokenIsNullOrExpired
 	}
 
 	private fetchBearerToken = async (): Promise<BearerToken> => {

--- a/modules/zuora/src/auth/bearerTokenProvider.ts
+++ b/modules/zuora/src/auth/bearerTokenProvider.ts
@@ -15,8 +15,8 @@ export interface BearerTokenProvider {
 export class ZuoraBearerTokenProvider implements BearerTokenProvider {
 	private bearerToken: ZuoraBearerToken | null = null;
 	private tokenExpiryTime: number | null = null;
-	// 5 minute buffer in case of early expiry
-	private bufferInMilliseconds = 5 * 60 * 1000;
+	// 1 minute buffer in case of early expiry
+	private bufferInMilliseconds = 60 * 1000;
 
 	constructor(
 		private stage: string,

--- a/modules/zuora/src/types/auth.ts
+++ b/modules/zuora/src/types/auth.ts
@@ -8,8 +8,6 @@ export const oAuthClientCredentialsSchema = z.object({
 	clientSecret: z.string(),
 });
 
-export type ZuoraBearerToken = z.infer<typeof zuoraBearerTokenSchema>;
-
 export const zuoraBearerTokenSchema = z.object({
 	access_token: z.string(),
 	expires_in: z.number(),

--- a/modules/zuora/test/zuoraIntegration.test.ts
+++ b/modules/zuora/test/zuoraIntegration.test.ts
@@ -4,10 +4,10 @@
  * @group integration
  */
 
+import { ZuoraBearerTokenProvider } from '@modules/zuora/auth';
+import { getOAuthClientCredentials } from '@modules/zuora/auth';
 import { getSubscription } from '@modules/zuora/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { ZuoraBearerTokenProvider } from '../src/auth/bearerTokenProvider';
-import { getOAuthClientCredentials } from '../src/auth/oAuthCredentials';
 
 test('getZuoraCredentials', async () => {
 	const credentials = await getOAuthClientCredentials('CODE');
@@ -21,7 +21,7 @@ test('BearerTokenProvider', async () => {
 		credentials,
 	);
 	const token = await provider.getBearerToken();
-	expect(token.access_token.length).toBeGreaterThan(0);
+	expect(token.bearerToken.length).toBeGreaterThan(0);
 });
 
 test('GetSubscription', async () => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We are still getting auth errors from Zuora in the process supporter item lambda. This PR adds a buffer to avoid any millisecond delays from taking us over the expiry limit as well as some slightly more verbose logging.