### PR TITLE
Augment promos with catalog information

### DIFF
--- a/modules/promotions/src/v2/addCatalogInformationToPromo.ts
+++ b/modules/promotions/src/v2/addCatalogInformationToPromo.ts
@@ -1,3 +1,4 @@
+import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import type {
 	ProductCatalogHelper,
@@ -40,11 +41,38 @@ export const addCatalogInformationToPromo = (
 	};
 };
 
+/**
+ * The result of resolving catalog information for a batch of promotions:
+ * `succeeded` contains the enriched promos and `failed` contains the original
+ * promos whose rate plan ids could not be resolved against the catalog.
+ */
+export type AddCatalogInformationResult = {
+	succeeded: PromoWithCatalogInformation[];
+	failed: Promo[];
+};
+
 export const addCatalogInformationToPromos = (
 	promos: Promo[],
 	catalogHelper: ProductCatalogHelper,
-): PromoWithCatalogInformation[] =>
-	promos.map((promo) => addCatalogInformationToPromo(promo, catalogHelper));
+): AddCatalogInformationResult => {
+	const succeeded: PromoWithCatalogInformation[] = [];
+	const failed: Promo[] = [];
+
+	for (const promo of promos) {
+		try {
+			succeeded.push(addCatalogInformationToPromo(promo, catalogHelper));
+		} catch (error) {
+			// Collect promos whose rate plan ids can't be resolved against the
+			// catalog rather than failing the whole batch.
+			logger.log(
+				`Failed to resolve catalog information for promotion ${promo.promoCode}: ${String(error)}`,
+			);
+			failed.push(promo);
+		}
+	}
+
+	return { succeeded, failed };
+};
 
 export const promoAppliesTo = (
 	promo: PromoWithCatalogInformation,

--- a/modules/promotions/src/v2/addCatalogInformationToPromo.ts
+++ b/modules/promotions/src/v2/addCatalogInformationToPromo.ts
@@ -21,10 +21,13 @@ export const addCatalogInformationToPromo = (
 				catalogHelper.findProductDetails(productRatePlanId),
 				`Promotion ${promo.promoCode} references product rate plan id ${productRatePlanId} which does not exist in the product catalog`,
 			);
-			return {
-				productKey: productDetails.zuoraProduct,
-				productRatePlanKey: productDetails.productRatePlan,
-			};
+			// validateOrThrow returns a correlated GuardianCatalogKeys
+			// (productKey constrained to its rate plan key) rather than the widened union
+			// produced by findProductDetails.
+			return catalogHelper.validateOrThrow(
+				productDetails.zuoraProduct,
+				productDetails.productRatePlan,
+			);
 		},
 	);
 

--- a/modules/promotions/src/v2/addCatalogInformationToPromo.ts
+++ b/modules/promotions/src/v2/addCatalogInformationToPromo.ts
@@ -1,0 +1,64 @@
+import { getIfDefined } from '@modules/nullAndUndefined';
+import type {
+	ProductCatalogHelper,
+	ProductKey,
+} from '@modules/product-catalog/productCatalog';
+import type { Promo, PromoWithCatalogInformation } from './schema';
+
+/**
+ * Augments a promotion retrieved from Dynamo with the product catalog keys
+ * (ProductKey + ProductRatePlanKey) it applies to, resolved from its raw
+ * `productRatePlanIds`. Throws if any rate plan id cannot be resolved against
+ * the product catalog, so that stale data is surfaced immediately.
+ */
+export const addCatalogInformationToPromo = (
+	promo: Promo,
+	catalogHelper: ProductCatalogHelper,
+): PromoWithCatalogInformation => {
+	const catalogRatePlans = promo.appliesTo.productRatePlanIds.map(
+		(productRatePlanId) => {
+			const productDetails = getIfDefined(
+				catalogHelper.findProductDetails(productRatePlanId),
+				`Promotion ${promo.promoCode} references product rate plan id ${productRatePlanId} which does not exist in the product catalog`,
+			);
+			return {
+				productKey: productDetails.zuoraProduct,
+				productRatePlanKey: productDetails.productRatePlan,
+			};
+		},
+	);
+
+	return {
+		...promo,
+		appliesTo: {
+			...promo.appliesTo,
+			catalogRatePlans,
+		},
+	};
+};
+
+export const addCatalogInformationToPromos = (
+	promos: Promo[],
+	catalogHelper: ProductCatalogHelper,
+): PromoWithCatalogInformation[] =>
+	promos.map((promo) => addCatalogInformationToPromo(promo, catalogHelper));
+
+export const promoAppliesTo = (
+	promo: PromoWithCatalogInformation,
+	productKey: ProductKey,
+	productRatePlanKey: string,
+): boolean =>
+	promo.appliesTo.catalogRatePlans.some(
+		(catalogKey) =>
+			catalogKey.productKey === productKey &&
+			catalogKey.productRatePlanKey === productRatePlanKey,
+	);
+
+export const findPromosForProduct = (
+	promos: PromoWithCatalogInformation[],
+	productKey: ProductKey,
+	productRatePlanKey: string,
+): PromoWithCatalogInformation[] =>
+	promos.filter((promo) =>
+		promoAppliesTo(promo, productKey, productRatePlanKey),
+	);

