### PR TITLE
reduce the amount of unnecessary async in product-switch-api

### DIFF
--- a/handlers/product-switch-api/src/changePlan/changePlanEndpoint.ts
+++ b/handlers/product-switch-api/src/changePlan/changePlanEndpoint.ts
@@ -1,11 +1,6 @@
 import { ValidationError } from '@modules/errors';
 import type { GuardianSubscription } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
-import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
-import type { GuardianSubscriptionMultiPlan } from '@modules/guardian-subscription/guardianSubscriptionParser';
-import { GuardianSubscriptionParser } from '@modules/guardian-subscription/guardianSubscriptionParser';
-import { SubscriptionFilter } from '@modules/guardian-subscription/subscriptionFilter';
 import { logger } from '@modules/logger/logger';
-import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import { ok } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
@@ -15,7 +10,6 @@ import type {
 	ZuoraSubscription,
 } from '@modules/zuora/types/objects';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import type dayjs from 'dayjs';
 import { removePendingUpdateAmendments } from './action/amendments';
@@ -25,6 +19,7 @@ import { SwitchOrderRequestBuilder } from './prepare/buildSwitchOrderRequest';
 import { isEligibleForSwitch } from './prepare/isEligibleForSwitch';
 import { getSwitchInformation } from './prepare/switchInformation';
 import type { ProductSwitchRequestBody } from './schemas';
