### PR TITLE
Create /secondary-user/me endpoint

### DIFF
--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -203,6 +203,68 @@ paths:
               schema:
                 type: string
                 example: Internal server error
+  /secondary-user/me:
+    get:
+      operationId: getSecondaryUserMe
+      summary: Get primary users for the signed-in secondary user
+      description: >-
+        Returns the contact details of the primary user for each subscription
+        the signed-in secondary user is linked to. The secondary user is
+        identified by their Okta bearer token.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Primary users returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecondaryUserMeResponse'
+              examples:
+                default:
+                  value:
+                    primaryUsers:
+                      - firstName: Jane
+                        lastName: Smith
+                        workEmail: jane.smith@example.com
+        '401':
+          description: Missing, expired, or invalid Okta token.
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                noToken:
+                  value: No Authorization header provided
+                expired:
+                  value: Token has expired
+                invalid:
+                  value: Token is invalid
+                signingKey:
+                  value: Unable to find a signing key for the token
+        '403':
+          description: Token does not have the required scopes.
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                invalidScopes:
+                  value: Token does not have the required scopes
+        '404':
+          description: Route not found.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Not Found
+        '500':
+          description: Internal server error.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
   /invitation/{invitationCode}:
     delete:
       operationId: deleteInvitation
@@ -499,6 +561,34 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SecondaryUser'
+    PrimaryUser:
+      type: object
+      additionalProperties: false
+      required:
+        - firstName
+        - lastName
+        - workEmail
+      properties:
+        firstName:
+          type: string
+          example: Jane
+        lastName:
+          type: string
+          example: Smith
+        workEmail:
+          type: string
+          format: email
+          example: jane.smith@example.com
+    SecondaryUserMeResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - primaryUsers
+      properties:
+        primaryUsers:
+          type: array
+          items:
+            $ref: '#/components/schemas/PrimaryUser'
     ParserError:
       type: object
       additionalProperties: true

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -10,6 +10,7 @@ import { Router } from '@modules/routing/router';
 import { withMMAIdentityCheck } from '@modules/routing/withMMAIdentityCheck';
 import { withBodyParser, withPathParser } from '@modules/routing/withParsers';
 import { stageFromEnvironment } from '@modules/stage';
