### PR TITLE
add annual discount to s+ -> D+

### DIFF
--- a/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
@@ -7,6 +7,7 @@ import type {
 	TargetInformation,
 } from '../prepare/targetInformation';
 import type { Discount } from './discounts';
+import { annualDigiPlus } from './discounts';
 import { monthlyDigiPlus } from './discounts';
 
 export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
@@ -29,11 +30,12 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 			throw new ValidationError("digital plus doesn't have a variable amount");
 		}
 		let discount: Discount | undefined = undefined;
-		if (
-			switchActionData.discountEnabled &&
-			productRatePlan.billingPeriod === 'Month'
-		) {
-			discount = monthlyDigiPlus;
+		if (switchActionData.discountEnabled) {
+			if (productRatePlan.billingPeriod === 'Month') {
+				discount = monthlyDigiPlus;
+			} else {
+				discount = annualDigiPlus;
+			}
 		}
 
 		const catalogPrice = productRatePlan.pricing[switchActionData.currency];

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/discounts.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/discounts.ts
@@ -39,3 +39,17 @@ export const monthlyDigiPlus: Discount = {
 	upToPeriods: 6,
 	upToPeriodsType: 'Months',
 };
+
+export const annualDigiPlus: Discount = {
+	productRatePlanId: {
+		PROD: '8a1296cc9f1ba695019f21feb57a4350',
+		CODE: '71a1b1d5a1f9f1dbccff21fbf2d4001f',
+	},
+	productRatePlanChargeId: {
+		PROD: '8a1296cc9f1ba695019f21feb5cc4352',
+		CODE: '71a1b1d5a1f9f1dbccff21fbf3610020',
+	},
+	name: 'Upsell - Supporter Plus to Digital Plus Switch - Annual Price Match',
+	upToPeriods: 12,
+	upToPeriodsType: 'Months',
+};


### PR DESCRIPTION
This PR adds annual support to the upsell discount function.

The discounts have already been added to zuora sandbox and prod
see the "Upsell - Supporter Plus to Digital Plus Switch - Annual Price Match" rate plan in the below discounts product:
https://apisandbox.zuora.com/apps/Product.do?method=view&id=2c92c0f85721ff7c01572940171363db
https://www.zuora.com/apps/Product.do?method=view&id=2c92a0ff5345f9200153559c6d2a3385

also see the config here: https://github.com/guardian/zuora-config/pull/206

Tested in CODE and working ok
<img width="1447" height="1160" alt="image" src="https://github.com/user-attachments/assets/d0befa92-094e-4dd0-a301-14ddeec9e5dd" />
