### PR TITLE
allow object query subscriptionRatePlanNumber to be null

### DIFF
--- a/modules/zuora/src/objectQuery/expandSchemas/ratePlanItemSchema.ts
+++ b/modules/zuora/src/objectQuery/expandSchemas/ratePlanItemSchema.ts
@@ -37,7 +37,7 @@ export const ratePlanItemSchema = z.object({
 	/** The original ID of the subscription rate plan in the version-1 subscription. */
 	originalRatePlanId: z.string(),
 	/** The number of the rate plan in the subscription. */
-	subscriptionRatePlanNumber: z.string(),
+	subscriptionRatePlanNumber: z.string().nullable(),
 	/** Indicates whether the rate plan has been reverted. */
 	reverted: z.boolean(),
 });


### PR DESCRIPTION
we are getting alarms from the user-subscriptions-api.

This is because subscriptionRatePlanNumber is often null, even though the docs suggest it's always present
docs: https://developer.zuora.com/v1-api-reference/api/object-queries/queryrateplanbykey#object-queries/queryrateplanbykey/t=response&c=200&path=subscriptionrateplannumber

This PR makes it nullable, as it is in reality.

