### PR TITLE
Fix write-off-unpaid-invoices missing Orders API cancellations

### DIFF
--- a/handlers/write-off-unpaid-invoices/src/handlers/getUnpaidInvoices.ts
+++ b/handlers/write-off-unpaid-invoices/src/handlers/getUnpaidInvoices.ts
@@ -23,31 +23,22 @@ export const handler = async ({ filePath }: { filePath: string }) => {
 };
 
 const query = `
-    WITH cancellations AS 
-        (SELECT 
-            ame.id AS amendment_id,
-            ame.type AS amendment_type,
-            ame.name AS amendment_name,
-            ame.description as amendment_description,
-            ame.subscription_id AS orig_sub_id,
-            orig_sub.version AS orig_version,
-            orig_sub.name AS orig_sub_number,
-            new_sub.id AS new_sub_id,
-            new_sub.version AS new_version,
-            new_sub.name AS new_sub_number,
-            new_sub.cancellation_reason_c,
-            new_sub.cancel_reason,
-            CASE 
-                WHEN new_sub.cancellation_reason_c = 'System AutoCancel' THEN 'Autocancel'
-                WHEN new_sub.cancellation_reason_c = 'Customer' THEN 'MMA'
+    -- Source cancellations from cancelled subscriptions directly, rather than from
+    -- "Cancellation" amendments. Cancellations completed via the Zuora Orders API
+    -- produce a "Composite" amendment, so the previous amendment-based filter missed
+    -- them (and their leftover unbalanced invoices never got written off).
+    WITH cancellations AS
+        (SELECT DISTINCT
+            sub.name AS orig_sub_number,
+            CASE
+                WHEN sub.cancellation_reason_c = 'System AutoCancel' THEN 'Autocancel'
+                WHEN sub.cancellation_reason_c = 'Customer' THEN 'MMA'
                 ELSE 'Salesforce' END as cancellation_source
-        FROM datatech-fivetran.zuora.amendment ame
-        LEFT JOIN datatech-fivetran.zuora.subscription orig_sub ON ame.subscription_id = orig_sub.id
-        LEFT JOIN datatech-fivetran.zuora.subscription new_sub ON (new_sub.name = orig_sub.name AND new_sub.version = orig_sub.version + 1)
+        FROM datatech-fivetran.zuora.subscription sub
         WHERE
-            ame.type = "Cancellation"
-            AND DATE(ame.created_date) >= DATE_SUB(CURRENT_DATE, INTERVAL 5 DAY)
-            AND DATE(ame.created_date) <= DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+            sub.status = 'Cancelled'
+            AND DATE(sub.created_date) >= DATE_SUB(CURRENT_DATE, INTERVAL 5 DAY)
+            AND DATE(sub.created_date) <= DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
         )
     ,
 


### PR DESCRIPTION
## What does this change?

The `write-off-unpaid-invoices` clean-up job wasn't clearing invoices left unbalanced after refunds for a sizeable chunk of cancellations. The query in `getUnpaidInvoices.ts` sourced cancellations from amendments of type `Cancellation`, but since we complete cancellations through the Zuora Orders API those are recorded as `Composite` amendments (the order bundles its actions), so they were never picked up and their leftover invoices never got written off.

This changes the first CTE to source cancellations from the subscriptions themselves (`status = 'Cancelled'`) rather than from amendments, which is agnostic to how the cancellation was made. Nothing downstream changed: the rest of the query only ever used the subscription number and the cancellation source, both still produced.

One choice worth calling out: I used the cancelled subscription version's `created_date` for the 1–5 day window (the analog of the old `amendment.created_date`), not `cancelled_date` (the effective date, which can be back- or future-dated). And order/Salesforce cancellations fall into the existing `Salesforce` bucket for the write-off comment — happy to distinguish order cancellations if we'd prefer.

## How has this change been tested?

Ran the handler gates locally (type-check, lint, prettier, tests, build), all green. The query itself has no unit test (it's a raw SQL string), so I validated it directly against the warehouse (BigQuery, `datatech-fivetran.zuora`):

- On the job's window, `Composite` amendments outnumber `Cancellation` ones roughly 2:1, and about 15% of cancelled subscriptions were invisible to the old query.
- Comparing the old vs new invoice sets across several historical windows, the new query is a strict superset: it loses nothing the old one caught (0 in every window) and rescues ~75 unbalanced invoices per window, including the negative-balance-after-refund cases this addresses.

Happy to deploy the fetch step to `CODE` and eyeball the S3 output before we ship if that's useful.

## How can we measure success?

After this ships, the number of unbalanced posted invoices sitting on recently-cancelled subscriptions should trend towards zero instead of accumulating — the older windows still show 60–115 such invoices today that were never cleaned. We can watch the size of the daily S3 output and the number of invoices the job adjusts, and re-run the warehouse check periodically to confirm the gap is closed.

## Have we considered potential risks?

The new query is deliberately more inclusive, so the main risk is writing off an invoice we shouldn't. Mitigations: it keeps exactly the same downstream filters (`balance <> 0`, `status = 'Posted'`, the existing exclude list), and the superset check shows it never drops anything the current query already handled — it only adds the order-based cancellations the job was always meant to cover. The write-off itself is the existing, bounded invoice-item-adjustment path, and the job already alarms via its FAILED-file notification.

Separately and out of scope here: the query still carries a ~8,500-id hardcoded `NOT IN (...)` exclude list. Worth a backlog item to revisit how that's maintained.

## Images

N/A — no UI change.

## Accessibility

N/A — no UI change.