+import { ToSingleGuardianSubscription } from './toSingleGuardianSubscription';
 
 export class ChangePlanEndpoint {
 	private doPreviewAction: DoPreviewAction;
@@ -32,6 +27,7 @@ export class ChangePlanEndpoint {
 
 	constructor(
 		private stage: Stage,
+		private toSingleGuardianSubscription: ToSingleGuardianSubscription,
 		private today: dayjs.Dayjs,
 		private body: ProductSwitchRequestBody,
 		private zuoraClient: ZuoraClient,
@@ -51,6 +47,7 @@ export class ChangePlanEndpoint {
 		): Promise<APIGatewayProxyResult> => {
 			const productSwitchEndpoint = new ChangePlanEndpoint(
 				stage,
+				await ToSingleGuardianSubscription.build(stage),
 				today,
 				body,
 				zuoraClient,
@@ -71,6 +68,7 @@ export class ChangePlanEndpoint {
 		): Promise<APIGatewayProxyResult> => {
 			const productSwitchEndpoint = new ChangePlanEndpoint(
 				stage,
+				await ToSingleGuardianSubscription.build(stage),
 				today,
 				body,
 				zuoraClient,
@@ -83,9 +81,7 @@ export class ChangePlanEndpoint {
 	}
 
 	async doPreview() {
-		const switchInformation = await this.gatherSwitchData(
-			this.originalSubscription,
-		);
+		const switchInformation = this.gatherSwitchData(this.originalSubscription);
 
 		const orderRequest: SwitchOrderRequestBuilder =
 			new SwitchOrderRequestBuilder(
@@ -115,7 +111,7 @@ export class ChangePlanEndpoint {
 			this.originalSubscription.subscriptionNumber,
 		);
 
-		const switchInformation = await this.gatherSwitchData(updatedSubscription);
+		const switchInformation = this.gatherSwitchData(updatedSubscription);
 
 		const orderRequest: SwitchOrderRequestBuilder =
 			new SwitchOrderRequestBuilder(
@@ -132,31 +128,12 @@ export class ChangePlanEndpoint {
 		);
 	}
 
-	async gatherSwitchData(zuoraSubscription: ZuoraSubscription) {
-		logger.log('Loading the product catalog');
-		const productCatalog = await getProductCatalogFromApi(this.stage);
-		const productCatalogHelper = new ProductCatalogHelper(productCatalog);
-		const guardianSubscriptionParser = new GuardianSubscriptionParser(
-			await getZuoraCatalogFromS3(this.stage), // need zuora catalog to identify non product-catalog plans e.g. Discount
-			productCatalog,
-		);
-
-		const activeCurrentSubscriptionFilter =
-			SubscriptionFilter.activeNonEndedSubscriptionFilter(this.today);
-
-		const guardianSubscriptionAllPlans: GuardianSubscriptionMultiPlan =
-			guardianSubscriptionParser.toGuardianSubscription(zuoraSubscription);
-		const guardianSubscriptionCurrentPlans: GuardianSubscriptionMultiPlan =
-			activeCurrentSubscriptionFilter.filterSubscription(
-				guardianSubscriptionAllPlans,
-			);
-
+	gatherSwitchData(zuoraSubscription: ZuoraSubscription) {
 		const subscription: GuardianSubscription =
-			getSinglePlanFlattenedSubscriptionOrThrow(
-				guardianSubscriptionCurrentPlans,
+			this.toSingleGuardianSubscription.getSubscription(
+				this.today,
+				zuoraSubscription,
 			);
-
-		logger.log('guardian subscription', subscription);
 
 		if (
 			!isEligibleForSwitch(
@@ -170,7 +147,11 @@ export class ChangePlanEndpoint {
 			);
 		}
 
-		const switchInformation = await getSwitchInformation(
+		const productCatalogHelper = new ProductCatalogHelper(
+			this.toSingleGuardianSubscription.productCatalog,
+		);
+
+		const switchInformation = getSwitchInformation(
 			productCatalogHelper,
 			this.body,
 			this.account,

--- a/handlers/product-switch-api/src/changePlan/legacyContributionToSupporterPlusEndpoint.ts
+++ b/handlers/product-switch-api/src/changePlan/legacyContributionToSupporterPlusEndpoint.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import type { PreviewResponse, SwitchDiscountResponse } from './action/preview';
 import { ChangePlanEndpoint } from './changePlanEndpoint';
 import { productSwitchCommonRequestSchema } from './schemas';
+import { ToSingleGuardianSubscription } from './toSingleGuardianSubscription';
 
 export async function legacyContributionToSupporterPlus(
 	stage: Stage,
@@ -20,6 +21,7 @@ export async function legacyContributionToSupporterPlus(
 ) {
 	const productSwitchEndpoint = new ChangePlanEndpoint(
 		stage,
+		await ToSingleGuardianSubscription.build(stage),
 		today,
 		{
 			...body,

--- a/handlers/product-switch-api/src/changePlan/prepare/switchCatalogHelper.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/switchCatalogHelper.ts
@@ -18,7 +18,7 @@ export interface SwitchTargetInformation<
 	fromUserInformation(
 		productRatePlan: ProductRatePlan<P, RPK>,
 		switchActionData: SwitchActionData,
-	): Promise<TargetInformation>;
+	): TargetInformation;
 }
 
 type AvailableTargetRatePlans<P extends ProductKey> = {

--- a/handlers/product-switch-api/src/changePlan/prepare/switchInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/switchInformation.ts
@@ -15,19 +15,19 @@ export type SwitchInformation = {
 	target: TargetInformation;
 };
 
-export async function getSwitchInformation(
+export function getSwitchInformation(
 	productCatalogHelper: ProductCatalogHelper,
 	input: ProductSwitchTargetBody,
 	account: ZuoraAccount,
 	subscription: GuardianSubscription,
 	discountEnabled: boolean,
-): Promise<SwitchInformation> {
+): SwitchInformation {
 	const accountInformation = getAccountInformation(account);
 
 	const subscriptionInformation: SubscriptionInformation =
 		getSubscriptionInformation(subscription);
 
-	const targetInformation = await getTargetInformation(
+	const targetInformation = getTargetInformation(
 		input,
 		subscription.ratePlan,
 		accountInformation.currency,

--- a/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
@@ -63,7 +63,7 @@ export const getTargetInformation = (
 	includesContribution: boolean,
 	productCatalogHelper: ProductCatalogHelper,
 	discountEnabled?: boolean,
-): Promise<TargetInformation> => {
+): TargetInformation => {
 	const targetProductKeys: GuardianCatalogKeys<typeof input.targetProduct> =
 		productCatalogHelper.validateOrThrow(
 			input.targetProduct,
@@ -108,7 +108,7 @@ function getSwitchSpecificTargetInformationOrThrow<
 	sourceProductKeys: GuardianCatalogKeys<SP>,
 	targetProductKeys: GuardianCatalogKeys<TP>,
 	switchActionData: SwitchActionData,
-): Promise<TargetInformation> {
+): TargetInformation {
 	const validSwitches: AvailableTargetProducts = getAvailableTargetProducts(
 		sourceProductKeys.productKey,
 		sourceProductKeys.productRatePlanKey,

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
@@ -19,7 +19,7 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 			'Annual' | 'Monthly'
 		>,
 		switchActionData: SwitchActionData,
-	): Promise<TargetInformation> => {
+	): TargetInformation => {
 		if (switchActionData.mode === 'save') {
 			throw new ValidationError(
 				'you cannot currently get a discount on t2->3 switch',
@@ -45,7 +45,7 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 				? `Digital Pack Monthly`
 				: `Digital Pack Annual`;
 
-		return Promise.resolve({
+		return {
 			actualTotalPrice: catalogPrice,
 			productRatePlanId: productRatePlan.id,
 			ratePlanName,
@@ -53,6 +53,6 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 			subscriptionChargeId: productRatePlan.charges.Subscription.id,
 			discount,
 			dataExtensionName: DataExtensionNames.supporterPlusToDigitalPlusSwitch,
-		} satisfies TargetInformation);
+		} satisfies TargetInformation;
 	},
 };

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/supporterPlusTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/supporterPlusTargetInformation.ts
@@ -16,7 +16,7 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 	fromUserInformation: (
 		productRatePlan: ProductRatePlan<'SupporterPlus', 'Annual' | 'Monthly'>,
 		switchActionData: SwitchActionData,
-	): Promise<TargetInformation> => {
+	): TargetInformation => {
 		const targetCatalogBasePrice =
 			productRatePlan.pricing[switchActionData.currency];
 
@@ -43,15 +43,14 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 			const isEligible =
 				productRatePlan.billingPeriod === 'Annual' &&
 				switchActionData.previousAmount <= discountedPrice;
-			if (isEligible) {
-				discount = discountDetails;
-				contributionAmount = 0;
-				actualTotalPrice = discountedPrice;
-			} else {
+			if (!isEligible) {
 				throw new ValidationError(
 					`Cannot switch to Supporter Plus: not eligible for a save discount: ${productRatePlan.billingPeriod} === Annual, ${switchActionData.previousAmount} <= ${discountedPrice}`,
 				);
 			}
+			discount = discountDetails;
+			contributionAmount = 0;
+			actualTotalPrice = discountedPrice;
 		} else {
 			actualTotalPrice =
 				switchActionData.mode === 'switchWithPriceOverride'
@@ -66,7 +65,7 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 				? `Supporter Plus V2 - Monthly`
 				: `Supporter Plus V2 - Annual`;
 
-		return Promise.resolve({
+		return {
 			actualTotalPrice,
 			productRatePlanId: productRatePlan.id,
 			ratePlanName,
@@ -78,6 +77,6 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 			discount,
 			dataExtensionName:
 				DataExtensionNames.recurringContributionToSupporterPlusSwitch,
-		} satisfies TargetInformation);
+		} satisfies TargetInformation;
 	},
 };

--- a/handlers/product-switch-api/src/changePlan/toSingleGuardianSubscription.ts
+++ b/handlers/product-switch-api/src/changePlan/toSingleGuardianSubscription.ts
@@ -1,0 +1,55 @@
+import type { GuardianSubscription } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
+import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
+import {
+	type GuardianSubscriptionMultiPlan,
+	GuardianSubscriptionParser,
+} from '@modules/guardian-subscription/guardianSubscriptionParser';
+import { SubscriptionFilter } from '@modules/guardian-subscription/subscriptionFilter';
+import { logger } from '@modules/logger/logger';
+import { getProductCatalogFromApi } from '@modules/product-catalog/api';
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
+import type { Stage } from '@modules/stage';
+import type { ZuoraSubscription } from '@modules/zuora/types';
+import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
+import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
+import type dayjs from 'dayjs';
+
+export class ToSingleGuardianSubscription {
+	constructor(
+		private zuoraCatalog: ZuoraCatalog,
+		public productCatalog: ProductCatalog,
+	) {}
+
+	static async build(stage: Stage): Promise<ToSingleGuardianSubscription> {
+		logger.log('Loading the product catalog');
+		const productCatalog: ProductCatalog =
+			await getProductCatalogFromApi(stage);
+		const zuoraCatalog: ZuoraCatalog = await getZuoraCatalogFromS3(stage);
+
+		return new ToSingleGuardianSubscription(zuoraCatalog, productCatalog);
+	}
+
+	getSubscription(today: dayjs.Dayjs, zuoraSubscription: ZuoraSubscription) {
+		const guardianSubscriptionParser = new GuardianSubscriptionParser(
+			this.zuoraCatalog, // need zuora catalog to identify non product-catalog plans e.g. Discount
+			this.productCatalog,
+		);
+		const activeCurrentSubscriptionFilter =
+			SubscriptionFilter.activeNonEndedSubscriptionFilter(today);
+
+		const guardianSubscriptionAllPlans: GuardianSubscriptionMultiPlan =
+			guardianSubscriptionParser.toGuardianSubscription(zuoraSubscription);
+		const guardianSubscriptionCurrentPlans: GuardianSubscriptionMultiPlan =
+			activeCurrentSubscriptionFilter.filterSubscription(
+				guardianSubscriptionAllPlans,
+			);
+
+		const subscription: GuardianSubscription =
+			getSinglePlanFlattenedSubscriptionOrThrow(
+				guardianSubscriptionCurrentPlans,
+			);
+
+		logger.log('guardian subscription', subscription);
+		return subscription;
+	}
+}

--- a/handlers/product-switch-api/test/changePlan/action/pendingAmendments.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/pendingAmendments.test.ts
@@ -42,8 +42,8 @@ const { subscription } = loadSubscription(
 );
 const account = zuoraAccountSchema.parse(accountJson);
 
-const getTestTargetInformation = async () =>
-	await supporterPlusTargetInformation.fromUserInformation(
+const getTestTargetInformation = () =>
+	supporterPlusTargetInformation.fromUserInformation(
 		productCatalog.SupporterPlus.ratePlans.Annual,
 		{
 			mode: 'switchToBasePrice',
@@ -98,8 +98,7 @@ describe('pendingAmendments, e.g. contribution amount changes, are dealt with co
 			},
 		} satisfies ZuoraPreviewResponse);
 
-		const switchInformation: TargetInformation =
-			await getTestTargetInformation();
+		const switchInformation: TargetInformation = getTestTargetInformation();
 
 		const subscriptionInformation = getSubscriptionInformation(subscription);
 
@@ -188,8 +187,7 @@ describe('pendingAmendments, e.g. contribution amount changes, are dealt with co
 			sendToSupporterProductData,
 		}));
 
-		const targetInformation: TargetInformation =
-			await getTestTargetInformation();
+		const targetInformation: TargetInformation = getTestTargetInformation();
 
 		const subscriptionInformation = getSubscriptionInformation(subscription);
 

--- a/handlers/product-switch-api/test/changePlan/contributionToSupporterPlusIntegration.test.ts
+++ b/handlers/product-switch-api/test/changePlan/contributionToSupporterPlusIntegration.test.ts
@@ -25,6 +25,7 @@ import type { LegacyProductSwitchRequestBody } from '../../src/changePlan/legacy
 import { legacyContributionToSupporterPlus } from '../../src/changePlan/legacyContributionToSupporterPlusEndpoint';
 import type { ValidTargetProduct } from '../../src/changePlan/prepare/switchCatalogHelper';
 import type { ProductSwitchRequestBody } from '../../src/changePlan/schemas';
+import { ToSingleGuardianSubscription } from '../../src/changePlan/toSingleGuardianSubscription';
 
 // change to true to test the version on CODE instead of local
 const testCODELambda: boolean = false;
@@ -149,6 +150,7 @@ async function testCall(
 	} else {
 		const changePlanEndpoint = new ChangePlanEndpoint(
 			'CODE',
+			await ToSingleGuardianSubscription.build('CODE'),
 			dayjs(),
 			input,
 			testData.zuoraClient,

--- a/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
@@ -41,11 +41,11 @@ const buildGuardianSubscriptionWithKeys = (): GuardianSubscription => {
 };
 
 describe('getTargetInformation', () => {
-	test('returns supporter plus target info for a valid contribution switch', async () => {
+	test('returns supporter plus target info for a valid contribution switch', () => {
 		const subscription = buildGuardianSubscriptionWithKeys();
 		const previousAmount = 50;
 
-		const targetInfo = await getTargetInformation(
+		const targetInfo = getTargetInformation(
 			{
 				mode: 'switchToBasePrice',
 				targetProduct: 'SupporterPlus',
@@ -79,13 +79,13 @@ describe('getTargetInformation', () => {
 		} satisfies TargetInformation);
 	});
 
-	test('applies the supporter plus annual discount during save flows when eligible', async () => {
+	test('applies the supporter plus annual discount during save flows when eligible', () => {
 		const subscription = buildGuardianSubscriptionWithKeys();
 		const targetRatePlan = productCatalog.SupporterPlus.ratePlans.Annual;
 		const targetBasePrice = targetRatePlan.pricing.EUR;
 		const discountedPrice = targetBasePrice / 2;
 		const discountEligiblePreviousAmount = Math.min(50, discountedPrice);
-		const targetInfo = await getTargetInformation(
+		const targetInfo = getTargetInformation(
 			{
 				mode: 'save',
 				targetProduct: 'SupporterPlus',

--- a/handlers/product-switch-api/test/changePlan/switchDefinition/digitalSubscriptionTargetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/switchDefinition/digitalSubscriptionTargetInformation.test.ts
@@ -13,7 +13,7 @@ const annualDigitalSubscriptionRatePlan =
 	productCatalog.DigitalSubscription.ratePlans.Annual;
 
 describe('digitalSubscriptionTargetInformation', () => {
-	test("returns target info when amount doesn't include a contribution", async () => {
+	test("returns target info when amount doesn't include a contribution", () => {
 		const catalogPrice = annualDigitalSubscriptionRatePlan.pricing.GBP;
 
 		const switchActionData: SwitchActionData = {
@@ -23,11 +23,10 @@ describe('digitalSubscriptionTargetInformation', () => {
 			includesContribution: false,
 		};
 
-		const result =
-			await digitalSubscriptionTargetInformation.fromUserInformation(
-				annualDigitalSubscriptionRatePlan,
-				switchActionData,
-			);
+		const result = digitalSubscriptionTargetInformation.fromUserInformation(
+			annualDigitalSubscriptionRatePlan,
+			switchActionData,
+		);
 
 		expect(result.actualTotalPrice).toBe(catalogPrice);
 		expect(result.productRatePlanId).toBe(annualDigitalSubscriptionRatePlan.id);
@@ -54,7 +53,7 @@ describe('digitalSubscriptionTargetInformation', () => {
 		).toThrow(ValidationError);
 	});
 
-	test('accepts user-requested amount when it matches catalog price', async () => {
+	test('accepts user-requested amount when it matches catalog price', () => {
 		const catalogPrice = annualDigitalSubscriptionRatePlan.pricing.GBP;
 
 		const switchActionData: SwitchActionData = {
@@ -64,11 +63,10 @@ describe('digitalSubscriptionTargetInformation', () => {
 			includesContribution: false,
 		};
 
-		const result =
-			await digitalSubscriptionTargetInformation.fromUserInformation(
-				annualDigitalSubscriptionRatePlan,
-				switchActionData,
-			);
+		const result = digitalSubscriptionTargetInformation.fromUserInformation(
+			annualDigitalSubscriptionRatePlan,
+			switchActionData,
+		);
 
 		expect(result.actualTotalPrice).toBe(catalogPrice);
 	});

--- a/handlers/product-switch-api/test/changePlan/switchDefinition/supporterPlusTargetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/switchDefinition/supporterPlusTargetInformation.test.ts
@@ -13,7 +13,7 @@ const productCatalog = generateProductCatalog(
 const annualSupporterPlusRatePlan =
 	productCatalog.SupporterPlus.ratePlans.Annual;
 describe('getSupporterPlusTargetInformation', () => {
-	test('returns target info with contribution when previous amount exceeds base price', async () => {
+	test('returns target info with contribution when previous amount exceeds base price', () => {
 		const basePrice = annualSupporterPlusRatePlan.pricing.GBP;
 		const previousAmount = basePrice + 50;
 
@@ -24,7 +24,7 @@ describe('getSupporterPlusTargetInformation', () => {
 			includesContribution: true,
 		};
 
-		const result = await supporterPlusTargetInformation.fromUserInformation(
+		const result = supporterPlusTargetInformation.fromUserInformation(
 			annualSupporterPlusRatePlan,
 			switchActionData,
 		);
@@ -36,7 +36,7 @@ describe('getSupporterPlusTargetInformation', () => {
 		expect(result.discount).toBeUndefined();
 	});
 
-	test('puts people up onto the base price if they switch from below', async () => {
+	test('puts people up onto the base price if they switch from below', () => {
 		const basePrice = annualSupporterPlusRatePlan.pricing.GBP;
 		const previousAmount = basePrice - 50;
 
@@ -47,7 +47,7 @@ describe('getSupporterPlusTargetInformation', () => {
 			includesContribution: true,
 		};
 
-		const result = await supporterPlusTargetInformation.fromUserInformation(
+		const result = supporterPlusTargetInformation.fromUserInformation(
 			annualSupporterPlusRatePlan,
 			switchActionData,
 		);
@@ -56,7 +56,7 @@ describe('getSupporterPlusTargetInformation', () => {
 		expect(result.contributionCharge?.contributionAmount).toBe(0);
 	});
 
-	test('uses user-requested amount when provided and valid', async () => {
+	test('uses user-requested amount when provided and valid', () => {
 		const basePrice = annualSupporterPlusRatePlan.pricing.GBP;
 		const userRequestedAmount = basePrice + 100;
 
@@ -66,7 +66,7 @@ describe('getSupporterPlusTargetInformation', () => {
 			userRequestedAmount,
 		};
 
-		const result = await supporterPlusTargetInformation.fromUserInformation(
+		const result = supporterPlusTargetInformation.fromUserInformation(
 			annualSupporterPlusRatePlan,
 			switchActionData,
 		);
@@ -93,7 +93,7 @@ describe('getSupporterPlusTargetInformation', () => {
 		).toThrow(ValidationError);
 	});
 
-	test('applies discount when eligible for annual plan with low previous amount', async () => {
+	test('applies discount when eligible for annual plan with low previous amount', () => {
 		const basePrice = annualSupporterPlusRatePlan.pricing.GBP;
 		const discountedPrice = basePrice / 2;
 		const previousAmount = discountedPrice - 10;
@@ -105,7 +105,7 @@ describe('getSupporterPlusTargetInformation', () => {
 			includesContribution: true,
 		};
 
-		const result = await supporterPlusTargetInformation.fromUserInformation(
+		const result = supporterPlusTargetInformation.fromUserInformation(
 			annualSupporterPlusRatePlan,
 			switchActionData,
 		);
@@ -116,8 +116,6 @@ describe('getSupporterPlusTargetInformation', () => {
 		expect(result.discount?.discountPercentage).toBe(
 			annualContribHalfPriceSupporterPlusForOneYear.discountPercentage,
 		);
-		expect(result.actualTotalPrice).toBe(discountedPrice);
-		expect(result.contributionCharge?.contributionAmount).toBe(0);
 	});
 
 	test('does not apply discount when previous amount exceeds discounted price', () => {
@@ -140,7 +138,7 @@ describe('getSupporterPlusTargetInformation', () => {
 		).toThrow(ValidationError);
 	});
 
-	test('does not apply discount when not generally eligible', async () => {
+	test('does not apply discount when not generally eligible', () => {
 		const basePrice = annualSupporterPlusRatePlan.pricing.GBP;
 		const discountedPrice =
 			(basePrice *
@@ -156,7 +154,7 @@ describe('getSupporterPlusTargetInformation', () => {
 			includesContribution: true,
 		};
 
-		const result = await supporterPlusTargetInformation.fromUserInformation(
+		const result = supporterPlusTargetInformation.fromUserInformation(
 			annualSupporterPlusRatePlan,
 			switchActionData,
 		);


### PR DESCRIPTION
pre-refactoring for https://github.com/guardian/support-service-lambdas/pull/3675

I noticed there's a thread of async all through the "get switch information" code, presumably we needed it at some point, but not now.

This PR removes the async from the above, and also extract the "to filtered guardian subscription" logic to further reduce the async nested in the code.

There are several inline PR comments to call out anything interesting.