+import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
 import {
 	acceptInvitationEndpoint,
@@ -33,6 +34,7 @@ import {
 	listSecondaryUsersPathSchema,
 } from './listSecondaryUsersEndpoint';
 import { mmaPrimarySummaryEndpoint } from './mmaPrimarySummaryEndpoint';
+import { secondaryUserMeEndpoint } from './secondaryUserMeEndpoint';
 
 const stage = stageFromEnvironment();
 const authenticate = buildAuthenticate(stage, []);
@@ -50,6 +52,10 @@ const lazyProductCatalog = new Lazy(
 const lazyZuoraCatalog = new Lazy(
 	async () => await getZuoraCatalogFromS3(stage),
 	'Get Zuora catalog',
+);
+const lazyZuoraClient = new Lazy(
+	async () => await ZuoraClient.create(stage),
+	'Get Zuora client',
 );
 
 export const handler: Handler = Router([
@@ -148,5 +154,15 @@ export const handler: Handler = Router([
 				({ path }) => path.subscriptionName,
 			),
 		),
+	},
+	{
+		httpMethod: 'GET',
+		path: '/secondary-user/me',
+		handler: async (event) =>
+			secondaryUserMeEndpoint(
+				event,
+				secondaryUserRepository,
+				await lazyZuoraClient.get(),
+			),
 	},
 ]);

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -158,11 +158,18 @@ export const handler: Handler = Router([
 	{
 		httpMethod: 'GET',
 		path: '/secondary-user/me',
-		handler: async (event) =>
-			secondaryUserMeEndpoint(
-				event,
+		handler: async (event) => {
+			const maybeAuthenticatedEvent = await authenticate(event);
+
+			if (maybeAuthenticatedEvent.type === 'failure') {
+				return maybeAuthenticatedEvent.response;
+			}
+
+			return secondaryUserMeEndpoint(
+				maybeAuthenticatedEvent.userDetails.identityId,
 				secondaryUserRepository,
 				await lazyZuoraClient.get(),
-			),
+			);
+		},
 	},
 ]);

--- a/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
+++ b/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
@@ -1,0 +1,60 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { z } from 'zod';
+import type {
+	SecondaryUserRecord,
+	SecondaryUserRepository,
+} from '@modules/multiple-account/secondaryUserRepository';
+import { notFound, ok } from '@modules/routing/apiGatewayResponses';
+import { getAccount } from '@modules/zuora/account';
+import { getSubscription } from '@modules/zuora/subscription';
+import type { ZuoraAccount } from '@modules/zuora/types';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+
+const responseSchema = z.object({
+	primaryUsers: z
+		.object({
+			firstName: z.string(),
+			lastName: z.string(),
+			workEmail: z.string(),
+		})
+		.array(),
+});
+
+export async function secondaryUserMeEndpoint(
+	event: APIGatewayProxyEvent,
+	secondaryUserRepository: SecondaryUserRepository,
+	zuoraClient: ZuoraClient,
+): Promise<APIGatewayProxyResult> {
+	const identityId = event.headers['x-identity-id'];
+	if (!identityId) {
+		return notFound();
+	}
+
+	const secondaryUsers: SecondaryUserRecord[] =
+		await secondaryUserRepository.get(identityId);
+
+	const primaryUsers = await Promise.all(
+		secondaryUsers.map(async (secondaryUser) =>
+			getPrimaryUserInformationForSubscription(
+				zuoraClient,
+				secondaryUser.subscriptionName,
+			),
+		),
+	);
+	return ok({ primaryUsers }, responseSchema);
+}
+
+async function getPrimaryUserInformationForSubscription(
+	zuoraClient: ZuoraClient,
+	subscriptionName: string,
+) {
+	const subscription = await getSubscription(zuoraClient, subscriptionName);
+	const account: ZuoraAccount = await getAccount(
+		zuoraClient,
+		subscription.accountNumber,
+	);
+	const { zipCode, ...billToContactWithoutZipCode } = account.billToContact;
+	return {
+		...billToContactWithoutZipCode,
+	};
+}

--- a/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
+++ b/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
@@ -1,10 +1,10 @@
-import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import type { APIGatewayProxyResult } from 'aws-lambda';
 import { z } from 'zod';
 import type {
 	SecondaryUserRecord,
 	SecondaryUserRepository,
 } from '@modules/multiple-account/secondaryUserRepository';
-import { notFound, ok } from '@modules/routing/apiGatewayResponses';
+import { ok } from '@modules/routing/apiGatewayResponses';
 import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraAccount } from '@modules/zuora/types';
