### PR TITLE
Fetch tax rates from Zuora

### DIFF
--- a/cdk/lib/__snapshots__/sales-tax-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/sales-tax-api.test.ts.snap
@@ -836,6 +836,42 @@ exports[`The Sales tax api stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "ZuoraOAuthSecretsManagerpolicy5448D99B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ZuoraOAuthSecretsManagerpolicy5448D99B",
+        "Roles": [
+          {
+            "Ref": "LambdaServiceRoleA8ED4D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
   },
 }
 `;
@@ -1744,6 +1780,42 @@ exports[`The Sales tax api stack matches the snapshot 2`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "LambdaServiceRoleDefaultPolicyDAE46E21",
+        "Roles": [
+          {
+            "Ref": "LambdaServiceRoleA8ED4D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ZuoraOAuthSecretsManagerpolicy5448D99B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ZuoraOAuthSecretsManagerpolicy5448D99B",
         "Roles": [
           {
             "Ref": "LambdaServiceRoleA8ED4D3B",

--- a/cdk/lib/sales-tax-api.ts
+++ b/cdk/lib/sales-tax-api.ts
@@ -1,4 +1,5 @@
 import type { App } from 'aws-cdk-lib';
+import { AllowZuoraOAuthSecretsPolicy } from './cdk/policies';
 import { SrApiLambda } from './cdk/SrApiLambda';
 import type { SrStageNames } from './cdk/SrStack';
 import { SrStack } from './cdk/SrStack';
@@ -7,7 +8,7 @@ export class SalesTaxApi extends SrStack {
 	constructor(scope: App, stage: SrStageNames) {
 		super(scope, { stage, app: 'sales-tax-api' });
 
-		new SrApiLambda(this, 'Lambda', {
+		const lambda = new SrApiLambda(this, 'Lambda', {
 			lambdaOverrides: {
 				description: 'Handles API requests for state or province sales tax',
 			},
@@ -19,5 +20,7 @@ export class SalesTaxApi extends SrStack {
 				burstLimit: 10,
 			},
 		});
+
+		lambda.addPolicies(new AllowZuoraOAuthSecretsPolicy(this));
 	}
 }

--- a/handlers/sales-tax-api/src/index.ts
+++ b/handlers/sales-tax-api/src/index.ts
@@ -1,8 +1,17 @@
+import { Lazy } from '@modules/lazy';
 import { logger } from '@modules/logger/logger';
 import { Router } from '@modules/routing/router';
 import { withBodyParser } from '@modules/routing/withParsers';
+import { stageFromEnvironment } from '@modules/stage';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { taxRatesRequestSchema } from './schemas';
-import { taxRatesRequestEndpoint } from './taxRatesEndpoint';
+import { taxRatesEndpoint } from './taxRatesEndpoint';
+
+const stage = stageFromEnvironment();
+const lazyZuoraClient = new Lazy(
+	async () => await ZuoraClient.create(stage),
+	'Create Zuora client',
+);
 
 export const handler = Router([
 	{
@@ -12,7 +21,7 @@ export const handler = Router([
 			taxRatesRequestSchema,
 			async (event, path, body) => {
 				logger.log('Received POST /tax-rates request', body);
-				return taxRatesRequestEndpoint(body);
+				return taxRatesEndpoint(await lazyZuoraClient.get(), body);
 			},
 		),
 	},

--- a/handlers/sales-tax-api/src/schemas.ts
+++ b/handlers/sales-tax-api/src/schemas.ts
@@ -1,3 +1,4 @@
+import { caStateSchema } from '@modules/internationalisation/country';
 import { isoCountrySchema } from '@modules/internationalisation/schemas';
 import { productKeySchema } from '@modules/product-catalog/productCatalogSchema';
 import { z } from 'zod';
@@ -6,21 +7,7 @@ export const taxRatesRequestSchema = z.object({
 	productKey: productKeySchema,
 	country: isoCountrySchema,
 });
-
 export type TaxRatesRequest = z.infer<typeof taxRatesRequestSchema>;
-export const taxRatesResponseSchema = z.object({
-	AB: z.number(),
-	BC: z.number(),
-	MB: z.number(),
-	NB: z.number(),
-	NL: z.number(),
-	NT: z.number(),
-	NS: z.number(),
-	NU: z.number(),
-	ON: z.number(),
-	PE: z.number(),
-	QC: z.number(),
-	SK: z.number(),
-	YT: z.number(),
-});
+
+export const taxRatesResponseSchema = z.record(caStateSchema, z.number());
 export type TaxRatesResponse = z.infer<typeof taxRatesResponseSchema>;

--- a/handlers/sales-tax-api/src/taxRatesEndpoint.ts
+++ b/handlers/sales-tax-api/src/taxRatesEndpoint.ts
@@ -1,57 +1,157 @@
 import { ValidationError } from '@modules/errors';
-import { logger } from '@modules/logger/logger';
-import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
-import type { APIGatewayProxyResult } from 'aws-lambda';
+import type {
+	CaState,
+	IsoCountry,
+} from '@modules/internationalisation/country';
 import {
-	type TaxRatesRequest,
-	type TaxRatesResponse,
-	taxRatesResponseSchema,
-} from './schemas';
+	caStates,
+	caStateSchema,
+	getCountryNameByIsoCode,
+} from '@modules/internationalisation/country';
+import { logger } from '@modules/logger/logger';
+import type { ProductKey } from '@modules/product-catalog/productCatalog';
+import { ok } from '@modules/routing/apiGatewayResponses';
+import {
+	getZuoraTaxCodes,
+	getZuoraTaxPeriods,
+	getZuoraTaxRates,
+} from '@modules/zuora/tax';
+import type {
+	ZuoraTaxPeriod,
+	ZuoraTaxRate,
+} from '@modules/zuora/types/objects/tax';
+import { type ZuoraTaxCode } from '@modules/zuora/types/objects/tax';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import type { TaxRatesResponse } from './schemas';
+import { type TaxRatesRequest, taxRatesResponseSchema } from './schemas';
 
-export const cadStates: TaxRatesResponse = {
-	AB: 0.05,
-	BC: 0.12,
-	MB: 0.12,
-	NB: 0.15,
-	NL: 0.15,
-	NT: 0.05,
-	NS: 0.15,
-	NU: 0.05,
-	ON: 0.13,
-	PE: 0.15,
-	QC: 0.1498,
-	SK: 0.11,
-	YT: 0.05,
+type TaxCodeName = 'Supporter Plus Global Tax' | 'Digital Pack Global Tax';
+const taxExclusiveProductCodeNames: Partial<Record<ProductKey, TaxCodeName>> = {
+	SupporterPlus: `Supporter Plus Global Tax`,
+	DigitalSubscription: `Digital Pack Global Tax`,
 };
 
-export const taxRatesRequestEndpoint = async ({
-	productKey,
-	country,
-}: TaxRatesRequest): Promise<APIGatewayProxyResult> => {
-	try {
-		logger.log('Checking sales taxes for', {
-			productKey,
-			country,
-		});
-		return ok(
-			getSalesTaxRates({ productKey, country }),
-			taxRatesResponseSchema,
-		);
-	} catch (error) {
-		logger.error('Error fetching sales tax', error);
-		return Promise.resolve(buildErrorResponse(error));
-	}
+export const taxRatesEndpoint = async (
+	zuoraClient: ZuoraClient,
+	{ productKey, country }: TaxRatesRequest,
+): Promise<APIGatewayProxyResult> => {
+	logger.log('Retrieving Zuora taxes for', {
+		productKey,
+		country,
+	});
+
+	return ok(await getZuoraSalesTaxRates(zuoraClient, { productKey, country }));
 };
 
-function getSalesTaxRates({
-	productKey,
-	country,
-}: TaxRatesRequest): TaxRatesResponse {
-	if (!['SupporterPlus', 'DigitalSubscription'].includes(productKey)) {
-		throw new ValidationError(`invalid productKey:${productKey}`);
-	}
+async function getZuoraSalesTaxRates(
+	zuoraClient: ZuoraClient,
+	{ productKey, country }: TaxRatesRequest,
+): Promise<TaxRatesResponse> {
 	if (!['CA'].includes(country)) {
 		throw new ValidationError(`invalid country:${country}`);
 	}
-	return cadStates;
+
+	const zuoraTaxCodes = await getZuoraTaxCodes(zuoraClient);
+	if (!zuoraTaxCodes) {
+		throw new Error('no tax codes found');
+	}
+	const zuoraTaxCode = getProductZuoraTaxCode(
+		productKey,
+		zuoraTaxCodes.taxCodes,
+	);
+	if (!zuoraTaxCode) {
+		throw new Error(`No tax data found for productKey: ${productKey}`);
+	}
+
+	const zuoraTaxPeriods = await getZuoraTaxPeriods(zuoraClient);
+	if (!zuoraTaxPeriods) {
+		throw new Error('no tax periods found');
+	}
+	const zuoraTaxPeriod = getZuoraTaxPeriod(
+		zuoraTaxCode.id,
+		zuoraTaxPeriods.taxRatePeriods,
+	);
+	if (!zuoraTaxPeriod) {
+		throw new Error(`invalid period for productKey:${productKey}`);
+	}
+
+	const zuoraTaxRates = await getZuoraTaxRates(zuoraClient, zuoraTaxPeriod.id);
+	const cadZuoraTaxRates = extractZuoraTaxRatesForCountry(
+		zuoraTaxRates.taxRates,
+		country,
+	);
+
+	return createCadStateTaxRates(cadZuoraTaxRates);
+}
+
+function getProductZuoraTaxCode(
+	productKey: ProductKey,
+	zuoraTaxCodes: ZuoraTaxCode[],
+) {
+	return zuoraTaxCodes.find(
+		(zuoraTaxCode) =>
+			zuoraTaxCode.name === taxExclusiveProductCodeNames[productKey],
+	);
+}
+
+function getZuoraTaxPeriod(
+	zuoraTaxCode: string,
+	zuoraTaxPeriods: ZuoraTaxPeriod[],
+) {
+	return zuoraTaxPeriods.find(
+		(zuoraTaxPeriod) => zuoraTaxPeriod.taxCodeId === zuoraTaxCode,
+	);
+}
+
+function extractZuoraTaxRatesForCountry(
+	zuoraTaxRates: ZuoraTaxRate[],
+	country: IsoCountry,
+): ZuoraTaxRate[] {
+	return zuoraTaxRates.filter(
+		(zuoraTaxRate) => zuoraTaxRate.country === getCountryNameByIsoCode(country),
+	);
+}
+
+function createCadStateTaxRates(
+	cadZuoraTaxRates: ZuoraTaxRate[],
+): TaxRatesResponse {
+	const stateCodes = caStateSchema.options;
+	const missingStateCodes: CaState[] = [];
+
+	const taxCodesByState = stateCodes.reduce<Partial<TaxRatesResponse>>(
+		(
+			memo: Partial<TaxRatesResponse>,
+			stateCode: CaState,
+		): Partial<TaxRatesResponse> => {
+			const zuoraTaxRate = cadZuoraTaxRates.find(
+				(zuoraTaxRate) => caStates[stateCode] === zuoraTaxRate.state,
+			);
+
+			if (zuoraTaxRate) {
+				memo[stateCode] = zuoraTaxRate.taxRate1;
+			} else {
+				missingStateCodes.push(stateCode);
+			}
+
+			return memo;
+		},
+		{},
+	);
+
+	if (missingStateCodes.length > 0) {
+		throw new Error(
+			`Zuora is missing tax rates for the following CA provinces: ${missingStateCodes.join(', ')}`,
+		);
+	}
+
+	const parsedResult = taxRatesResponseSchema.safeParse(taxCodesByState);
+
+	if (!parsedResult.success) {
+		// It shouldn't be possible to get here since we already validated all CA states
+		// are present above. But it's useful to resolve the type to a complete TaxRatesResponse
+		throw new Error('Failed to parse constructed CAD tax rates');
+	}
+
+	return parsedResult.data;
 }

--- a/handlers/sales-tax-api/test/fixtures.ts
+++ b/handlers/sales-tax-api/test/fixtures.ts
@@ -1,0 +1,81 @@
+import type { CaState } from '@modules/internationalisation/country';
+import {
+	caStates,
+	type IsoCountry,
+} from '@modules/internationalisation/country';
+import type {
+	ZuoraTaxCode,
+	ZuoraTaxPeriod,
+	ZuoraTaxRate,
+	ZuoraTaxRates,
+} from '@modules/zuora/types/objects/tax';
+import type { TaxRatesResponse } from '../src/schemas';
+
+export const supporterPlusTaxCodeId = '8ad0887181de06d70181de659fb63b57';
+export const supporterPlusTaxEngineId = '8ad095dd81de1cf00181de66e7404253';
+
+export const zuoraTaxCodeSupporterPlus: ZuoraTaxCode = {
+	id: supporterPlusTaxCodeId,
+	taxEngineId: '2c92c0f94568f996014570f746f75c52',
+	active: true,
+	name: 'Supporter Plus',
+	description: '',
+};
+
+export const zuoraTaxCodePeriod: ZuoraTaxPeriod = {
+	id: supporterPlusTaxEngineId,
+	startDate: '2022-07-08',
+	endDate: null,
+	taxCodeId: supporterPlusTaxCodeId,
+};
+
+export const zuoraTaxRateSupporterPlus: ZuoraTaxRate = {
+	id: '8ad095dd81de1cf00181de66f5cf43b4',
+	taxRatePeriodId: supporterPlusTaxEngineId,
+	country: 'Canada',
+	state: 'Ontario',
+	taxRate1: 0.13,
+};
+
+export const canadianCountryStates: TaxRatesResponse = {
+	AB: 0.05,
+	BC: 0.12,
+	MB: 0.12,
+	NB: 0.15,
+	NL: 0.15,
+	NT: 0.05,
+	NS: 0.14,
+	NU: 0.05,
+	ON: 0.13,
+	PE: 0.15,
+	QC: 0.1475,
+	SK: 0.11,
+	YT: 0.05,
+};
+export function canadianZuoraTaxRates(): ZuoraTaxRates {
+	return {
+		taxRates: Object.keys(canadianCountryStates).map((state) =>
+			canadianZuoraTaxRate(
+				state as keyof TaxRatesResponse,
+				canadianCountryStates,
+			),
+		),
+	};
+}
+
+function canadianZuoraTaxRate(
+	state: CaState,
+	cadTaxRates: TaxRatesResponse,
+): ZuoraTaxRate {
+	return {
+		id: '8ad095dd81de1cf00181de66f5cf43b4',
+		taxRatePeriodId: supporterPlusTaxEngineId,
+		country: 'Canada',
+		state: caStates[state],
+		taxRate1: cadTaxRates[state],
+	};
+}
+
+export const countryStates: Partial<Record<IsoCountry, TaxRatesResponse>> = {
+	CA: canadianCountryStates,
+};

--- a/handlers/sales-tax-api/test/index.test.ts
+++ b/handlers/sales-tax-api/test/index.test.ts
@@ -1,16 +1,74 @@
+import {
+	getZuoraTaxCodes,
+	getZuoraTaxPeriods,
+	getZuoraTaxRates,
+} from '@modules/zuora/tax';
+import type {
+	ZuoraTaxCodes,
+	ZuoraTaxPeriods,
+	ZuoraTaxRates,
+} from '@modules/zuora/types/objects/tax';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { handler } from '../src/index';
 import type { TaxRatesResponse } from '../src/schemas';
-import { cadStates } from '../src/taxRatesEndpoint';
+import {
+	canadianZuoraTaxRates,
+	countryStates,
+	supporterPlusTaxCodeId,
+	zuoraTaxCodePeriod,
+} from './fixtures';
+
+jest.mock('@modules/stage', () => ({
+	stageFromEnvironment: () => 'CODE',
+}));
+
+jest.mock('@modules/zuora/zuoraClient', () => ({
+	ZuoraClient: { create: jest.fn().mockResolvedValue({}) },
+}));
+
+jest.mock('@modules/zuora/tax', () => ({
+	getZuoraTaxCodes: jest.fn(),
+	getZuoraTaxPeriods: jest.fn(),
+	getZuoraTaxRates: jest.fn(),
+}));
 
 describe('SalesTax API', () => {
+	const province = 'ON';
+
+	const mockGetZuoraTaxCodes = jest.mocked(getZuoraTaxCodes);
+	const mockZuoraTaxCodes = {
+		taxCodes: [
+			{
+				id: supporterPlusTaxCodeId,
+				taxEngineId: '2c92c0f94568f996014570f746f75c52',
+				active: true,
+				name: 'Supporter Plus Global Tax',
+				description: '',
+			},
+		],
+	} as unknown as ZuoraTaxCodes;
+
+	const mockGetZuoraTaxPeriods = jest.mocked(getZuoraTaxPeriods);
+	const mockZuoraTaxPeriods = {
+		taxRatePeriods: [zuoraTaxCodePeriod],
+	} as unknown as ZuoraTaxPeriods;
+
+	const mockGetZuoraTaxRates = jest.mocked(getZuoraTaxRates);
+	const mockZuoraTaxRates = canadianZuoraTaxRates() as unknown as ZuoraTaxRates;
+
 	const baseTaxRatesEvent: Partial<APIGatewayProxyEvent> = {
 		path: '/tax-rates',
 		httpMethod: 'POST',
 		headers: {},
 	};
 
-	describe('routing and body parsing taxRatesEndpoint', () => {
+	beforeEach(() => {
+		mockGetZuoraTaxCodes.mockResolvedValue(mockZuoraTaxCodes);
+		mockGetZuoraTaxPeriods.mockResolvedValue(mockZuoraTaxPeriods);
+		mockGetZuoraTaxRates.mockResolvedValue(mockZuoraTaxRates);
+	});
+
+	describe('handler', () => {
 		it('returns 400 for an empty body', async () => {
 			const response = await handler(
 				baseTaxRatesEvent as unknown as APIGatewayProxyEvent,
@@ -18,6 +76,7 @@ describe('SalesTax API', () => {
 
 			expect(response.statusCode).toEqual(400);
 		});
+
 		it('returns 400 when body not valid JSON', async () => {
 			const requestEvent = {
 				...baseTaxRatesEvent,
@@ -27,6 +86,7 @@ describe('SalesTax API', () => {
 			const response = await handler(requestEvent);
 			expect(response.statusCode).toEqual(400);
 		});
+
 		it('returns 400 when body is missing required fields', async () => {
 			const requestEvent = {
 				...baseTaxRatesEvent,
@@ -38,6 +98,7 @@ describe('SalesTax API', () => {
 			const response = await handler(requestEvent);
 			expect(response.statusCode).toEqual(400);
 		});
+
 		it('returns 400 for an invalid productKey', async () => {
 			const requestEvent = {
 				...baseTaxRatesEvent,
@@ -49,6 +110,7 @@ describe('SalesTax API', () => {
 			const response = await handler(requestEvent);
 			expect(response.statusCode).toEqual(400);
 		});
+
 		it('returns 400 for an invalid country', async () => {
 			const requestEvent = {
 				...baseTaxRatesEvent,
@@ -60,9 +122,27 @@ describe('SalesTax API', () => {
 			const response = await handler(requestEvent);
 			expect(response.statusCode).toEqual(400);
 		});
-	});
 
-	describe('taxRatesEndpoint', () => {
+		it('returns 500 if Zuora is missing data', async () => {
+			const mockZuoraTaxRatesWithMissingRate = {
+				// Remove the tax rate data for a single state
+				taxRates: mockZuoraTaxRates.taxRates.slice(0, -1),
+			};
+			mockGetZuoraTaxRates.mockResolvedValue(mockZuoraTaxRatesWithMissingRate);
+			const country = 'CA';
+			const requestEvent = {
+				...baseTaxRatesEvent,
+				body: JSON.stringify({
+					productKey: 'SupporterPlus',
+					country: country,
+				}),
+			} as unknown as APIGatewayProxyEvent;
+
+			const response = await handler(requestEvent);
+
+			expect(response.statusCode).toEqual(500);
+		});
+
 		it('returns 200 for a valid country, product', async () => {
 			const country = 'CA';
 			const requestEvent = {
@@ -77,7 +157,9 @@ describe('SalesTax API', () => {
 			expect(response.statusCode).toEqual(200);
 
 			const taxRatesResponse = JSON.parse(response.body) as TaxRatesResponse;
-			expect(taxRatesResponse).toEqual(cadStates);
+			expect(taxRatesResponse[province]).toEqual(
+				countryStates[country]?.[province],
+			);
 		});
 	});
 });

--- a/handlers/sales-tax-api/test/integration.test.ts
+++ b/handlers/sales-tax-api/test/integration.test.ts
@@ -1,0 +1,28 @@
+/**
+ * This is an integration test, the `@group integration` tag ensures that it will only be run by the `pnpm it-test`
+ * command and will not be run during continuous integration.
+ * This makes it useful for testing things that require credentials which are available locally but not on the CI server.
+ *
+ * @group integration
+ */
+
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { taxRatesResponseSchema } from '../src/schemas';
+import { taxRatesEndpoint } from '../src/taxRatesEndpoint';
+import { countryStates } from './fixtures';
+
+describe('SalesTax API Integration', () => {
+	const country = 'CA';
+	test('we can retrieve SupporterPlus Canadian tax rates', async () => {
+		const zuoraClient = await ZuoraClient.create('CODE');
+
+		const result = await taxRatesEndpoint(zuoraClient, {
+			productKey: 'SupporterPlus',
+			country,
+		});
+
+		expect(result.statusCode).toEqual(200);
+		const body = taxRatesResponseSchema.parse(JSON.parse(result.body));
+		expect(body).toEqual(countryStates[country]);
+	});
+});

--- a/modules/internationalisation/src/country.ts
+++ b/modules/internationalisation/src/country.ts
@@ -1,3 +1,5 @@
+import z from 'zod';
+
 export const usStates: Record<string, string> = {
 	AL: 'Alabama',
 	AK: 'Alaska',
@@ -57,7 +59,25 @@ export const usStates: Record<string, string> = {
 	WI: 'Wisconsin',
 	WY: 'Wyoming',
 };
-export const caStates: Record<string, string> = {
+
+export const caStateSchema = z.enum([
+	'AB',
+	'BC',
+	'MB',
+	'NB',
+	'NL',
+	'NT',
+	'NS',
+	'NU',
+	'ON',
+	'PE',
+	'QC',
+	'SK',
+	'YT',
+]);
+
+export type CaState = z.infer<typeof caStateSchema>;
+export const caStates: Record<CaState, string> = {
 	AB: 'Alberta',
 	BC: 'British Columbia',
 	MB: 'Manitoba',
@@ -72,6 +92,7 @@ export const caStates: Record<string, string> = {
 	SK: 'Saskatchewan',
 	YT: 'Yukon',
 };
+
 export const auStates: Record<string, string> = {
 	ACT: 'Australian Capital Territory',
 	NSW: 'New South Wales',
@@ -597,6 +618,5 @@ export function getCountryNameByIsoCode(code: IsoCountry) {
 }
 // ----- Types ----- //
 export type UsState = keyof typeof usStates;
-export type CaState = keyof typeof caStates;
 export type AuState = keyof typeof auStates;
 export type StateProvince = UsState;

--- a/modules/zuora/src/tax.ts
+++ b/modules/zuora/src/tax.ts
@@ -1,0 +1,24 @@
+import {
+	zuoraTaxCodesSchema,
+	zuoraTaxPeriodsSchema,
+	zuoraTaxRatesSchema,
+} from './types/objects/tax';
+import type { ZuoraClient } from './zuoraClient';
+
+export const getZuoraTaxCodes = async (zuoraClient: ZuoraClient) => {
+	const path = `settings/tax-codes`;
+	return zuoraClient.get(path, zuoraTaxCodesSchema);
+};
+
+export const getZuoraTaxPeriods = async (zuoraClient: ZuoraClient) => {
+	const path = `settings/tax-rate-periods`;
+	return zuoraClient.get(path, zuoraTaxPeriodsSchema);
+};
+
+export const getZuoraTaxRates = async (
+	zuoraClient: ZuoraClient,
+	id: string,
+) => {
+	const path = `settings/tax-rate-periods/${id}/tax-rates?page=1&size=500`;
+	return zuoraClient.get(path, zuoraTaxRatesSchema);
+};

--- a/modules/zuora/src/types/objects/tax.ts
+++ b/modules/zuora/src/types/objects/tax.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+export const zuoraTaxCodeSchema = z.object({
+	id: z.string(),
+	taxEngineId: z.string(),
+	active: z.boolean(),
+	name: z.string(),
+	description: z.string(),
+});
+export const zuoraTaxCodesSchema = z
+	.object({
+		taxCodes: z.array(zuoraTaxCodeSchema),
+	})
+	.optional();
+export type ZuoraTaxCode = z.infer<typeof zuoraTaxCodeSchema>;
+export type ZuoraTaxCodes = z.infer<typeof zuoraTaxCodesSchema> | undefined;
+
+export const zuoraTaxPeriodSchema = z.object({
+	id: z.string(),
+	startDate: z.string().nullable(),
+	endDate: z.string().nullable(),
+	taxCodeId: z.string(),
+});
+export const zuoraTaxPeriodsSchema = z
+	.object({
+		taxRatePeriods: z.array(zuoraTaxPeriodSchema),
+	})
+	.optional();
+export type ZuoraTaxPeriod = z.infer<typeof zuoraTaxPeriodSchema>;
+export type ZuoraTaxPeriods = z.infer<typeof zuoraTaxPeriodsSchema> | undefined;
+
+export const zuoraTaxRateSchema = z.object({
+	id: z.string(),
+	taxRatePeriodId: z.string(),
+	country: z.string(),
+	state: z.string().nullable(),
+	taxRate1: z.number(),
+});
+export const zuoraTaxRatesSchema = z.object({
+	taxRates: z.array(zuoraTaxRateSchema),
+});
+export type ZuoraTaxRate = z.infer<typeof zuoraTaxRateSchema>;
+export type ZuoraTaxRates = z.infer<typeof zuoraTaxRatesSchema>;


### PR DESCRIPTION
This is a recreation of #3616.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
