### PR TITLE
Make eslint work correctly in editors for module directories

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -18,3 +18,6 @@ c7065a7fd22fc65c30d5c71f7ce819e84133be1b
 
 # Scala Steward: Reformat with scalafmt 3.10.4
 038ad7cbb7bcd2353cce4ec04273df16f7b6dd07
+
+# Reformat imports after setting all @modules imports to 'internal' for sort purposes
+b5401250344c270d473481f628c26c71699b713f

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,12 @@
 import guardian from '@guardian/eslint-config';
+import { importOrderConfig } from './eslint.shared.mjs';
 
 export default [
 	...guardian.configs.recommended,
 	...guardian.configs.jest,
 	...guardian.configs.react,
 	...guardian.configs.storybook,
+	importOrderConfig,
 	{
 		rules: {
 			'@typescript-eslint/consistent-type-assertions': [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,8 +4,6 @@ import { importOrderConfig } from './eslint.shared.mjs';
 export default [
 	...guardian.configs.recommended,
 	...guardian.configs.jest,
-	...guardian.configs.react,
-	...guardian.configs.storybook,
 	importOrderConfig,
 	{
 		rules: {

--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -1,0 +1,43 @@
+// Shared ESLint override that makes import ordering deterministic across
+// working directories.
+//
+// Workspace packages (@modules/*) are pnpm symlinks, so import/order's
+// external-vs-internal classification otherwise depends on the directory ESLint
+// runs from (the package dir on the CLI vs the workspace root in editors like
+// VS Code / IntelliJ). That flips their position relative to real external
+// packages. Pinning @modules/** to the "internal" group makes the order the
+// same everywhere.
+//
+// Spread this after `guardian.configs.recommended` in every eslint.config.mjs
+// so package-level configs (which don't inherit the root config) stay in sync.
+export const importOrderConfig = {
+	rules: {
+		'import/order': [
+			'error',
+			{
+				groups: [
+					'builtin',
+					'external',
+					'internal',
+					'parent',
+					'sibling',
+					'index',
+					'object',
+					'unknown',
+				],
+				pathGroups: [
+					{
+						pattern: '@modules/**',
+						group: 'internal',
+					},
+				],
+				pathGroupsExcludedImportTypes: [],
+				'newlines-between': 'never',
+				alphabetize: {
+					order: 'asc',
+					caseInsensitive: true,
+				},
+			},
+		],
+	},
+};

--- a/handlers/alarms-handler/src/buildDiagnosticLinks.ts
+++ b/handlers/alarms-handler/src/buildDiagnosticLinks.ts
@@ -1,6 +1,6 @@
-import { logger } from '@modules/logger/logger';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import { logger } from '@modules/logger/logger';
 
 dayjs.extend(utc);
 

--- a/handlers/alarms-handler/src/buildStuckInAlarmMessage.ts
+++ b/handlers/alarms-handler/src/buildStuckInAlarmMessage.ts
@@ -1,6 +1,6 @@
 import type { MetricAlarm } from '@aws-sdk/client-cloudwatch';
-import { getIfDefined } from '@modules/nullAndUndefined';
 import dayjs from 'dayjs';
+import { getIfDefined } from '@modules/nullAndUndefined';
 import { buildDiagnosticLinks } from './buildDiagnosticLinks';
 import { buildAlarmUrl, buildText } from './buildRow';
 

--- a/handlers/alarms-handler/src/cloudwatch.ts
+++ b/handlers/alarms-handler/src/cloudwatch.ts
@@ -1,9 +1,9 @@
 import type { AlarmHistoryItem } from '@aws-sdk/client-cloudwatch';
 import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
+import type { Dayjs } from 'dayjs';
 import { awsConfig, getAwsConfig, isRunningLocally } from '@modules/aws/config';
 import { wrapAwsClient } from '@modules/logger/wrapAwsClient';
-import type { Dayjs } from 'dayjs';
 import { getAlarmHistory } from './cloudwatch/getAlarmHistory';
 import type { AlarmWithTags } from './cloudwatch/getAllAlarmsInAlarm';
 import { getAllAlarmsInAlarm } from './cloudwatch/getAllAlarmsInAlarm';

--- a/handlers/alarms-handler/src/cloudwatch/getAlarmHistory.ts
+++ b/handlers/alarms-handler/src/cloudwatch/getAlarmHistory.ts
@@ -7,6 +7,7 @@ import {
 	DescribeAlarmsCommand,
 	HistoryItemType,
 } from '@aws-sdk/client-cloudwatch';
+import type { Dayjs } from 'dayjs';
 import {
 	chunkArray,
 	flatten,
@@ -18,7 +19,6 @@ import { Lazy } from '@modules/lazy';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { objectInnerJoin, objectKeys } from '@modules/objectFunctions';
-import type { Dayjs } from 'dayjs';
 import type { Tags } from './getTags';
 import { getTags } from './getTags';
 

--- a/handlers/alarms-handler/src/index.ts
+++ b/handlers/alarms-handler/src/index.ts
@@ -1,11 +1,11 @@
+import type { SNSEventRecord, SQSRecord } from 'aws-lambda';
+import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import type { HandlerEnv } from '@modules/routing/lambdaHandler';
 import { SQSHandler } from '@modules/routing/sqsHandler';
 import type { Authorisation } from '@modules/zuora/auth';
 import { RestClient } from '@modules/zuora/restClient';
-import type { SNSEventRecord, SQSRecord } from 'aws-lambda';
-import { z } from 'zod';
 import type { AppToTeams } from './alarmMappings';
 import { prodAppToTeams } from './alarmMappings';
 import { buildCloudWatchAlarmMessage } from './buildCloudWatchAlarmMessage';

--- a/handlers/alarms-handler/src/indexScheduled.ts
+++ b/handlers/alarms-handler/src/indexScheduled.ts
@@ -1,10 +1,10 @@
 import type { MetricAlarm } from '@aws-sdk/client-cloudwatch';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { flatten, groupMap } from '@modules/arrayFunctions';
 import { logger } from '@modules/logger/logger';
 import type { HandlerEnv } from '@modules/routing/lambdaHandler';
 import { LambdaHandler } from '@modules/routing/lambdaHandler';
-import type { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
 import type { AppToTeams } from './alarmMappings';
 import { prodAppToTeams } from './alarmMappings';
 import { buildStuckInAlarmMessage } from './buildStuckInAlarmMessage';

--- a/handlers/alarms-handler/src/indexSummary.ts
+++ b/handlers/alarms-handler/src/indexSummary.ts
@@ -1,11 +1,11 @@
 import type { AlarmHistoryItem } from '@aws-sdk/client-cloudwatch';
+import { z } from 'zod';
 import { groupMap } from '@modules/arrayFunctions';
 import type { Lazy } from '@modules/lazy';
 import { logger } from '@modules/logger/logger';
 import { objectEntries, objectKeys } from '@modules/objectFunctions';
 import type { HandlerEnv } from '@modules/routing/lambdaHandler';
 import { LambdaHandler } from '@modules/routing/lambdaHandler';
-import { z } from 'zod';
 import type { AppToTeams, Team } from './alarmMappings';
 import { prodAppToTeams } from './alarmMappings';
 import { buildCloudWatchSummaryMessage } from './buildCloudWatchSummaryMessage';

--- a/handlers/alarms-handler/test/indexScheduled.test.ts
+++ b/handlers/alarms-handler/test/indexScheduled.test.ts
@@ -1,6 +1,6 @@
 import type { MetricAlarm } from '@aws-sdk/client-cloudwatch';
-import { Lazy } from '@modules/lazy';
 import dayjs from 'dayjs';
+import { Lazy } from '@modules/lazy';
 import { prodAppToTeams } from '../src/alarmMappings';
 import type { Tags } from '../src/cloudwatch/getTags';
 import type { WebhookUrls } from '../src/configSchema';

--- a/handlers/braze-acquisition-events-sync/src/brazeClient.ts
+++ b/handlers/braze-acquisition-events-sync/src/brazeClient.ts
@@ -1,5 +1,5 @@
-import { logger } from '@modules/logger/logger';
 import { z } from 'zod';
+import { logger } from '@modules/logger/logger';
 
 export type BrazeTrackPayload = {
 	attributes?: Array<

--- a/handlers/braze-acquisition-events-sync/src/config.ts
+++ b/handlers/braze-acquisition-events-sync/src/config.ts
@@ -1,6 +1,6 @@
+import { z } from 'zod';
 import { loadConfig } from '@modules/aws/appConfig';
 import { getIfDefined } from '@modules/nullAndUndefined';
-import { z } from 'zod';
 
 export const ConfigSchema = z.object({
 	braze: z.object({

--- a/handlers/braze-acquisition-events-sync/src/index.ts
+++ b/handlers/braze-acquisition-events-sync/src/index.ts
@@ -1,5 +1,5 @@
-import { logger } from '@modules/logger/logger';
 import type { Handler } from 'aws-lambda';
+import { logger } from '@modules/logger/logger';
 import {
 	type AcquisitionsEventBridgeEvent,
 	acquisitionsEventSchema,

--- a/handlers/braze-acquisition-events-sync/src/services.ts
+++ b/handlers/braze-acquisition-events-sync/src/services.ts
@@ -1,8 +1,8 @@
+import { z } from 'zod';
 import { getUserByIdentityId } from '@modules/identity/idapi';
 import { IdentityClient } from '@modules/identity/identityClient';
 import { logger } from '@modules/logger/logger';
 import { stageFromEnvironment } from '@modules/stage';
-import { z } from 'zod';
 import { BrazeClient, type BrazeTrackPayload } from './brazeClient';
 import { getAppConfig } from './config';
 

--- a/handlers/contributions-only-countries-api/src/index.ts
+++ b/handlers/contributions-only-countries-api/src/index.ts
@@ -1,12 +1,12 @@
-import { contributionsOnlyCountries } from '@modules/internationalisation/contributionsOnlyCountries';
-import { logger } from '@modules/logger/logger';
-import { ok } from '@modules/routing/apiGatewayResponses';
-import { Router } from '@modules/routing/router';
 import type {
 	APIGatewayProxyEvent,
 	APIGatewayProxyResult,
 	Handler,
 } from 'aws-lambda';
+import { contributionsOnlyCountries } from '@modules/internationalisation/contributionsOnlyCountries';
+import { logger } from '@modules/logger/logger';
+import { ok } from '@modules/routing/apiGatewayResponses';
+import { Router } from '@modules/routing/router';
 
 const contributionsOnlyCountriesPath = '/contributions-only-countries';
 

--- a/handlers/contributions-only-countries-api/test/index.test.ts
+++ b/handlers/contributions-only-countries-api/test/index.test.ts
@@ -1,5 +1,5 @@
-import { contributionsOnlyCountries } from '@modules/internationalisation/contributionsOnlyCountries';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { contributionsOnlyCountries } from '@modules/internationalisation/contributionsOnlyCountries';
 import { handler } from '../src/index';
 
 describe('contributions-only-countries-api handler', () => {

--- a/handlers/discount-api/src/discountEndpoint.ts
+++ b/handlers/discount-api/src/discountEndpoint.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { sum } from '@modules/arrayFunctions';
 import { Lazy } from '@modules/lazy';
 import { logger } from '@modules/logger/logger';
@@ -17,7 +18,6 @@ import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { getZuoraCatalog } from '@modules/zuora-catalog/S3';
-import dayjs from 'dayjs';
 import { EligibilityChecker } from './eligibilityChecker';
 import { generateCancellationDiscountConfirmationEmail } from './generateCancellationDiscountConfirmationEmail';
 import { getDiscountFromSubscription } from './productToDiscountMapping';

--- a/handlers/discount-api/src/eligibilityChecker.ts
+++ b/handlers/discount-api/src/eligibilityChecker.ts
@@ -1,3 +1,5 @@
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { ValidationError } from '@modules/errors';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
@@ -5,8 +7,6 @@ import type { SimpleInvoiceItem } from '@modules/zuora/billingPreview';
 import { getNextInvoiceTotal } from '@modules/zuora/billingPreview';
 import type { ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
-import type { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
 
 export class EligibilityChecker {
 	constructor() {}

--- a/handlers/discount-api/src/generateCancellationDiscountConfirmationEmail.ts
+++ b/handlers/discount-api/src/generateCancellationDiscountConfirmationEmail.ts
@@ -1,8 +1,8 @@
+import type dayjs from 'dayjs';
 import type {
 	DataExtensionName,
 	EmailMessageWithUserId,
 } from '@modules/email/email';
-import type dayjs from 'dayjs';
 
 export type EmailFields = {
 	firstDiscountedPaymentDate: dayjs.Dayjs;

--- a/handlers/discount-api/src/index.ts
+++ b/handlers/discount-api/src/index.ts
@@ -1,3 +1,5 @@
+import type { APIGatewayProxyResult, Handler } from 'aws-lambda';
+import dayjs from 'dayjs';
 import { sendEmail } from '@modules/email/email';
 import { logger } from '@modules/logger/logger';
 import { ok } from '@modules/routing/apiGatewayResponses';
@@ -11,8 +13,6 @@ import type {
 	ZuoraSubscription,
 } from '@modules/zuora/types/objects';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { APIGatewayProxyResult, Handler } from 'aws-lambda';
-import dayjs from 'dayjs';
 import {
 	applyDiscountEndpoint,
 	previewDiscountEndpoint,

--- a/handlers/discount-api/test/addDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/addDiscountIntegration.test.ts
@@ -4,11 +4,11 @@
  * @group integration
  */
 
+import dayjs from 'dayjs';
 import type { Stage } from '@modules/stage';
 import { addDiscount } from '@modules/zuora/discount';
 import { getSubscription } from '@modules/zuora/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 import { createDigitalSubscription } from '../../../modules/zuora/test/it-helpers/createGuardianSubscription';
 import { doPriceRise } from './helpers';
 

--- a/handlers/discount-api/test/applyDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/applyDiscountIntegration.test.ts
@@ -1,6 +1,7 @@
 /**
  * @group integration
  */
+import dayjs from 'dayjs';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import type { Stage } from '@modules/stage';
 import { getAccount } from '@modules/zuora/account';
@@ -10,7 +11,6 @@ import {
 } from '@modules/zuora/subscription';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 import {
 	createDigitalSubscription,
 	createSupporterPlusSubscription,

--- a/handlers/discount-api/test/eligibilityChecker.test.ts
+++ b/handlers/discount-api/test/eligibilityChecker.test.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import {
 	getNextInvoiceItems,
 	itemsForSubscription,
@@ -9,7 +10,6 @@ import {
 } from '@modules/zuora/types';
 import { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import catalogJsonProd from '../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import {
 	EligibilityChecker,

--- a/handlers/discount-api/test/fixtures/request-bodies/update-subscription-body.ts
+++ b/handlers/discount-api/test/fixtures/request-bodies/update-subscription-body.ts
@@ -1,5 +1,5 @@
-import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { Dayjs } from 'dayjs';
+import { zuoraDateFormat } from '@modules/zuora/utils';
 
 export const updateSubscriptionBody = (
 	contractEffectiveDate: Dayjs,

--- a/handlers/discount-api/test/getNextPaymentDate.test.ts
+++ b/handlers/discount-api/test/getNextPaymentDate.test.ts
@@ -1,6 +1,6 @@
+import dayjs from 'dayjs';
 import { getNextNonFreePaymentDate } from '@modules/zuora/billingPreview';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import dayjs from 'dayjs';
 
 test('getNextNonFreePaymentDate fails if all payments are free', () => {
 	const items = [

--- a/handlers/discount-api/test/helpers.ts
+++ b/handlers/discount-api/test/helpers.ts
@@ -1,7 +1,7 @@
+import type { Dayjs } from 'dayjs';
 import type { ZuoraSubscription } from '@modules/zuora/types';
 import { voidSchema } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { Dayjs } from 'dayjs';
 import { updateSubscriptionBody } from './fixtures/request-bodies/update-subscription-body';
 
 export const doPriceRise = async (

--- a/handlers/discount-api/test/newTermLength.test.ts
+++ b/handlers/discount-api/test/newTermLength.test.ts
@@ -1,5 +1,5 @@
-import { getNewTermLengthIfRequired } from '@modules/zuora/discount';
 import dayjs from 'dayjs';
+import { getNewTermLengthIfRequired } from '@modules/zuora/discount';
 
 test('getNewTermLengthIfRequired works out the new term length if the next billing date is after the current end date', () => {
 	const termStartDate = dayjs('2023-12-22');

--- a/handlers/discount-api/test/previewDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/previewDiscountIntegration.test.ts
@@ -1,12 +1,13 @@
 /**
  * @group integration
  */
-import { withMMAIdentityCheck } from '@modules/routing/withMMAIdentityCheck';
-import type { Stage } from '@modules/stage';
 import {
 	createDigitalSubscription,
 	createSupporterPlusSubscription,
 } from '@modules/zuora/../test/it-helpers/createGuardianSubscription';
+import dayjs from 'dayjs';
+import { withMMAIdentityCheck } from '@modules/routing/withMMAIdentityCheck';
+import type { Stage } from '@modules/stage';
 import { getAccount } from '@modules/zuora/account';
 import {
 	cancelSubscription,
@@ -14,7 +15,6 @@ import {
 } from '@modules/zuora/subscription';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 import { previewDiscountHandler } from '../src';
 import { previewDiscountEndpoint } from '../src/discountEndpoint';
 import { validationRequirements } from '../src/eligibilityChecker';

--- a/handlers/discount-expiry-notifier/src/handlers/filterRecords.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/filterRecords.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await -- this is required to ensure the lambda returns a value*/
-import { getIfDefined } from '@modules/nullAndUndefined';
 import { z } from 'zod';
+import { getIfDefined } from '@modules/nullAndUndefined';
 import { BigQueryResultDataSchema } from '../types';
 
 export const FilterRecordsInputSchema = z

--- a/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getNewPaymentAmount.ts
@@ -1,8 +1,8 @@
+import dayjs from 'dayjs';
+import type { z } from 'zod';
 import { stageFromEnvironment } from '@modules/stage';
 import { getBillingPreview } from '@modules/zuora/billingPreview';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
-import type { z } from 'zod';
 import { calculateTotalAmount, filterRecords } from '../helpers';
 import { BaseRecordForEmailSendSchema } from '../types';
 

--- a/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getOldPaymentAmount.ts
@@ -1,10 +1,10 @@
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import { stageFromEnvironment } from '@modules/stage';
 import { getBillingPreview } from '@modules/zuora/billingPreview';
 import { doQuery } from '@modules/zuora/query';
 import type { BillingPreviewInvoiceItem } from '@modules/zuora/types';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 import { calculateTotalAmount, filterRecords } from '../helpers';
 import {
 	BaseRecordForEmailSendSchema,

--- a/handlers/discount-expiry-notifier/src/handlers/getSubStatus.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/getSubStatus.ts
@@ -1,7 +1,7 @@
+import type { z } from 'zod';
 import { stageFromEnvironment } from '@modules/stage';
 import { getSubscription } from '@modules/zuora/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { z } from 'zod';
 import { BigQueryRecordSchema } from '../types';
 
 export type SubIsActiveInput = z.infer<typeof BigQueryRecordSchema>;

--- a/handlers/discount-expiry-notifier/src/handlers/saveResults.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/saveResults.ts
@@ -1,6 +1,6 @@
+import { z } from 'zod';
 import { uploadFileToS3 } from '@modules/aws/s3';
 import { getIfDefined } from '@modules/nullAndUndefined';
-import { z } from 'zod';
 import {
 	BigQueryRecordSchema,
 	DiscountProcessingAttemptSchema,

--- a/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
+++ b/handlers/discount-expiry-notifier/src/handlers/sendEmail.ts
@@ -1,6 +1,6 @@
+import type { z } from 'zod';
 import { DataExtensionNames, sendEmail } from '@modules/email/email';
 import { stageFromEnvironment } from '@modules/stage';
-import type { z } from 'zod';
 import { BaseRecordForEmailSendSchema } from '../types';
 
 export const SendEmailInputSchema = BaseRecordForEmailSendSchema;

--- a/handlers/discount-expiry-notifier/src/helpers.ts
+++ b/handlers/discount-expiry-notifier/src/helpers.ts
@@ -1,5 +1,5 @@
-import type { BillingPreviewInvoiceItem } from '@modules/zuora/types';
 import dayjs from 'dayjs';
+import type { BillingPreviewInvoiceItem } from '@modules/zuora/types';
 
 export const calculateTotalAmount = (records: BillingPreviewInvoiceItem[]) => {
 	return records.reduce(

--- a/handlers/generate-product-catalog/src/index.ts
+++ b/handlers/generate-product-catalog/src/index.ts
@@ -1,4 +1,5 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import type { Handler, S3CreateEvent } from 'aws-lambda';
 import { putMetric } from '@modules/aws/cloudwatch';
 import { awsConfig } from '@modules/aws/config';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
@@ -6,7 +7,6 @@ import { productCatalogSchema } from '@modules/product-catalog/productCatalogSch
 import type { Stage } from '@modules/stage';
 import { stageFromEnvironment } from '@modules/stage';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
-import type { Handler, S3CreateEvent } from 'aws-lambda';
 import {
 	failedSchemaValidationMetricName,
 	productCatalogBucketName,

--- a/handlers/imovo-voucher-api/src/index.ts
+++ b/handlers/imovo-voucher-api/src/index.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
-import { stageFromEnvironment } from '@modules/stage';
 import type { SQSEvent } from 'aws-lambda';
+import { stageFromEnvironment } from '@modules/stage';
 import { BrazeEmailSender } from './adapters/brazeEmailSender';
 import { DynamoVoucherRepository } from './adapters/dynamoVoucherRepository';
 import { ImovoVoucherProvider } from './adapters/imovoVoucherProvider';

--- a/handlers/metric-push-api/src/index.ts
+++ b/handlers/metric-push-api/src/index.ts
@@ -1,7 +1,7 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { putMetric } from '@modules/aws/cloudwatch';
 import { Router } from '@modules/routing/router';
 import { stageFromEnvironment } from '@modules/stage';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 const stage = stageFromEnvironment();
 

--- a/handlers/metric-push-api/test/index.test.ts
+++ b/handlers/metric-push-api/test/index.test.ts
@@ -1,5 +1,5 @@
-import { putMetric } from '@modules/aws/cloudwatch';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { putMetric } from '@modules/aws/cloudwatch';
 import { handler } from '../src/index';
 
 jest.mock('@modules/stage', () => ({

--- a/handlers/mobile-purchases-to-supporter-product-data/src/config.ts
+++ b/handlers/mobile-purchases-to-supporter-product-data/src/config.ts
@@ -1,8 +1,8 @@
+import { z } from 'zod';
 import { loadConfig } from '@modules/aws/appConfig';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import type { Stage } from '@modules/stage';
-import { z } from 'zod';
 
 const configSchema = z.object({
 	mobilePurchasesApiKey: z.string(),

--- a/handlers/mobile-purchases-to-supporter-product-data/src/fullSyncCommand.ts
+++ b/handlers/mobile-purchases-to-supporter-product-data/src/fullSyncCommand.ts
@@ -1,4 +1,6 @@
 import * as fs from 'node:fs';
+import { parse } from 'csv-parse/sync';
+import dayjs from 'dayjs';
 import { chunkArray } from '@modules/arrayFunctions';
 import { sendBatchMessagesToQueue } from '@modules/aws/sqs';
 import { logger } from '@modules/logger/logger';
@@ -6,8 +8,6 @@ import { getIfDefined } from '@modules/nullAndUndefined';
 import { prettyPrint } from '@modules/prettyPrint';
 import type { Stage } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
-import { parse } from 'csv-parse/sync';
-import dayjs from 'dayjs';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/handlers/mobile-purchases-to-supporter-product-data/src/index.ts
+++ b/handlers/mobile-purchases-to-supporter-product-data/src/index.ts
@@ -1,3 +1,5 @@
+import type { DynamoDBRecord, Handler, SQSEvent } from 'aws-lambda';
+import dayjs from 'dayjs';
 import { Lazy } from '@modules/lazy';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
@@ -7,8 +9,6 @@ import type { Stage } from '@modules/stage';
 import { stageFromEnvironment } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import { sendToSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
-import type { DynamoDBRecord, Handler, SQSEvent } from 'aws-lambda';
-import dayjs from 'dayjs';
 import type { Config } from './config';
 import { getConfig } from './config';
 import { fetchSubscription } from './mobileProductPurchasesApi';

--- a/handlers/mobile-purchases-to-supporter-product-data/src/mobileProductPurchasesApi.ts
+++ b/handlers/mobile-purchases-to-supporter-product-data/src/mobileProductPurchasesApi.ts
@@ -1,6 +1,6 @@
-import type { Stage } from '@modules/stage';
 import dayjs from 'dayjs';
 import { z } from 'zod';
+import type { Stage } from '@modules/stage';
 
 const subscriptionResponseSchema = z.object({
 	subscriptions: z.array(

--- a/handlers/mparticle-api/src/index.ts
+++ b/handlers/mparticle-api/src/index.ts
@@ -1,5 +1,3 @@
-import { logger } from '@modules/logger/logger';
-import { internalServerError } from '@modules/routing/apiGatewayResponses';
 import type {
 	APIGatewayProxyEvent,
 	APIGatewayProxyResult,
@@ -7,6 +5,8 @@ import type {
 	SQSEvent,
 	SQSRecord,
 } from 'aws-lambda';
+import { logger } from '@modules/logger/logger';
+import { internalServerError } from '@modules/routing/apiGatewayResponses';
 import { processUserDeletion } from './apis/dataSubjectRequests/deleteUser';
 import type { BatonEventRequest, BatonEventResponse } from './routers/baton';
 import { batonRerRouter } from './routers/baton';

--- a/handlers/mparticle-api/src/services/brazeClient.ts
+++ b/handlers/mparticle-api/src/services/brazeClient.ts
@@ -1,6 +1,6 @@
+import { z } from 'zod';
 import { getCallerInfo } from '@modules/logger/getCallerInfo';
 import { logger } from '@modules/logger/logger';
-import { z } from 'zod';
 import type { DeletionResult } from '../types/deletionMessage';
 import {
 	HttpError,

--- a/handlers/mparticle-api/src/services/config.ts
+++ b/handlers/mparticle-api/src/services/config.ts
@@ -1,6 +1,6 @@
+import { z } from 'zod';
 import { loadConfig } from '@modules/aws/appConfig';
 import { getIfDefined } from '@modules/nullAndUndefined';
-import { z } from 'zod';
 
 export const ConfigSchema = z.object({
 	workspace: z.object({

--- a/handlers/mparticle-api/src/services/make-http-request.ts
+++ b/handlers/mparticle-api/src/services/make-http-request.ts
@@ -1,6 +1,6 @@
+import type { z } from 'zod';
 import { groupMap } from '@modules/arrayFunctions';
 import { logger } from '@modules/logger/logger';
-import type { z } from 'zod';
 
 export class HttpError extends Error {
 	public statusCode: number;

--- a/handlers/mparticle-api/test/index.test.ts
+++ b/handlers/mparticle-api/test/index.test.ts
@@ -1,5 +1,5 @@
-import { logger } from '@modules/logger/logger';
 import type { Context, SQSEvent } from 'aws-lambda';
+import { logger } from '@modules/logger/logger';
 import { processUserDeletion } from '../src/apis/dataSubjectRequests/deleteUser';
 import { handlerDeletion } from '../src/index';
 

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -1,5 +1,7 @@
 import { TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import { createSecondarySubscription } from '@modules/multiple-account/secondarySubscription';
 import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { secondaryUserTTLFromPrimarySubscriptionTTL } from '@modules/multiple-account/secondaryUserRepository';
@@ -13,8 +15,6 @@ import {
 import type { Stage } from '@modules/stage';
 import { getSupporterRatePlan } from '@modules/supporter-product-data/supporterProductData';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 import type { InvitationRepository } from './invitationRepository';
 
 export const acceptInvitationPathSchema = z.object({

--- a/handlers/multiple-account-api/src/createInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/createInvitationEndpoint.ts
@@ -1,3 +1,7 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import dayjs from 'dayjs';
+import { customAlphabet } from 'nanoid';
+import { z } from 'zod';
 import { getOrCreateUserFromEmail } from '@modules/identity/idapi';
 import type { IdentityClient } from '@modules/identity/identityClient';
 import { logger } from '@modules/logger/logger';
@@ -10,10 +14,6 @@ import type {
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import type { APIGatewayProxyResult } from 'aws-lambda';
-import dayjs from 'dayjs';
-import { customAlphabet } from 'nanoid';
-import { z } from 'zod';
 import type { InvitationRepository } from './invitationRepository';
 import {
 	checkSubscriptionHasMultipleAccountsBenefit,

--- a/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
@@ -1,10 +1,10 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import {
 	internalServerError,
 	notFound,
 } from '@modules/routing/apiGatewayResponses';
-import type { APIGatewayProxyResult } from 'aws-lambda';
-import { z } from 'zod';
 import { type InvitationRepository } from './invitationRepository';
 
 export const deleteInvitationPathSchema = z.object({

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -1,4 +1,5 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import type { Handler } from 'aws-lambda';
 import { awsConfig } from '@modules/aws/config';
 import { buildAuthenticate } from '@modules/identity/apiGateway';
 import { IdentityClient } from '@modules/identity/identityClient';
@@ -10,7 +11,6 @@ import { withMMAIdentityCheck } from '@modules/routing/withMMAIdentityCheck';
 import { withBodyParser, withPathParser } from '@modules/routing/withParsers';
 import { stageFromEnvironment } from '@modules/stage';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
-import type { Handler } from 'aws-lambda';
 import {
 	acceptInvitationEndpoint,
 	acceptInvitationPathSchema,

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -6,9 +6,9 @@ import {
 	type TransactWriteItem,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { z } from 'zod';
 import { getMaybeSingleOrThrow } from '@modules/arrayFunctions';
 import type { Stage } from '@modules/stage';
-import { z } from 'zod';
 
 const invitationRecordSchema = z.object({
 	subscriptionName: z.string(),

--- a/handlers/multiple-account-api/src/listInvitationsEndpoint.ts
+++ b/handlers/multiple-account-api/src/listInvitationsEndpoint.ts
@@ -1,6 +1,6 @@
+import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
-import { z } from 'zod';
 import type { InvitationRepository } from './invitationRepository';
 
 export const listInvitationsPathSchema = z.object({

--- a/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
+++ b/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
@@ -1,7 +1,7 @@
+import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
-import { z } from 'zod';
 
 export const listSecondaryUsersPathSchema = z.object({
 	subscriptionName: z.string(),

--- a/handlers/multiple-account-api/src/validation.ts
+++ b/handlers/multiple-account-api/src/validation.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { ValidationError } from '@modules/errors';
 import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
 import { GuardianSubscriptionParser } from '@modules/guardian-subscription/guardianSubscriptionParser';
@@ -10,7 +11,6 @@ import type {
 } from '@modules/product-catalog/productCatalog';
 import type { ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import type { InvitationRepository } from './invitationRepository';
 
 const MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION = 5;

--- a/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
@@ -6,9 +6,9 @@
  * @group integration
  */
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import dayjs from 'dayjs';
 import { getAwsConfig } from '@modules/aws/config';
 import type { Stage } from '@modules/stage';
-import dayjs from 'dayjs';
 import { deleteInvitationEndpoint } from '../src/deleteInvitationEndpoint';
 import {
 	type InvitationRecord,

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import * as identity from '@modules/identity/idapi';
 import type { IdentityClient } from '@modules/identity/identityClient';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
@@ -8,7 +9,6 @@ import type {
 import { zuoraSubscriptionSchema } from '@modules/zuora/types/objects';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import code from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import { createInvitationEndpoint } from '../src/createInvitationEndpoint';
 import type {

--- a/handlers/multiple-account-api/test/invitationRepositoryIntegration.test.ts
+++ b/handlers/multiple-account-api/test/invitationRepositoryIntegration.test.ts
@@ -6,9 +6,9 @@
  * @group integration
  */
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import dayjs from 'dayjs';
 import { getAwsConfig } from '@modules/aws/config';
 import type { Stage } from '@modules/stage';
-import dayjs from 'dayjs';
 import type { InvitationRecord } from '../src/invitationRepository';
 import { InvitationRepository } from '../src/invitationRepository';
 

--- a/handlers/negative-invoices-processor/src/handlers/checkForActiveSub.ts
+++ b/handlers/negative-invoices-processor/src/handlers/checkForActiveSub.ts
@@ -1,8 +1,8 @@
+import { z } from 'zod';
 import { stageFromEnvironment } from '@modules/stage';
 import { doQuery } from '@modules/zuora/query';
 import { createQueryResponseSchema } from '@modules/zuora/types';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { z } from 'zod';
 import type { CheckForActiveSubInput, CheckForActiveSubOutput } from '../types';
 import { CheckForActiveSubInputSchema } from '../types';
 

--- a/handlers/negative-invoices-processor/src/handlers/doCreditBalanceRefund.ts
+++ b/handlers/negative-invoices-processor/src/handlers/doCreditBalanceRefund.ts
@@ -1,7 +1,7 @@
+import dayjs from 'dayjs';
 import { stageFromEnvironment } from '@modules/stage';
 import { doRefund } from '@modules/zuora/refund';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 import type {
 	DoCreditBalanceRefundInput,
 	DoCreditBalanceRefundOutput,

--- a/handlers/negative-invoices-processor/src/types/shared/paymentMethod.ts
+++ b/handlers/negative-invoices-processor/src/types/shared/paymentMethod.ts
@@ -1,5 +1,5 @@
-import { BasePaymentMethodSchema } from '@modules/zuora/types';
 import { z } from 'zod';
+import { BasePaymentMethodSchema } from '@modules/zuora/types';
 import { successOrFailureSchema } from './successOrFailureSchema';
 
 export const PaymentMethodSchema = z.object({

--- a/handlers/new-subscription-api/src/createSubscriptionEndpoint.ts
+++ b/handlers/new-subscription-api/src/createSubscriptionEndpoint.ts
@@ -1,3 +1,4 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
 import { ValidationError } from '@modules/errors';
 import { supportRegionIdFromCountry } from '@modules/internationalisation/countryGroup';
 import { isoCountrySchema } from '@modules/internationalisation/schemas';
@@ -9,7 +10,6 @@ import type { Stage } from '@modules/stage';
 import { getDeliveryFields } from '@modules/zuora/createSubscription/createSubscription';
 import { createSubscriptionWithExistingPaymentMethod } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { CreateSubscriptionRequest } from './requestSchema';
 import type { CreateSubscriptionResponse } from './responseSchema';
 

--- a/handlers/new-subscription-api/src/index.ts
+++ b/handlers/new-subscription-api/src/index.ts
@@ -1,3 +1,4 @@
+import type { Handler } from 'aws-lambda';
 import { Lazy } from '@modules/lazy';
 import { logger } from '@modules/logger/logger';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
@@ -5,7 +6,6 @@ import { Router } from '@modules/routing/router';
 import { withBodyParser } from '@modules/routing/withParsers';
 import { stageFromEnvironment } from '@modules/stage';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { Handler } from 'aws-lambda';
 import { createNewSubscriptionEndpoint } from './createSubscriptionEndpoint';
 import type { CreateSubscriptionRequest } from './requestSchema';
 import { createSubscriptionRequestSchema } from './requestSchema';

--- a/handlers/new-subscription-api/src/requestSchema.ts
+++ b/handlers/new-subscription-api/src/requestSchema.ts
@@ -1,9 +1,9 @@
+import { z } from 'zod';
 import { isoCurrencySchema } from '@modules/internationalisation/schemas';
 import { productPurchaseSchema } from '@modules/product-catalog/productPurchaseSchema';
 import { existingPaymentMethodInputSchema } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
 import { giftRecipientSchema } from '@modules/zuora/createSubscription/giftRecipient';
 import { paymentGatewaySchema } from '@modules/zuora/orders/paymentGateways';
-import { z } from 'zod';
 
 export const contactSchema = z.object({
 	firstName: z.string(),

--- a/handlers/new-subscription-api/test/createSubscriptionEndpoint.test.ts
+++ b/handlers/new-subscription-api/test/createSubscriptionEndpoint.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return -- jest expect matchers and requireActual return any */
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import { getPromotion } from '@modules/promotions/v2/getPromotion';
@@ -6,7 +7,6 @@ import { clonePaymentMethod } from '@modules/zuora/createSubscription/clonePayme
 import { executeOrderRequest } from '@modules/zuora/orders/orderRequests';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
 import catalogCode from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import type { CreateSubscriptionResponse } from '../src/responseSchema';
 

--- a/handlers/observer-benefits-api/src/index.ts
+++ b/handlers/observer-benefits-api/src/index.ts
@@ -1,3 +1,4 @@
+import type { Handler } from 'aws-lambda';
 import { Lazy } from '@modules/lazy';
 import { logger } from '@modules/logger/logger';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
@@ -6,7 +7,6 @@ import { withBodyParser } from '@modules/routing/withParsers';
 import { stageFromEnvironment } from '@modules/stage';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
-import type { Handler } from 'aws-lambda';
 import { isActiveEndpoint } from './isActiveEndpoint';
 import type { RequestBody } from './schemas';
 import { requestSchema } from './schemas';

--- a/handlers/observer-benefits-api/src/isActiveEndpoint.ts
+++ b/handlers/observer-benefits-api/src/isActiveEndpoint.ts
@@ -1,3 +1,5 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import dayjs from 'dayjs';
 import type { GuardianSubscription } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
 import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
 import { GuardianSubscriptionParser } from '@modules/guardian-subscription/guardianSubscriptionParser';
@@ -11,8 +13,6 @@ import { getSubscription } from '@modules/zuora/subscription';
 import { zuoraDateFormat } from '@modules/zuora/utils/common';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import type { APIGatewayProxyResult } from 'aws-lambda';
-import dayjs from 'dayjs';
 import type { RequestBody } from './schemas';
 import { validateSubscription } from './validation';
 

--- a/handlers/observer-benefits-api/test/index.test.ts
+++ b/handlers/observer-benefits-api/test/index.test.ts
@@ -1,10 +1,10 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import type { GuardianSubscription } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
 import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
 import { getAccount } from '@modules/zuora/account';
 import { ZuoraError } from '@modules/zuora/errors/zuoraError';
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { handler } from '../src/index';
 import type { ResponseBody } from '../src/schemas';
 

--- a/handlers/observer-data-export/src/handlers/encryptAndUploadObserverData.ts
+++ b/handlers/observer-data-export/src/handlers/encryptAndUploadObserverData.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
-import { getFileFromS3, uploadFileToS3 } from '@modules/aws/s3';
 import type { S3Event, SQSEvent } from 'aws-lambda';
+import { getFileFromS3, uploadFileToS3 } from '@modules/aws/s3';
 
 export const handler = async (event: SQSEvent) => {
 	console.log(JSON.stringify(event, null, 2));

--- a/handlers/press-reader-entitlements/src/index.ts
+++ b/handlers/press-reader-entitlements/src/index.ts
@@ -1,3 +1,9 @@
+import type {
+	APIGatewayProxyEvent,
+	APIGatewayProxyResult,
+	Handler,
+} from 'aws-lambda';
+import dayjs from 'dayjs';
 import { Lazy } from '@modules/lazy';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
@@ -8,12 +14,6 @@ import type { Stage } from '@modules/stage';
 import { stageFromEnvironment } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import type {
-	APIGatewayProxyEvent,
-	APIGatewayProxyResult,
-	Handler,
-} from 'aws-lambda';
-import dayjs from 'dayjs';
 import { getClientAccessToken, getUserDetails } from './identity';
 import { getLatestSubscription } from './supporterProductData';
 import type { Member } from './xmlBuilder';

--- a/handlers/press-reader-entitlements/test/pressReaderEntitlements.test.ts
+++ b/handlers/press-reader-entitlements/test/pressReaderEntitlements.test.ts
@@ -1,7 +1,7 @@
+import dayjs from 'dayjs';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import codeZuoraCatalog from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import { getLatestValidSubscription } from '../src/supporterProductData';
 import type { Member } from '../src/xmlBuilder';

--- a/handlers/product-switch-api/src/changePlan/action/amendments.ts
+++ b/handlers/product-switch-api/src/changePlan/action/amendments.ts
@@ -1,9 +1,9 @@
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { logger } from '@modules/logger/logger';
 import { ZuoraError } from '@modules/zuora/errors/zuoraError';
 import { voidSchema } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
 import type { ZuoraGetAmendmentResponse } from '../schemas';
 import { zuoraGetAmendmentResponseSchema } from '../schemas';
 

--- a/handlers/product-switch-api/src/changePlan/action/getPaymentSchedule.ts
+++ b/handlers/product-switch-api/src/changePlan/action/getPaymentSchedule.ts
@@ -1,3 +1,4 @@
+import type dayjs from 'dayjs';
 import type { SimpleInvoiceTotal } from '@modules/zuora/billingPreview';
 import {
 	getBillingPreview,
@@ -6,7 +7,6 @@ import {
 	toSimpleInvoiceItems,
 } from '@modules/zuora/billingPreview';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type dayjs from 'dayjs';
 
 /**
  * returns the payment schedule for a given subscription in a simple format suitable for summary display e.g. on screen or in confirmation emails

--- a/handlers/product-switch-api/src/changePlan/action/preview.ts
+++ b/handlers/product-switch-api/src/changePlan/action/preview.ts
@@ -1,3 +1,4 @@
+import dayjs, { type Dayjs } from 'dayjs';
 import {
 	getSingleOrThrow,
 	groupByUniqueOrThrow,
@@ -8,7 +9,6 @@ import type { Stage } from '@modules/stage';
 import type { PreviewOrderRequest } from '@modules/zuora/orders/orderRequests';
 import { zuoraDateFormat } from '@modules/zuora/utils/common';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs, { type Dayjs } from 'dayjs';
 import type {
 	ZuoraPreviewResponse,
 	ZuoraPreviewResponseInvoice,

--- a/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
+++ b/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
@@ -1,8 +1,8 @@
+import dayjs from 'dayjs';
 import { describePayments } from '@modules/email/dataFields/dayZero/paymentDescription';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { getCurrencyInfo } from '@modules/internationalisation/currency';
 import type { SimpleInvoiceTotal } from '@modules/zuora/billingPreview';
-import dayjs from 'dayjs';
 import type { PaymentMethodType } from '../prepare/accountInformation';
 import type { SwitchInformation } from '../prepare/switchInformation';
 

--- a/handlers/product-switch-api/src/changePlan/action/switch.ts
+++ b/handlers/product-switch-api/src/changePlan/action/switch.ts
@@ -1,9 +1,9 @@
+import type dayjs from 'dayjs';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import type { Stage } from '@modules/stage';
 import { sendToSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
 import type { SimpleInvoiceTotal } from '@modules/zuora/billingPreview';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type dayjs from 'dayjs';
 import { takePaymentOrAdjustInvoice } from '../../payment';
 import { sendSalesforceTracking } from '../../salesforceTracking';
 import { supporterRatePlanItemFromSwitchInformation } from '../../supporterProductData';

--- a/handlers/product-switch-api/src/changePlan/changePlanEndpoint.ts
+++ b/handlers/product-switch-api/src/changePlan/changePlanEndpoint.ts
@@ -1,3 +1,5 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import type dayjs from 'dayjs';
 import { sendEmail } from '@modules/email/email';
 import { ValidationError } from '@modules/errors';
 import type { GuardianSubscription } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
@@ -11,8 +13,6 @@ import type {
 	ZuoraSubscription,
 } from '@modules/zuora/types/objects';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { APIGatewayProxyResult } from 'aws-lambda';
-import type dayjs from 'dayjs';
 import { removePendingUpdateAmendments } from './action/amendments';
 import { CreateSwitchOrder } from './action/createSwitchOrder';
 import { GetPaymentSchedule } from './action/getPaymentSchedule';

--- a/handlers/product-switch-api/src/changePlan/legacyContributionToSupporterPlusEndpoint.ts
+++ b/handlers/product-switch-api/src/changePlan/legacyContributionToSupporterPlusEndpoint.ts
@@ -1,11 +1,11 @@
+import type dayjs from 'dayjs';
+import { z } from 'zod';
 import { ValidationError } from '@modules/errors';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { ok } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type dayjs from 'dayjs';
-import { z } from 'zod';
 import type { PreviewResponse, SwitchDiscountResponse } from './action/preview';
 import { ChangePlanEndpoint } from './changePlanEndpoint';
 import { productSwitchCommonRequestSchema } from './schemas';

--- a/handlers/product-switch-api/src/changePlan/prepare/buildSwitchOrderRequest.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/buildSwitchOrderRequest.ts
@@ -1,3 +1,5 @@
+import type dayjs from 'dayjs';
+import type { Dayjs } from 'dayjs';
 import type {
 	ChangePlanOrderAction,
 	OrderAction,
@@ -5,8 +7,6 @@ import type {
 import { singleTriggerDate } from '@modules/zuora/orders/orderActions';
 import type { OrderRequest } from '@modules/zuora/orders/orderRequests';
 import { zuoraDateFormat } from '@modules/zuora/utils/common';
-import type dayjs from 'dayjs';
-import type { Dayjs } from 'dayjs';
 import type { SubscriptionInformation } from './subscriptionInformation';
 import type { TargetContribution } from './targetInformation';
 

--- a/handlers/product-switch-api/src/changePlan/prepare/subscriptionInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/subscriptionInformation.ts
@@ -1,3 +1,5 @@
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import type { SafeForDistinct } from '@modules/arrayFunctions';
 import {
 	distinct,
@@ -13,8 +15,6 @@ import {
 } from '@modules/nullAndUndefined';
 import { objectValues } from '@modules/objectFunctions';
 import type { RatePlanCharge } from '@modules/zuora/types';
-import type { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
 import type { ValidSwitchableRatePlanKey } from './switchCatalogHelper';
 import { asSwitchableRatePlanKey } from './switchCatalogHelper';
 

--- a/handlers/product-switch-api/src/changePlan/toSingleGuardianSubscription.ts
+++ b/handlers/product-switch-api/src/changePlan/toSingleGuardianSubscription.ts
@@ -1,3 +1,4 @@
+import type dayjs from 'dayjs';
 import type { GuardianSubscription } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
 import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
 import {
@@ -12,7 +13,6 @@ import type { Stage } from '@modules/stage';
 import type { ZuoraSubscription } from '@modules/zuora/types';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
 import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import type dayjs from 'dayjs';
 
 export class ToSingleGuardianSubscription {
 	constructor(

--- a/handlers/product-switch-api/src/doPreviewInvoices.ts
+++ b/handlers/product-switch-api/src/doPreviewInvoices.ts
@@ -1,7 +1,7 @@
+import z from 'zod';
 import type { PreviewOrderRequest } from '@modules/zuora/orders/orderRequests';
 import { previewOrderRequest } from '@modules/zuora/orders/orderRequests';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import z from 'zod';
 
 const zuoraPreviewResponseInvoiceItemSchema = z
 	.object({

--- a/handlers/product-switch-api/src/frequencySwitchEmail.ts
+++ b/handlers/product-switch-api/src/frequencySwitchEmail.ts
@@ -1,10 +1,10 @@
+import type dayjs from 'dayjs';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { DataExtensionNames, sendEmail } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getCurrencyInfo } from '@modules/internationalisation/currency';
 import type { Stage } from '@modules/stage';
 import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
-import type dayjs from 'dayjs';
 
 /**
  * Build the email message for frequency switch confirmation.

--- a/handlers/product-switch-api/src/frequencySwitchEndpoint.ts
+++ b/handlers/product-switch-api/src/frequencySwitchEndpoint.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { ValidationError } from '@modules/errors';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { isoCurrencySchema } from '@modules/internationalisation/schemas';
@@ -29,7 +30,6 @@ import type {
 } from '@modules/zuora/types/objects/subscription';
 import { zuoraDateFormat } from '@modules/zuora/utils/common';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 import { EligibilityChecker } from '../../discount-api/src/eligibilityChecker';
 import { zuoraSwitchResponseSchema } from './changePlan/schemas';
 import type { ZuoraPreviewResponse } from './doPreviewInvoices';

--- a/handlers/product-switch-api/src/frequencySwitchSchemas.ts
+++ b/handlers/product-switch-api/src/frequencySwitchSchemas.ts
@@ -1,5 +1,5 @@
-import { isoCurrencySchema } from '@modules/internationalisation/schemas';
 import { z } from 'zod';
+import { isoCurrencySchema } from '@modules/internationalisation/schemas';
 
 export const frequencySwitchRequestSchema = z.object({
 	preview: z.boolean(),

--- a/handlers/product-switch-api/src/index.ts
+++ b/handlers/product-switch-api/src/index.ts
@@ -1,10 +1,10 @@
+import type { Handler } from 'aws-lambda';
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import { Router } from '@modules/routing/router';
 import { withMMAIdentityCheck } from '@modules/routing/withMMAIdentityCheck';
 import { withParsers } from '@modules/routing/withParsers';
 import { stageFromEnvironment } from '@modules/stage';
-import type { Handler } from 'aws-lambda';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 import { ChangePlanEndpoint } from './changePlan/changePlanEndpoint';
 import {
 	legacyContributionToSupporterPlusEndpoint,

--- a/handlers/product-switch-api/src/payment.ts
+++ b/handlers/product-switch-api/src/payment.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import {
 	creditInvoice,
@@ -6,7 +7,6 @@ import {
 } from '@modules/zuora/invoice';
 import { createPayment } from '@modules/zuora/payment';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 
 export const adjustNonCollectedInvoice = async (
 	zuoraClient: ZuoraClient,

--- a/handlers/product-switch-api/src/supporterProductData.ts
+++ b/handlers/product-switch-api/src/supporterProductData.ts
@@ -1,5 +1,5 @@
-import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import type { Dayjs } from 'dayjs';
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import type { SwitchInformation } from './changePlan/prepare/switchInformation';
 
 export type ContributionAmount = { amount: number; currency: string };

--- a/handlers/product-switch-api/test/changePlan/action/email.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/email.test.ts
@@ -1,6 +1,6 @@
+import dayjs from 'dayjs';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
-import dayjs from 'dayjs';
 import { buildEmailMessage } from '../../../src/changePlan/action/productSwitchEmail';
 import type { AccountInformation } from '../../../src/changePlan/prepare/accountInformation';
 import type { SubscriptionInformation } from '../../../src/changePlan/prepare/subscriptionInformation';

--- a/handlers/product-switch-api/test/changePlan/action/removePendingUpdateAmendments.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/removePendingUpdateAmendments.test.ts
@@ -1,5 +1,5 @@
-import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { removePendingUpdateAmendments } from '../../../src/changePlan/action/amendments';
 
 const mockZuoraClient = {

--- a/handlers/product-switch-api/test/changePlan/action/switch/previewAction.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/switch/previewAction.test.ts
@@ -1,10 +1,10 @@
+import dayjs from 'dayjs';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { OrderAction } from '@modules/zuora/orders/orderActions';
 import type { OrderRequest } from '@modules/zuora/orders/orderRequests';
 import { zuoraSubscriptionSchema } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import zuoraCatalogFixture from '../../../../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import { DoPreviewAction } from '../../../../src/changePlan/action/preview';
 import { SwitchOrderRequestBuilder } from '../../../../src/changePlan/prepare/buildSwitchOrderRequest';

--- a/handlers/product-switch-api/test/changePlan/action/switch/switchAction.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/switch/switchAction.test.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { GetInvoiceResponse } from '@modules/zuora/types';
@@ -7,7 +8,6 @@ import {
 } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import zuoraCatalogFixture from '../../../../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import type { CreateSwitchOrder } from '../../../../src/changePlan/action/createSwitchOrder';
 import type { GetPaymentSchedule } from '../../../../src/changePlan/action/getPaymentSchedule';

--- a/handlers/product-switch-api/test/changePlan/contributionToSupporterPlusIntegration.test.ts
+++ b/handlers/product-switch-api/test/changePlan/contributionToSupporterPlusIntegration.test.ts
@@ -4,6 +4,9 @@
  * @group integration
  */
 import console from 'console';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import dayjs from 'dayjs';
+import z from 'zod';
 import { invokeFunction } from '@modules/aws/lambda';
 import { ValidationError } from '@modules/errors';
 import { logger } from '@modules/logger/logger';
@@ -13,9 +16,6 @@ import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
 import { voidSchema } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import dayjs from 'dayjs';
-import z from 'zod';
 import type { ContributionTestAdditionalOptions } from '../../../../modules/zuora/test/it-helpers/createGuardianSubscription';
 import { createContribution } from '../../../../modules/zuora/test/it-helpers/createGuardianSubscription';
 import type { PreviewResponse } from '../../src/changePlan/action/preview';

--- a/handlers/product-switch-api/test/changePlan/prepare/subscriptionInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/prepare/subscriptionInformation.test.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
 import { GuardianSubscriptionParser } from '@modules/guardian-subscription/guardianSubscriptionParser';
 import { SubscriptionFilter } from '@modules/guardian-subscription/subscriptionFilter';
@@ -9,7 +10,6 @@ import {
 } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import zuoraCatalogFixtureCode from '../../../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import zuoraCatalogFixtureProd from '../../../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import type { SubscriptionInformation } from '../../../src/changePlan/prepare/subscriptionInformation';

--- a/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import { ValidationError } from '@modules/errors';
 import type { GuardianSubscription } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
@@ -11,7 +12,6 @@ import {
 	zuoraSubscriptionSchema,
 } from '@modules/zuora/types';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import zuoraCatalogFixture from '../../../../../modules/zuora-catalog/test/fixtures/catalog-prod.json';
 import type { TargetInformation } from '../../../src/changePlan/prepare/targetInformation';
 import { getTargetInformation } from '../../../src/changePlan/prepare/targetInformation';

--- a/handlers/product-switch-api/test/frequencySwitch.test.ts
+++ b/handlers/product-switch-api/test/frequencySwitch.test.ts
@@ -2,6 +2,7 @@
  * Unit tests for frequency switch functionality.
  * Tests the candidate selection logic and edge cases without external API calls.
  */
+import dayjs from 'dayjs';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type {
 	RatePlanCharge,
@@ -14,7 +15,6 @@ import type {
 	ProductRatePlanChargeId,
 	ProductRatePlanId,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import { selectCandidateSubscriptionCharge } from '../src/frequencySwitchEndpoint';
 import { productCatalog } from './productCatalogFixture';
 

--- a/handlers/product-switch-api/test/frequencySwitchIntegration.test.ts
+++ b/handlers/product-switch-api/test/frequencySwitchIntegration.test.ts
@@ -11,6 +11,7 @@
  * @group integration
  */
 import console from 'console';
+import dayjs from 'dayjs';
 import { getAccount } from '@modules/zuora/account';
 import {
 	getBillingPreview,
@@ -19,7 +20,6 @@ import {
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraSubscription } from '@modules/zuora/types';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 import type { ContributionTestAdditionalOptions } from '../../../modules/zuora/test/it-helpers/createGuardianSubscription';
 import { createContribution } from '../../../modules/zuora/test/it-helpers/createGuardianSubscription';
 import { getSwitchResult } from '../src/frequencySwitchEndpoint';

--- a/handlers/product-switch-api/test/supporterProductDataIntegration.test.ts
+++ b/handlers/product-switch-api/test/supporterProductDataIntegration.test.ts
@@ -2,9 +2,9 @@
  * @group integration
  */
 
+import dayjs from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import { sendToSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
-import dayjs from 'dayjs';
 import type { SwitchInformation } from '../src/changePlan/prepare/switchInformation';
 import { supporterRatePlanItemFromSwitchInformation } from '../src/supporterProductData';
 

--- a/handlers/product-switch-api/test/supporterRatePlanItem.test.ts
+++ b/handlers/product-switch-api/test/supporterRatePlanItem.test.ts
@@ -1,5 +1,5 @@
-import { DataExtensionNames } from '@modules/email/email';
 import dayjs from 'dayjs';
+import { DataExtensionNames } from '@modules/email/email';
 import type { SwitchInformation } from '../src/changePlan/prepare/switchInformation';
 import { supporterRatePlanItemFromSwitchInformation } from '../src/supporterProductData';
 

--- a/handlers/promotions-lambdas/src/handlers/promoCodeView.ts
+++ b/handlers/promotions-lambdas/src/handlers/promoCodeView.ts
@@ -4,15 +4,15 @@ import {
 	DynamoDBClient,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import { awsConfig } from '@modules/aws/config';
-import { logger } from '@modules/logger/logger';
-import { promoCampaignSchema } from '@modules/promotions/v2/schema';
 import type {
 	AttributeValue,
 	DynamoDBBatchResponse,
 	DynamoDBRecord,
 	DynamoDBStreamEvent,
 } from 'aws-lambda';
+import { awsConfig } from '@modules/aws/config';
+import { logger } from '@modules/logger/logger';
+import { promoCampaignSchema } from '@modules/promotions/v2/schema';
 import type { PromoCodeViewItem } from '../lib/promoCodeViewSchema';
 
 const getString = (attr: AttributeValue | undefined): string | undefined =>

--- a/handlers/promotions-lambdas/src/handlers/salesforceExport.ts
+++ b/handlers/promotions-lambdas/src/handlers/salesforceExport.ts
@@ -1,12 +1,12 @@
 import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
+import { z } from 'zod';
 import { awsConfig } from '@modules/aws/config';
 import { logger } from '@modules/logger/logger';
 import { sfApiVersion } from '@modules/salesforce/config';
 import { SfClient } from '@modules/salesforce/sfClient';
 import type { Stage } from '@modules/stage';
 import { voidSchema } from '@modules/zuora/types';
-import { z } from 'zod';
 import type { PromoCodeViewItem } from '../lib/promoCodeViewSchema';
 import { promoCodeViewSchema } from '../lib/promoCodeViewSchema';
 

--- a/handlers/sales-tax-api/src/schemas.ts
+++ b/handlers/sales-tax-api/src/schemas.ts
@@ -1,7 +1,7 @@
+import { z } from 'zod';
 import { caStateCodes } from '@modules/internationalisation/country';
 import { isoCountrySchema } from '@modules/internationalisation/schemas';
 import { productKeySchema } from '@modules/product-catalog/productCatalogSchema';
-import { z } from 'zod';
 
 export const taxRatesRequestSchema = z.object({
 	productKey: productKeySchema,

--- a/handlers/sales-tax-api/src/taxRatesEndpoint.ts
+++ b/handlers/sales-tax-api/src/taxRatesEndpoint.ts
@@ -1,3 +1,4 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
 import { ValidationError } from '@modules/errors';
 import type {
 	CaState,
@@ -21,7 +22,6 @@ import type {
 } from '@modules/zuora/types/objects/tax';
 import { type ZuoraTaxCode } from '@modules/zuora/types/objects/tax';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { TaxRatesResponse } from './schemas';
 import {
 	caStateSchema,

--- a/handlers/sales-tax-api/test/index.test.ts
+++ b/handlers/sales-tax-api/test/index.test.ts
@@ -1,3 +1,4 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 import {
 	getZuoraTaxCodes,
 	getZuoraTaxPeriods,
@@ -8,7 +9,6 @@ import type {
 	ZuoraTaxPeriods,
 	ZuoraTaxRates,
 } from '@modules/zuora/types/objects/tax';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { handler } from '../src/index';
 import type { TaxRatesResponse } from '../src/schemas';
 import {

--- a/handlers/stripe-disputes/eslint.config.mjs
+++ b/handlers/stripe-disputes/eslint.config.mjs
@@ -1,8 +1,10 @@
 import guardian from '@guardian/eslint-config';
 import { defineConfig } from 'eslint/config';
+import { importOrderConfig } from '../../eslint.shared.mjs';
 
 export default defineConfig([
 	guardian.configs.recommended,
+	importOrderConfig,
 	{
 		extends: [guardian.configs.recommended],
 		files: ['test/**/*.ts', '**/*.test.ts'],

--- a/handlers/stripe-disputes/src/consumer.ts
+++ b/handlers/stripe-disputes/src/consumer.ts
@@ -1,5 +1,5 @@
-import { Logger } from '@modules/logger/logger';
 import type { SQSEvent } from 'aws-lambda';
+import { Logger } from '@modules/logger/logger';
 import type {
 	ListenDisputeClosedRequestBody,
 	ListenDisputeCreatedRequestBody,

--- a/handlers/stripe-disputes/src/producer.ts
+++ b/handlers/stripe-disputes/src/producer.ts
@@ -1,12 +1,12 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import Stripe from 'stripe';
+import { z } from 'zod';
 import { Logger } from '@modules/logger/logger';
 import { badRequest, ok } from '@modules/routing/apiGatewayResponses';
 import { Router } from '@modules/routing/router';
 import { withBodyParser } from '@modules/routing/withParsers';
 import { getSecretValue } from '@modules/secrets-manager/getSecret';
 import { stageFromEnvironment } from '@modules/stage';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import Stripe from 'stripe';
-import { z } from 'zod';
 import { handleStripeWebhook } from './services';
 import type { StripeCredentials } from './types';
 

--- a/handlers/stripe-disputes/src/services/cancelSubscriptionService.ts
+++ b/handlers/stripe-disputes/src/services/cancelSubscriptionService.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import {
 	DataExtensionNames,
 	type EmailMessageWithIdentityUserId,
@@ -12,7 +13,6 @@ import {
 } from '@modules/zuora/subscription';
 import type { ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 
 export interface CancelSubscriptionResult {
 	cancelled: boolean;

--- a/handlers/stripe-disputes/src/services/webhookHandler.ts
+++ b/handlers/stripe-disputes/src/services/webhookHandler.ts
@@ -1,8 +1,8 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import AWS from 'aws-sdk';
 import type { Logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { internalServerError, ok } from '@modules/routing/apiGatewayResponses';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import AWS from 'aws-sdk';
 import type {
 	ListenDisputeClosedRequestBody,
 	ListenDisputeCreatedRequestBody,

--- a/handlers/supporter-product-data-lambdas/src/handlers/addSupporterRatePlanItemToQueueLambda.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/addSupporterRatePlanItemToQueueLambda.ts
@@ -1,7 +1,7 @@
+import type { Handler } from 'aws-lambda';
 import { sendBatchMessagesToQueue } from '@modules/aws/sqs';
 import { Lazy } from '@modules/lazy';
 import { stageFromEnvironment } from '@modules/stage';
-import type { Handler } from 'aws-lambda';
 import { ConfigService } from '../services/configService';
 import { parseCsvStreamWithHeader } from '../services/csvService';
 import { S3Service } from '../services/s3Service';

--- a/handlers/supporter-product-data-lambdas/src/handlers/fetchResultsLambda.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/fetchResultsLambda.ts
@@ -1,7 +1,7 @@
+import type { Handler } from 'aws-lambda';
 import { Lazy } from '@modules/lazy';
 import { stageFromEnvironment } from '@modules/stage';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { Handler } from 'aws-lambda';
 import { ConfigService } from '../services/configService';
 import { S3Service } from '../services/s3Service';
 import { ZuoraQuerierService } from '../services/zuoraQuerierService';

--- a/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItem.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItem.ts
@@ -1,9 +1,9 @@
+import type { SQSRecord } from 'aws-lambda';
 import { logger } from '@modules/logger/logger';
 import type { SecondaryUserRecord } from '@modules/multiple-account/secondaryUserRepository';
 import { secondaryUserTTLFromPrimarySubscriptionTTL } from '@modules/multiple-account/secondaryUserRepository';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import { supporterRatePlanItemSchema } from '@modules/supporter-product-data/supporterProductData';
-import type { SQSRecord } from 'aws-lambda';
 import { addContributionAmountIfNeeded } from '../services/contributions';
 import type { MinimalZuoraSubscription } from '../services/zuoraSubscriptionService';
 

--- a/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItemLambda.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItemLambda.ts
@@ -1,3 +1,5 @@
+import type { Handler, SQSEvent } from 'aws-lambda';
+import dayjs from 'dayjs';
 import { Lazy } from '@modules/lazy';
 import { createSecondarySubscription } from '@modules/multiple-account/secondarySubscription';
 import { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
@@ -5,8 +7,6 @@ import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { stageFromEnvironment } from '@modules/stage';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
-import type { Handler, SQSEvent } from 'aws-lambda';
-import dayjs from 'dayjs';
 import {
 	getDiscountProductRatePlanIds,
 	isDiscountProductRatePlanItem,

--- a/handlers/supporter-product-data-lambdas/src/handlers/queryZuora.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/queryZuora.ts
@@ -1,6 +1,6 @@
-import { logger } from '@modules/logger/logger';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import { logger } from '@modules/logger/logger';
 import type { BatchQueryRequest, ZoqlExportQuery } from '../model/query';
 import {
 	currentAttemptedQueryTime,

--- a/handlers/supporter-product-data-lambdas/src/handlers/queryZuoraLambda.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/queryZuoraLambda.ts
@@ -1,8 +1,8 @@
+import type { Handler } from 'aws-lambda';
 import { Lazy } from '@modules/lazy';
 import { stageFromEnvironment } from '@modules/stage';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
-import type { Handler } from 'aws-lambda';
 import { ConfigService } from '../services/configService';
 import { getDiscountProductRatePlanIds } from '../services/discounts';
 import { ZuoraQuerierService } from '../services/zuoraQuerierService';

--- a/handlers/supporter-product-data-lambdas/src/model/supporterRatePlanItem.ts
+++ b/handlers/supporter-product-data-lambdas/src/model/supporterRatePlanItem.ts
@@ -1,5 +1,5 @@
-import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import dayjs from 'dayjs';
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 
 export class CsvDecodeError extends Error {
 	constructor(message: unknown) {

--- a/handlers/supporter-product-data-lambdas/src/services/dynamoService.ts
+++ b/handlers/supporter-product-data-lambdas/src/services/dynamoService.ts
@@ -3,14 +3,14 @@ import {
 	DynamoDBClient,
 	UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import { awsConfig } from '@modules/aws/config';
 import { logger } from '@modules/logger/logger';
 import type { Stage } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import type { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(utc);
 

--- a/handlers/supporter-product-data-lambdas/src/services/zuoraQuerierService.ts
+++ b/handlers/supporter-product-data-lambdas/src/services/zuoraQuerierService.ts
@@ -1,6 +1,6 @@
+import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { z } from 'zod';
 import type { BatchQueryRequest } from '../model/query';
 
 const batchQueryItemSchema = z.object({

--- a/handlers/supporter-product-data-lambdas/src/services/zuoraSubscriptionService.ts
+++ b/handlers/supporter-product-data-lambdas/src/services/zuoraSubscriptionService.ts
@@ -1,6 +1,6 @@
+import { z } from 'zod';
 import { isoCurrencySchema } from '@modules/internationalisation/schemas';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { z } from 'zod';
 
 const ratePlanChargeSchema = z.object({
 	price: z.number().nullable(),

--- a/handlers/supporter-product-data-lambdas/test/dynamoService.it.test.ts
+++ b/handlers/supporter-product-data-lambdas/test/dynamoService.it.test.ts
@@ -7,9 +7,9 @@ import {
 	DynamoDBClient,
 	GetItemCommand,
 } from '@aws-sdk/client-dynamodb';
+import dayjs from 'dayjs';
 import { getAwsConfig } from '@modules/aws/config';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
-import dayjs from 'dayjs';
 import { DynamoService } from '../src/services/dynamoService';
 
 const stage = 'CODE';

--- a/handlers/supporter-product-data-lambdas/test/processSupporterRatePlanItemLambda.test.ts
+++ b/handlers/supporter-product-data-lambdas/test/processSupporterRatePlanItemLambda.test.ts
@@ -1,7 +1,7 @@
+import dayjs from 'dayjs';
 import type { SecondaryUserRecord } from '@modules/multiple-account/secondaryUserRepository';
 import { secondaryUserTTLFromPrimarySubscriptionTTL } from '@modules/multiple-account/secondaryUserRepository';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
-import dayjs from 'dayjs';
 import { processItem } from '../src/handlers/processSupporterRatePlanItem';
 
 const termEndDate = '2026-03-01';

--- a/handlers/ticket-tailor-webhook/src/idapiService.ts
+++ b/handlers/ticket-tailor-webhook/src/idapiService.ts
@@ -1,7 +1,7 @@
+import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import { getSecretValue } from '@modules/secrets-manager/getSecret';
 import type { Stage } from '@modules/stage';
-import { z } from 'zod';
 
 export type IdApiToken = {
 	token: string;

--- a/handlers/ticket-tailor-webhook/src/index.ts
+++ b/handlers/ticket-tailor-webhook/src/index.ts
@@ -1,8 +1,8 @@
+import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import { putMetric } from '@modules/aws/cloudwatch';
 import { logger } from '@modules/logger/logger';
 import type { Stage } from '@modules/stage';
 import { stageFromEnvironment } from '@modules/stage';
-import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import type { ApiGatewayToSqsEvent } from './apiGatewayToSqsEvent';
 import { apiGatewayToSqsEventSchema } from './apiGatewayToSqsEvent';
 import { createGuestAccount, fetchUserType } from './idapiService';

--- a/handlers/update-supporter-plus-amount/src/index.ts
+++ b/handlers/update-supporter-plus-amount/src/index.ts
@@ -1,3 +1,6 @@
+import type { APIGatewayProxyResult, Handler } from 'aws-lambda';
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import { sendEmail } from '@modules/email/email';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { ok } from '@modules/routing/apiGatewayResponses';
@@ -10,9 +13,6 @@ import type {
 	ZuoraSubscription,
 } from '@modules/zuora/types/objects';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { APIGatewayProxyResult, Handler } from 'aws-lambda';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 import type { RequestBody } from './schema';
 import { requestBodySchema } from './schema';
 import { createThankYouEmail } from './sendEmail';

--- a/handlers/update-supporter-plus-amount/src/sendEmail.ts
+++ b/handlers/update-supporter-plus-amount/src/sendEmail.ts
@@ -1,8 +1,8 @@
+import type dayjs from 'dayjs';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type { ProductBillingPeriod } from '@modules/product-catalog/productBillingPeriods';
-import type dayjs from 'dayjs';
 
 export type EmailFields = {
 	nextPaymentDate: dayjs.Dayjs;

--- a/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
+++ b/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
@@ -1,3 +1,5 @@
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { getSingleOrThrow } from '@modules/arrayFunctions';
 import { ValidationError } from '@modules/errors';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
@@ -18,8 +20,6 @@ import type {
 } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
 import type { EmailFields } from './sendEmail';
 import { supporterPlusAmountBands } from './supporterPlusAmountBands';
 import { doEnsureTerm, doUpdate } from './zuoraApi';

--- a/handlers/update-supporter-plus-amount/src/zuoraApi.ts
+++ b/handlers/update-supporter-plus-amount/src/zuoraApi.ts
@@ -1,10 +1,10 @@
+import type { Dayjs } from 'dayjs';
 import type { OrderAction } from '@modules/zuora/orders/orderActions';
 import { singleTriggerDate } from '@modules/zuora/orders/orderActions';
 import type { OrderRequest } from '@modules/zuora/orders/orderRequests';
 import { voidSchema } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { Dayjs } from 'dayjs';
 
 export const doUpdate = async ({
 	zuoraClient,

--- a/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmountIntegration.test.ts
+++ b/handlers/update-supporter-plus-amount/test/updateSupporterPlusAmountIntegration.test.ts
@@ -1,10 +1,10 @@
 import console from 'console';
+import dayjs from 'dayjs';
 import { sendEmail } from '@modules/email/email';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 import { createThankYouEmail } from '../src/sendEmail';
 import { updateSupporterPlusAmount } from '../src/updateSupporterPlusAmount';
 

--- a/handlers/user-benefits/src/benefitsIdentityId.ts
+++ b/handlers/user-benefits/src/benefitsIdentityId.ts
@@ -1,3 +1,4 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { Lazy } from '@modules/lazy';
 import type { UserBenefitsResponse } from '@modules/product-benefits/schemas';
 import { getUserBenefitsExcludingStaff } from '@modules/product-benefits/userBenefits';
@@ -9,7 +10,6 @@ import {
 } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import { stageFromEnvironment } from '@modules/stage';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { buildHttpResponse } from './response';
 import { getTrialInformation } from './trials';
 

--- a/handlers/user-benefits/src/benefitsList.ts
+++ b/handlers/user-benefits/src/benefitsList.ts
@@ -1,10 +1,10 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
 import {
 	getCustomerFacingName,
 	isProductKey,
 } from '@modules/product-catalog/productCatalog';
 import { zuoraCatalogToProductKey } from '@modules/product-catalog/zuoraToProductNameMappings';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 
 export const benefitsListHandler = async (
 	event: APIGatewayProxyEvent,

--- a/handlers/user-benefits/src/benefitsMe.ts
+++ b/handlers/user-benefits/src/benefitsMe.ts
@@ -1,3 +1,4 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { buildAuthenticate } from '@modules/identity/apiGateway';
 import type { IdentityUserDetails } from '@modules/identity/oktaTokenHelper';
 import { Lazy } from '@modules/lazy';
@@ -8,7 +9,6 @@ import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import { buildErrorResponse } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import { stageFromEnvironment } from '@modules/stage';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { buildHttpResponse } from './response';
 import { getTrialInformation } from './trials';
 

--- a/handlers/user-benefits/src/response.ts
+++ b/handlers/user-benefits/src/response.ts
@@ -1,6 +1,6 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { UserBenefitsResponse } from '@modules/product-benefits/schemas';
 import type { Stage } from '@modules/stage';
-import type { APIGatewayProxyResult } from 'aws-lambda';
 import { allowedOriginsForStage } from './cors';
 
 const buildCorsHeaders = (

--- a/handlers/user-benefits/test/benefitsIdentityId.test.ts
+++ b/handlers/user-benefits/test/benefitsIdentityId.test.ts
@@ -1,7 +1,7 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { getUserBenefitsExcludingStaff } from '@modules/product-benefits/userBenefits';
 import type { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { benefitsIdentityIdHandler } from '../src/benefitsIdentityId';
 
 jest.mock('@modules/product-catalog/api', () => ({

--- a/handlers/user-benefits/test/benefitsMe.test.ts
+++ b/handlers/user-benefits/test/benefitsMe.test.ts
@@ -1,5 +1,5 @@
-import type { UserBenefitsResponse } from '@modules/product-benefits/schemas';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
+import type { UserBenefitsResponse } from '@modules/product-benefits/schemas';
 import { benefitsMeHandler } from '../src/benefitsMe';
 
 jest.mock('@modules/identity/apiGateway', () => ({

--- a/handlers/user-subscriptions-api/src/index.ts
+++ b/handlers/user-subscriptions-api/src/index.ts
@@ -1,9 +1,9 @@
+import type { Handler } from 'aws-lambda';
 import { Lazy } from '@modules/lazy';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { Router } from '@modules/routing/router';
 import { stageFromEnvironment } from '@modules/stage';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { Handler } from 'aws-lambda';
 import { MeEndpoint } from './meEndpoint';
 
 const services = new Lazy(loadServices, 'services');

--- a/handlers/user-subscriptions-api/src/meEndpoint.ts
+++ b/handlers/user-subscriptions-api/src/meEndpoint.ts
@@ -1,9 +1,9 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import { ok } from '@modules/routing/apiGatewayResponses';
 import { objectQuery } from '@modules/zuora/objectQuery';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { APIGatewayProxyResult } from 'aws-lambda';
-import { z } from 'zod';
 
 const availableActionSchema = z.discriminatedUnion('action', [
 	z.object({

--- a/handlers/write-off-unpaid-invoices/src/handlers/writeOffInvoices.ts
+++ b/handlers/write-off-unpaid-invoices/src/handlers/writeOffInvoices.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { stageFromEnvironment } from '@modules/stage';
 import { getAccount } from '@modules/zuora/account';
 import { applyCreditToAccountBalance } from '@modules/zuora/creditBalanceAdjustment';
@@ -13,7 +14,6 @@ import type {
 	ZuoraAccount,
 } from '@modules/zuora/types';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 
 export type CancelSource = 'MMA' | 'Autocancel' | 'Salesforce';
 

--- a/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/getBillingAccounts.ts
@@ -1,8 +1,8 @@
+import { z } from 'zod';
 import { executeSalesforceQuery } from '@modules/salesforce/query';
 import { RecordSchema } from '@modules/salesforce/recordSchema';
 import { SfClient } from '@modules/salesforce/sfClient';
 import { stageFromEnvironment } from '@modules/stage';
-import { z } from 'zod';
 import { getSalesforceSecretNames } from '../salesforceSecretNames';
 
 export async function handler() {

--- a/handlers/zuora-salesforce-link-remover/src/handlers/updateSfBillingAccounts.ts
+++ b/handlers/zuora-salesforce-link-remover/src/handlers/updateSfBillingAccounts.ts
@@ -1,3 +1,5 @@
+import type { Handler } from 'aws-lambda';
+import { z } from 'zod';
 import { sfApiVersion } from '@modules/salesforce/config';
 import { SfClient } from '@modules/salesforce/sfClient';
 import type {
@@ -6,8 +8,6 @@ import type {
 } from '@modules/salesforce/updateRecords';
 import { doCompositeCallout } from '@modules/salesforce/updateRecords';
 import { stageFromEnvironment } from '@modules/stage';
-import type { Handler } from 'aws-lambda';
-import { z } from 'zod';
 import { getSalesforceSecretNames } from '../salesforceSecretNames';
 import type { BillingAccountRecord } from './getBillingAccounts';
 import { BillingAccountRecordSchema } from './getBillingAccounts';

--- a/modules/aws/src/appConfig.ts
+++ b/modules/aws/src/appConfig.ts
@@ -1,7 +1,7 @@
 import { GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
+import type { z } from 'zod';
 import { wrapAwsClient } from '@modules/logger/wrapAwsClient';
 import { objectEntries } from '@modules/objectFunctions';
-import type { z } from 'zod';
 import { groupMap, mapValues, partitionByType } from '../../arrayFunctions';
 import { awsConfig } from '../src/config';
 import { fetchAllPages } from './fetchAllPages';

--- a/modules/aws/src/sqs.ts
+++ b/modules/aws/src/sqs.ts
@@ -8,8 +8,8 @@ import {
 	SendMessageCommand,
 	SQSClient,
 } from '@aws-sdk/client-sqs';
-import { logger } from '@modules/logger/logger';
 import { awsConfig } from '@modules/aws/config';
+import { logger } from '@modules/logger/logger';
 
 export class SqsSendError extends Error {
 	constructor(cause: unknown) {

--- a/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
@@ -1,7 +1,7 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
 	EmailBillingPeriod,

--- a/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
@@ -1,6 +1,6 @@
+import type { Dayjs } from 'dayjs';
 import { getCountryNameByIsoCode } from '@modules/internationalisation/country';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
-import type { Dayjs } from 'dayjs';
 import type { NonDeliveryEmailFields } from './emailFields';
 import { buildNonDeliveryEmailFields } from './emailFields';
 import type {

--- a/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
@@ -1,7 +1,7 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
 	EmailBillingPeriod,

--- a/modules/email/src/dataFields/dayZero/emailFields.ts
+++ b/modules/email/src/dataFields/dayZero/emailFields.ts
@@ -1,10 +1,10 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import type {
 	DataExtensionName,
 	EmailMessageWithIdentityUserId,
 } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { describePayments, firstPayment } from './paymentDescription';
 import type { EmailPaymentFields } from './paymentEmailFields';
 import { getPaymentFields } from './paymentEmailFields';

--- a/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
@@ -1,7 +1,7 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
 	EmailPaymentMethod,

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
@@ -1,9 +1,9 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
-import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
 import { buildEmailFields } from './emailFields';
 import { formatDate } from './paymentEmailFields';

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
@@ -1,8 +1,8 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
-import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import type { Dayjs } from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
 import { buildEmailFields } from './emailFields';
 import type {

--- a/modules/email/src/dataFields/dayZero/paperEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paperEmailFields.ts
@@ -1,11 +1,11 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
-import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import type { Dayjs } from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type {
 	DataExtensionName,
 	EmailMessageWithIdentityUserId,
 } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
 import { buildEmailFields } from './emailFields';
 import type {

--- a/modules/email/src/dataFields/dayZero/paymentDescription.ts
+++ b/modules/email/src/dataFields/dayZero/paymentDescription.ts
@@ -1,8 +1,8 @@
+import dayjs from 'dayjs';
 import { partition } from '@modules/arrayFunctions';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getCurrencyInfo } from '@modules/internationalisation/currency';
 import { getNonEmptyOrThrow, isNonEmpty } from '@modules/nullAndUndefined';
-import dayjs from 'dayjs';
 import type { EmailBillingPeriod, EmailPaymentSchedule } from './types';
 
 type Payment = EmailPaymentSchedule['payments'][number];

--- a/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paymentEmailFields.ts
@@ -1,7 +1,7 @@
-import { getIfDefined } from '@modules/nullAndUndefined';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import minMax from 'dayjs/plugin/minMax';
+import { getIfDefined } from '@modules/nullAndUndefined';
 import type { EmailPaymentMethod } from './types';
 
 dayjs.extend(minMax);

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -1,6 +1,6 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type dayjs from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import { getPaymentMethodFieldsSupporterPlus } from './paymentEmailFields';
 import type {

--- a/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
@@ -1,8 +1,8 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
-import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import type { Dayjs } from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
 import { buildEmailFields } from './emailFields';
 import type {

--- a/modules/guardian-subscription/src/subscriptionFilter.ts
+++ b/modules/guardian-subscription/src/subscriptionFilter.ts
@@ -1,10 +1,10 @@
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { partitionByType } from '@modules/arrayFunctions';
 import { logger } from '@modules/logger/logger';
 import { mapValuesMap, partitionByValueType } from '@modules/mapFunctions';
 import type { RatePlan, RatePlanCharge } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import type { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
 import type { GuardianSubscriptionMultiPlan } from './guardianSubscriptionParser';
 import type { GuardianRatePlanMap } from './reprocessRatePlans/guardianRatePlanBuilder';
 import type { ZuoraRatePlan } from './reprocessRatePlans/zuoraRatePlanBuilder';

--- a/modules/guardian-subscription/test/getSinglePlanFlattenedSubscription.test.ts
+++ b/modules/guardian-subscription/test/getSinglePlanFlattenedSubscription.test.ts
@@ -1,9 +1,9 @@
+import dayjs from 'dayjs';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import { zuoraSubscriptionSchema } from '@modules/zuora/types';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import alreadySwitchedJson from '../../../handlers/product-switch-api/test/fixtures/already-switched-subscription.json';
 import subscriptionJson from '../../../handlers/product-switch-api/test/fixtures/subscription.json';
 import zuoraCatalogFixture from '../../zuora-catalog/test/fixtures/catalog-prod.json';

--- a/modules/identity/src/apiGateway.ts
+++ b/modules/identity/src/apiGateway.ts
@@ -1,6 +1,5 @@
-import { ValidationError } from '@modules/errors';
-import type { Stage } from '@modules/stage';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ValidationError } from '@modules/errors';
 import type { IdentityUserDetails } from '@modules/identity/oktaTokenHelper';
 import { SigningKeyNotFoundError } from '@modules/identity/oktaTokenHelper';
 import {
@@ -9,6 +8,7 @@ import {
 	InvalidTokenError,
 	OktaTokenHelper,
 } from '@modules/identity/oktaTokenHelper';
+import type { Stage } from '@modules/stage';
 
 type SuccessfulAuthentication = {
 	type: 'success';

--- a/modules/identity/src/idapi.ts
+++ b/modules/identity/src/idapi.ts
@@ -1,6 +1,6 @@
 import * as console from 'node:console';
-import { RestClientError } from '@modules/zuora/restClient';
 import { z } from 'zod';
+import { RestClientError } from '@modules/zuora/restClient';
 import type { IdentityClient } from './identityClient';
 
 const identityUserSchema = z.object({

--- a/modules/identity/src/oktaTokenHelper.ts
+++ b/modules/identity/src/oktaTokenHelper.ts
@@ -1,7 +1,7 @@
 import * as console from 'node:console';
-import type { Stage } from '@modules/stage';
 import OktaJwtVerifier from '@okta/jwt-verifier';
 import { z } from 'zod';
+import type { Stage } from '@modules/stage';
 
 // The claims object returned by Okta. It should include the identity ID and email
 const jwtClaimsSchema = z.object({

--- a/modules/internationalisation/src/gwDeliverableCountries.ts
+++ b/modules/internationalisation/src/gwDeliverableCountries.ts
@@ -1,6 +1,6 @@
-import { objectEntries, objectFromEntries } from '@modules/objectFunctions';
 import type { IsoCountry } from '@modules/internationalisation/country';
 import { gwCountries } from '@modules/internationalisation/gwCountries';
+import { objectEntries, objectFromEntries } from '@modules/objectFunctions';
 
 const gwNonDeliverableCountries: Set<IsoCountry> = new Set([
 	'AF', // Afghanistan

--- a/modules/multiple-account/src/secondarySubscription.ts
+++ b/modules/multiple-account/src/secondarySubscription.ts
@@ -1,7 +1,7 @@
+import type { Dayjs } from 'dayjs';
 import type { Stage } from '@modules/stage';
 import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import { sendToSupporterProductData } from '@modules/supporter-product-data/supporterProductData';
-import type { Dayjs } from 'dayjs';
 
 const secondarySubscriptionName = (
 	primarySubscriptionName: string,

--- a/modules/multiple-account/src/secondaryUserRepository.ts
+++ b/modules/multiple-account/src/secondaryUserRepository.ts
@@ -7,10 +7,10 @@ import {
 	UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import { logger } from '@modules/logger/logger';
-import type { Stage } from '@modules/stage';
 import type { Dayjs } from 'dayjs';
 import { z } from 'zod';
+import { logger } from '@modules/logger/logger';
+import type { Stage } from '@modules/stage';
 
 const secondaryUserRecordSchema = z.object({
 	subscriptionName: z.string(),

--- a/modules/multiple-account/test/secondaryUserRepositoryIntegration.test.ts
+++ b/modules/multiple-account/test/secondaryUserRepositoryIntegration.test.ts
@@ -6,9 +6,9 @@
  * @group integration
  */
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import dayjs from 'dayjs';
 import { getAwsConfig } from '@modules/aws/config';
 import type { Stage } from '@modules/stage';
-import dayjs from 'dayjs';
 import { SecondaryUserRepository } from '../src/secondaryUserRepository';
 
 const stage: Stage = 'CODE';

--- a/modules/product-benefits/src/productBenefit.ts
+++ b/modules/product-benefits/src/productBenefit.ts
@@ -1,7 +1,7 @@
-import type { ProductKey } from '@modules/product-catalog/productCatalog';
-import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import dayjs from 'dayjs';
 import type { InAppPurchaseProductKey } from '@modules/product-benefits/inAppPurchase';
+import type { ProductKey } from '@modules/product-catalog/productCatalog';
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
 import type { ProductBenefit } from './schemas';
 import { productBenefitListSchema } from './schemas';
 

--- a/modules/product-benefits/src/userBenefits.ts
+++ b/modules/product-benefits/src/userBenefits.ts
@@ -1,13 +1,6 @@
+import dayjs from 'dayjs';
 import { distinct } from '@modules/arrayFunctions';
 import type { IdentityUserDetails } from '@modules/identity/oktaTokenHelper';
-import type {
-	ProductCatalogHelper,
-	ProductKey,
-} from '@modules/product-catalog/productCatalog';
-import type { Stage } from '@modules/stage';
-import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
-import { getSupporterRatePlans } from '@modules/supporter-product-data/supporterProductData';
-import dayjs from 'dayjs';
 import {
 	inAppPurchaseProductKey,
 	isInAppPurchase,
@@ -19,6 +12,13 @@ import {
 	productBenefitMapping,
 } from '@modules/product-benefits/productBenefit';
 import type { ProductBenefit } from '@modules/product-benefits/schemas';
+import type {
+	ProductCatalogHelper,
+	ProductKey,
+} from '@modules/product-catalog/productCatalog';
+import type { Stage } from '@modules/stage';
+import type { SupporterRatePlanItem } from '@modules/supporter-product-data/supporterProductData';
+import { getSupporterRatePlans } from '@modules/supporter-product-data/supporterProductData';
 
 export const getUserProducts = async (
 	stage: Stage,

--- a/modules/product-benefits/test/getUserBenefits.test.ts
+++ b/modules/product-benefits/test/getUserBenefits.test.ts
@@ -1,6 +1,3 @@
-import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
-import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import dayjs from 'dayjs';
 import {
 	digitalSubscriptionBenefits,
@@ -10,6 +7,9 @@ import {
 	getUserBenefitsFromUserProducts,
 	getValidUserProducts,
 } from '@modules/product-benefits/userBenefits';
+import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
+import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import codeZuoraCatalog from '../../zuora-catalog/test/fixtures/catalog-code.json';
 
 const codeProductCatalog = generateProductCatalog(

--- a/modules/product-catalog/eslint.config.mjs
+++ b/modules/product-catalog/eslint.config.mjs
@@ -1,8 +1,10 @@
 import guardian from '@guardian/eslint-config';
 import sortKeysFix from 'eslint-plugin-sort-keys-fix';
+import { importOrderConfig } from '../../eslint.shared.mjs';
 
 export default [
 	...guardian.configs.recommended,
+	importOrderConfig,
 	{
 		files: [
 			'src/productCatalogSchema.ts',

--- a/modules/product-catalog/src/generateProductBillingPeriods.ts
+++ b/modules/product-catalog/src/generateProductBillingPeriods.ts
@@ -1,13 +1,13 @@
 import { arrayToObject, distinct } from '@modules/arrayFunctions';
 import { objectEntries } from '@modules/objectFunctions';
-import type {
-	ZuoraCatalog,
-	ZuoraProductRatePlan,
-} from '@modules/zuora-catalog/zuoraCatalogSchema';
 import {
 	getZuoraProductKey,
 	isSupportedProduct,
 } from '@modules/product-catalog/zuoraToProductNameMappings';
+import type {
+	ZuoraCatalog,
+	ZuoraProductRatePlan,
+} from '@modules/zuora-catalog/zuoraCatalogSchema';
 import type { StripeProduct, StripeProductKey } from './stripeProducts';
 import { stripeProducts } from './stripeProducts';
 

--- a/modules/product-catalog/src/generateProductCatalog.ts
+++ b/modules/product-catalog/src/generateProductCatalog.ts
@@ -1,10 +1,5 @@
 import { arrayToObject } from '@modules/arrayFunctions';
 import { isBillingPeriod } from '@modules/billingPeriod';
-import {
-	type ZuoraCatalog,
-	type ZuoraProductRatePlan,
-	type ZuoraProductRatePlanCharge,
-} from '@modules/zuora-catalog/zuoraCatalogSchema';
 import { findDiscountRatePlan } from '@modules/product-catalog/generateSchema';
 import type {
 	ProductCatalog,
@@ -30,6 +25,11 @@ import {
 	isSupportedProduct,
 	isSupportedProductRatePlan,
 } from '@modules/product-catalog/zuoraToProductNameMappings';
+import {
+	type ZuoraCatalog,
+	type ZuoraProductRatePlan,
+	type ZuoraProductRatePlanCharge,
+} from '@modules/zuora-catalog/zuoraCatalogSchema';
 
 type NonNullPrice = { currency: string; price: number };
 type PricingObject = Record<string, number>;

--- a/modules/product-catalog/src/generateProductPurchaseSchema.ts
+++ b/modules/product-catalog/src/generateProductPurchaseSchema.ts
@@ -1,8 +1,3 @@
-import type {
-	CatalogProduct,
-	ZuoraCatalog,
-	ZuoraProductRatePlan,
-} from '@modules/zuora-catalog/zuoraCatalogSchema';
 import {
 	isDeliveryProduct,
 	requiresDeliveryInstructions,
@@ -13,6 +8,11 @@ import {
 	isSupportedProduct,
 	isSupportedProductRatePlan,
 } from '@modules/product-catalog/zuoraToProductNameMappings';
+import type {
+	CatalogProduct,
+	ZuoraCatalog,
+	ZuoraProductRatePlan,
+} from '@modules/zuora-catalog/zuoraCatalogSchema';
 
 const header = `
 // ---------- This file is auto-generated. Do not edit manually. -------------

--- a/modules/product-catalog/src/generateSchema.ts
+++ b/modules/product-catalog/src/generateSchema.ts
@@ -1,11 +1,5 @@
 import { distinct } from '@modules/arrayFunctions';
 import { getIfDefined, isNotNull } from '@modules/nullAndUndefined';
-import type {
-	CatalogProduct,
-	ZuoraCatalog,
-	ZuoraProductRatePlan,
-	ZuoraProductRatePlanCharge,
-} from '@modules/zuora-catalog/zuoraCatalogSchema';
 import {
 	isDeliveryProduct,
 	supportsPromotions,
@@ -19,6 +13,12 @@ import {
 	isSupportedProduct,
 	isSupportedProductRatePlan,
 } from '@modules/product-catalog/zuoraToProductNameMappings';
+import type {
+	CatalogProduct,
+	ZuoraCatalog,
+	ZuoraProductRatePlan,
+	ZuoraProductRatePlanCharge,
+} from '@modules/zuora-catalog/zuoraCatalogSchema';
 
 const header = `
 // ---------- This file is auto-generated. Do not edit manually. -------------

--- a/modules/product-catalog/src/generateSchemaCommand.ts
+++ b/modules/product-catalog/src/generateSchemaCommand.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
-import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
 import { generateProductBillingPeriods } from '@modules/product-catalog/generateProductBillingPeriods';
 import { generateProductPurchaseSchema } from '@modules/product-catalog/generateProductPurchaseSchema';
 import { generateSchema } from '@modules/product-catalog/generateSchema';
+import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
 
 const writeSchemaToFile = async () => {
 	const prodCatalog = await getZuoraCatalogFromS3('PROD');

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -1,7 +1,7 @@
+import { z } from 'zod';
 import { isInList } from '@modules/arrayFunctions';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { objectEntries, objectKeysNonEmpty } from '@modules/objectFunctions';
-import { z } from 'zod';
 import type { termTypeSchema } from '@modules/product-catalog/productCatalogSchema';
 import { productCatalogSchema } from '@modules/product-catalog/productCatalogSchema';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';

--- a/modules/product-catalog/test/generateProductCatalog.test.ts
+++ b/modules/product-catalog/test/generateProductCatalog.test.ts
@@ -1,7 +1,7 @@
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import { generateProductBillingPeriods } from '@modules/product-catalog/generateProductBillingPeriods';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import { productCatalogSchema } from '@modules/product-catalog/productCatalogSchema';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 import prod from '../../zuora-catalog/test/fixtures/catalog-prod.json';
 

--- a/modules/product-catalog/test/parsingTest.test.ts
+++ b/modules/product-catalog/test/parsingTest.test.ts
@@ -1,6 +1,6 @@
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import { productCatalogSchema } from '@modules/product-catalog/productCatalogSchema';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 import prod from '../../zuora-catalog/test/fixtures/catalog-prod.json';
 

--- a/modules/product-catalog/test/productCatalogMapping.test.ts
+++ b/modules/product-catalog/test/productCatalogMapping.test.ts
@@ -1,9 +1,9 @@
 import { findDuplicates } from '@modules/arrayFunctions';
+import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
+import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import type { Stage } from '@modules/stage';
 import { ZuoraCatalogHelper } from '@modules/zuora-catalog/zuoraCatalog';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
-import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import codeZuoraCatalog from '../../zuora-catalog/test/fixtures/catalog-code.json';
 import prodZuoraCatalog from '../../zuora-catalog/test/fixtures/catalog-prod.json';
 

--- a/modules/promotions/src/v1/schema.ts
+++ b/modules/promotions/src/v1/schema.ts
@@ -1,8 +1,8 @@
+import { z } from 'zod';
 import {
 	isoCountrySchema,
 	supportRegionSchema,
 } from '@modules/internationalisation/schemas';
-import { z } from 'zod';
 
 export const promotionCopySchema = z.object({
 	title: z.string().optional(),

--- a/modules/promotions/src/v2/getPromotion.ts
+++ b/modules/promotions/src/v2/getPromotion.ts
@@ -7,9 +7,9 @@ import type {
 	ProductKey,
 } from '@modules/product-catalog/productCatalog';
 import { supportsPromotions } from '@modules/product-catalog/productCatalog';
-import type { Stage } from '@modules/stage';
 import type { Promo } from '@modules/promotions/v2/schema';
 import { promoSchema } from '@modules/promotions/v2/schema';
+import type { Stage } from '@modules/stage';
 
 const dynamoClient = new DynamoDBClient(awsConfig);
 

--- a/modules/promotions/src/v2/schema.ts
+++ b/modules/promotions/src/v2/schema.ts
@@ -1,9 +1,9 @@
+import { z } from 'zod';
 import {
 	isoCountrySchema,
 	supportRegionSchema,
 } from '@modules/internationalisation/schemas';
 import { optionalDropNulls } from '@modules/schemaUtils';
-import { z } from 'zod';
 
 export const promoCampaignSchema = z.object({
 	campaignCode: z.string(),

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -1,8 +1,8 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import type { z } from 'zod';
 import { ValidationError } from '@modules/errors';
 import { prettyPrint } from '@modules/prettyPrint';
 import { stringify } from '@modules/stringify';
-import type { APIGatewayProxyResult } from 'aws-lambda';
-import type { z } from 'zod';
 
 function jsonResponse(message: string, statusCode: number) {
 	return {

--- a/modules/routing/src/lambdaHandler.ts
+++ b/modules/routing/src/lambdaHandler.ts
@@ -1,11 +1,11 @@
+import dayjs from 'dayjs';
+import type { z } from 'zod';
 import { loadConfig } from '@modules/aws/appConfig';
 import { invokeFunction } from '@modules/aws/lambda';
 import { Lazy } from '@modules/lazy';
 import { getCallerInfo } from '@modules/logger/getCallerInfo';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
-import dayjs from 'dayjs';
-import type { z } from 'zod';
 
 export type HandlerEnv<ConfigType> = {
 	now: () => dayjs.Dayjs;

--- a/modules/routing/src/router.ts
+++ b/modules/routing/src/router.ts
@@ -1,8 +1,8 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { mapPartition, mapValues, zipAll } from '@modules/arrayFunctions';
 import { getCallerInfo } from '@modules/logger/getCallerInfo';
 import { logger } from '@modules/logger/logger';
 import { objectEntries } from '@modules/objectFunctions';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { buildErrorResponse } from '@modules/routing/apiGatewayResponses';
 
 export type HttpMethod =

--- a/modules/routing/src/sqsHandler.ts
+++ b/modules/routing/src/sqsHandler.ts
@@ -1,7 +1,7 @@
-import { getCallerInfo } from '@modules/logger/getCallerInfo';
-import { logger } from '@modules/logger/logger';
 import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import type { z } from 'zod';
+import { getCallerInfo } from '@modules/logger/getCallerInfo';
+import { logger } from '@modules/logger/logger';
 import type { HandlerEnv } from '@modules/routing/lambdaHandler';
 import { LambdaHandlerWithServices } from '@modules/routing/lambdaHandler';
 

--- a/modules/routing/src/withMMAIdentityCheck.ts
+++ b/modules/routing/src/withMMAIdentityCheck.ts
@@ -1,5 +1,11 @@
+import type {
+	APIGatewayProxyEvent,
+	APIGatewayProxyEventHeaders,
+	APIGatewayProxyResult,
+} from 'aws-lambda';
 import { ValidationError } from '@modules/errors';
 import { logger } from '@modules/logger/logger';
+import type { Handler } from '@modules/routing/router';
 import type { Stage } from '@modules/stage';
 import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
@@ -8,12 +14,6 @@ import type {
 	ZuoraSubscription,
 } from '@modules/zuora/types/objects';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type {
-	APIGatewayProxyEvent,
-	APIGatewayProxyEventHeaders,
-	APIGatewayProxyResult,
-} from 'aws-lambda';
-import type { Handler } from '@modules/routing/router';
 
 export function assertIdentityIdMatches(
 	account: ZuoraAccount,

--- a/modules/salesforce/src/auth/sfClientCredentialsTokenProvider.ts
+++ b/modules/salesforce/src/auth/sfClientCredentialsTokenProvider.ts
@@ -1,8 +1,8 @@
-import { getSecretValue } from '@modules/secrets-manager/getSecret';
-import type { Authorisation, BearerTokenProvider } from '@modules/zuora/auth';
 import type { SfConnectedAppAuth } from '@modules/salesforce/auth/auth';
 import { authenticateSalesforce } from '@modules/salesforce/auth/auth';
 import type { ConnectedAppSecret } from '@modules/salesforce/secrets';
+import { getSecretValue } from '@modules/secrets-manager/getSecret';
+import type { Authorisation, BearerTokenProvider } from '@modules/zuora/auth';
 
 export type SfClientCredentials = {
 	authUrl: string;

--- a/modules/salesforce/src/auth/sfPasswordFlowTokenProvider.ts
+++ b/modules/salesforce/src/auth/sfPasswordFlowTokenProvider.ts
@@ -1,5 +1,3 @@
-import { getSecretValue } from '@modules/secrets-manager/getSecret';
-import type { Authorisation, BearerTokenProvider } from '@modules/zuora/auth';
 import type { SfConnectedAppAuth } from '@modules/salesforce/auth/auth';
 import { authenticateSalesforce } from '@modules/salesforce/auth/auth';
 import type {
@@ -7,6 +5,8 @@ import type {
 	ConnectedAppSecret,
 	SecretNames,
 } from '@modules/salesforce/secrets';
+import { getSecretValue } from '@modules/secrets-manager/getSecret';
+import type { Authorisation, BearerTokenProvider } from '@modules/zuora/auth';
 
 export type SfPasswordCredentials = {
 	authUrl: string;

--- a/modules/salesforce/src/sfClient.ts
+++ b/modules/salesforce/src/sfClient.ts
@@ -1,5 +1,3 @@
-import type { BearerTokenProvider } from '@modules/zuora/auth';
-import { RestClient } from '@modules/zuora/restClient';
 import {
 	getSfClientCredentials,
 	SfClientCredentialsTokenProvider,
@@ -9,6 +7,8 @@ import {
 	SfPasswordFlowTokenProvider,
 } from '@modules/salesforce/auth/sfPasswordFlowTokenProvider';
 import type { SecretNames } from '@modules/salesforce/secrets';
+import type { BearerTokenProvider } from '@modules/zuora/auth';
+import { RestClient } from '@modules/zuora/restClient';
 
 export class SfClient extends RestClient {
 	constructor(tokenProvider: BearerTokenProvider) {

--- a/modules/supporter-product-data/src/supporterProductData.ts
+++ b/modules/supporter-product-data/src/supporterProductData.ts
@@ -5,14 +5,14 @@ import {
 	QueryCommand,
 } from '@aws-sdk/client-dynamodb';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import { awsConfig } from '@modules/aws/config';
 import { sendMessageToQueue } from '@modules/aws/sqs';
 import { logger } from '@modules/logger/logger';
 import { prettyPrint } from '@modules/prettyPrint';
 import type { Stage } from '@modules/stage';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 
 const dynamoClient = new DynamoDBClient(awsConfig);
 

--- a/modules/sync-supporter-product-data/src/syncUser.ts
+++ b/modules/sync-supporter-product-data/src/syncUser.ts
@@ -1,4 +1,6 @@
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import { awsConfig } from '@modules/aws/config';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
@@ -9,8 +11,6 @@ import { createQueryResponseSchema } from '@modules/zuora/types';
 import type { RatePlan, ZuoraSubscription } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 
 export const getActiveAccountNumbersForIdentityId = async (
 	zuoraClient: ZuoraClient,

--- a/modules/test-users/src/cancel.ts
+++ b/modules/test-users/src/cancel.ts
@@ -1,6 +1,6 @@
+import dayjs from 'dayjs';
 import { cancelSubscription } from '@modules/zuora/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 
 void (async () => {
 	const subscriptionNumber = process.argv[2];

--- a/modules/test-users/src/create.ts
+++ b/modules/test-users/src/create.ts
@@ -1,8 +1,8 @@
+import type { Dayjs } from 'dayjs';
 import { zuoraSubscribeResponseSchema } from '@modules/zuora/types';
 import type { ZuoraSubscribeResponse } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import type { Dayjs } from 'dayjs';
 
 type SubscribeItem = {
 	productRatePlanId: string;

--- a/modules/test-users/src/createAnnualContribution.ts
+++ b/modules/test-users/src/createAnnualContribution.ts
@@ -1,7 +1,7 @@
-import { getProductCatalogFromApi } from '@modules/product-catalog/api';
-import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
+import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { createAccountAndSubscription } from '@modules/test-users/create';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
 
 void (async () => {
 	const amount = process.argv[2];

--- a/modules/test-users/src/createDigitalSubscription.ts
+++ b/modules/test-users/src/createDigitalSubscription.ts
@@ -1,7 +1,7 @@
-import { getProductCatalogFromApi } from '@modules/product-catalog/api';
-import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
+import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { createAccountAndSubscription } from '@modules/test-users/create';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
 
 void (async () => {
 	const stage = 'CODE';

--- a/modules/test-users/src/createMonthlyContribution.ts
+++ b/modules/test-users/src/createMonthlyContribution.ts
@@ -1,7 +1,7 @@
-import { getProductCatalogFromApi } from '@modules/product-catalog/api';
-import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import dayjs from 'dayjs';
+import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { createAccountAndSubscription } from '@modules/test-users/create';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
 
 void (async () => {
 	const amount = process.argv[2];

--- a/modules/test-users/src/updateMonthlyContributionAmount.ts
+++ b/modules/test-users/src/updateMonthlyContributionAmount.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { prettyPrint } from '@modules/prettyPrint';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
@@ -7,7 +8,6 @@ import type { ZuoraSubscription } from '@modules/zuora/types';
 import { zuoraSuccessSchema } from '@modules/zuora/types';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
-import dayjs from 'dayjs';
 
 const getFirstContributionRatePlan = (
 	productCatalog: ProductCatalog,

--- a/modules/zuora/src/billingPreview.ts
+++ b/modules/zuora/src/billingPreview.ts
@@ -1,7 +1,7 @@
-import { groupBy, sortBy, sumNumbers } from '@modules/arrayFunctions';
-import { getIfDefined } from '@modules/nullAndUndefined';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
+import { groupBy, sortBy, sumNumbers } from '@modules/arrayFunctions';
+import { getIfDefined } from '@modules/nullAndUndefined';
 import type { BillingPreview } from './types';
 import { billingPreviewSchema } from './types';
 import { zuoraDateFormat } from './utils';

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs';
+import type { Dayjs } from 'dayjs';
+import { z } from 'zod';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import type {
@@ -9,9 +12,6 @@ import { getDiscountRatePlanFromCatalog } from '@modules/promotions/v2/getPromot
 import type { AppliedPromotion, Promo } from '@modules/promotions/v2/schema';
 import type { ValidatedPromotion } from '@modules/promotions/v2/validatePromotion';
 import { validatePromotion } from '@modules/promotions/v2/validatePromotion';
-import dayjs from 'dayjs';
-import type { Dayjs } from 'dayjs';
-import { z } from 'zod';
 import { getChargeOverride } from '@modules/zuora/createSubscription/chargeOverride';
 import type { ClonedPaymentMethod } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import { getProductRatePlan } from '@modules/zuora/createSubscription/getProductRatePlan';

--- a/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
+++ b/modules/zuora/src/createSubscription/createSubscriptionWithExistingPaymentMethod.ts
@@ -1,6 +1,6 @@
+import { z } from 'zod';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Promo } from '@modules/promotions/v2/schema';
-import { z } from 'zod';
 import { clonePaymentMethod } from '@modules/zuora/createSubscription/clonePaymentMethod';
 import type {
 	CreateSubscriptionInputFields,

--- a/modules/zuora/src/createSubscription/previewCreateSubscription.ts
+++ b/modules/zuora/src/createSubscription/previewCreateSubscription.ts
@@ -1,11 +1,11 @@
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import type { AppliedPromotion, Promo } from '@modules/promotions/v2/schema';
 import { dateFromStringSchema } from '@modules/schemaUtils';
 import type { Stage } from '@modules/stage';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 import { getChargeOverride } from '@modules/zuora/createSubscription/chargeOverride';
 import { getPromotionInputFields } from '@modules/zuora/createSubscription/createSubscription';
 import { getProductRatePlan } from '@modules/zuora/createSubscription/getProductRatePlan';

--- a/modules/zuora/src/createSubscription/subscriptionDates.ts
+++ b/modules/zuora/src/createSubscription/subscriptionDates.ts
@@ -1,7 +1,7 @@
-import { isDeliveryProductPurchase } from '@modules/product-catalog/productCatalog';
-import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
+import { isDeliveryProductPurchase } from '@modules/product-catalog/productCatalog';
+import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 
 const DigitalSubscription = {
 	freeTrialPeriodInDays: 14,

--- a/modules/zuora/src/objectQuery/expandSchemas/ratePlanChargeItemSchema.ts
+++ b/modules/zuora/src/objectQuery/expandSchemas/ratePlanChargeItemSchema.ts
@@ -1,5 +1,5 @@
-import { productRatePlanChargeIdSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import z from 'zod';
+import { productRatePlanChargeIdSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 
 export const ratePlanChargeItemSchema = z.object({
 	/** The unique identifier of the rate plan charge. */

--- a/modules/zuora/src/objectQuery/expandSchemas/ratePlanItemSchema.ts
+++ b/modules/zuora/src/objectQuery/expandSchemas/ratePlanItemSchema.ts
@@ -1,9 +1,9 @@
+import z from 'zod';
+import { ratePlanChargeItemSchema } from '@modules/zuora/objectQuery/expandSchemas/ratePlanChargeItemSchema';
 import {
 	productIdSchema,
 	productRatePlanIdSchema,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import z from 'zod';
-import { ratePlanChargeItemSchema } from '@modules/zuora/objectQuery/expandSchemas/ratePlanChargeItemSchema';
 
 export const ratePlanItemSchema = z.object({
 	/** The unique identifier of the rate plan. */

--- a/modules/zuora/src/objectQuery/objectQueryBuilder.ts
+++ b/modules/zuora/src/objectQuery/objectQueryBuilder.ts
@@ -1,6 +1,6 @@
-import { mergeValues, pickKeys } from '@modules/objectFunctions';
 import type { ZodType } from 'zod';
 import { z } from 'zod';
+import { mergeValues, pickKeys } from '@modules/objectFunctions';
 import type { DoesNotHaveDuplicateResponseKey } from '@modules/zuora/objectQuery/doesNotHaveDuplicateResponseKey';
 import type {
 	ObjectQueryExpandRegistry,

--- a/modules/zuora/src/orders/orderActions.ts
+++ b/modules/zuora/src/orders/orderActions.ts
@@ -1,5 +1,5 @@
-import type { TermType } from '@modules/product-catalog/productCatalog';
 import type { Dayjs } from 'dayjs';
+import type { TermType } from '@modules/product-catalog/productCatalog';
 import type { PromotionInputFields } from '@modules/zuora/createSubscription/createSubscription';
 import { zuoraDateFormat } from '../utils/common';
 

--- a/modules/zuora/src/restClient.ts
+++ b/modules/zuora/src/restClient.ts
@@ -1,7 +1,7 @@
+import type { z, ZodType } from 'zod';
 import { groupMap } from '@modules/arrayFunctions';
 import { getCallerInfo } from '@modules/logger/getCallerInfo';
 import { logger } from '@modules/logger/logger';
-import type { z, ZodType } from 'zod';
 import type { BearerTokenProvider } from '@modules/zuora/auth';
 
 export class RestClientError extends Error implements RestResult {

--- a/modules/zuora/src/types/objects/account.ts
+++ b/modules/zuora/src/types/objects/account.ts
@@ -1,5 +1,5 @@
-import { CurrencyValues } from '@modules/internationalisation/currency';
 import { z } from 'zod';
+import { CurrencyValues } from '@modules/internationalisation/currency';
 import { zuoraSubscriptionSchema } from './subscription';
 
 export const zuoraAccountBasicInfoSchema = z

--- a/modules/zuora/src/types/objects/subscription.ts
+++ b/modules/zuora/src/types/objects/subscription.ts
@@ -1,10 +1,10 @@
+import { z } from 'zod';
 import { BillingPeriodValues } from '@modules/billingPeriod';
 import {
 	productIdSchema,
 	productRatePlanChargeIdSchema,
 	productRatePlanIdSchema,
 } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import { z } from 'zod';
 
 const billingPeriodAlignmentValues = [
 	'AlignToCharge',

--- a/modules/zuora/src/zuoraClient.ts
+++ b/modules/zuora/src/zuoraClient.ts
@@ -1,7 +1,7 @@
-import { logger } from '@modules/logger/logger';
-import type { Stage } from '@modules/stage';
 import type { ZodType } from 'zod';
 import { z } from 'zod';
+import { logger } from '@modules/logger/logger';
+import type { Stage } from '@modules/stage';
 import { getOAuthClientCredentials, ZuoraBearerTokenProvider } from './auth';
 import { generateZuoraError } from './errors';
 import { RestClient, RestClientError } from './restClient';

--- a/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
+++ b/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
@@ -1,15 +1,15 @@
+import dayjs from 'dayjs';
 import { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { AppliedPromotion, Promo } from '@modules/promotions/v2/schema';
 import type { Stage } from '@modules/stage';
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import { buildCreateSubscriptionRequest } from '@modules/zuora/createSubscription/createSubscription';
 import type { CreateSubscriptionInputFields } from '@modules/zuora/createSubscription/createSubscription';
 import type { CreateSubscriptionOrderAction } from '@modules/zuora/orders/orderActions';
 import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
 import type { CreditCardReferenceTransaction } from '@modules/zuora/orders/paymentMethods';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 import { ReaderType } from '../src/createSubscription/readerType';
 

--- a/modules/zuora/test/chargeOverride.test.ts
+++ b/modules/zuora/test/chargeOverride.test.ts
@@ -1,7 +1,7 @@
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import { getChargeOverride } from '@modules/zuora/createSubscription/chargeOverride';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import prod from '../../zuora-catalog/test/fixtures/catalog-prod.json';
 import { deliveryContact } from './fixtures/createSubscriptionFixtures';
 

--- a/modules/zuora/test/createSubscriptionIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionIntegration.test.ts
@@ -4,6 +4,8 @@
  * @group integration
  */
 
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getIfDefined } from '@modules/nullAndUndefined';
@@ -11,9 +13,6 @@ import { generateProductCatalog } from '@modules/product-catalog/generateProduct
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { getPromotion } from '@modules/promotions/v2/getPromotion';
 import type { Promo } from '@modules/promotions/v2/schema';
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 import type { CreateSubscriptionInputFields } from '@modules/zuora/createSubscription/createSubscription';
 import { createSubscription } from '@modules/zuora/createSubscription/createSubscription';
 import type { PreviewCreateSubscriptionInputFields } from '@modules/zuora/createSubscription/previewCreateSubscription';
@@ -27,6 +26,7 @@ import type {
 import { getSubscription } from '@modules/zuora/subscription';
 import { zuoraSubscriptionSchema } from '@modules/zuora/types/objects/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 
 describe('createSubscription integration', () => {

--- a/modules/zuora/test/createSubscriptionWithExistingPaymentMethod.test.ts
+++ b/modules/zuora/test/createSubscriptionWithExistingPaymentMethod.test.ts
@@ -1,11 +1,11 @@
+import dayjs from 'dayjs';
 import { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { Promo } from '@modules/promotions/v2/schema';
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import { createSubscriptionWithExistingPaymentMethod } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 
 const buildMockZuoraClient = (

--- a/modules/zuora/test/createSubscriptionWithExistingPaymentMethodIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionWithExistingPaymentMethodIntegration.test.ts
@@ -3,12 +3,11 @@
  * @group integration
  */
 
+import dayjs from 'dayjs';
+import { z } from 'zod';
 import { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import { getPromotion } from '@modules/promotions/v2/getPromotion';
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
-import { z } from 'zod';
 import { deleteAccount } from '@modules/zuora/account';
 import type { CreateSubscriptionWithExistingPaymentMethodInput } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
 import { createSubscriptionWithExistingPaymentMethod } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
@@ -17,6 +16,7 @@ import type { PaymentMethod } from '@modules/zuora/orders/paymentMethods';
 import { getSubscription } from '@modules/zuora/subscription';
 import { zuoraSubscriptionSchema } from '@modules/zuora/types/objects/subscription';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 
 describe('createSubscriptionWithExistingPaymentMethod integration', () => {

--- a/modules/zuora/test/fixtures/request-bodies/contribution-subscribe-body.ts
+++ b/modules/zuora/test/fixtures/request-bodies/contribution-subscribe-body.ts
@@ -1,5 +1,5 @@
-import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Dayjs } from 'dayjs';
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ContributionTestAdditionalOptions } from '../../it-helpers/createGuardianSubscription';
 

--- a/modules/zuora/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
+++ b/modules/zuora/test/fixtures/request-bodies/digitalSub-subscribe-body-old-price.ts
@@ -1,5 +1,5 @@
-import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Dayjs } from 'dayjs';
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 
 export const digiSubSubscribeBody = (

--- a/modules/zuora/test/fixtures/request-bodies/supporterplus-subscribe-body-tier2.ts
+++ b/modules/zuora/test/fixtures/request-bodies/supporterplus-subscribe-body-tier2.ts
@@ -1,5 +1,5 @@
-import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { Dayjs } from 'dayjs';
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import { zuoraDateFormat } from '@modules/zuora/utils';
 
 export const supporterPlusSubscribeBody = (

--- a/modules/zuora/test/it-helpers/createGuardianSubscription.ts
+++ b/modules/zuora/test/it-helpers/createGuardianSubscription.ts
@@ -1,11 +1,11 @@
+import dayjs from 'dayjs';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
-import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
-import dayjs from 'dayjs';
 import { zuoraSubscribeResponseSchema } from '@modules/zuora/types';
 import type { ZuoraSubscribeResponse } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import code from '../../../zuora-catalog/test/fixtures/catalog-code.json';
 import { contributionSubscribeBody } from '../fixtures/request-bodies/contribution-subscribe-body';
 import { digiSubSubscribeBody } from '../fixtures/request-bodies/digitalSub-subscribe-body-old-price';

--- a/modules/zuora/test/objectQuery/buildSchema.test.ts
+++ b/modules/zuora/test/objectQuery/buildSchema.test.ts
@@ -1,5 +1,5 @@
-import { mergeValues, pickKeys } from '@modules/objectFunctions';
 import { z } from 'zod';
+import { mergeValues, pickKeys } from '@modules/objectFunctions';
 import { objectQueryResponseSchema } from '@modules/zuora/objectQuery/objectQueryBuilder';
 import {
 	accountExpandRegistry,

--- a/modules/zuora/test/subscription.test.ts
+++ b/modules/zuora/test/subscription.test.ts
@@ -1,8 +1,3 @@
-import type {
-	ProductId,
-	ProductRatePlanChargeId,
-	ProductRatePlanId,
-} from '@modules/zuora-catalog/zuoraCatalogSchema';
 import dayjs from 'dayjs';
 import { ZuoraError } from '@modules/zuora/errors/zuoraError';
 import {
@@ -19,6 +14,11 @@ import {
 	zuoraSubscriptionSchema,
 	zuoraSubscriptionsFromAccountSchema,
 } from '@modules/zuora/types';
+import type {
+	ProductId,
+	ProductRatePlanChargeId,
+	ProductRatePlanId,
+} from '@modules/zuora-catalog/zuoraCatalogSchema';
 import { mockZuoraClient } from '../test/mocks/mockZuoraClient';
 
 jest.mock('@modules/zuora/zuoraClient');

--- a/modules/zuora/test/subscriptionDates.test.ts
+++ b/modules/zuora/test/subscriptionDates.test.ts
@@ -1,5 +1,5 @@
-import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import dayjs from 'dayjs';
+import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { getSubscriptionDates } from '@modules/zuora/createSubscription/subscriptionDates';
 import { deliveryContact } from './fixtures/createSubscriptionFixtures';
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
I noticed that for some files my editor whether VS Code or Intellij was showing lint errors for import ordering which were not picked up by on the command line, and if I let it 'fix' them, the command line highlighted the change as an error. 

The particular example I investigated was `modules/internationalisation/src/schemas.ts` where the editor wanted
```typescript
import { isoCountries } from '@modules/internationalisation/country';
import { SupportRegionId } from '@modules/internationalisation/countryGroup';
import { CurrencyValues } from '@modules/internationalisation/currency';
import { z } from 'zod';
```
but the cli wanted
```typescript
import { z } from 'zod';
import { isoCountries } from '@modules/internationalisation/country';
import { SupportRegionId } from '@modules/internationalisation/countryGroup';
import { CurrencyValues } from '@modules/internationalisation/currency';
```
After a bit of investigation it turned out that the reason for this was that our import ordering specifies that external package imports should always come before internal ones, but the editor and the CLI had a different understanding of whether @modules packages were internal or external.

- The CLI (pnpm -r run lint) runs ESLint once per package, with the package folder as the cwd. 
From there, @modules/* (pnpm-symlinked workspace packages) resolve to the real repo paths and classifies them as internal → correct order is zod first.

- VS Code and IntelliJ run ESLint from the workspace root by default. From there the same imports resolve via the root node_modules symlink and get classified as external → they sort before zod (because @ < z, which is why the editor flags the correct order and "fixes" it to the wrong one.

## Fix
To solve this inconsistency I have added some config which specifies that any code in @modules is an internal dependency. This has been added in  in eslint.shared.mjs so that it can be imported and used from each of the three separate eslint.config.mjs files in the project.

## Note
As a result of this change there has been a large reordering of imports across the repo because previously any @modules import from the _same directory_ was counted as internal whereas all others were external. Now we are explicitly saying that they are all internal that has affected ordering. I have done this update as a separate commit, so to see the relevant changes just look at [the first commit](https://github.com/guardian/support-service-lambdas/pull/3677/changes/4f5ff5d85f9110ca2aca855c91c50d1d345e3b68). Everything else is just reordering.