### PR TITLE
Fix Day 0 email first payment date for Direct Debit

### DIFF
--- a/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
@@ -74,19 +74,14 @@ export function getPaymentMethodFieldsSupporterPlus(
 	created: Dayjs,
 	mandateId?: string,
 ):
-	| {
-			payment_method: 'credit / debit card' | 'PayPal';
-			first_payment_date: string;
-	  }
+	| Record<string, never>
 	| {
 			payment_method: 'Direct Debit';
 			account_name: string;
 			account_number: string;
 			sort_code: string;
 			Mandate_ID: string;
-			first_payment_date: string;
 	  } {
-	const DIRECT_DEBIT_LEAD_TIME_DAYS = 10;
 	switch (paymentMethod.Type) {
 		case 'BankTransfer':
 			return {
@@ -98,19 +93,9 @@ export function getPaymentMethodFieldsSupporterPlus(
 					mandateId,
 					'No Mandate ID was provided for a Direct Debit payment',
 				),
-				first_payment_date: formatDate(
-					created.add(DIRECT_DEBIT_LEAD_TIME_DAYS, 'days'),
-				),
 			};
 		case 'CreditCardReferenceTransaction':
-			return {
-				payment_method: 'credit / debit card',
-				first_payment_date: formatDate(created),
-			};
 		case 'PayPal':
-			return {
-				payment_method: 'PayPal',
-				first_payment_date: formatDate(created),
-			};
+			return {};
 	}
 }

--- a/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
@@ -35,38 +35,58 @@ export type EmailPaymentFields =
 			mandate_id: string;
 	  };
 
+function getFirstPaymentDateCopy(
+	paymentMethod: EmailPaymentMethod,
+	firstZuoraPaymentDate: Dayjs,
+	today: Dayjs,
+): string {
+	const firstPaymentDateFormatted = formatDate(firstZuoraPaymentDate);
+
+	if (paymentMethod.Type !== 'BankTransfer') {
+		return firstPaymentDateFormatted;
+	}
+
+	const isFirstPaymentLessThan10DaysAway =
+		firstZuoraPaymentDate < today.add(DIRECT_DEBIT_LEAD_TIME_DAYS, 'day');
+	const directDebitDisclaimer = isFirstPaymentLessThan10DaysAway
+		? ' (Direct Debit may be up to 10 days after this)'
+		: '';
+
+	return `${firstPaymentDateFormatted}${directDebitDisclaimer}`;
+}
+
 export function getPaymentFields(
 	today: Dayjs,
 	paymentMethod: EmailPaymentMethod,
 	firstZuoraPaymentDate: Dayjs,
 	mandateId?: string,
 ): EmailPaymentFields {
+	const firstPaymentDateCopy = getFirstPaymentDateCopy(
+		paymentMethod,
+		firstZuoraPaymentDate,
+		today,
+	);
+
 	switch (paymentMethod.Type) {
 		case 'BankTransfer': {
-			const isFirstPaymentLessThan10DaysAway =
-				firstZuoraPaymentDate < today.add(DIRECT_DEBIT_LEAD_TIME_DAYS, 'day');
-			const directDebitDisclaimer = isFirstPaymentLessThan10DaysAway
-				? ' (Direct Debit may be up to 10 days after this)'
-				: '';
-
 			return {
 				bank_account_no: mask(paymentMethod.BankTransferAccountNumber),
 				bank_sort_code: hyphenate(paymentMethod.BankCode),
 				account_holder: paymentMethod.BankTransferAccountName,
 				payment_method: 'Direct Debit',
 				mandate_id: mandateId ?? '',
-				first_payment_date: `${formatDate(firstZuoraPaymentDate)}${directDebitDisclaimer}`,
+				first_payment_date: firstPaymentDateCopy,
 			};
 		}
 		case 'CreditCardReferenceTransaction':
 			return {
 				payment_method: 'Credit/Debit Card',
-				first_payment_date: formatDate(firstZuoraPaymentDate),
+				first_payment_date: firstPaymentDateCopy,
 			};
 		case 'PayPal':
 			return {
 				payment_method: 'PayPal',
-				first_payment_date: formatDate(firstZuoraPaymentDate),
+				first_payment_date: firstPaymentDateCopy,
 			};
 	}
 }

--- a/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
@@ -96,7 +96,7 @@ export function getPaymentMethodFieldsSupporterPlus(
 	created: Dayjs,
 	mandateId?: string,
 ):
-	| Record<string, never>
+	| undefined
 	| {
 			payment_method: 'Direct Debit';
 			account_name: string;
@@ -118,6 +118,6 @@ export function getPaymentMethodFieldsSupporterPlus(
 			};
 		case 'CreditCardReferenceTransaction':
 		case 'PayPal':
-			return {};
+			return undefined;
 	}
 }

