### PR TITLE
Revert "add t2->t3 upsell discount email for PROD"

### DIFF
--- a/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
@@ -1,7 +1,4 @@
-import {
-	type DataExtensionName,
-	DataExtensionNames,
-} from '@modules/email/email';
+import { DataExtensionNames } from '@modules/email/email';
 import { ValidationError } from '@modules/errors';
 import type { ProductRatePlan } from '@modules/product-catalog/productCatalog';
 import type { SwitchTargetInformation } from '../prepare/switchCatalogHelper';
@@ -32,16 +29,11 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 			throw new ValidationError("digital plus doesn't have a variable amount");
 		}
 		let discount: Discount | undefined = undefined;
-		let dataExtensionName: DataExtensionName;
 		if (
 			switchActionData.discountEnabled &&
 			productRatePlan.billingPeriod === 'Month'
 		) {
 			discount = monthlyDigiPlus;
-			dataExtensionName =
-				DataExtensionNames.supporterPlusToDigitalPlusSwitchWithDiscount;
-		} else {
-			dataExtensionName = DataExtensionNames.supporterPlusToDigitalPlusSwitch;
 		}
 
 		const catalogPrice = productRatePlan.pricing[switchActionData.currency];
@@ -60,7 +52,7 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 			contributionCharge: undefined,
 			subscriptionChargeId: productRatePlan.charges.Subscription.id,
 			discount,
-			dataExtensionName,
+			dataExtensionName: DataExtensionNames.supporterPlusToDigitalPlusSwitch,
 		} satisfies TargetInformation);
 	},
 };

--- a/modules/email/src/email.ts
+++ b/modules/email/src/email.ts
@@ -29,7 +29,6 @@ export type EmailPayload = {
 export const DataExtensionNames = {
 	recurringContributionToSupporterPlusSwitch: 'SV_RCtoSP_Switch',
 	supporterPlusToDigitalPlusSwitch: 'SV_SPtoDP_SwitchConfirmation',
-	supporterPlusToDigitalPlusSwitchWithDiscount: 'SV_DP_ManualDiscount',
 	subscriptionCancelledEmail: 'subscription-cancelled-email',
 	updateSupporterPlusAmount: 'payment-amount-changed-email',
 	cancellationDiscountConfirmation: 'cancellation-discount-confirmation-email',


### PR DESCRIPTION
Reverts guardian/support-service-lambdas#3653

Due to a misunderstanding, we were trying to connect to the marketing email, but actually the email for non discounted switches is being reused
https://www.figma.com/design/iqt4KtIjj6cSDcSsApLib2/MMA-Self-Serve-Upsell-from-T2-to-T3?node-id=241-19693&t=mdEINdvMyj7qb64e-4

This PR reverts the changes to use the marketing email, and changes back to using the standard one.