### PR TITLE
Upgrade Zod to v4

### DIFF
--- a/handlers/mparticle-api/src/routers/http/dataSubjectRequestCallback/data-subject-request-callback.ts
+++ b/handlers/mparticle-api/src/routers/http/dataSubjectRequestCallback/data-subject-request-callback.ts
@@ -29,6 +29,7 @@ export const dataSubjectRequestCallbackParser = {
 		results_url: z.string().url().nullable(),
 		extensions: z
 			.record(
+				z.string(),
 				z.object({
 					domain: z.string(),
 					name: z.string(),

--- a/handlers/mparticle-api/src/services/make-http-request.ts
+++ b/handlers/mparticle-api/src/services/make-http-request.ts
@@ -34,7 +34,7 @@ export type HttpResponse<T> =
 	  };
 
 export type Schema<RESP> =
-	| z.ZodType<RESP, z.ZodTypeDef, unknown>
+	| z.ZodType<RESP>
 	| ((body: string, contentType?: string) => RESP);
 
 export class RestRequestMaker {

--- a/handlers/product-switch-api/src/changePlan/action/switch.ts
+++ b/handlers/product-switch-api/src/changePlan/action/switch.ts
@@ -1,3 +1,4 @@
+import { getIfDefined } from '@modules/nullAndUndefined';
 import type { Stage } from '@modules/stage';
 import { sendToSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
 import type {
@@ -79,6 +80,9 @@ export class DoSwitchAction {
 				zuoraSwitchResponseWithIdsSchema,
 			);
 
-		return switchResponse.invoiceIds[0];
+		return getIfDefined(
+			switchResponse.invoiceIds[0],
+			'No invoice id returned from switch order',
+		);
 	};
 }

--- a/handlers/product-switch-api/src/frequencySwitchSchemas.ts
+++ b/handlers/product-switch-api/src/frequencySwitchSchemas.ts
@@ -3,10 +3,11 @@ import { z } from 'zod';
 
 export const frequencySwitchRequestSchema = z.object({
 	preview: z.boolean(),
-	targetBillingPeriod: z.enum(['Annual'], {
-		description:
+	targetBillingPeriod: z
+		.enum(['Annual'])
+		.describe(
 			'Target billing period - only Annual is supported (monthly to annual switch)',
-	}),
+		),
 	csrUserId: z.optional(z.string()),
 	caseId: z.optional(z.string()),
 });

--- a/handlers/product-switch-api/test/changePlan/action/pendingAmendments.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/pendingAmendments.test.ts
@@ -19,7 +19,7 @@ import { getAccountInformation } from '../../../src/changePlan/prepare/accountIn
 import { SwitchOrderRequestBuilder } from '../../../src/changePlan/prepare/buildSwitchOrderRequest';
 import { getSubscriptionInformation } from '../../../src/changePlan/prepare/subscriptionInformation';
 import type { TargetInformation } from '../../../src/changePlan/prepare/targetInformation';
-import type { ZuoraSwitchResponse } from '../../../src/changePlan/schemas';
+import type { ZuoraSwitchResponseWithIds } from '../../../src/changePlan/schemas';
 import { supporterPlusTargetInformation } from '../../../src/changePlan/switchDefinition/supporterPlusTargetInformation';
 import type { ZuoraPreviewResponse } from '../../../src/doPreviewInvoices';
 import accountJson from '../../fixtures/account.json';
@@ -153,7 +153,7 @@ describe('pendingAmendments, e.g. contribution amount changes, are dealt with co
 		mockZuoraClient.post.mockResolvedValueOnce({
 			success: true,
 			invoiceIds: ['invoice-id'],
-		} as ZuoraSwitchResponse);
+		} as ZuoraSwitchResponseWithIds);
 
 		// getInvoices
 		mockZuoraClient.get.mockResolvedValueOnce({

--- a/handlers/product-switch-api/test/frequencySwitchIntegration.test.ts
+++ b/handlers/product-switch-api/test/frequencySwitchIntegration.test.ts
@@ -23,7 +23,6 @@ import dayjs from 'dayjs';
 import type { ContributionTestAdditionalOptions } from '../../../modules/zuora/test/it-helpers/createGuardianSubscription';
 import { createContribution } from '../../../modules/zuora/test/it-helpers/createGuardianSubscription';
 import { getSwitchResult } from '../src/frequencySwitchEndpoint';
-import type { FrequencySwitchResponse } from '../src/frequencySwitchSchemas';
 
 interface FrequencySwitchTestSetup {
 	zuoraClient: ZuoraClient;
@@ -126,7 +125,7 @@ describe('frequency switch behaviour', () => {
 					zuoraClient,
 					subscription.accountNumber,
 				);
-				const result: FrequencySwitchResponse = await getSwitchResult(
+				const result = await getSwitchResult(
 					stage,
 					dayjs(),
 					false,

--- a/handlers/ticket-tailor-webhook/src/apiGatewayToSqsEvent.ts
+++ b/handlers/ticket-tailor-webhook/src/apiGatewayToSqsEvent.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 
 export const apiGatewayToSqsEventSchema = z.object({
-	pathParameters: z.record(z.string()),
-	headers: z.record(z.string()),
-	queryStringParameters: z.record(z.string()),
+	pathParameters: z.record(z.string(), z.string()),
+	headers: z.record(z.string(), z.string()),
+	queryStringParameters: z.record(z.string(), z.string()),
 	body: z.string(),
 	httpMethod: z.string(),
 	path: z.string(),

--- a/modules/aws/src/appConfig.ts
+++ b/modules/aws/src/appConfig.ts
@@ -19,7 +19,7 @@ export const loadConfig = async <O, I>(
 	stage: string,
 	stack: string,
 	app: string,
-	schema: z.ZodType<O, z.ZodTypeDef, I>,
+	schema: z.ZodType<O, I>,
 ): Promise<O> => {
 	const configRoot = '/' + [stage, stack, app].join('/');
 	console.log('getting app config from SSM', configRoot);
@@ -65,7 +65,7 @@ async function readAllRecursive(configRoot: string): Promise<SSMKeyValuePairs> {
 export function parseSSMConfigToObject<O, I>(
 	ssmKeyValuePairs: SSMKeyValuePairs,
 	configRoot: string,
-	schema: z.ZodType<O, z.ZodTypeDef, I>,
+	schema: z.ZodType<O, I>,
 ): O {
 	const configValuesByPath = ssmKeyValuePairs
 		.flatMap(objectEntries)

--- a/modules/product-benefits/src/schemas.ts
+++ b/modules/product-benefits/src/schemas.ts
@@ -20,7 +20,10 @@ const trialSchema = z.object({
 	androidOfferTag: z.string(),
 });
 export type Trial = z.infer<typeof trialSchema>;
-const trialInformationSchema = z.record(productBenefitListSchema, trialSchema);
+const trialInformationSchema = z.partialRecord(
+	productBenefitListSchema,
+	trialSchema,
+);
 export type TrialInformation = z.infer<typeof trialInformationSchema>;
 
 export const userBenefitsSchema = z.object({

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -13,7 +13,7 @@ export type ProductCatalog = z.infer<typeof productCatalogSchema>;
 // -------- Product --------
 export type ProductKey = keyof ProductCatalog;
 export const isProductKey = isInList(
-	objectKeysNonEmpty(productCatalogSchema._def.shape()),
+	objectKeysNonEmpty(productCatalogSchema.shape),
 );
 
 export type ZuoraProductKey = {

--- a/modules/routing/src/lambdaHandler.ts
+++ b/modules/routing/src/lambdaHandler.ts
@@ -24,7 +24,7 @@ export type HandlerEnv<ConfigType> = {
  * @constructor
  */
 export function LambdaHandler<ConfigType, E>(
-	configSchema: z.ZodType<ConfigType, z.ZodTypeDef, unknown>,
+	configSchema: z.ZodType<ConfigType>,
 	handler: (event: E, env: HandlerEnv<ConfigType>) => Promise<void>,
 ) {
 	const callerInfo = getCallerInfo();
@@ -58,7 +58,7 @@ type GuEnv = { stage: string; stack: string; app: string };
  * @constructor
  */
 export function LambdaHandlerWithServices<ConfigType, Services, E>(
-	configSchema: z.ZodType<ConfigType, z.ZodTypeDef, unknown>,
+	configSchema: z.ZodType<ConfigType>,
 	handler: (event: E, services: Services) => Promise<void>,
 	buildServices: (handlerProps: HandlerEnv<ConfigType>) => Services,
 	callerInfo: string,

--- a/modules/routing/src/sqsHandler.ts
+++ b/modules/routing/src/sqsHandler.ts
@@ -6,7 +6,7 @@ import type { HandlerEnv } from '@modules/routing/lambdaHandler';
 import { LambdaHandlerWithServices } from '@modules/routing/lambdaHandler';
 
 export function SQSHandler<ConfigType, Services>(
-	configSchema: z.ZodType<ConfigType, z.ZodTypeDef, unknown>,
+	configSchema: z.ZodType<ConfigType>,
 	handler: (record: SQSRecord, services: Services) => Promise<void>,
 	buildServices: (handlerProps: HandlerEnv<ConfigType>) => Services,
 ) {

--- a/modules/routing/src/withParsers.ts
+++ b/modules/routing/src/withParsers.ts
@@ -45,7 +45,7 @@ export const withBodyParser =
 				statusCode: 400,
 				body: JSON.stringify({
 					error: 'Invalid request body - wrong type',
-					details: parsedBody.error.errors,
+					details: parsedBody.error.issues,
 				}),
 			};
 		}
@@ -64,7 +64,7 @@ export const withPathParser =
 				statusCode: 400,
 				body: JSON.stringify({
 					error: 'Invalid request path',
-					details: parsedPath.error.errors,
+					details: parsedPath.error.issues,
 				}),
 			};
 		}

--- a/modules/routing/test/router.test.ts
+++ b/modules/routing/test/router.test.ts
@@ -166,13 +166,13 @@ describe('Router', () => {
 		};
 		expect(payload.error).toEqual('Invalid request body - wrong type');
 		expect(payload.details[0]?.message).toEqual(
-			'Expected string, received number',
+			'Invalid input: expected string, received number',
 		);
 		expect(payload.details[1]?.message).toEqual(
-			'Expected number, received string',
+			'Invalid input: expected number, received string',
 		);
 		expect(payload.details[2]?.message).toEqual(
-			'Expected boolean, received string',
+			'Invalid input: expected boolean, received string',
 		);
 	});
 	test('it should return a suitable error for broken json body', async () => {

--- a/modules/stage.ts
+++ b/modules/stage.ts
@@ -6,8 +6,9 @@ const stageSchema = z.enum(['CODE', 'PROD']);
 
 export const stageFromEnvironment = (): Stage => {
 	const stage = process.env.STAGE;
+
 	return stageSchema.parse(stage, {
-		errorMap: () => ({
+		error: () => ({
 			message: `Stage environment variable is invalid`,
 		}),
 	});

--- a/modules/zuora/src/creditBalanceAdjustment.ts
+++ b/modules/zuora/src/creditBalanceAdjustment.ts
@@ -1,4 +1,4 @@
-import type { z, ZodTypeDef } from 'zod';
+import type { z } from 'zod';
 import type { ZuoraUpperCaseSuccess } from './types';
 import { zuoraUpperCaseSuccessSchema } from './types';
 import type { ZuoraClient } from './zuoraClient';
@@ -7,12 +7,12 @@ export async function applyCreditToAccountBalance(
 	zuoraClient: ZuoraClient,
 	body: string,
 ): Promise<ZuoraUpperCaseSuccess>;
-export async function applyCreditToAccountBalance<
-	T extends z.ZodType<unknown, ZodTypeDef, unknown>,
->(zuoraClient: ZuoraClient, body: string, schema: T): Promise<z.infer<T>>;
-export async function applyCreditToAccountBalance<
-	T extends z.ZodType<unknown, ZodTypeDef, unknown>,
->(
+export async function applyCreditToAccountBalance<T extends z.ZodType>(
+	zuoraClient: ZuoraClient,
+	body: string,
+	schema: T,
+): Promise<z.infer<T>>;
+export async function applyCreditToAccountBalance<T extends z.ZodType>(
 	zuoraClient: ZuoraClient,
 	body: string,
 	schema?: T,

--- a/modules/zuora/src/objectQuery/objectQueryBuilder.ts
+++ b/modules/zuora/src/objectQuery/objectQueryBuilder.ts
@@ -1,6 +1,6 @@
 import { mergeValues, pickKeys } from '@modules/objectFunctions';
+import type { ZodType } from 'zod';
 import { z } from 'zod';
-import type { ZodType, ZodTypeDef } from 'zod';
 import type { DoesNotHaveDuplicateResponseKey } from '@modules/zuora/objectQuery/doesNotHaveDuplicateResponseKey';
 import type {
 	ObjectQueryExpandRegistry,
@@ -26,8 +26,8 @@ export type ObjectQuerySortObject<F extends string> = {
 };
 
 export const objectQueryResponseSchema = <T>(
-	itemSchema: z.ZodType<T, ZodTypeDef, unknown>,
-): ZodType<{ nextPage: string | null; data: T[] }, ZodTypeDef, unknown> =>
+	itemSchema: z.ZodType<T>,
+): ZodType<{ nextPage: string | null; data: T[] }> =>
 	z.object({
 		nextPage: z.string().nullable(),
 		data: z.array(itemSchema),

--- a/modules/zuora/src/orders/orderRequests.ts
+++ b/modules/zuora/src/orders/orderRequests.ts
@@ -41,16 +41,12 @@ export type CreateOrderRequest = OrderRequest & {
 	processingOptions: ProcessingOptions;
 };
 
-export function executeOrderRequest<
-	I,
-	O,
-	T extends z.ZodType<O, z.ZodTypeDef, I>,
->(
+export function executeOrderRequest<T extends z.ZodType>(
 	zuoraClient: ZuoraClient,
 	orderRequest: CreateOrderRequest,
 	responseSchema: T,
 	idempotencyKey?: string,
-): Promise<O> {
+): Promise<z.infer<T>> {
 	const path = `/v1/orders`;
 	const body = JSON.stringify(orderRequest);
 	const headers = idempotencyKey
@@ -59,15 +55,11 @@ export function executeOrderRequest<
 	return zuoraClient.post(path, body, responseSchema, headers);
 }
 
-export function previewOrderRequest<
-	I,
-	O,
-	T extends z.ZodType<O, z.ZodTypeDef, I>,
->(
+export function previewOrderRequest<T extends z.ZodType>(
 	zuoraClient: ZuoraClient,
 	orderRequest: PreviewOrderRequest,
 	responseSchema: T,
-): Promise<O> {
+): Promise<z.infer<T>> {
 	const path = `/v1/orders/preview`;
 	const body = JSON.stringify(orderRequest);
 	return zuoraClient.post(path, body, responseSchema);

--- a/modules/zuora/src/paymentMethod.ts
+++ b/modules/zuora/src/paymentMethod.ts
@@ -1,4 +1,4 @@
-import type { z, ZodTypeDef } from 'zod';
+import type { z } from 'zod';
 import { DefaultPaymentMethodResponseSchema } from './types';
 import type { ZuoraClient } from './zuoraClient';
 
@@ -6,12 +6,12 @@ export async function getPaymentMethods(
 	zuoraClient: ZuoraClient,
 	accountId: string,
 ): Promise<z.infer<typeof DefaultPaymentMethodResponseSchema>>;
-export async function getPaymentMethods<
-	T extends z.ZodType<unknown, ZodTypeDef, unknown>,
->(zuoraClient: ZuoraClient, accountId: string, schema: T): Promise<z.infer<T>>;
-export async function getPaymentMethods<
-	T extends z.ZodType<unknown, ZodTypeDef, unknown>,
->(
+export async function getPaymentMethods<T extends z.ZodType>(
+	zuoraClient: ZuoraClient,
+	accountId: string,
+	schema: T,
+): Promise<z.infer<T>>;
+export async function getPaymentMethods<T extends z.ZodType>(
 	zuoraClient: ZuoraClient,
 	accountId: string,
 	schema?: T,

--- a/modules/zuora/src/refund.ts
+++ b/modules/zuora/src/refund.ts
@@ -1,4 +1,4 @@
-import type { z, ZodTypeDef } from 'zod';
+import type { z } from 'zod';
 import type { ZuoraUpperCaseSuccess } from './types';
 import { zuoraUpperCaseSuccessSchema } from './types';
 import type { ZuoraClient } from './zuoraClient';
@@ -7,12 +7,12 @@ export async function doRefund(
 	zuoraClient: ZuoraClient,
 	body: string,
 ): Promise<ZuoraUpperCaseSuccess>;
-export async function doRefund<
-	T extends z.ZodType<unknown, ZodTypeDef, unknown>,
->(zuoraClient: ZuoraClient, body: string, schema: T): Promise<z.infer<T>>;
-export async function doRefund<
-	T extends z.ZodType<unknown, ZodTypeDef, unknown>,
->(
+export async function doRefund<T extends z.ZodType>(
+	zuoraClient: ZuoraClient,
+	body: string,
+	schema: T,
+): Promise<z.infer<T>>;
+export async function doRefund<T extends z.ZodType>(
 	zuoraClient: ZuoraClient,
 	body: string,
 	schema?: T,

--- a/modules/zuora/src/restClient.ts
+++ b/modules/zuora/src/restClient.ts
@@ -1,7 +1,7 @@
 import { groupMap } from '@modules/arrayFunctions';
 import { getCallerInfo } from '@modules/logger/getCallerInfo';
 import { logger } from '@modules/logger/logger';
-import type { z, ZodType, ZodTypeDef } from 'zod';
+import type { z, ZodType } from 'zod';
 import type { BearerTokenProvider } from '@modules/zuora/auth';
 
 export class RestClientError extends Error implements RestResult {
@@ -27,7 +27,7 @@ export type RestResult = {
 export abstract class RestClient {
 	public constructor(readonly tokenProvider: BearerTokenProvider) {}
 
-	public async get<S extends ZodType<unknown, ZodTypeDef, unknown>>(
+	public async get<S extends ZodType>(
 		path: string,
 		schema: S,
 		urlSearchParams?: URLSearchParams,
@@ -42,7 +42,7 @@ export abstract class RestClient {
 		);
 	}
 
-	public async post<S extends ZodType<unknown, ZodTypeDef, unknown>>(
+	public async post<S extends ZodType>(
 		path: string,
 		body: string,
 		schema: S,
@@ -57,7 +57,7 @@ export abstract class RestClient {
 		);
 	}
 
-	public async put<S extends ZodType<unknown, ZodTypeDef, unknown>>(
+	public async put<S extends ZodType>(
 		path: string,
 		body: string,
 		schema: S,
@@ -72,7 +72,7 @@ export abstract class RestClient {
 		);
 	}
 
-	public async patch<S extends ZodType<unknown, ZodTypeDef, unknown>>(
+	public async patch<S extends ZodType>(
 		path: string,
 		body: string,
 		schema: S,
@@ -87,7 +87,7 @@ export abstract class RestClient {
 		);
 	}
 
-	public async delete<S extends ZodType<unknown, ZodTypeDef, unknown>>(
+	public async delete<S extends ZodType>(
 		path: string,
 		schema: S,
 	): Promise<z.infer<S>> {
@@ -126,7 +126,7 @@ export abstract class RestClient {
 			}),
 		);
 
-	protected async fetch<S extends ZodType<unknown, ZodTypeDef, unknown>>(
+	protected async fetch<S extends ZodType>(
 		path: string,
 		method: string,
 		schema: S,

--- a/modules/zuora/src/subscription.ts
+++ b/modules/zuora/src/subscription.ts
@@ -1,5 +1,5 @@
 import type { Dayjs } from 'dayjs';
-import type { z, ZodTypeDef } from 'zod';
+import type { z } from 'zod';
 import type {
 	CancelSubscriptionResponse,
 	ZuoraSubscription,
@@ -54,16 +54,12 @@ export async function getSubscription(
 	zuoraClient: ZuoraClient,
 	subscriptionNumber: string,
 ): Promise<ZuoraSubscription>;
-export async function getSubscription<
-	T extends z.ZodType<unknown, ZodTypeDef, unknown>,
->(
+export async function getSubscription<T extends z.ZodType>(
 	zuoraClient: ZuoraClient,
 	subscriptionNumber: string,
 	schema: T,
 ): Promise<z.infer<T>>;
-export async function getSubscription<
-	T extends z.ZodType<unknown, ZodTypeDef, unknown>,
->(
+export async function getSubscription<T extends z.ZodType>(
 	zuoraClient: ZuoraClient,
 	subscriptionNumber: string,
 	schema?: T,

--- a/modules/zuora/src/zuoraClient.ts
+++ b/modules/zuora/src/zuoraClient.ts
@@ -1,6 +1,6 @@
 import { logger } from '@modules/logger/logger';
 import type { Stage } from '@modules/stage';
-import type { ZodType, ZodTypeDef } from 'zod';
+import type { ZodType } from 'zod';
 import { z } from 'zod';
 import { getOAuthClientCredentials, ZuoraBearerTokenProvider } from './auth';
 import { generateZuoraError } from './errors';
@@ -21,7 +21,7 @@ export class ZuoraClient extends RestClient {
 	 * a normal RestClient throws non-2xx responses as Errors.  For Zuora, there are an extra layer of errors that
 	 * come back as 200 responses, and thus need their own special errors thrown.
 	 */
-	override async fetch<S extends ZodType<unknown, ZodTypeDef, unknown>>(
+	override async fetch<S extends ZodType>(
 		path: string,
 		method: string,
 		schema: S,
@@ -34,7 +34,7 @@ export class ZuoraClient extends RestClient {
 			 * since zuora returns a wide variety of unsuccessful responses inside of 200 statuses, we need to check for
 			 * failure and fail parsing if we detect one.  Then handleZuoraFailure will throw a suitable detailed exception.
 			 */
-			const successSchema: ZodType<z.infer<S>, ZodTypeDef, unknown> = z
+			const successSchema: ZodType<z.infer<S>> = z
 				.any()
 				.refine(isLogicalSuccess)
 				.pipe(schema);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^5.6.3
       version: 5.9.2
     zod:
-      specifier: ^3.23.8
-      version: 3.25.76
+      specifier: ^4.4.3
+      version: 4.4.3
 
 overrides:
   typescript-eslint: ^8.46.2
@@ -79,7 +79,7 @@ importers:
         version: 5.9.2
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   buildcheck:
     dependencies:
@@ -146,7 +146,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -168,7 +168,7 @@ importers:
         version: link:../../modules/logger
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@redocly/cli':
         specifier: 2.30.5
@@ -190,7 +190,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.147
@@ -209,7 +209,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -249,7 +249,7 @@ importers:
         version: 9.15.1
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -296,7 +296,7 @@ importers:
         version: link:../../modules/email
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.147
@@ -337,7 +337,7 @@ importers:
         version: link:../../modules/supporter-product-data
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.147
@@ -365,7 +365,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.940.0
@@ -414,7 +414,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@redocly/cli':
         specifier: 2.30.5
@@ -445,7 +445,7 @@ importers:
         version: 9.15.1
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -473,7 +473,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -492,7 +492,7 @@ importers:
         version: 3.996.2(@aws-sdk/client-dynamodb@3.1054.0)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.147
@@ -514,7 +514,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -575,7 +575,7 @@ importers:
         version: link:../../modules/supporter-product-data
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -615,7 +615,7 @@ importers:
         version: link:../../modules/supporter-product-data
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -668,7 +668,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@redocly/cli':
         specifier: 2.30.5
@@ -739,7 +739,7 @@ importers:
         version: 18.5.0(@types/node@24.10.1)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -797,7 +797,7 @@ importers:
         version: link:../../modules/supporter-product-data
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -822,7 +822,7 @@ importers:
         version: link:../../modules/secrets-manager
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.147
@@ -853,7 +853,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -888,7 +888,7 @@ importers:
         version: link:../../modules/routing
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -931,7 +931,7 @@ importers:
         version: link:../../modules/salesforce
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../../modules/zuora
@@ -971,7 +971,7 @@ importers:
         version: link:../logger
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   modules/bigquery:
     dependencies:
@@ -989,7 +989,7 @@ importers:
         version: 9.15.1
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1054,7 +1054,7 @@ importers:
         version: link:../aws
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../zuora
@@ -1067,7 +1067,7 @@ importers:
     dependencies:
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   modules/logger:
     devDependencies:
@@ -1098,7 +1098,7 @@ importers:
         version: 1.11.21
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   modules/product-benefits:
     dependencies:
@@ -1116,7 +1116,7 @@ importers:
         version: link:../supporter-product-data
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   modules/product-catalog:
     dependencies:
@@ -1141,7 +1141,7 @@ importers:
         version: 5.9.2
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   modules/promotions:
     dependencies:
@@ -1165,7 +1165,7 @@ importers:
         version: link:../product-catalog
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   modules/routing:
     dependencies:
@@ -1180,7 +1180,7 @@ importers:
         version: link:../logger
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../zuora
@@ -1196,7 +1196,7 @@ importers:
         version: link:../secrets-manager
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../zuora
@@ -1246,7 +1246,7 @@ importers:
         version: 1.11.21
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   modules/sync-supporter-product-data:
     dependencies:
@@ -1258,7 +1258,7 @@ importers:
         version: link:../product-catalog
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora:
         specifier: workspace:*
         version: link:../zuora
@@ -1320,7 +1320,7 @@ importers:
         version: link:../promotions
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
       zuora-catalog:
         specifier: workspace:*
         version: link:../zuora-catalog
@@ -1338,7 +1338,7 @@ importers:
         version: link:../logger
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
 packages:
 
@@ -5780,8 +5780,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -11751,4 +11751,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ packages:
   - 'buildcheck'
 
 catalog:
-  zod: ^3.23.8
+  zod: ^4.4.3
   typescript: ^5.6.3
   "@aws-sdk/client-ssm": ^3.848.0,
   tsconfig-paths: ^4.2.0


### PR DESCRIPTION

## What does this change?
This PR upgrades Zod from v3 to v4 using this [migration guide](https://zod.dev/v4/changelog) to gain the benefits mentioned in the [release announcement](https://zod.dev/v4) but particularly the [improved enum support](https://zod.dev/v4/changelog?id=improves-enum-support#improves-enum-support)