### PR TITLE
Add Canadian tax-exclusive plans to the new-product-api product list

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -37,6 +37,7 @@ object WireModel {
       startDateRules: WireStartDateRules,
       paymentPlans: List[WirePaymentPlan],
       paymentPlan: Option[String], // todo legacy field, remove once salesforce is reading from paymentPlans
+      enabledForBillingCountries: Option[List[String]],
   )
 
   case class WirePaymentPlan(
@@ -129,12 +130,20 @@ object WireModel {
 
       val legacyPaymentPlan = plan.paymentPlans.get(GBP).map(_.description)
 
+      val enabledForBillingCountries = plan.id match {
+        case PlanId.DigipackAnnualTaxExclusive | PlanId.DigipackMonthlyTaxExclusive |
+            PlanId.AnnualSupporterPlusTaxExclusive | PlanId.MonthlySupporterPlusTaxExclusive =>
+          Some(List(Country.Canada.name))
+        case _ => None
+      }
+
       WirePlanInfo(
         id = plan.id.name,
         label = plan.description.value,
         startDateRules = toWireRules(plan.startDateRules),
         paymentPlans = paymentPlans.toList,
         paymentPlan = legacyPaymentPlan,
+        enabledForBillingCountries = enabledForBillingCountries,
       )
     }
   }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/DigitalPackPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/DigitalPackPlans.scala
@@ -1,6 +1,11 @@
 package com.gu.newproduct.api.productcatalog.plans
 
-import com.gu.newproduct.api.productcatalog.PlanId.{DigipackAnnual, DigipackMonthly}
+import com.gu.newproduct.api.productcatalog.PlanId.{
+  DigipackAnnual,
+  DigipackAnnualTaxExclusive,
+  DigipackMonthly,
+  DigipackMonthlyTaxExclusive,
+}
 import com.gu.newproduct.api.productcatalog._
 
 import java.time.LocalDate
@@ -19,6 +24,8 @@ class DigitalPackPlans(today: LocalDate) {
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
     (DigipackAnnual, PlanDescription("Annual"), startRules, Annual),
     (DigipackMonthly, PlanDescription("Monthly"), startRules, Monthly),
+    (DigipackAnnualTaxExclusive, PlanDescription("Annual"), startRules, Annual),
+    (DigipackMonthlyTaxExclusive, PlanDescription("Monthly"), startRules, Monthly),
   )
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/DigitalPackPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/DigitalPackPlans.scala
@@ -24,8 +24,8 @@ class DigitalPackPlans(today: LocalDate) {
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
     (DigipackAnnual, PlanDescription("Annual"), startRules, Annual),
     (DigipackMonthly, PlanDescription("Monthly"), startRules, Monthly),
-    (DigipackAnnualTaxExclusive, PlanDescription("Annual"), startRules, Annual),
-    (DigipackMonthlyTaxExclusive, PlanDescription("Monthly"), startRules, Monthly),
+    (DigipackAnnualTaxExclusive, PlanDescription("Annual (Tax Exclusive)"), startRules, Annual),
+    (DigipackMonthlyTaxExclusive, PlanDescription("Monthly (Tax Exclusive)"), startRules, Monthly),
   )
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/SupporterPlusPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/SupporterPlusPlans.scala
@@ -22,8 +22,8 @@ class SupporterPlusPlans(today: LocalDate) {
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
     (MonthlySupporterPlus, PlanDescription("Monthly"), rule, Monthly),
     (AnnualSupporterPlus, PlanDescription("Annual"), rule, Annual),
-    (MonthlySupporterPlusTaxExclusive, PlanDescription("Monthly"), rule, Monthly),
-    (AnnualSupporterPlusTaxExclusive, PlanDescription("Annual"), rule, Annual),
+    (MonthlySupporterPlusTaxExclusive, PlanDescription("Monthly (Tax Exclusive)"), rule, Monthly),
+    (AnnualSupporterPlusTaxExclusive, PlanDescription("Annual (Tax Exclusive)"), rule, Annual),
   )
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/SupporterPlusPlans.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/plans/SupporterPlusPlans.scala
@@ -1,6 +1,11 @@
 package com.gu.newproduct.api.productcatalog.plans
 
-import com.gu.newproduct.api.productcatalog.PlanId.{AnnualSupporterPlus, MonthlySupporterPlus}
+import com.gu.newproduct.api.productcatalog.PlanId.{
+  AnnualSupporterPlus,
+  AnnualSupporterPlusTaxExclusive,
+  MonthlySupporterPlus,
+  MonthlySupporterPlusTaxExclusive,
+}
 import com.gu.newproduct.api.productcatalog._
 
 import java.time.LocalDate
