### PR TITLE
add t2->t3 upsell discount for PROD

### DIFF
--- a/handlers/product-switch-api/src/changePlan/action/preview.ts
+++ b/handlers/product-switch-api/src/changePlan/action/preview.ts
@@ -31,7 +31,7 @@ export interface SwitchDiscountResponse {
 	discountedPrice: number;
 	upToPeriods: number;
 	upToPeriodsType: 'Months' | 'Years';
-	discountPercentage: number;
+	discountPercentage?: number;
 }
 
 export const isRefundExpected = (

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/discounts.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/discounts.ts
@@ -8,10 +8,10 @@ export type Discount = {
 	name: string;
 	upToPeriods: number;
 	upToPeriodsType: 'Months' | 'Years';
-	discountPercentage: number;
+	discountPercentage?: number;
 };
 
-export const annualContribHalfPriceSupporterPlusForOneYear: Discount = {
+export const annualContribHalfPriceSupporterPlusForOneYear = {
 	productRatePlanId: {
 		PROD: '8a12994695aa4f680195ae2dc9d221d8',
 		CODE: '71a1383e2b395842e6f58a2754ad00c1',
@@ -24,19 +24,18 @@ export const annualContribHalfPriceSupporterPlusForOneYear: Discount = {
 	upToPeriods: 1,
 	upToPeriodsType: 'Years',
 	discountPercentage: 50,
-};
+} satisfies Discount;
 
 export const monthlyDigiPlus: Discount = {
 	productRatePlanId: {
-		PROD: 'tbc',
+		PROD: '8a1296cc9ef2fa7a019ef3bee7570e20',
 		CODE: '6257d4fb107e4b438a6ede085f86d628',
 	},
 	productRatePlanChargeId: {
-		PROD: 'tbc',
+		PROD: '8a1281679ef2e320019ef3c14e6a71a2',
 		CODE: '4a02ba3ebdcb4a469c402e09895cc716',
 	},
-	name: 'Upsell - Supporter Plus to Digital Plus Switch tbc off',
-	upToPeriods: 1,
+	name: 'Upsell - Supporter Plus to Digital Plus Switch - Price Match',
+	upToPeriods: 6,
 	upToPeriodsType: 'Months',
-	discountPercentage: 25,
 };


### PR DESCRIPTION
card https://app.asana.com/1/1210045093164357/project/1213134855566811/task/1214357149767966

We have previously done the work to add the upsell discount switch for CODE.
see main PR https://github.com/guardian/support-service-lambdas/pull/3547

Now we have the discount duration confirmed, and I have added the actual discount in PROD zuora.

This PR adds the suitable IDs and updates the duration accordingly.

It is still disabled in PROD, but the values are there ready.