### PR TITLE
Move currency schema into currency.ts

### DIFF
--- a/modules/internationalisation/src/currency.ts
+++ b/modules/internationalisation/src/currency.ts
@@ -1,4 +1,5 @@
 import { isInList } from '@modules/arrayFunctions';
+import z from 'zod';
 
 export const CurrencyValues = [
 	'GBP',
@@ -54,3 +55,5 @@ export const isSupportedCurrency = isInList(CurrencyValues);
 
 export const getCurrencyInfo = (currency: IsoCurrency): CurrencyInfo =>
 	currencies[currency];
+
+export const isoCurrencySchema = z.enum(CurrencyValues);

--- a/modules/internationalisation/src/schemas.ts
+++ b/modules/internationalisation/src/schemas.ts
@@ -1,8 +1,6 @@
-import { z } from 'zod';
 import { isoCountries } from '@modules/internationalisation/country';
 import { SupportRegionId } from '@modules/internationalisation/countryGroup';
-import { CurrencyValues } from '@modules/internationalisation/currency';
+import { z } from 'zod';
 
-export const isoCurrencySchema = z.enum(CurrencyValues);
 export const isoCountrySchema = z.enum(isoCountries);
 export const supportRegionSchema = z.nativeEnum(SupportRegionId);


### PR DESCRIPTION
This was a test to see whether moving zod schemas into the same file as the enumerated values are defined in would swell the support-frontend bundle size. It confirmed that it does because there are some pages which use the `currency` type but didn't previously import Zod.

Closing the PR as it has confirmed that this is not the recommended way to structure code, and that we should keep the schemas separate from the types.