@@ -17,6 +22,8 @@ class SupporterPlusPlans(today: LocalDate) {
   val planInfo: List[(PlanId, PlanDescription, StartDateRules, BillingPeriod)] = List(
     (MonthlySupporterPlus, PlanDescription("Monthly"), rule, Monthly),
     (AnnualSupporterPlus, PlanDescription("Annual"), rule, Annual),
+    (MonthlySupporterPlusTaxExclusive, PlanDescription("Monthly"), rule, Monthly),
+    (AnnualSupporterPlusTaxExclusive, PlanDescription("Annual"), rule, Annual),
   )
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -62,6 +62,10 @@ class CatalogWireTest extends AnyFlatSpec with Matchers with ResourceLoader {
         Currency.GBP -> AmountMinorUnits(66666),
         Currency.USD -> AmountMinorUnits(66665),
       )
+    case DigipackAnnualTaxExclusive => Map(Currency.CAD -> AmountMinorUnits(11999))
+    case DigipackMonthlyTaxExclusive => Map(Currency.CAD -> AmountMinorUnits(1199))
+    case AnnualSupporterPlusTaxExclusive => Map(Currency.CAD -> AmountMinorUnits(16999))
+    case MonthlySupporterPlusTaxExclusive => Map(Currency.CAD -> AmountMinorUnits(1699))
     case GuardianWeeklyPlusDomesticMonthly =>
       Map(
         Currency.GBP -> AmountMinorUnits(1111111),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
@@ -63,7 +63,8 @@
         "amount" : 16.99,
         "billingPeriod" : "Monthly",
         "description" : "CAD 16.99 every month"
-      } ]
+      } ],
+      "enabledForBillingCountries" : [ "Canada" ]
     }, {
       "id" : "annual_supporter_plus_tax_exclusive",
       "label" : "Annual",
@@ -79,7 +80,8 @@
         "amount" : 169.99,
         "billingPeriod" : "Annual",
         "description" : "CAD 169.99 every 12 months"
-      } ]
+      } ],
+      "enabledForBillingCountries" : [ "Canada" ]
     } ]
   }, {
     "label" : "Digital Plus",
@@ -142,7 +144,8 @@
         "amount" : 119.99,
         "billingPeriod" : "Annual",
         "description" : "CAD 119.99 every 12 months"
-      } ]
+      } ],
+      "enabledForBillingCountries" : [ "Canada" ]
     }, {
       "id" : "digipack_monthly_tax_exclusive",
       "label" : "Monthly",
@@ -158,7 +161,8 @@
         "amount" : 11.99,
         "billingPeriod" : "Monthly",
         "description" : "CAD 11.99 every month"
-      } ]
+      } ],
+      "enabledForBillingCountries" : [ "Canada" ]
     } ]
   }, {
     "label" : "Home Delivery",

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
@@ -50,7 +50,7 @@
       "paymentPlans" : [ ]
     }, {
       "id" : "monthly_supporter_plus_tax_exclusive",
-      "label" : "Monthly",
+      "label" : "Monthly (Tax Exclusive)",
       "startDateRules" : {
         "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
         "selectableWindow" : {
@@ -67,7 +67,7 @@
       "enabledForBillingCountries" : [ "Canada" ]
     }, {
       "id" : "annual_supporter_plus_tax_exclusive",
-      "label" : "Annual",
+      "label" : "Annual (Tax Exclusive)",
       "startDateRules" : {
         "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
         "selectableWindow" : {
@@ -131,7 +131,7 @@
       "paymentPlan" : "GBP 55.55 every month"
     }, {
       "id" : "digipack_annual_tax_exclusive",
-      "label" : "Annual",
+      "label" : "Annual (Tax Exclusive)",
       "startDateRules" : {
         "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
         "selectableWindow" : {
@@ -148,7 +148,7 @@
       "enabledForBillingCountries" : [ "Canada" ]
     }, {
       "id" : "digipack_monthly_tax_exclusive",
-      "label" : "Monthly",
+      "label" : "Monthly (Tax Exclusive)",
       "startDateRules" : {
         "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
         "selectableWindow" : {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
@@ -48,6 +48,38 @@
         }
       },
       "paymentPlans" : [ ]
+    }, {
+      "id" : "monthly_supporter_plus_tax_exclusive",
+      "label" : "Monthly",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-01",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "CAD",
+        "amount" : 16.99,
+        "billingPeriod" : "Monthly",
+        "description" : "CAD 16.99 every month"
+      } ]
+    }, {
+      "id" : "annual_supporter_plus_tax_exclusive",
+      "label" : "Annual",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-01",
+          "sizeInDays" : 1
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "CAD",
+        "amount" : 169.99,
+        "billingPeriod" : "Annual",
+        "description" : "CAD 169.99 every 12 months"
+      } ]
     } ]
   }, {
     "label" : "Digital Plus",
@@ -95,6 +127,38 @@
         "description" : "USD 55.54 every month"
       } ],
       "paymentPlan" : "GBP 55.55 every month"
