### PR TITLE
disable discount for monthly/annual in CODE unless param passed

### DIFF
--- a/handlers/product-switch-api/src/changePlan/changePlanEndpoint.ts
+++ b/handlers/product-switch-api/src/changePlan/changePlanEndpoint.ts
@@ -166,7 +166,6 @@ export class ChangePlanEndpoint {
 			this.body,
 			this.account,
 			subscription,
-			this.stage !== 'PROD',
 		);
 		logger.log(`switching from/to`, {
 			from: {

--- a/handlers/product-switch-api/src/changePlan/prepare/switchInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/switchInformation.ts
@@ -20,7 +20,6 @@ export function getSwitchInformation(
 	input: ProductSwitchTargetBody,
 	account: ZuoraAccount,
 	subscription: GuardianSubscription,
-	discountEnabled: boolean,
 ): SwitchInformation {
 	const accountInformation = getAccountInformation(account);
 
@@ -34,7 +33,7 @@ export function getSwitchInformation(
 		subscriptionInformation.previousAmount,
 		subscriptionInformation.includesContribution,
 		productCatalogHelper,
-		discountEnabled || input.discountSwitchEnabled,
+		input.discountSwitchEnabled,
 	);
 
 	return {


### PR DESCRIPTION
at the moment switch discounts are enabled in CODE regardless of what branch of manage is deployed.

This PR changes it to match PROD, so discounts are controlled by the `discountSwitchEnabled: true/false` parameter.

If the param isn't supplied, it's treated as falsey.