--- a/modules/promotions/src/v2/schema.ts
+++ b/modules/promotions/src/v2/schema.ts
@@ -3,10 +3,7 @@ import {
 	isoCountrySchema,
 	supportRegionSchema,
 } from '@modules/internationalisation/schemas';
-import type {
-	ProductKey,
-	ProductRatePlanKey,
-} from '@modules/product-catalog/productCatalog';
+import type { GuardianCatalogKeys } from '@modules/product-catalog/productCatalog';
 import { optionalDropNulls } from '@modules/schemaUtils';
 
 export const promoCampaignSchema = z.object({
@@ -57,21 +54,12 @@ export const promoSchema = z.object({
 export type Promo = z.infer<typeof promoSchema>;
 
 /**
- * A product catalog rate plan a promotion applies to, resolved from a raw
- * Zuora `productRatePlanId` stored in Dynamo.
- */
-export type PromoCatalogInformation = {
-	productKey: ProductKey;
-	productRatePlanKey: ProductRatePlanKey<ProductKey>;
-};
-
-/**
  * The catalog rate plans a promotion applies to, resolved from the raw
  * `productRatePlanIds` stored in Dynamo so that promotions can be searched by
  * ProductKey and ProductRatePlanKey.
  */
 export type AppliesToCatalogInformation = AppliesTo & {
-	catalogRatePlans: PromoCatalogInformation[];
+	catalogRatePlans: GuardianCatalogKeys[];
 };
 
 export type PromoWithCatalogInformation = Omit<Promo, 'appliesTo'> & {

--- a/modules/promotions/src/v2/schema.ts
+++ b/modules/promotions/src/v2/schema.ts
@@ -3,6 +3,10 @@ import {
 	isoCountrySchema,
 	supportRegionSchema,
 } from '@modules/internationalisation/schemas';
+import type {
+	ProductKey,
+	ProductRatePlanKey,
+} from '@modules/product-catalog/productCatalog';
 import { optionalDropNulls } from '@modules/schemaUtils';
 
 export const promoCampaignSchema = z.object({
@@ -24,6 +28,8 @@ export const appliesToSchema = z.object({
 	productRatePlanIds: z.array(z.string()),
 	countries: z.array(isoCountrySchema),
 });
+
+export type AppliesTo = z.infer<typeof appliesToSchema>;
 
 export const discountDetailsSchema = z.object({
 	amount: z.number(),
@@ -49,6 +55,28 @@ export const promoSchema = z.object({
 });
 
 export type Promo = z.infer<typeof promoSchema>;
+
+/**
+ * A product catalog rate plan a promotion applies to, resolved from a raw
+ * Zuora `productRatePlanId` stored in Dynamo.
+ */
+export type PromoCatalogInformation = {
+	productKey: ProductKey;
+	productRatePlanKey: ProductRatePlanKey<ProductKey>;
+};
+
+/**
+ * The catalog rate plans a promotion applies to, resolved from the raw
+ * `productRatePlanIds` stored in Dynamo so that promotions can be searched by
+ * ProductKey and ProductRatePlanKey.
+ */
+export type AppliesToCatalogInformation = AppliesTo & {
+	catalogRatePlans: PromoCatalogInformation[];
+};
+
+export type PromoWithCatalogInformation = Omit<Promo, 'appliesTo'> & {
+	appliesTo: AppliesToCatalogInformation;
+};
 
 export const appliedPromotionSchema = z.object({
 	promoCode: z.string(),

--- a/modules/promotions/test/v2/addCatalogInformationToPromo.test.ts
+++ b/modules/promotions/test/v2/addCatalogInformationToPromo.test.ts
@@ -69,25 +69,44 @@ describe('addCatalogInformationToPromo', () => {
 
 describe('findPromosForProduct', () => {
 	it('returns only promos whose catalog keys include the queried pair', () => {
-		const promos = addCatalogInformationToPromos(
+		const { succeeded } = addCatalogInformationToPromos(
 			[buildPromo([supporterPlusMonthlyId]), buildPromo([])],
 			catalogHelper,
 		);
 
-		const matches = findPromosForProduct(promos, 'SupporterPlus', 'Monthly');
+		const matches = findPromosForProduct(succeeded, 'SupporterPlus', 'Monthly');
 
 		expect(matches).toHaveLength(1);
 		expect(promoAppliesTo(matches[0]!, 'SupporterPlus', 'Monthly')).toBe(true);
 	});
 
 	it('returns an empty array when no promo applies', () => {
-		const promos = addCatalogInformationToPromos(
+		const { succeeded } = addCatalogInformationToPromos(
 			[buildPromo([supporterPlusMonthlyId])],
 			catalogHelper,
 		);
 
 		expect(
-			findPromosForProduct(promos, 'SupporterPlus', 'Annual'),
+			findPromosForProduct(succeeded, 'SupporterPlus', 'Annual'),
 		).toStrictEqual([]);
+	});
+});
+
+describe('addCatalogInformationToPromos', () => {
+	it('returns enriched promos in succeeded and unresolvable promos in failed', () => {
+		const validPromo = buildPromo([supporterPlusMonthlyId]);
+		const invalidPromo = buildPromo(['not-a-real-id']);
+
+		const { succeeded, failed } = addCatalogInformationToPromos(
+			[validPromo, invalidPromo],
+			catalogHelper,
+		);
+
+		expect(succeeded).toHaveLength(1);
+		expect(succeeded[0]!.appliesTo.catalogRatePlans).toStrictEqual([
+			{ productKey: 'SupporterPlus', productRatePlanKey: 'Monthly' },
+		]);
+
+		expect(failed).toStrictEqual([invalidPromo]);
 	});
 });

--- a/modules/promotions/test/v2/addCatalogInformationToPromo.test.ts
+++ b/modules/promotions/test/v2/addCatalogInformationToPromo.test.ts
@@ -1,0 +1,92 @@
+import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
+import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
+import type { Promo } from '@modules/promotions/v2/schema';
+import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
+import codeZuoraCatalog from '../../../zuora-catalog/test/fixtures/catalog-code.json';
+import {
+	addCatalogInformationToPromo,
+	addCatalogInformationToPromos,
+	findPromosForProduct,
+	promoAppliesTo,
+} from '../../src/v2/addCatalogInformationToPromo';
+
+const catalogHelper = new ProductCatalogHelper(
+	generateProductCatalog(zuoraCatalogSchema.parse(codeZuoraCatalog)),
+);
+
+// SupporterPlus / Monthly in the code catalog
+const supporterPlusMonthlyId = '8ad08cbd8586721c01858804e3275376';
+
+const buildPromo = (productRatePlanIds: string[]): Promo => ({
+	name: 'Test Promotion',
+	promoCode: 'TEST123',
+	campaignCode: 'campaign',
+	startTimestamp: '2024-09-25T23:00:00.000Z',
+	endTimestamp: '2099-11-05T23:59:59.000Z',
+	discount: {
+		amount: 25,
+		durationMonths: 3,
+	},
+	appliesTo: {
+		countries: ['GB'],
+		productRatePlanIds,
+	},
+});
+
+describe('addCatalogInformationToPromo', () => {
+	it('resolves productRatePlanIds to catalog keys', () => {
+		const promosWithCatalogInformation = addCatalogInformationToPromo(
+			buildPromo([supporterPlusMonthlyId]),
+			catalogHelper,
+		);
+
+		expect(
+			promosWithCatalogInformation.appliesTo.catalogRatePlans,
+		).toStrictEqual([
+			{ productKey: 'SupporterPlus', productRatePlanKey: 'Monthly' },
+		]);
+		// original fields are preserved
+		expect(
+			promosWithCatalogInformation.appliesTo.productRatePlanIds,
+		).toStrictEqual([supporterPlusMonthlyId]);
+		expect(promosWithCatalogInformation.appliesTo.countries).toStrictEqual([
+			'GB',
+		]);
+	});
+
+	it('throws if a productRatePlanId is not in the product catalog', () => {
+		expect(() =>
+			addCatalogInformationToPromo(
+				buildPromo(['not-a-real-id']),
+				catalogHelper,
+			),
+		).toThrow(
+			'Promotion TEST123 references product rate plan id not-a-real-id which does not exist in the product catalog',
+		);
+	});
+});
+
+describe('findPromosForProduct', () => {
+	it('returns only promos whose catalog keys include the queried pair', () => {
+		const promos = addCatalogInformationToPromos(
+			[buildPromo([supporterPlusMonthlyId]), buildPromo([])],
+			catalogHelper,
+		);
+
+		const matches = findPromosForProduct(promos, 'SupporterPlus', 'Monthly');
+
+		expect(matches).toHaveLength(1);
+		expect(promoAppliesTo(matches[0]!, 'SupporterPlus', 'Monthly')).toBe(true);
+	});
+
+	it('returns an empty array when no promo applies', () => {
+		const promos = addCatalogInformationToPromos(
+			[buildPromo([supporterPlusMonthlyId])],
+			catalogHelper,
+		);
+
+		expect(
+			findPromosForProduct(promos, 'SupporterPlus', 'Annual'),
+		).toStrictEqual([]);
+	});
+});

--- a/modules/promotions/test/v2/addCatalogInformationToPromo.test.ts
+++ b/modules/promotions/test/v2/addCatalogInformationToPromo.test.ts
@@ -10,12 +10,13 @@ import {
 	promoAppliesTo,
 } from '../../src/v2/addCatalogInformationToPromo';
 
-const catalogHelper = new ProductCatalogHelper(
-	generateProductCatalog(zuoraCatalogSchema.parse(codeZuoraCatalog)),
+const productCatalog = generateProductCatalog(
+	zuoraCatalogSchema.parse(codeZuoraCatalog),
 );
+const catalogHelper = new ProductCatalogHelper(productCatalog);
 
-// SupporterPlus / Monthly in the code catalog
-const supporterPlusMonthlyId = '8ad08cbd8586721c01858804e3275376';
+const supporterPlusMonthlyId =
+	productCatalog.SupporterPlus.ratePlans.Monthly.id;
 
 const buildPromo = (productRatePlanIds: string[]): Promo => ({
 	name: 'Test Promotion',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR add some code to augment the Promo model with product catalog information. This will make it easier to 
- find all promotions for a given product
- check whether a given promotion applies to a particular product and rate plan

This is the first step towards creating an API which makes this promotion information available to support-frontend.

## Changes
Adds a new `PromoWithCatalogInformation` type where the `appliesTo` field contains a `catalogRatePlans` field of type `PromoCatalogInformation[]`.
Example Json:

```json
{
  "name": "Test Promotion",
  "promoCode": "TEST123",
  "campaignCode": "campaign",
  "startTimestamp": "2024-09-25T23:00:00.000Z",
  "endTimestamp": "2099-11-05T23:59:59.000Z",
  "discount": {
    "amount": 25,
    "durationMonths": 3
  },
  "appliesTo": {
    "countries": [
      "GB"
    ],
    "productRatePlanIds": [
      "8ad08cbd8586721c01858804e3275376"
    ],
    "catalogRatePlans": [
      {
        "productKey": "SupporterPlus",
        "productRatePlanKey": "Monthly"
      }
    ]
  }
}
```