### PR TITLE
fix type inference in object-query builder

### DIFF
--- a/modules/objectFunctions.ts
+++ b/modules/objectFunctions.ts
@@ -77,13 +77,13 @@ export function objectEntries<T extends object>(
 /**
  * Returns a new object containing only the specified keys, preserving per-key value types.
  */
-export function pickKeys<O extends Record<string, unknown>, K extends keyof O>(
-	obj: O,
-	keys: readonly K[],
-): { [P in K]: O[P] } {
+export function pickKeys<
+	O extends Record<string, unknown>,
+	const K extends ReadonlyArray<keyof O>,
+>(obj: O, keys: K): { [P in K[number]]: O[P] } {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- allowed in utility function - get back type lost by Object.fromEntries
 	return Object.fromEntries(keys.map((k) => [k, obj[k]])) as {
-		[P in K]: O[P];
+		[P in K[number]]: O[P];
 	};
 }
 

--- a/modules/zuora/src/objectQuery/objectQueryBuilder.ts
+++ b/modules/zuora/src/objectQuery/objectQueryBuilder.ts
@@ -1,6 +1,6 @@
 import { mergeValues, pickKeys } from '@modules/objectFunctions';
-import type { ZodType, ZodTypeDef } from 'zod';
 import { z } from 'zod';
+import type { ZodType, ZodTypeDef } from 'zod';
 import type { DoesNotHaveDuplicateResponseKey } from '@modules/zuora/objectQuery/doesNotHaveDuplicateResponseKey';
 import type {
 	ObjectQueryExpandRegistry,
@@ -57,7 +57,7 @@ export class ObjectQueryBuilder<
 	 * @param expand
 	 */
 	buildItemSchema<
-		TFields extends keyof TFieldRegistry,
+		const TFields extends keyof TFieldRegistry,
 		const TExpandKeys extends ReadonlyArray<keyof TExpandRegistry>,
 	>(
 		fields: readonly TFields[],
@@ -84,7 +84,7 @@ export class ObjectQueryBuilder<
 	 * @param sort
 	 */
 	async execute<
-		TFields extends keyof TFieldRegistry,
+		const TFields extends keyof TFieldRegistry,
 		const TExpandKeys extends ReadonlyArray<keyof TExpandRegistry>,
 	>(
 		zuoraClient: ZuoraClient,

--- a/modules/zuora/test/objectQuery/buildSchema.test.ts
+++ b/modules/zuora/test/objectQuery/buildSchema.test.ts
@@ -29,6 +29,11 @@ test('single item deserialiser', () => {
 	expect(actual.subscriptions[0]?.ratePlans[0]?.name).toEqual(
 		'Monthly Contribution',
 	);
+	// if the types aren't narrowed properly then it doesn't find the type in map as it may not exist on all
+	expect(actual.subscriptions.map((sub) => sub.ratePlans[0]?.name)).toEqual([
+		'Monthly Contribution',
+		'Monthly Contribution',
+	]);
 });
 
 test('multiple item deserialiser', () => {


### PR DESCRIPTION
I noticed that when mapping over a subscription returned from object query, all the expands were available when using dot completion, but when mapping, none were available.

This PR tightens up the type inference of `pickKeys` so it doesn't widen the array when it shouldn't, it prefers to keep it as a const array.