+    }, {
+      "id" : "digipack_annual_tax_exclusive",
+      "label" : "Annual",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-15",
+          "sizeInDays" : 90
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "CAD",
+        "amount" : 119.99,
+        "billingPeriod" : "Annual",
+        "description" : "CAD 119.99 every 12 months"
+      } ]
+    }, {
+      "id" : "digipack_monthly_tax_exclusive",
+      "label" : "Monthly",
+      "startDateRules" : {
+        "daysOfWeek" : [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" ],
+        "selectableWindow" : {
+          "startDate" : "2019-12-15",
+          "sizeInDays" : 90
+        }
+      },
+      "paymentPlans" : [ {
+        "currencyCode" : "CAD",
+        "amount" : 11.99,
+        "billingPeriod" : "Monthly",
+        "description" : "CAD 11.99 every month"
+      } ]
     } ]
   }, {
     "label" : "Home Delivery",

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/PlanId.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/PlanId.scala
@@ -21,6 +21,14 @@ object PlanId {
 
   case object MonthlySupporterPlus extends PlanId("monthly_supporter_plus") with SupporterPlusPlanId
 
+  case object AnnualSupporterPlusTaxExclusive
+      extends PlanId("annual_supporter_plus_tax_exclusive")
+      with SupporterPlusPlanId
+
+  case object MonthlySupporterPlusTaxExclusive
+      extends PlanId("monthly_supporter_plus_tax_exclusive")
+      with SupporterPlusPlanId
+
   case object AnnualContribution extends PlanId("annual_contribution") with ContributionPlanId
 
   case object MonthlyContribution extends PlanId("monthly_contribution") with ContributionPlanId
@@ -64,6 +72,10 @@ object PlanId {
   case object DigipackMonthly extends PlanId("digipack_monthly") with DigipackPlanId
 
   case object DigipackAnnual extends PlanId("digipack_annual") with DigipackPlanId
+
+  case object DigipackMonthlyTaxExclusive extends PlanId("digipack_monthly_tax_exclusive") with DigipackPlanId
+
+  case object DigipackAnnualTaxExclusive extends PlanId("digipack_annual_tax_exclusive") with DigipackPlanId
 
   case object GuardianWeeklyPlusDomesticMonthly
       extends PlanId("guardian_weekly_plus_domestic_monthly")
@@ -135,6 +147,8 @@ object PlanId {
   val enabledSupporterPlusPlans = List(
     MonthlySupporterPlus,
     AnnualSupporterPlus,
+    MonthlySupporterPlusTaxExclusive,
+    AnnualSupporterPlusTaxExclusive,
   )
 
   val enabledHomeDeliveryPlans = List(
@@ -152,6 +166,8 @@ object PlanId {
   val enabledDigipackPlans = List(
     DigipackAnnual,
     DigipackMonthly,
+    DigipackAnnualTaxExclusive,
+    DigipackMonthlyTaxExclusive,
   )
 
   val enabledGuardianWeeklyPlusDomesticPlans = List(

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -104,6 +104,22 @@ object ZuoraIds {
     )
   }
 
+  // Canadian tax-exclusive variants of Digital Plus (Digipack) and All Access Digital (Supporter Plus).
+  // The catalog only needs the product rate plan id, so we don't carry the charge ids here.
+  case class TaxExclusiveZuoraIds(
+      digipackMonthly: ProductRatePlanId,
+      digipackAnnual: ProductRatePlanId,
+      supporterPlusMonthly: ProductRatePlanId,
+      supporterPlusAnnual: ProductRatePlanId,
+  ) {
+    val byApiPlanId: Map[PlanId, ProductRatePlanId] = Map(
+      DigipackAnnualTaxExclusive -> digipackAnnual,
+      DigipackMonthlyTaxExclusive -> digipackMonthly,
+      AnnualSupporterPlusTaxExclusive -> supporterPlusAnnual,
+      MonthlySupporterPlusTaxExclusive -> supporterPlusMonthly,
+    )
+  }
+
   case class GuardianWeeklyDomesticIds(
       monthlyPlus: ProductRatePlanId,
       quarterlyPlus: ProductRatePlanId,
@@ -183,6 +199,7 @@ object ZuoraIds {
       guardianWeeklyPlusROW: GuardianWeeklyROWIds,
       digitalVoucher: DigitalVoucherZuoraIds,
       nationalDeliveryZuoraIds: NationalDeliveryZuoraIds,
+      taxExclusiveZuoraIds: TaxExclusiveZuoraIds,
   ) {
     def apiIdToRateplanId: Map[PlanId, ProductRatePlanId] =
       (supporterPlusZuoraIds.planAndChargeByApiPlanId.view.mapValues(_.productRatePlanId) ++
@@ -193,7 +210,8 @@ object ZuoraIds {
         guardianWeeklyPlusDomestic.zuoraRatePlanIdByApiPlanId ++
         guardianWeeklyPlusROW.zuoraRatePlanIdByApiPlanId ++
         digitalVoucher.byApiPlanId ++
-        nationalDeliveryZuoraIds.byApiPlanId).toMap
+        nationalDeliveryZuoraIds.byApiPlanId ++
+        taxExclusiveZuoraIds.byApiPlanId).toMap
 
     val rateplanIdToApiId: Map[ProductRatePlanId, PlanId] = apiIdToRateplanId.map(_.swap)
 
@@ -298,6 +316,12 @@ object ZuoraIds {
           weekendPlus = ProductRatePlanId("8a1280be96d33dbf0196d487b55c1283"),
           sixDayPlus = ProductRatePlanId("8a12994696d3587b0196d484491e3beb"),
         ),
+        TaxExclusiveZuoraIds(
+          digipackMonthly = ProductRatePlanId("8a129dff9e981ec8019ea80a4c9e5b24"),
+          digipackAnnual = ProductRatePlanId("8a129aae9e981ec4019eab88633c78ab"),
+          supporterPlusMonthly = ProductRatePlanId("8a1296cc9e981ec9019eab9092864ae0"),
+          supporterPlusAnnual = ProductRatePlanId("8a128e579e9807b1019eab92efee3f74"),
+        ),
       ),
       Stage("CODE") -> ZuoraIds(
         SupporterPlusZuoraIds(
@@ -388,6 +412,12 @@ object ZuoraIds {
           everydayPlus = ProductRatePlanId("71a116628be96ab11606b51ec6060555"),
           weekendPlus = ProductRatePlanId("71a1166283a96ab11606b50ebbb50381"),
           sixDayPlus = ProductRatePlanId("71a1383e2a796aafcb16b527842001ca"),
+        ),
+        TaxExclusiveZuoraIds(
+          digipackMonthly = ProductRatePlanId("71a1889a1579daf14eedb5c64fe800c9"),
+          digipackAnnual = ProductRatePlanId("14253478e8ca41888a2742f139823b51"),
+          supporterPlusMonthly = ProductRatePlanId("7a825d4a79bb49ec9a36883cad075fde"),
+          supporterPlusAnnual = ProductRatePlanId("f59be1a754254cf7bff266358fa14e7b"),
         ),
       ),
     )


### PR DESCRIPTION
## What does this change?

The product catalog that new-product-api returns to Salesforce now includes the Canadian tax-exclusive variants of Digital Plus and All Access Digital (Supporter Plus), so CSRs can see and pick them when setting up an acquisition. Each new plan only carries a CAD payment plan since these are Canada-only. The four new plan ids are `digipack_annual_tax_exclusive`, `digipack_monthly_tax_exclusive`, `annual_supporter_plus_tax_exclusive` and `monthly_supporter_plus_tax_exclusive`, wired to their Zuora rate plan ids for both CODE and PROD.

Each new plan also carries a new plan-level `enabledForBillingCountries` field set to `[ "Canada" ]`, which Graham asked for. It mirrors the existing product-level `enabledForDeliveryCountries`, but on the plan rather than the product. It's an Option, so it only appears on these four plans and stays absent on every other plan.

This is the first of two PRs for the CA sales tax CSR work. A follow-up will add a `taxMode` field to paymentPlans so Salesforce can tell which plans are tax-exclusive. The tax amount itself stays out of the catalog by design, Salesforce works it out per province using the existing sales-tax-api.

## How has this change been tested?

Unit tested. The catalog serialisation snapshot test was updated and the full new-product-api suite passes locally. Nothing deployed to CODE yet. The new plans are catalog-only and aren't meant to be created through this API's add-subscription endpoint, since acquisition happens via Zuora Quotes in Salesforce; the charge lookups there are Option-based, so an unsupported plan returns an error rather than failing.

## How can we measure success?

Salesforce can read the new plans from the catalog, see they're billable in Canada, and CSRs can select the Canadian tax-exclusive plans. Once the follow-up taxMode change lands they'll be able to show the right tax messaging too.

## Have we considered potential risks?

Low risk, the change is additive. Existing plans and pricing are untouched, and the new plans only appear with CAD pricing and a Canada billing restriction. They do become valid plan names for the add-subscription endpoint, but that path isn't used for them and fails safely if it ever is.