@@ -21,15 +21,10 @@ const responseSchema = z.object({
 });
 
 export async function secondaryUserMeEndpoint(
-	event: APIGatewayProxyEvent,
+	identityId: string,
 	secondaryUserRepository: SecondaryUserRepository,
 	zuoraClient: ZuoraClient,
 ): Promise<APIGatewayProxyResult> {
-	const identityId = event.headers['x-identity-id'];
-	if (!identityId) {
-		return notFound();
-	}
-
 	const secondaryUsers: SecondaryUserRecord[] =
 		await secondaryUserRepository.get(identityId);
 

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -1,4 +1,3 @@
-import type { APIGatewayProxyEvent } from 'aws-lambda';
 import type {
 	SecondaryUserRecord,
 	SecondaryUserRepository,
@@ -53,27 +52,8 @@ describe('secondaryUserMeEndpoint', () => {
 				.mockResolvedValue(users),
 		}) as unknown as SecondaryUserRepository;
 
-	const eventWithIdentity = (
-		identityId: string | undefined,
-	): APIGatewayProxyEvent =>
-		({
-			headers: identityId ? { 'x-identity-id': identityId } : {},
-		}) as unknown as APIGatewayProxyEvent;
-
 	beforeEach(() => {
 		jest.clearAllMocks();
-	});
-
-	it('returns 404 when the x-identity-id header is missing', async () => {
-		const result = await secondaryUserMeEndpoint(
-			eventWithIdentity(undefined),
-			makeRepository([]),
-			zuoraClient,
-		);
-
-		expect(result.statusCode).toBe(404);
-		expect(mockGetSubscription).not.toHaveBeenCalled();
-		expect(mockGetAccount).not.toHaveBeenCalled();
 	});
 
 	it('returns the primary user contact details (without zipCode) for each secondary user subscription', async () => {
@@ -89,7 +69,7 @@ describe('secondaryUserMeEndpoint', () => {
 			.mockResolvedValueOnce(makeAccount('Alan', 'Turing', 'alan@example.com'));
 
 		const result = await secondaryUserMeEndpoint(
-			eventWithIdentity('secondary-id'),
+			'secondary-id',
 			makeRepository(secondaryUsers),
 			zuoraClient,
 		);
@@ -123,7 +103,7 @@ describe('secondaryUserMeEndpoint', () => {
 
 	it('returns an empty primaryUsers list when there are no secondary users', async () => {
 		const result = await secondaryUserMeEndpoint(
-			eventWithIdentity('secondary-id'),
+			'secondary-id',
 			makeRepository([]),
 			zuoraClient,
 		);
@@ -139,7 +119,7 @@ describe('secondaryUserMeEndpoint', () => {
 
 		await expect(
 			secondaryUserMeEndpoint(
-				eventWithIdentity('secondary-id'),
+				'secondary-id',
 				makeRepository([makeSecondaryUser('A-S00000001')]),
 				zuoraClient,
 			),

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -1,0 +1,148 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import type {
+	SecondaryUserRecord,
+	SecondaryUserRepository,
+} from '@modules/multiple-account/secondaryUserRepository';
+import { getAccount } from '@modules/zuora/account';
+import { getSubscription } from '@modules/zuora/subscription';
+import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { secondaryUserMeEndpoint } from '../src/secondaryUserMeEndpoint';
+
+jest.mock('@modules/zuora/subscription', () => ({
+	getSubscription: jest.fn(),
+}));
+
+jest.mock('@modules/zuora/account', () => ({
+	getAccount: jest.fn(),
+}));
+
+describe('secondaryUserMeEndpoint', () => {
+	const mockGetSubscription = jest.mocked(getSubscription);
+	const mockGetAccount = jest.mocked(getAccount);
+	const zuoraClient = {} as unknown as ZuoraClient;
+
+	const makeSubscription = (accountNumber: string): ZuoraSubscription =>
+		({ accountNumber }) as unknown as ZuoraSubscription;
+
+	const makeAccount = (
+		firstName: string,
+		lastName: string,
+		workEmail: string,
+	): ZuoraAccount =>
+		({
+			billToContact: { firstName, lastName, workEmail, zipCode: 'N1 9GU' },
+		}) as unknown as ZuoraAccount;
+
+	const makeSecondaryUser = (
+		subscriptionName: string,
+	): SecondaryUserRecord => ({
+		subscriptionName,
+		secondaryIdentityId: 'secondary-id',
+		primaryIdentityId: 'primary-id',
+		acceptedDate: '2026-06-12',
+		expiryDate: 1781218800,
+	});
+
+	const makeRepository = (
+		users: SecondaryUserRecord[],
+	): SecondaryUserRepository =>
+		({
+			get: jest
+				.fn<Promise<SecondaryUserRecord[]>, [string]>()
+				.mockResolvedValue(users),
+		}) as unknown as SecondaryUserRepository;
+
+	const eventWithIdentity = (
+		identityId: string | undefined,
+	): APIGatewayProxyEvent =>
+		({
+			headers: identityId ? { 'x-identity-id': identityId } : {},
+		}) as unknown as APIGatewayProxyEvent;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('returns 404 when the x-identity-id header is missing', async () => {
+		const result = await secondaryUserMeEndpoint(
+			eventWithIdentity(undefined),
+			makeRepository([]),
+			zuoraClient,
+		);
+
+		expect(result.statusCode).toBe(404);
+		expect(mockGetSubscription).not.toHaveBeenCalled();
+		expect(mockGetAccount).not.toHaveBeenCalled();
+	});
+
+	it('returns the primary user contact details (without zipCode) for each secondary user subscription', async () => {
+		const secondaryUsers = [
+			makeSecondaryUser('A-S00000001'),
+			makeSecondaryUser('A-S00000002'),
+		];
+		mockGetSubscription
+			.mockResolvedValueOnce(makeSubscription('A00000001'))
+			.mockResolvedValueOnce(makeSubscription('A00000002'));
+		mockGetAccount
+			.mockResolvedValueOnce(makeAccount('Ada', 'Lovelace', 'ada@example.com'))
+			.mockResolvedValueOnce(makeAccount('Alan', 'Turing', 'alan@example.com'));
+
+		const result = await secondaryUserMeEndpoint(
+			eventWithIdentity('secondary-id'),
+			makeRepository(secondaryUsers),
+			zuoraClient,
+		);
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({
+			primaryUsers: [
+				{
+					firstName: 'Ada',
+					lastName: 'Lovelace',
+					workEmail: 'ada@example.com',
+				},
+				{
+					firstName: 'Alan',
+					lastName: 'Turing',
+					workEmail: 'alan@example.com',
+				},
+			],
+		});
+		expect(mockGetSubscription).toHaveBeenCalledWith(
+			zuoraClient,
+			'A-S00000001',
+		);
+		expect(mockGetSubscription).toHaveBeenCalledWith(
+			zuoraClient,
+			'A-S00000002',
+		);
+		expect(mockGetAccount).toHaveBeenCalledWith(zuoraClient, 'A00000001');
+		expect(mockGetAccount).toHaveBeenCalledWith(zuoraClient, 'A00000002');
+	});
+
+	it('returns an empty primaryUsers list when there are no secondary users', async () => {
+		const result = await secondaryUserMeEndpoint(
+			eventWithIdentity('secondary-id'),
+			makeRepository([]),
+			zuoraClient,
+		);
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({ primaryUsers: [] });
+		expect(mockGetSubscription).not.toHaveBeenCalled();
+		expect(mockGetAccount).not.toHaveBeenCalled();
+	});
+
+	it('propagates errors thrown while fetching from Zuora', async () => {
+		mockGetSubscription.mockRejectedValue(new Error('Zuora unavailable'));
+
+		await expect(
+			secondaryUserMeEndpoint(
+				eventWithIdentity('secondary-id'),
+				makeRepository([makeSecondaryUser('A-S00000001')]),
+				zuoraClient,
+			),
+		).rejects.toThrow('Zuora unavailable');
+	});
+});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR is part of the API work for the multiple accounts feature. It is described in more detail [in this doc](https://docs.google.com/document/d/1eqMn9zkg-iRK3Gi9ecmgGh8WWUYpLX6B3cOasTRYpns/edit?tab=t.0)

This PR adds a new endpoint to the multiple-accounts-api to enable MMA to display any secondary user access a user has.

## Authentication 
Authentication is via an Okta JWT token in the Authorization header. This is to prevent enumeration of identity ids - the signed in user will only be able to retrieve a list for their own identity id.

## Testing
Testing this endpoint is a little more complicated than some others because it requires an Okta Authorization header. 

To get one of these follow the steps in [this README](https://github.com/guardian/identity/tree/main/docs/generating_tokens_locally) to generate a header in Postman or Hopscotch. 

You can then make your request to secondary users endpoint:
```
## Example request 

```shell
curl --location --request GET 'https://multiple-account-api-code.support.guardianapis.com/secondary-user/me' \
--header 'x-api-key: [API_KEY]' \
--header 'Content-Type: application/json' \
--header 'Authorization: ••••••' \
```

```json
{
    "primaryUsers": [
        {
            "firstName": "Test",
            "lastName": "User
            "workEmail": "test.user@thegulocal.com"
        }
    ]
}
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215969403983007