### PR TITLE
add a body field for switching on the discount even in PROD

### DIFF
--- a/handlers/product-switch-api/src/changePlan/prepare/switchInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/switchInformation.ts
@@ -34,7 +34,7 @@ export async function getSwitchInformation(
 		subscriptionInformation.previousAmount,
 		subscriptionInformation.includesContribution,
 		productCatalogHelper,
-		discountEnabled,
+		discountEnabled || input.discountSwitchEnabled,
 	);
 
 	return {

--- a/handlers/product-switch-api/src/changePlan/schemas.ts
+++ b/handlers/product-switch-api/src/changePlan/schemas.ts
@@ -4,6 +4,7 @@ import { validTargetProductKeys } from './prepare/switchCatalogHelper';
 export const productSwitchCommonRequestSchema = z.object({
 	csrUserId: z.optional(z.string()),
 	caseId: z.optional(z.string()),
+	discountSwitchEnabled: z.optional(z.boolean()),
 });
 
 export const productSwitchRequestSchema = z.discriminatedUnion('mode', [
@@ -37,11 +38,11 @@ export type ProductSwitchRequestBody = z.infer<
 export type ProductSwitchTargetBody =
 	| Pick<
 			Extract<ProductSwitchRequestBody, { mode: 'switchToBasePrice' | 'save' }>,
-			'mode' | 'targetProduct'
+			'mode' | 'targetProduct' | 'discountSwitchEnabled'
 	  >
 	| Pick<
 			Extract<ProductSwitchRequestBody, { mode: 'switchWithPriceOverride' }>,
-			'mode' | 'targetProduct' | 'newAmount'
+			'mode' | 'targetProduct' | 'newAmount' | 'discountSwitchEnabled'
 	  >;
 
 export const zuoraSwitchResponseSchema = z.object({});


### PR DESCRIPTION
In preparation for https://github.com/guardian/manage-frontend/pull/1642

It would be good to have the option to control the feature via deploying manage, rather than having to do two deployments in tandem.

This PR makes a new optional body property `discountSwitchEnabled`, when set to true, it will offer the discount even in PROD.

Theoretically someone could do a POST to the endpoint to get the discount early, but that's probably not an issue given we're going to start giving it out for real imminently!