### PR TITLE
rename actualTotalPrice to ongoingPrice

### DIFF
--- a/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
+++ b/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
@@ -35,11 +35,10 @@ export const buildEmailMessage = (
 					first_name: firstName,
 					last_name: lastName,
 					currency: getCurrencyInfo(currency).extendedGlyph,
-					price: switchInformation.target.actualTotalPrice.toFixed(2),
+					price: switchInformation.target.ongoingPrice.toFixed(2),
 					first_payment_amount: firstPaymentAmount.toFixed(2),
 					date_of_first_payment: today.format('DD MMMM YYYY'),
-					next_payment_amount:
-						switchInformation.target.actualTotalPrice.toFixed(2),
+					next_payment_amount: switchInformation.target.ongoingPrice.toFixed(2),
 					date_of_next_payment: today
 						.add(billingPeriodMonths, 'month')
 						.format('DD MMMM YYYY'),

--- a/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
@@ -18,7 +18,7 @@ import {
 } from './switchCatalogHelper';
 
 export type TargetInformation = {
-	actualTotalPrice: number; // email, sf tracking
+	ongoingPrice: number; // email, sf tracking
 	productRatePlanId: string; // order, supporter product data
 	ratePlanName: string; // supporter product data
 	dataExtensionName: DataExtensionName; // email

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
@@ -46,7 +46,7 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 				: `Digital Pack Annual`;
 
 		return {
-			actualTotalPrice: catalogPrice,
+			ongoingPrice: catalogPrice,
 			productRatePlanId: productRatePlan.id,
 			ratePlanName,
 			contributionCharge: undefined,

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/supporterPlusTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/supporterPlusTargetInformation.ts
@@ -33,7 +33,7 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 
 		let discount: Discount | undefined;
 		let contributionAmount: number;
-		let actualTotalPrice: number;
+		let ongoingPrice: number;
 		if (switchActionData.mode === 'save') {
 			const discountDetails = annualContribHalfPriceSupporterPlusForOneYear;
 			const discountedPrice =
@@ -50,15 +50,15 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 			}
 			discount = discountDetails;
 			contributionAmount = 0;
-			actualTotalPrice = discountedPrice;
+			ongoingPrice = discountedPrice;
 		} else {
 			// no initial discount possible
-			actualTotalPrice =
+			ongoingPrice =
 				switchActionData.mode === 'switchWithPriceOverride'
 					? switchActionData.userRequestedAmount
 					: Math.max(switchActionData.previousAmount, targetCatalogBasePrice);
 
-			contributionAmount = actualTotalPrice - targetCatalogBasePrice;
+			contributionAmount = ongoingPrice - targetCatalogBasePrice;
 		}
 
 		const ratePlanName =
@@ -67,7 +67,7 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 				: `Supporter Plus V2 - Annual`;
 
 		return {
-			actualTotalPrice,
+			ongoingPrice,
 			productRatePlanId: productRatePlan.id,
 			ratePlanName,
 			contributionCharge: {

--- a/handlers/product-switch-api/src/salesforceTracking.ts
+++ b/handlers/product-switch-api/src/salesforceTracking.ts
@@ -37,7 +37,7 @@ export function createSQSMessageBody(
 	const salesforceTrackingInput: SalesforceTrackingInput = {
 		subscriptionName: subscriptionNumber,
 		previousAmount,
-		newAmount: targetInformation.actualTotalPrice,
+		newAmount: targetInformation.ongoingPrice,
 		previousProductName: previousProductName,
 		previousRatePlanName: previousRatePlanName,
 		newRatePlanName: targetInformation.ratePlanName.startsWith('Supporter Plus')

--- a/handlers/product-switch-api/test/changePlan/action/email.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/email.test.ts
@@ -67,7 +67,7 @@ const testSubscriptionInformation: SubscriptionInformation = {
 };
 
 const testTargetInformation: TargetInformation = {
-	actualTotalPrice: 10,
+	ongoingPrice: 10,
 	contributionCharge: undefined,
 	dataExtensionName:
 		DataExtensionNames.recurringContributionToSupporterPlusSwitch,

--- a/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
@@ -65,7 +65,7 @@ describe('getTargetInformation', () => {
 		);
 
 		expect(targetInfo).toStrictEqual({
-			actualTotalPrice: expectedActualTotalPrice,
+			ongoingPrice: expectedActualTotalPrice,
 			productRatePlanId: targetRatePlan.id,
 			ratePlanName: 'Supporter Plus V2 - Annual',
 			subscriptionChargeId: targetRatePlan.charges.Subscription.id,
@@ -97,17 +97,17 @@ describe('getTargetInformation', () => {
 			productCatalogHelper,
 		);
 
-		const { actualTotalPrice, discount, contributionCharge } = targetInfo;
+		const { ongoingPrice, discount, contributionCharge } = targetInfo;
 		const expectedDiscount = {
 			discountPercentage:
 				annualContribHalfPriceSupporterPlusForOneYear.discountPercentage,
 		};
 		expect({
-			actualTotalPrice,
+			ongoingPrice,
 			discount,
 			contributionAmount: contributionCharge?.contributionAmount,
 		}).toMatchObject({
-			actualTotalPrice: discountedPrice,
+			ongoingPrice: discountedPrice,
 			discount: expectedDiscount,
 			contributionAmount: 0,
 		});

--- a/handlers/product-switch-api/test/changePlan/switchDefinition/digitalSubscriptionTargetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/switchDefinition/digitalSubscriptionTargetInformation.test.ts
@@ -28,7 +28,7 @@ describe('digitalSubscriptionTargetInformation', () => {
 			switchActionData,
 		);
 
-		expect(result.actualTotalPrice).toBe(catalogPrice);
+		expect(result.ongoingPrice).toBe(catalogPrice);
 		expect(result.productRatePlanId).toBe(annualDigitalSubscriptionRatePlan.id);
 		expect(result.ratePlanName).toBe('Digital Pack Annual');
 		expect(result.contributionCharge).toBeUndefined();
@@ -68,7 +68,7 @@ describe('digitalSubscriptionTargetInformation', () => {
 			switchActionData,
 		);
 
-		expect(result.actualTotalPrice).toBe(catalogPrice);
+		expect(result.ongoingPrice).toBe(catalogPrice);
 	});
 
 	test('throws ValidationError in save mode', () => {

--- a/handlers/product-switch-api/test/changePlan/switchDefinition/supporterPlusTargetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/switchDefinition/supporterPlusTargetInformation.test.ts
@@ -29,7 +29,7 @@ describe('getSupporterPlusTargetInformation', () => {
 			switchActionData,
 		);
 
-		expect(result.actualTotalPrice).toBe(previousAmount);
+		expect(result.ongoingPrice).toBe(previousAmount);
 		expect(result.contributionCharge?.contributionAmount).toBe(50);
 		expect(result.productRatePlanId).toBe(annualSupporterPlusRatePlan.id);
 		expect(result.ratePlanName).toBe('Supporter Plus V2 - Annual');
@@ -52,7 +52,7 @@ describe('getSupporterPlusTargetInformation', () => {
 			switchActionData,
 		);
 
-		expect(result.actualTotalPrice).toBe(basePrice);
+		expect(result.ongoingPrice).toBe(basePrice);
 		expect(result.contributionCharge?.contributionAmount).toBe(0);
 	});
 
@@ -71,7 +71,7 @@ describe('getSupporterPlusTargetInformation', () => {
 			switchActionData,
 		);
 
-		expect(result.actualTotalPrice).toBe(userRequestedAmount);
+		expect(result.ongoingPrice).toBe(userRequestedAmount);
 		expect(result.contributionCharge?.contributionAmount).toBe(100);
 	});
 
@@ -111,7 +111,7 @@ describe('getSupporterPlusTargetInformation', () => {
 		);
 
 		expect(result.discount).toBeDefined();
-		expect(result.actualTotalPrice).toBe(discountedPrice);
+		expect(result.ongoingPrice).toBe(discountedPrice);
 		expect(result.contributionCharge?.contributionAmount).toBe(0);
 		expect(result.discount?.discountPercentage).toBe(
 			annualContribHalfPriceSupporterPlusForOneYear.discountPercentage,
@@ -160,6 +160,6 @@ describe('getSupporterPlusTargetInformation', () => {
 		);
 
 		expect(result.discount).toBeUndefined();
-		expect(result.actualTotalPrice).toBe(basePrice);
+		expect(result.ongoingPrice).toBe(basePrice);
 	});
 });

--- a/handlers/product-switch-api/test/salesforceTracking.test.ts
+++ b/handlers/product-switch-api/test/salesforceTracking.test.ts
@@ -7,7 +7,7 @@ test('salesforce tracking data is serialised to the queue correctly', () => {
 	const targetInformation: TargetInformation = {
 		dataExtensionName:
 			DataExtensionNames.recurringContributionToSupporterPlusSwitch,
-		actualTotalPrice: 45.5,
+		ongoingPrice: 45.5,
 		contributionCharge: {
 			id: '',
 			contributionAmount: 10.5,

--- a/handlers/product-switch-api/test/supporterProductDataIntegration.test.ts
+++ b/handlers/product-switch-api/test/supporterProductDataIntegration.test.ts
@@ -36,7 +36,7 @@ test('supporter product data', async () => {
 		target: {
 			productRatePlanId: '8a128ed885fc6ded018602296ace3eb8',
 			subscriptionChargeId: 'subscriptionChargeId',
-			actualTotalPrice: 10,
+			ongoingPrice: 10,
 			ratePlanName: 'Supporter Plus V2 - Monthly',
 			dataExtensionName:
 				DataExtensionNames.recurringContributionToSupporterPlusSwitch,

--- a/handlers/product-switch-api/test/supporterRatePlanItem.test.ts
+++ b/handlers/product-switch-api/test/supporterRatePlanItem.test.ts
@@ -28,7 +28,7 @@ const getSwitchInformation = (): SwitchInformation => ({
 	target: {
 		productRatePlanId: 'supporterPlusProductRatePlanId',
 		subscriptionChargeId: 'subscriptionChargeId',
-		actualTotalPrice: 1,
+		ongoingPrice: 1,
 		ratePlanName: 'Supporter Plus V2 - Monthly',
 		dataExtensionName:
 			DataExtensionNames.recurringContributionToSupporterPlusSwitch,


### PR DESCRIPTION
refactoring needed before https://github.com/guardian/support-service-lambdas/pull/3675

At the moment, when switching, you get one payment at a reduced price, followed by all the rest at a standard long term price.

The reduced price is mostly because we reduce it by however much you have paid for the existing product and not yet used.  However it's also possible for there to be a discount also, if it's an annual S+ cancellation save.

This means that the second payment is always the same as the long term payment amount.

This is going to change when we allow discounting of monthly subscriptions for 6 months, as there will be the initial small payment, then 5 months of discounted payments, followed by the base/ongoing payment amount.

At the moment the code calls the subsequent payment amount `actualTotalPrice`

This PR renames it to `ongoingPrice` instead.  A later PR (in draft here https://github.com/guardian/support-service-lambdas/pull/3675 ) will add next payment price, which may or may not differ from the ongoing price.

This is the only change in this PR, it's purely mechanical.