### PR TITLE
Add taxMode field to the product catalog paymentPlans

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -106,7 +106,7 @@ object Steps {
       zuoraEnv = ZuoraEnvironment.EnvForStage(stage)
       plansWithPrice <- PricesFromZuoraCatalog(zuoraEnv, fetchString, zuoraIds.rateplanIdToApiId.get)
         .toApiGatewayOp("get prices from zuora catalog")
-      getPricesForPlan = (planId: PlanId) => plansWithPrice.getOrElse(planId, Map.empty)
+      getPricesForPlan = (planId: PlanId) => plansWithPrice.getOrElse(planId, PlanPrices(Map.empty, None))
       startDateFromProductType <- StartDateFromFulfilmentFiles(stage, fetchString, currentDate())
         .toApiGatewayOp("get fulfilment date files")
       catalog = NewProductApi.catalog(getPricesForPlan, startDateFromProductType, currentDate())

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Handler.scala
@@ -38,7 +38,7 @@ object Handler extends Logging {
         "get prices from zuora catalog",
       )
       .withLogging("plansWithPrice")
-    getPricesForPlan = (planId: PlanId) => plansWithPrice.getOrElse(planId, Map.empty)
+    getPricesForPlan = (planId: PlanId) => plansWithPrice.getOrElse(planId, PlanPrices(Map.empty, None))
     startDateFromProductType <- StartDateFromFulfilmentFiles(stage, fetchString, today).toApiGatewayOpOr422.withLogging(
       "startDateFromProductType",
     )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -10,7 +10,7 @@ object NewProductApi {
 
   private def paymentPlansFor(
       billingPeriod: BillingPeriod,
-      pricesByCurrency: Map[Currency, AmountMinorUnits],
+      planPrices: PlanPrices,
   ): Map[Currency, PaymentPlan] = {
 
     val billingPeriodDescription = billingPeriod match {
@@ -19,19 +19,20 @@ object NewProductApi {
       case Annual => "every 12 months"
       case SixWeeks => "for the first six weeks"
     }
-    pricesByCurrency.map { case (currency, amount) =>
+    planPrices.priceMinorUnits.map { case (currency, amount) =>
       currency ->
         PaymentPlan(
           currency = currency,
           amountMinorUnits = amount,
           billingPeriod = billingPeriod,
           description = s"${currency.iso} ${amount.formatted} $billingPeriodDescription",
+          taxMode = planPrices.taxMode,
         )
     }
   }
 
   def catalog(
-      pricingFor: PlanId => Map[Currency, AmountMinorUnits],
+      pricingFor: PlanId => PlanPrices,
       getStartDateFromFulfilmentFiles: (ProductType, List[DayOfWeek]) => LocalDate,
       today: LocalDate,
   ): Map[PlanId, Plan] = {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/PricesFromZuoraCatalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/PricesFromZuoraCatalog.scala
@@ -10,7 +10,9 @@ import com.gu.i18n.Currency
 
 import scala.util.Try
 
-case class PlanWithPrice(planId: PlanId, priceMinorUnits: Map[Currency, AmountMinorUnits])
+case class PlanWithPrice(planId: PlanId, priceMinorUnits: Map[Currency, AmountMinorUnits], taxMode: Option[TaxMode])
+
+case class PlanPrices(priceMinorUnits: Map[Currency, AmountMinorUnits], taxMode: Option[TaxMode])
 
 object ZuoraCatalogWireModel {
 
@@ -22,6 +24,7 @@ object ZuoraCatalogWireModel {
 
   case class RateplanCharge(
       pricing: List[Price],
+      taxMode: Option[String],
   )
 
   object RateplanCharge {
@@ -67,7 +70,10 @@ object ZuoraCatalogWireModel {
 
         val totalPricesByCurrency: Map[Currency, AmountMinorUnits] = optionaltotalPricesByCurrency.flatten.toMap
 
-        PlanWithPrice(planId, totalPricesByCurrency)
+        // All charges in a Zuora rate plan share one taxMode (Zuora has no mixed mode), so take the first defined one.
+        val taxMode = productRatePlanCharges.flatMap(_.taxMode).flatMap(TaxMode.fromString).headOption
+
+        PlanWithPrice(planId, totalPricesByCurrency, taxMode)
       }
     }
   }
@@ -89,14 +95,14 @@ object ZuoraCatalogWireModel {
   case class ZuoraCatalog(
       products: List[Product],
   ) {
-    def toParsedPlans(planIdFor: ProductRatePlanId => Option[PlanId]): Map[PlanId, Map[Currency, AmountMinorUnits]] = {
+    def toParsedPlans(planIdFor: ProductRatePlanId => Option[PlanId]): Map[PlanId, PlanPrices] = {
       val plansWithPrice = for {
         product <- products
         rateplan <- product.productRatePlans
         parsedPlan <- rateplan.toParsedPlan(planIdFor).toList
       } yield parsedPlan
 
-      plansWithPrice.map(x => x.planId -> x.priceMinorUnits).toMap
+      plansWithPrice.map(x => x.planId -> PlanPrices(x.priceMinorUnits, x.taxMode)).toMap
     }
   }
 
@@ -111,7 +117,7 @@ object PricesFromZuoraCatalog {
       zuoraEnvironment: ZuoraEnvironment,
       fetchString: StringFromS3,
       planIdFor: ProductRatePlanId => Option[PlanId],
-  ): Try[Map[PlanId, Map[Currency, AmountMinorUnits]]] =
+  ): Try[Map[PlanId, PlanPrices]] =
     for {
       catalogString <- fetchString(
         S3Location(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -45,10 +45,15 @@ object WireModel {
       amount: BigDecimal,
       billingPeriod: WireBillingPeriod,
       description: String,
+      taxMode: Option[String],
   )
   object WirePaymentPlan {
     implicit val writes: OWrites[WirePaymentPlan] = Json.writes[WirePaymentPlan]
 
+    def wireTaxMode(taxMode: TaxMode): String = taxMode match {
+      case TaxMode.TaxExclusive => "TaxExclusive"
+      case TaxMode.TaxInclusive => "TaxInclusive"
+    }
   }
 
   case class WireSelectableWindow(
@@ -125,6 +130,7 @@ object WireModel {
           paymentPlan.amountMinorUnits.value / 100d,
           WireBillingPeriod.fromBillingPeriod(paymentPlan.billingPeriod),
           paymentPlan.description,
+          paymentPlan.taxMode.map(WirePaymentPlan.wireTaxMode),
         )
       }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogEffectsTest.scala
@@ -24,7 +24,9 @@ class PricesFromZuoraCatalogEffectsTest extends AnyFlatSpec with Matchers {
         zuoraIds.rateplanIdToApiId.get,
       ).toEither.left.map(_.toString)
     } yield response
-    actual.map(result => result(MonthlySupporterPlus).get(GBP)) shouldBe Right(Some(AmountMinorUnits(1200)))
+    actual.map(result => result(MonthlySupporterPlus).priceMinorUnits.get(GBP)) shouldBe Right(
+      Some(AmountMinorUnits(1200)),
+    )
     // the prices might change but at least we can assert that we got some price for each product
     actual.map(_.keySet) shouldBe Right(expectedProducts)
   }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/PricesFromZuoraCatalogTest.scala
@@ -5,7 +5,13 @@ import com.gu.i18n.Currency.{EUR, GBP, USD}
 import com.gu.newproduct.api.productcatalog.PlanId._
 import com.gu.newproduct.api.productcatalog.ZuoraCatalogWireModel.Price
 import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
-import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PricesFromZuoraCatalog, ZuoraCatalogWireModel}
+import com.gu.newproduct.api.productcatalog.{
+  AmountMinorUnits,
+  PlanPrices,
+  PricesFromZuoraCatalog,
+  TaxMode,
+  ZuoraCatalogWireModel,
+}
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.ZuoraEnvironment
 
@@ -29,6 +35,7 @@ class PricesFromZuoraCatalogTest extends AnyFlatSpec with Matchers {
         |          "productRatePlanCharges": [
         |            {
         |              "name": "Saturday",
+        |              "taxMode": "TaxExclusive",
         |              "pricing": [ { "currency": "GBP", "price": 10.36 }, { "currency": "EUR", "price": 10.26 }, { "currency": "USD", "price": 10.46 } ]
         |            },
         |            {
@@ -58,10 +65,13 @@ class PricesFromZuoraCatalogTest extends AnyFlatSpec with Matchers {
     )
     actual shouldBe Success(
       Map(
-        VoucherSaturdayPlus -> Map(
-          GBP -> AmountMinorUnits(2162),
-          USD -> AmountMinorUnits(2192),
-          EUR -> AmountMinorUnits(2152),
+        VoucherSaturdayPlus -> PlanPrices(
+          Map(
+            GBP -> AmountMinorUnits(2162),
+            USD -> AmountMinorUnits(2192),
+            EUR -> AmountMinorUnits(2152),
+          ),
+          Some(TaxMode.TaxExclusive),
         ),
       ),
     )

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -25,11 +25,17 @@ class CatalogWireTest extends AnyFlatSpec with Matchers with ResourceLoader {
     Json.prettyPrint(Json.toJson(wireCatalog)) shouldBe Json.prettyPrint(Json.parse(expected.get))
   }
 
-  def gbpPrice(amount: Int): Map[Currency, AmountMinorUnits] = Map(
-    Currency.GBP -> AmountMinorUnits(amount),
+  def gbpPrice(amount: Int): PlanPrices = PlanPrices(
+    Map(Currency.GBP -> AmountMinorUnits(amount)),
+    None,
   )
 
-  def fakePricesFor(planId: PlanId): Map[Currency, AmountMinorUnits] = planId match {
+  def prices(taxMode: Option[TaxMode], entries: (Currency, AmountMinorUnits)*): PlanPrices =
+    PlanPrices(entries.toMap, taxMode)
+
+  val noPrices: PlanPrices = PlanPrices(Map.empty, None)
+
+  def fakePricesFor(planId: PlanId): PlanPrices = planId match {
     case VoucherWeekendPlus => gbpPrice(2942)
     case VoucherWeekend => gbpPrice(2076)
     case VoucherSunday => gbpPrice(1079)
@@ -39,10 +45,10 @@ class CatalogWireTest extends AnyFlatSpec with Matchers with ResourceLoader {
     case VoucherEveryDayPlus => gbpPrice(5196)
     case VoucherSixDay => gbpPrice(4112)
     case VoucherSixDayPlus => gbpPrice(4762)
-    case MonthlySupporterPlus => Map.empty
-    case AnnualSupporterPlus => Map.empty
-    case MonthlyContribution => Map.empty
-    case AnnualContribution => Map.empty
+    case MonthlySupporterPlus => noPrices
+    case AnnualSupporterPlus => noPrices
+    case MonthlyContribution => noPrices
+    case AnnualContribution => noPrices
     case HomeDeliveryEveryDay => gbpPrice(123)
     case HomeDeliverySaturday => gbpPrice(456)
     case HomeDeliverySunday => gbpPrice(321)
@@ -53,49 +59,29 @@ class CatalogWireTest extends AnyFlatSpec with Matchers with ResourceLoader {
     case HomeDeliverySixDayPlus => gbpPrice(1111)
     case HomeDeliveryWeekendPlus => gbpPrice(2222)
     case DigipackMonthly =>
-      Map(
-        Currency.GBP -> AmountMinorUnits(5555),
-        Currency.USD -> AmountMinorUnits(5554),
-      )
+      prices(None, Currency.GBP -> AmountMinorUnits(5555), Currency.USD -> AmountMinorUnits(5554))
     case DigipackAnnual =>
-      Map(
-        Currency.GBP -> AmountMinorUnits(66666),
-        Currency.USD -> AmountMinorUnits(66665),
-      )
-    case DigipackAnnualTaxExclusive => Map(Currency.CAD -> AmountMinorUnits(11999))
-    case DigipackMonthlyTaxExclusive => Map(Currency.CAD -> AmountMinorUnits(1199))
-    case AnnualSupporterPlusTaxExclusive => Map(Currency.CAD -> AmountMinorUnits(16999))
-    case MonthlySupporterPlusTaxExclusive => Map(Currency.CAD -> AmountMinorUnits(1699))
+      prices(None, Currency.GBP -> AmountMinorUnits(66666), Currency.USD -> AmountMinorUnits(66665))
+    case DigipackAnnualTaxExclusive =>
+      prices(Some(TaxMode.TaxExclusive), Currency.CAD -> AmountMinorUnits(11999))
+    case DigipackMonthlyTaxExclusive =>
+      prices(Some(TaxMode.TaxExclusive), Currency.CAD -> AmountMinorUnits(1199))
+    case AnnualSupporterPlusTaxExclusive =>
+      prices(Some(TaxMode.TaxExclusive), Currency.CAD -> AmountMinorUnits(16999))
+    case MonthlySupporterPlusTaxExclusive =>
+      prices(Some(TaxMode.TaxExclusive), Currency.CAD -> AmountMinorUnits(1699))
     case GuardianWeeklyPlusDomesticMonthly =>
-      Map(
-        Currency.GBP -> AmountMinorUnits(1111111),
-        Currency.USD -> AmountMinorUnits(11111111),
-      )
+      prices(None, Currency.GBP -> AmountMinorUnits(1111111), Currency.USD -> AmountMinorUnits(11111111))
     case GuardianWeeklyPlusDomesticQuarterly =>
-      Map(
-        Currency.GBP -> AmountMinorUnits(2222222),
-        Currency.USD -> AmountMinorUnits(22222222),
-      )
+      prices(None, Currency.GBP -> AmountMinorUnits(2222222), Currency.USD -> AmountMinorUnits(22222222))
     case GuardianWeeklyPlusDomesticAnnual =>
-      Map(
-        Currency.GBP -> AmountMinorUnits(3333333),
-        Currency.USD -> AmountMinorUnits(33333333),
-      )
+      prices(None, Currency.GBP -> AmountMinorUnits(3333333), Currency.USD -> AmountMinorUnits(33333333))
     case GuardianWeeklyPlusROWMonthly =>
-      Map(
-        Currency.GBP -> AmountMinorUnits(4444444),
-        Currency.USD -> AmountMinorUnits(44444444),
-      )
+      prices(None, Currency.GBP -> AmountMinorUnits(4444444), Currency.USD -> AmountMinorUnits(44444444))
     case GuardianWeeklyPlusROWQuarterly =>
-      Map(
-        Currency.GBP -> AmountMinorUnits(5555555),
-        Currency.USD -> AmountMinorUnits(55555555),
-      )
+      prices(None, Currency.GBP -> AmountMinorUnits(5555555), Currency.USD -> AmountMinorUnits(55555555))
     case GuardianWeeklyPlusROWAnnual =>
-      Map(
-        Currency.GBP -> AmountMinorUnits(6666666),
-        Currency.USD -> AmountMinorUnits(66666666),
-      )
+      prices(None, Currency.GBP -> AmountMinorUnits(6666666), Currency.USD -> AmountMinorUnits(66666666))
     case DigitalVoucherEveryday => gbpPrice(7001)
     case DigitalVoucherEverydayPlus => gbpPrice(7002)
     case DigitalVoucherSixday => gbpPrice(7003)

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
@@ -62,7 +62,8 @@
         "currencyCode" : "CAD",
         "amount" : 16.99,
         "billingPeriod" : "Monthly",
-        "description" : "CAD 16.99 every month"
+        "description" : "CAD 16.99 every month",
+        "taxMode" : "TaxExclusive"
       } ],
       "enabledForBillingCountries" : [ "Canada" ]
     }, {
@@ -79,7 +80,8 @@
         "currencyCode" : "CAD",
         "amount" : 169.99,
         "billingPeriod" : "Annual",
-        "description" : "CAD 169.99 every 12 months"
+        "description" : "CAD 169.99 every 12 months",
+        "taxMode" : "TaxExclusive"
       } ],
       "enabledForBillingCountries" : [ "Canada" ]
     } ]
@@ -143,7 +145,8 @@
         "currencyCode" : "CAD",
         "amount" : 119.99,
         "billingPeriod" : "Annual",
-        "description" : "CAD 119.99 every 12 months"
+        "description" : "CAD 119.99 every 12 months",
+        "taxMode" : "TaxExclusive"
       } ],
       "enabledForBillingCountries" : [ "Canada" ]
     }, {
@@ -160,7 +163,8 @@
         "currencyCode" : "CAD",
         "amount" : 11.99,
         "billingPeriod" : "Monthly",
-        "description" : "CAD 11.99 every month"
+        "description" : "CAD 11.99 every month",
+        "taxMode" : "TaxExclusive"
       } ],
       "enabledForBillingCountries" : [ "Canada" ]
     } ]

--- a/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/Plan.scala
+++ b/lib/zuora-models/src/main/scala/com/gu/newproduct/api/productcatalog/Plan.scala
@@ -17,11 +17,26 @@ object Quarterly extends BillingPeriod
 object Annual extends BillingPeriod
 object SixWeeks extends BillingPeriod
 
+// Mirrors Zuora's charge-level taxMode. Tax-exclusive plans (e.g. the Canadian sales-tax plans)
+// quote the price net of tax; the others are tax-inclusive.
+sealed trait TaxMode
+object TaxMode {
+  case object TaxExclusive extends TaxMode
+  case object TaxInclusive extends TaxMode
+
+  def fromString(value: String): Option[TaxMode] = value match {
+    case "TaxExclusive" => Some(TaxExclusive)
+    case "TaxInclusive" => Some(TaxInclusive)
+    case _ => None
+  }
+}
+
 case class PaymentPlan(
     currency: Currency,
     amountMinorUnits: AmountMinorUnits,
     billingPeriod: BillingPeriod,
     description: String,
+    taxMode: Option[TaxMode] = None,
 )
 
 case class PlanDescription(value: String) extends AnyVal


### PR DESCRIPTION
## What does this change?

The product catalog returned to Salesforce now carries a `taxMode` on each paymentPlan, so Salesforce can tell when a plan is sold tax-exclusive (and show the right messaging). The value comes from the Zuora catalog: `PricesFromZuoraCatalog` now reads the charge's `taxMode` and threads it through to the wire model, bundled with the prices in a small `PlanPrices(priceMinorUnits, taxMode)` type. `taxMode` is a proper enum (`TaxExclusive | TaxInclusive`) rather than a boolean, mirroring Zuora's own vocabulary.

In the JSON the field only appears when set, so today only the Canadian tax-exclusive plans surface `"taxMode": "TaxExclusive"`; everything else stays as-is.

This is stacked on the tax-exclusive plans PR (#3651), so the diff here is just the taxMode work. When that one merges this will retarget onto main.

## How has this change been tested?

Unit tested. `PricesFromZuoraCatalogTest` now asserts the charge `taxMode` is parsed, and the catalog serialisation snapshot covers the wire output for the new plans. Ran the full new-product-api suite plus assembly locally, all green. Nothing deployed yet.

## How can we measure success?

Salesforce can read the taxMode per paymentPlan and use it to show tax-exclusive pricing information for Canadian plans.

## Have we considered potential risks?

Low and additive. Existing plans get no taxMode in the output (the field is omitted when absent), so their JSON is unchanged. The only behavioural change is the new field on the Canadian plans. `PaymentPlan.taxMode` defaults to None for construction convenience, but the catalog path always sets it explicitly from the Zuora data.