### PR TITLE
add t2->t3 upsell discount email for PROD

### DIFF
--- a/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
@@ -1,4 +1,7 @@
-import { DataExtensionNames } from '@modules/email/email';
+import {
+	type DataExtensionName,
+	DataExtensionNames,
+} from '@modules/email/email';
 import { ValidationError } from '@modules/errors';
 import type { ProductRatePlan } from '@modules/product-catalog/productCatalog';
 import type { SwitchTargetInformation } from '../prepare/switchCatalogHelper';
@@ -29,11 +32,16 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 			throw new ValidationError("digital plus doesn't have a variable amount");
 		}
 		let discount: Discount | undefined = undefined;
+		let dataExtensionName: DataExtensionName;
 		if (
 			switchActionData.discountEnabled &&
 			productRatePlan.billingPeriod === 'Month'
 		) {
 			discount = monthlyDigiPlus;
+			dataExtensionName =
+				DataExtensionNames.supporterPlusToDigitalPlusSwitchWithDiscount;
+		} else {
+			dataExtensionName = DataExtensionNames.supporterPlusToDigitalPlusSwitch;
 		}
 
 		const catalogPrice = productRatePlan.pricing[switchActionData.currency];
@@ -52,7 +60,7 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 			contributionCharge: undefined,
 			subscriptionChargeId: productRatePlan.charges.Subscription.id,
 			discount,
-			dataExtensionName: DataExtensionNames.supporterPlusToDigitalPlusSwitch,
+			dataExtensionName,
 		} satisfies TargetInformation);
 	},
 };

--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -29,6 +29,7 @@ export type EmailPayload = {
 export const DataExtensionNames = {
 	recurringContributionToSupporterPlusSwitch: 'SV_RCtoSP_Switch',
 	supporterPlusToDigitalPlusSwitch: 'SV_SPtoDP_SwitchConfirmation',
+	supporterPlusToDigitalPlusSwitchWithDiscount: 'SV_DP_ManualDiscount',
 	subscriptionCancelledEmail: 'subscription-cancelled-email',
 	updateSupporterPlusAmount: 'payment-amount-changed-email',
 	cancellationDiscountConfirmation: 'cancellation-discount-confirmation-email',


### PR DESCRIPTION
card https://app.asana.com/1/1210045093164357/project/1213134855566811/task/1214357149767966

Linked to https://github.com/guardian/membership-workflow/pull/704
see main PR https://github.com/guardian/support-service-lambdas/pull/3547

This PR makes us send the "discount" version of the email if the user is offered a discount.

The email is still a WIP by MRR - if there are any changes to the trigger fields (e.g. first_name, last_name) then this can be implemented in a separate PR.

dev https://dashboard-01.braze.eu/engagement/canvas/6a2beb33ce013c009e108670/5b75934336dc781764d855ae?locale=en&version=flow&isEditing=true
live https://dashboard-01.braze.eu/engagement/canvas/6a2be0edeba2850083642ffd/5b75933b36dc781650d85641?locale=en&version=flow&isEditing=true&step=basics