### PR TITLE
Add the secondary user's email as a field in an invite

### DIFF
--- a/handlers/multiple-account-api/src/createInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/createInvitationEndpoint.ts
@@ -75,6 +75,7 @@ export const createInvitationEndpoint =
 			subscriptionName: zuoraSubscription.subscriptionNumber,
 			invitationCode,
 			primaryIdentityId: account.basicInfo.identityId,
+			secondaryUserEmail: body.secondaryUserEmail,
 			secondaryIdentityId,
 			invitedDate: zuoraDateFormat(now),
 			expiryDate: now.add(1, 'month').toDate().getTime(),

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -14,6 +14,7 @@ const invitationRecordSchema = z.object({
 	subscriptionName: z.string(),
 	invitationCode: z.string(),
 	primaryIdentityId: z.string(),
+	secondaryUserEmail: z.string(),
 	secondaryIdentityId: z.string(),
 	invitedDate: z.string(),
 	expiryDate: z.number(),

--- a/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
@@ -30,6 +30,7 @@ const buildRecord = (
 	subscriptionName,
 	invitationCode,
 	primaryIdentityId: '12345678',
+	secondaryUserEmail: 'integration-test@thegulocal.com',
 	secondaryIdentityId: '87654321',
 	invitedDate: new Date().toISOString(),
 	expiryDate: dayjs().add(10, 'seconds').toDate().getTime(),

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -34,11 +34,12 @@ const mockSubscription: ZuoraSubscription =
 
 const testDay = dayjs('2026-05-11').startOf('day');
 
-const mockInvitations = [
+const mockInvitations: InvitationRecord[] = [
 	{
 		subscriptionName: 'A-S12345',
 		invitationCode: 'invitation-code',
 		primaryIdentityId: '99999999',
+		secondaryUserEmail: 'integration-test@thegulocal.com',
 		secondaryIdentityId: '8888888',
 		invitedDate: zuoraDateFormat(testDay),
 		expiryDate: dayjs(testDay).add(1, 'm').toDate().getTime(),

--- a/handlers/multiple-account-api/test/invitationRepositoryIntegration.test.ts
+++ b/handlers/multiple-account-api/test/invitationRepositoryIntegration.test.ts
@@ -9,14 +9,16 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { getAwsConfig } from '@modules/aws/config';
 import type { Stage } from '@modules/stage';
 import dayjs from 'dayjs';
+import type { InvitationRecord } from '../src/invitationRepository';
 import { InvitationRepository } from '../src/invitationRepository';
 
 const stage: Stage = 'CODE';
 
-const testRecord = {
+const testRecord: InvitationRecord = {
 	subscriptionName: 'A-S00099999',
 	invitationCode: 'it-test-code',
 	primaryIdentityId: '12345678',
+	secondaryUserEmail: 'integration-test@thegulocal.com',
 	secondaryIdentityId: '87654321',
 	invitedDate: new Date().toISOString(),
 	expiryDate: dayjs().add(10, 'seconds').toDate().getTime(),

--- a/handlers/multiple-account-api/test/listInvitationsEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listInvitationsEndpoint.test.ts
@@ -11,6 +11,7 @@ describe('listInvitationsEndpoint', () => {
 				subscriptionName: 'A-S00974337',
 				invitationCode: 'RpwR62kMnAxe',
 				primaryIdentityId: 'primary-id',
+				secondaryUserEmail: 'integration-test@thegulocal.com',
 				secondaryIdentityId: 'secondary-id',
 				invitedDate: '2026-06-12',
 				expiryDate: 1781222400000,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR is part of the work to build the multiple accounts feature [described here](https://docs.google.com/document/d/1eqMn9zkg-iRK3Gi9ecmgGh8WWUYpLX6B3cOasTRYpns/edit?tab=t.0)

When displaying a list of invites for a primary user we always need the email address that they have been sent to. Previously we didn't store this in the multiple-account-invitation Dynamo table which meant that we would always have to look it up with Identity whenever we wanted to display it to a user. 

This is very inefficient so this PR adds the email as a field on the Dynamo record. As invitations are short lived, the risk of a user changing their email address in that time is minimal and even if they do, any logic we have around invitation acceptance is driven by the identity ID, not the email address so will be unaffected.