--- a/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
@@ -42,20 +42,22 @@ export function getPaymentFields(
 	mandateId?: string,
 ): EmailPaymentFields {
 	switch (paymentMethod.Type) {
-		case 'BankTransfer':
+		case 'BankTransfer': {
+			const isFirstPaymentLessThan10DaysAway =
+				firstZuoraPaymentDate < today.add(DIRECT_DEBIT_LEAD_TIME_DAYS, 'day');
+			const directDebitDisclaimer = isFirstPaymentLessThan10DaysAway
+				? ' (Direct Debit may be up to 10 days after this)'
+				: '';
+
 			return {
 				bank_account_no: mask(paymentMethod.BankTransferAccountNumber),
 				bank_sort_code: hyphenate(paymentMethod.BankCode),
 				account_holder: paymentMethod.BankTransferAccountName,
 				payment_method: 'Direct Debit',
 				mandate_id: mandateId ?? '',
-				first_payment_date: formatDate(
-					dayjs.max(
-						firstZuoraPaymentDate,
-						today.add(DIRECT_DEBIT_LEAD_TIME_DAYS, 'day'),
-					),
-				),
+				first_payment_date: `${formatDate(firstZuoraPaymentDate)}${directDebitDisclaimer}`,
 			};
+		}
 		case 'CreditCardReferenceTransaction':
 			return {
 				payment_method: 'Credit/Debit Card',

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -1,6 +1,6 @@
+import { DataExtensionNames } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type dayjs from 'dayjs';
-import { DataExtensionNames } from '@modules/email/email';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import { getPaymentMethodFieldsSupporterPlus } from './paymentEmailFields';
 import type {

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -1,6 +1,6 @@
-import { DataExtensionNames } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type dayjs from 'dayjs';
+import { DataExtensionNames } from '@modules/email/email';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import { getPaymentMethodFieldsSupporterPlus } from './paymentEmailFields';
 import type {

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -51,7 +51,7 @@ export function buildSupporterPlusEmailFields({
 		currency: currency,
 		billing_period: billingPeriod.toLowerCase(),
 		is_fixed_term: isFixedTerm.toString(),
-		...oldNonStandardPaymentFields,
+		...(oldNonStandardPaymentFields ?? {}),
 		...nonDeliveryEmailFields,
 	};
 	return buildEmailFields(

--- a/modules/email/test/dataFields/dayZero/paperEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/paperEmailFields.test.ts
@@ -1,6 +1,6 @@
+import dayjs from 'dayjs';
 import { buildPaperEmailFields } from '@modules/email/dataFields/dayZero/paperEmailFields';
 import { DataExtensionNames } from '@modules/email/email';
-import dayjs from 'dayjs';
 import {
 	deliveryAgentDetails,
 	deliveryContact,

--- a/modules/email/test/dataFields/dayZero/paperEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/paperEmailFields.test.ts
@@ -1,6 +1,6 @@
-import dayjs from 'dayjs';
 import { buildPaperEmailFields } from '@modules/email/dataFields/dayZero/paperEmailFields';
 import { DataExtensionNames } from '@modules/email/email';
+import dayjs from 'dayjs';
 import {
 	deliveryAgentDetails,
 	deliveryContact,
@@ -31,7 +31,8 @@ describe('Paper email fields', () => {
 					last_name: deliveryContact.lastName,
 					account_holder: 'Mickey Mouse',
 					package: 'Everyday',
-					first_payment_date: 'Friday, 21 November 2025',
+					first_payment_date:
+						'Tuesday, 18 November 2025 (Direct Debit may be up to 10 days after this)',
 					bank_sort_code: '20-20-20',
 					mandate_id: mandateId,
 					bank_account_no: '******11',

--- a/modules/email/test/dataFields/dayZero/supporterPlusEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/supporterPlusEmailFields.test.ts
@@ -1,7 +1,7 @@
+import dayjs from 'dayjs';
 import { buildSupporterPlusEmailFields } from '@modules/email/dataFields/dayZero/supporterPlusEmailFields';
 import type { EmailPaymentMethod } from '@modules/email/dataFields/dayZero/types';
 import { DataExtensionNames } from '@modules/email/email';
-import dayjs from 'dayjs';
 import {
 	creditCardPaymentMethod,
 	directDebitPaymentMethod,

--- a/modules/email/test/dataFields/dayZero/supporterPlusEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/supporterPlusEmailFields.test.ts
@@ -1,7 +1,7 @@
-import dayjs from 'dayjs';
 import { buildSupporterPlusEmailFields } from '@modules/email/dataFields/dayZero/supporterPlusEmailFields';
 import type { EmailPaymentMethod } from '@modules/email/dataFields/dayZero/types';
 import { DataExtensionNames } from '@modules/email/email';
+import dayjs from 'dayjs';
 import {
 	creditCardPaymentMethod,
 	directDebitPaymentMethod,


### PR DESCRIPTION
## What does this change?

Before in Day 0 emails for Direct Debit we used to quote the later of the first date from the payment schedule or today + 10 days. When we showed today + 10 days this was quoted as an absolute date but in reality this padding is added to reflect the fact that the Direct Debit mandate can take up to 10 days to setup. So a customer could be surprised by being charged sooner than this.

Now we always show the first date from the payment schedule. If this is < 10 days in the future then we add a disclaimer for Direct Debit: `(Direct Debit may be up to 10 days after this)`.

## How has this change been tested?

Unit tests updated.

Verified on CODE: 

<img width="567" height="287" alt="Screenshot 2026-06-25 at 13 43 06" src="https://github.com/user-attachments/assets/61bbc82f-ef97-4e78-b897-548710f6f501" />