### PR TITLE
better logging for rest responses that fail schema parsing

### DIFF
--- a/modules/zuora/src/errors/zuoraErrorHandler.ts
+++ b/modules/zuora/src/errors/zuoraErrorHandler.ts
@@ -9,9 +9,9 @@ import type { ZuoraErrorDetail } from './zuoraError';
 import { ZuoraError } from './zuoraError';
 
 export function generateZuoraError(
-	json: unknown,
 	response: RestResult,
 ): ZuoraError | undefined {
+	const json: unknown = response.responseBody;
 	// Format 1: reasons array (authentication, account errors)
 	const lowerCaseParseResult = lowerCaseZuoraErrorSchema.safeParse(json);
 	if (lowerCaseParseResult.success) {

--- a/modules/zuora/src/restClient.ts
+++ b/modules/zuora/src/restClient.ts
@@ -6,7 +6,8 @@ import type { BearerTokenProvider } from '@modules/zuora/auth';
 
 export class RestClientError extends Error implements RestResult {
 	public status: number;
-	public responseBody: string;
+	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- either body string or json
+	public responseBody: string | unknown;
 	public responseHeaders: Record<string, string>;
 
 	constructor(message: string, restResult: RestResult, cause?: unknown) {
@@ -20,7 +21,8 @@ export class RestClientError extends Error implements RestResult {
 
 export type RestResult = {
 	status: number;
-	responseBody: string;
+	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- either string or json
+	responseBody: string | unknown;
 	responseHeaders: Record<string, string>;
 };
 
@@ -156,15 +158,30 @@ export abstract class RestClient {
 			responseBody,
 			responseHeaders,
 		};
+
+		let json: unknown;
+		try {
+			json = responseBody ? JSON.parse(responseBody) : {};
+		} catch (e) {
+			if (!response.ok) {
+				throw new RestClientError(`http call failed: ${result.status}`, result);
+			}
+
+			throw new RestClientError('json parsing failure', result, e);
+		}
+
+		const jsonResult: RestResult = { ...result, responseBody: json };
 		if (!response.ok) {
-			throw new RestClientError('http call failed', result);
+			throw new RestClientError(
+				`http call failed: ${result.status}`,
+				jsonResult,
+			);
 		}
 
 		try {
-			const json: unknown = responseBody ? JSON.parse(responseBody) : {};
 			return schema.parse(json);
 		} catch (e) {
-			throw new RestClientError('parsing failure', result, e);
+			throw new RestClientError('schema parsing failure', jsonResult, e);
 		}
 	}
 }

--- a/modules/zuora/src/zuoraClient.ts
+++ b/modules/zuora/src/zuoraClient.ts
@@ -54,14 +54,11 @@ export class ZuoraClient extends RestClient {
 						`Received a 429 rate limit response with response headers ${JSON.stringify(e.responseHeaders)}`,
 					);
 				}
-				let parsedBody: unknown;
-				try {
-					parsedBody = JSON.parse(e.responseBody);
-				} catch {
+				if (typeof e.responseBody === 'string') {
 					// we're not going to be able to extract anything useful from non-json
 					throw e;
 				}
-				const customError = generateZuoraError(parsedBody, e);
+				const customError = generateZuoraError(e);
 				if (customError !== undefined) {
 					throw customError;
 				}

--- a/modules/zuora/test/restClient.test.ts
+++ b/modules/zuora/test/restClient.test.ts
@@ -154,9 +154,9 @@ describe('RestClient', () => {
 
 			await expect(client.get('/users/999', schema)).rejects.toMatchObject({
 				name: 'RestClientError',
-				message: 'http call failed',
+				message: 'http call failed: 404',
 				status: 404,
-				responseBody: JSON.stringify(errorBody),
+				responseBody: errorBody,
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- any is ok in a test
 				responseHeaders: expect.objectContaining({ 'x-request-id': 'abc123' }),
 			});

--- a/modules/zuora/test/zuoraErrorHandler.test.ts
+++ b/modules/zuora/test/zuoraErrorHandler.test.ts
@@ -5,7 +5,7 @@ import type { RestResult } from '@modules/zuora/restClient';
 function mockResponse(status: number, body: unknown): RestResult {
 	return {
 		status: status,
-		responseBody: JSON.stringify(body),
+		responseBody: body,
 		responseHeaders: {},
 	};
 }
@@ -23,7 +23,7 @@ describe('generateZuoraError', () => {
 			],
 		};
 		const response = mockResponse(401, body);
-		const error = generateZuoraError(body, response);
+		const error = generateZuoraError(response);
 
 		expect(error).toBeInstanceOf(ZuoraError);
 
@@ -45,7 +45,7 @@ describe('generateZuoraError', () => {
 			Success: false,
 		};
 		const response = mockResponse(400, body);
-		const error = generateZuoraError(body, response);
+		const error = generateZuoraError(response);
 
 		expect(error?.message).toBe(errorMessage);
 		expect(error?.zuoraErrorDetails[0]?.code).toBe('INVALID_VALUE');
@@ -59,7 +59,7 @@ describe('generateZuoraError', () => {
 			FaultMessage: errorMessage,
 		};
 		const response = mockResponse(400, body);
-		const error = generateZuoraError(body, response);
+		const error = generateZuoraError(response);
 
 		expect(error?.message).toBe(errorMessage);
 		expect(error?.zuoraErrorDetails[0]?.code).toBe('INVALID_FIELD');
@@ -73,7 +73,7 @@ describe('generateZuoraError', () => {
 			message: errorMessage,
 		};
 		const response = mockResponse(400, body);
-		const error = generateZuoraError(body, response);
+		const error = generateZuoraError(response);
 
 		expect(error?.message).toBe(errorMessage);
 		expect(error?.zuoraErrorDetails[0]?.code).toBe('ClientError');
@@ -82,8 +82,8 @@ describe('generateZuoraError', () => {
 
 	it('returns undefined if no schema matches', () => {
 		const json = { unexpected: 'data' };
-		const response = mockResponse(418, "I'm a teapot");
-		const error = generateZuoraError(json, response);
+		const response = mockResponse(418, json);
+		const error = generateZuoraError(response);
 
 		expect(error).toBeUndefined();
 	});


### PR DESCRIPTION
At the moment, if there's a zod failure, we get a block of escaped json in a string in the logs.

This is hard to read

This PR expands the body type to potentially be unknown (parsed json), meaning that the logger's object formatter can kick in, making it easier to both read and to copy and paste if necessary.

before
<img width="1156" height="655" alt="image" src="https://github.com/user-attachments/assets/3acdef85-1dfa-4f19-8b39-d3148e1096a9" />
after
<img width="1087" height="1087" alt="image" src="https://github.com/user-attachments/assets/9db62c61-c501-4904-8224-4760b6727b91" />
