### PR TITLE
Sales Tax API: Fix an issue with DigitalSubscription tax rates in prod

### DIFF
--- a/handlers/sales-tax-api/src/taxRatesEndpoint.ts
+++ b/handlers/sales-tax-api/src/taxRatesEndpoint.ts
@@ -75,9 +75,6 @@ async function getZuoraSalesTaxRates(
 		zuoraTaxCode.id,
 		zuoraTaxPeriods.taxRatePeriods,
 	);
-	if (!zuoraTaxPeriod) {
-		throw new Error(`invalid period for productKey:${productKey}`);
-	}
 
 	const zuoraTaxRates = await getZuoraTaxRates(zuoraClient, zuoraTaxPeriod.id);
 	const cadZuoraTaxRates = extractZuoraTaxRatesForCountry(
@@ -117,7 +114,14 @@ function getZuoraTaxPeriod(
 		);
 	}
 
-	return periodsForTaxCodeWithNoEndDate[0];
+	const period = periodsForTaxCodeWithNoEndDate[0];
+	if (!period) {
+		throw new Error(
+			`Failed to find tax period for tax code ${zuoraTaxCode} with no end date`,
+		);
+	}
+
+	return period;
 }
 
 function extractZuoraTaxRatesForCountry(

--- a/handlers/sales-tax-api/src/taxRatesEndpoint.ts
+++ b/handlers/sales-tax-api/src/taxRatesEndpoint.ts
@@ -102,9 +102,22 @@ function getZuoraTaxPeriod(
 	zuoraTaxCode: string,
 	zuoraTaxPeriods: ZuoraTaxPeriod[],
 ) {
-	return zuoraTaxPeriods.find(
-		(zuoraTaxPeriod) => zuoraTaxPeriod.taxCodeId === zuoraTaxCode,
-	);
+	const periodMatchesTaxCode = (zuoraTaxPeriod: ZuoraTaxPeriod) =>
+		zuoraTaxPeriod.taxCodeId === zuoraTaxCode;
+	const periodHasNoEndDate = (zuoraTaxPeriod: ZuoraTaxPeriod) =>
+		zuoraTaxPeriod.endDate === null;
+
+	const periodsForTaxCodeWithNoEndDate = zuoraTaxPeriods
+		.filter((p) => periodMatchesTaxCode(p))
+		.filter((p) => periodHasNoEndDate(p));
+
+	if (periodsForTaxCodeWithNoEndDate.length > 1) {
+		throw new Error(
+			`Found multiple tax periods for tax code ${zuoraTaxCode} with no end date`,
+		);
+	}
+
+	return periodsForTaxCodeWithNoEndDate[0];
 }
 
 function extractZuoraTaxRatesForCountry(

--- a/handlers/sales-tax-api/test/integration.test.ts
+++ b/handlers/sales-tax-api/test/integration.test.ts
@@ -13,7 +13,8 @@ import { countryStates } from './fixtures';
 
 describe('SalesTax API Integration', () => {
 	const country = 'CA';
-	test('we can retrieve SupporterPlus Canadian tax rates', async () => {
+
+	it('returns SupporterPlus Canadian tax rates', async () => {
 		const zuoraClient = await ZuoraClient.create('CODE');
 
 		const result = await taxRatesEndpoint(zuoraClient, {
@@ -24,5 +25,16 @@ describe('SalesTax API Integration', () => {
 		expect(result.statusCode).toEqual(200);
 		const body = taxRatesResponseSchema.parse(JSON.parse(result.body));
 		expect(body).toEqual(countryStates[country]);
+	});
+
+	it('returns a successful response for DigitalSubscription Canadian tax rates', async () => {
+		const zuoraClient = await ZuoraClient.create('CODE');
+
+		const result = await taxRatesEndpoint(zuoraClient, {
+			productKey: 'DigitalSubscription',
+			country,
+		});
+
+		expect(result.statusCode).toEqual(200);
 	});
 });


### PR DESCRIPTION
## What does this change?

Previously we were returning the first tax period with a matching tax code, but there can be multiple of these so we need to make sure we get the current one.

This caused an issue in prod where the first matching period didn't have any tax rates for Canada and this caused the API to return a 500.

## How has this change been tested?

I've added an integration test for `DigitalSubscription` and have run this against prod (the committed code talks to CODE).