### PR TITLE
update to use TS7 in transitional mode

### DIFF
--- a/buildcheck/data/build.ts
+++ b/buildcheck/data/build.ts
@@ -166,6 +166,7 @@ const moduleBigquery: ModuleDefinition = {
 		...devDeps['@types/jest'],
 		...devDeps['jest'],
 		...devDeps['ts-jest'],
+		...devDeps['typescript'],
 	},
 	moduleDependencies: [],
 };
@@ -266,6 +267,7 @@ const moduleSalesforce: ModuleDefinition = {
 		...devDeps['@types/jest'],
 		...devDeps['jest'],
 		...devDeps['ts-jest'],
+		...devDeps['typescript'],
 	},
 	moduleDependencies: [moduleSecretsManager, moduleZuora],
 };

--- a/buildcheck/data/build.ts
+++ b/buildcheck/data/build.ts
@@ -82,7 +82,6 @@ const moduleProductCatalog: ModuleDefinition = {
 		...devDeps['tsconfig-paths'],
 		...dep['zod'],
 		...devDeps['eslint-plugin-sort-keys-fix'],
-		...devDeps['typescript'],
 	},
 	extraScripts: {
 		generateFiles: 'tsx src/generateSchemaCommand.ts',
@@ -161,12 +160,6 @@ const moduleBigquery: ModuleDefinition = {
 		...deprecatedDeps['aws-sdk'],
 		...dep['google-auth-library'],
 		...dep.zod,
-	},
-	devDependencies: {
-		...devDeps['@types/jest'],
-		...devDeps['jest'],
-		...devDeps['ts-jest'],
-		...devDeps['typescript'],
 	},
 	moduleDependencies: [],
 };
@@ -262,12 +255,6 @@ const moduleSalesforce: ModuleDefinition = {
 	name: 'salesforce',
 	dependencies: {
 		...dep['zod'],
-	},
-	devDependencies: {
-		...devDeps['@types/jest'],
-		...devDeps['jest'],
-		...devDeps['ts-jest'],
-		...devDeps['typescript'],
 	},
 	moduleDependencies: [moduleSecretsManager, moduleZuora],
 };

--- a/buildcheck/data/dependencies.ts
+++ b/buildcheck/data/dependencies.ts
@@ -40,11 +40,9 @@ export const dep = separateDepRecords({
 
 // intended for use in devDependencies
 export const devDeps = separateDepRecords({
-	typescript: 'catalog:',
 	// types
 	'@types/stripe': '^8.0.417',
 	'@types/aws-lambda': '^8.10.147',
-	'@types/jest': '^29.5.14',
 	'@smithy/types': '4.12.0',
 	// dev - for running locally
 	tsx: '^4.21.0',
@@ -53,8 +51,6 @@ export const devDeps = separateDepRecords({
 	'@faker-js/faker': '^9.8.0',
 	'aws-sdk-client-mock': '4.1.0',
 	'fetch-mock': '^11.1.1',
-	jest: '^29.7.0',
-	'ts-jest': '^29.3.2',
 	// linting
 	'eslint-plugin-sort-keys-fix': '^1.1.2',
 	'@redocly/cli': '2.30.5',

--- a/buildcheck/tsconfig.json
+++ b/buildcheck/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "lib": ["es2020"],
     "outDir": "dist",
+    "types": ["node", "jest"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/cdk/lib/cdk/SrApiLambda.ts
+++ b/cdk/lib/cdk/SrApiLambda.ts
@@ -1,9 +1,10 @@
 import { Duration } from 'aws-cdk-lib';
-import { ApiKeySourceType, LambdaRestApi } from 'aws-cdk-lib/aws-apigateway';
-import type {
-	QuotaSettings,
-	ThrottleSettings,
-} from 'aws-cdk-lib/aws-apigateway/lib/usage-plan';
+import {
+	ApiKeySourceType,
+	LambdaRestApi,
+	type QuotaSettings,
+	type ThrottleSettings,
+} from 'aws-cdk-lib/aws-apigateway';
 import { SrApiGateway5xxAlarm } from './SrApiGateway5xxAlarm';
 import type { SrLambdaProps } from './SrLambda';
 import { getNameWithStage, SrLambda } from './SrLambda';

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -5,7 +5,6 @@
 		"moduleResolution": "Node16",
 		"rootDir": "..",
 		"types": ["node", "jest"],
-		"resolvePackageJsonExports": false,
 		"lib": ["ES2020"],
 		"declaration": true,
 		"skipLibCheck": true,

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -1,10 +1,14 @@
 {
 	"compilerOptions": {
 		"target": "ES2020",
-		"module": "ES2020",
-		"moduleResolution": "node",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"rootDir": "..",
+		"types": ["node", "jest"],
+		"resolvePackageJsonExports": false,
 		"lib": ["ES2020"],
 		"declaration": true,
+		"skipLibCheck": true,
 		"strict": true,
 		"noImplicitAny": true,
 		"strictNullChecks": true,
@@ -19,7 +23,6 @@
 		"inlineSources": true,
 		"experimentalDecorators": true,
 		"strictPropertyInitialization": false,
-		"typeRoots": ["./node_modules/@types"],
 		"outDir": "dist"
 	},
 	"include": ["lib/**/*", "bin/**/*"],

--- a/handlers/contributions-only-countries-api/test/index.test.ts
+++ b/handlers/contributions-only-countries-api/test/index.test.ts
@@ -26,7 +26,7 @@ describe('contributions-only-countries-api handler', () => {
 			requestContext: {} as never,
 			body: null,
 			isBase64Encoded: false,
-		} as APIGatewayProxyEvent);
+		});
 
 		expect(response.statusCode).toBe(200);
 		expect(JSON.parse(response.body)).toEqual({

--- a/handlers/discount-api/test/applyDiscountIntegration.test.ts
+++ b/handlers/discount-api/test/applyDiscountIntegration.test.ts
@@ -62,7 +62,7 @@ test('Supporter Plus subscriptions can have a discount and get an email', async 
 		IdentityUserId: '200175946',
 	};
 
-	expect(response as ApplyDiscountResponseBody).toEqual(expected);
+	expect(response).toEqual(expected);
 	expect(emailPayload).toEqual(expectedEmail);
 
 	console.log('Cancelling the subscription');
@@ -119,7 +119,7 @@ test('digi subs can have a discount but dont get an email', async () => {
 		IdentityUserId: '200175946',
 	};
 
-	expect(response as ApplyDiscountResponseBody).toEqual(expected);
+	expect(response).toEqual(expected);
 	expect(emailPayload).toEqual(expectedEmail);
 
 	console.log('Cancelling the subscription');

--- a/handlers/mparticle-api/test/baton.spec.ts
+++ b/handlers/mparticle-api/test/baton.spec.ts
@@ -5,7 +5,6 @@ import type {
 	InitiationReference,
 } from '../src/routers/baton/initiationReference';
 import type { BatonS3Writer } from '../src/services/batonS3Writer';
-import type { AppConfig } from '../src/services/config';
 import type {
 	DataSubjectAPI,
 	MParticleClient,
@@ -32,7 +31,7 @@ jest.mock('../src/services/config', () => ({
 			secret: faker.string.nanoid(),
 		},
 		pod: 'EU1',
-	} as AppConfig),
+	}),
 	getEnv: jest.fn(() => 'CODE'),
 }));
 

--- a/handlers/mparticle-api/test/http.spec.ts
+++ b/handlers/mparticle-api/test/http.spec.ts
@@ -1,7 +1,6 @@
 import * as crypto from 'crypto';
 import { faker } from '@faker-js/faker';
 import { X509CertificateGenerator } from '@peculiar/x509';
-import type { AppConfig } from '../src/services/config';
 import { invokeHttpHandler } from './invoke-http-handler';
 import { mockFetchJsonResponse, mockFetchResponse } from './mockFetch';
 
@@ -16,7 +15,7 @@ jest.mock('../src/services/config', () => ({
 			secret: faker.string.nanoid(),
 		},
 		pod: 'EU1',
-	} as AppConfig),
+	}),
 	getEnv: jest.fn(() => 'CODE'),
 }));
 

--- a/handlers/mparticle-api/test/invoke-baton-handler.ts
+++ b/handlers/mparticle-api/test/invoke-baton-handler.ts
@@ -1,4 +1,4 @@
-import type { Callback, Context } from 'aws-lambda';
+import type { Context } from 'aws-lambda';
 import { handlerBaton } from '../src';
 import type {
 	BatonEventRequest,
@@ -8,10 +8,6 @@ import type {
 export const invokeBatonHandler = async (
 	event: BatonEventRequest,
 ): Promise<BatonEventResponse> => {
-	const result: unknown = await handlerBaton(
-		event,
-		{} as Context,
-		(() => {}) as Callback<unknown>,
-	);
+	const result: unknown = await handlerBaton(event, {} as Context, () => {});
 	return result as BatonEventResponse;
 };

--- a/handlers/mparticle-api/test/invoke-http-handler.ts
+++ b/handlers/mparticle-api/test/invoke-http-handler.ts
@@ -1,7 +1,6 @@
 import type {
 	APIGatewayProxyEvent,
 	APIGatewayProxyEventHeaders,
-	Callback,
 	Context,
 } from 'aws-lambda';
 import { handlerHttp } from '../src';
@@ -28,7 +27,7 @@ export const invokeHttpHandler = async ({
 			headers: headers ?? {},
 		} as APIGatewayProxyEvent,
 		{} as Context,
-		(() => {}) as Callback<unknown>,
+		() => {},
 	);
 	return result as {
 		statusCode: number;

--- a/handlers/sales-tax-api/test/index.test.ts
+++ b/handlers/sales-tax-api/test/index.test.ts
@@ -7,7 +7,6 @@ import {
 import type {
 	ZuoraTaxCodes,
 	ZuoraTaxPeriods,
-	ZuoraTaxRates,
 } from '@modules/zuora/types/objects/tax';
 import { handler } from '../src/index';
 import type { TaxRatesResponse } from '../src/schemas';
@@ -54,7 +53,7 @@ describe('SalesTax API', () => {
 	} as unknown as ZuoraTaxPeriods;
 
 	const mockGetZuoraTaxRates = jest.mocked(getZuoraTaxRates);
-	const mockZuoraTaxRates = canadianZuoraTaxRates() as unknown as ZuoraTaxRates;
+	const mockZuoraTaxRates = canadianZuoraTaxRates();
 
 	const baseTaxRatesEvent: Partial<APIGatewayProxyEvent> = {
 		path: '/tax-rates',

--- a/handlers/stripe-disputes/test/sqs-consumers/listenDisputeClosed.test.ts
+++ b/handlers/stripe-disputes/test/sqs-consumers/listenDisputeClosed.test.ts
@@ -349,7 +349,7 @@ describe('handleListenDisputeClosed', () => {
 			data: {
 				object: {
 					...mockWebhookData.data.object,
-					payment_method_details: undefined as any,
+					payment_method_details: undefined,
 				},
 			},
 		};

--- a/handlers/stripe-disputes/test/sqs-consumers/listenDisputeCreated.test.ts
+++ b/handlers/stripe-disputes/test/sqs-consumers/listenDisputeCreated.test.ts
@@ -283,7 +283,7 @@ describe('handleListenDisputeCreated', () => {
 				data: {
 					object: {
 						...mockWebhookData.data.object,
-						payment_method_details: undefined as any,
+						payment_method_details: undefined,
 					},
 				},
 			};

--- a/handlers/supporter-product-data-lambdas/test/addSupporterRatePlanItemToQueueLambda.test.ts
+++ b/handlers/supporter-product-data-lambdas/test/addSupporterRatePlanItemToQueueLambda.test.ts
@@ -74,8 +74,8 @@ describe('addSupporterRatePlanItemToQueueLambda', () => {
 				() => 120000,
 				{
 					streamCsvRows: () => streamCsvRows(''),
-					sendMessagesToQueue: noopAsync as never,
-					putLastSuccessfulQueryTime: noopAsync as never,
+					sendMessagesToQueue: noopAsync,
+					putLastSuccessfulQueryTime: noopAsync,
 				},
 			),
 		).rejects.toThrow('was empty');
@@ -104,7 +104,7 @@ describe('addSupporterRatePlanItemToQueueLambda', () => {
 			{
 				streamCsvRows: () => streamCsvRows(csv),
 				sendMessagesToQueue: sendBatch,
-				putLastSuccessfulQueryTime: noopAsync as never,
+				putLastSuccessfulQueryTime: noopAsync,
 			},
 		);
 
@@ -156,7 +156,7 @@ describe('addSupporterRatePlanItemToQueueLambda', () => {
 			{
 				streamCsvRows: () => streamCsvRows(csv),
 				sendMessagesToQueue: sendBatch,
-				putLastSuccessfulQueryTime: noopAsync as never,
+				putLastSuccessfulQueryTime: noopAsync,
 			},
 		);
 
@@ -178,8 +178,8 @@ describe('addSupporterRatePlanItemToQueueLambda', () => {
 				() => 120000,
 				{
 					streamCsvRows: () => streamCsvRows(csv),
-					sendMessagesToQueue: noopAsync as never,
-					putLastSuccessfulQueryTime: noopAsync as never,
+					sendMessagesToQueue: noopAsync,
+					putLastSuccessfulQueryTime: noopAsync,
 				},
 			),
 		).rejects.toBeInstanceOf(CsvDecodeError);
@@ -208,7 +208,7 @@ describe('addSupporterRatePlanItemToQueueLambda', () => {
 					streamCsvRows: () => streamCsvRows(csv),
 					sendMessagesToQueue: () =>
 						Promise.reject(new SqsSendError('SQS unavailable')),
-					putLastSuccessfulQueryTime: noopAsync as never,
+					putLastSuccessfulQueryTime: noopAsync,
 				},
 			),
 		).rejects.toBeInstanceOf(SqsSendError);

--- a/handlers/supporter-product-data-lambdas/test/fetchResultsLambda.test.ts
+++ b/handlers/supporter-product-data-lambdas/test/fetchResultsLambda.test.ts
@@ -95,7 +95,7 @@ describe('fetchResults', () => {
 					],
 				}),
 				getResultFileResponse: makeGetResultFileResponse('csv-data'),
-				uploadToS3: noopAsync as never,
+				uploadToS3: noopAsync,
 				putLastSuccessfulQueryTime,
 			},
 		);
@@ -119,8 +119,8 @@ describe('fetchResults', () => {
 						batches: [],
 					}),
 					getResultFileResponse: makeGetResultFileResponse(null),
-					uploadToS3: noopAsync as never,
-					putLastSuccessfulQueryTime: noopAsync as never,
+					uploadToS3: noopAsync,
+					putLastSuccessfulQueryTime: noopAsync,
 				},
 			),
 		).rejects.toThrow('Job with id job-789 is still in status executing');

--- a/handlers/ticket-tailor-webhook/test/testFixtures.ts
+++ b/handlers/ticket-tailor-webhook/test/testFixtures.ts
@@ -19,7 +19,7 @@ export const validSQSRecord: SQSRecord = {
 		queryStringParameters: {},
 		httpMethod: '',
 		path: '',
-	} as ApiGatewayToSqsEvent),
+	}),
 	attributes: {
 		ApproximateReceiveCount: '1',
 		AWSTraceHeader: 'Root=1-66c35630-058f68030b77da7b36b3a909',

--- a/handlers/write-off-unpaid-invoices/test/handlers/writeOffInvoices.test.ts
+++ b/handlers/write-off-unpaid-invoices/test/handlers/writeOffInvoices.test.ts
@@ -6,7 +6,6 @@ import {
 	getInvoiceItems,
 } from '@modules/zuora/invoice';
 import {
-	type CancelSource,
 	cancelSourceToCommentMap,
 	handler,
 	type LambdaEvent,
@@ -37,7 +36,7 @@ describe('writeOffInvoices', () => {
 		Items: [
 			{
 				invoice_id: 'inv123',
-				cancel_source: 'MMA' as CancelSource,
+				cancel_source: 'MMA',
 			},
 		],
 	} as LambdaEvent;

--- a/modules/bigquery/package.json
+++ b/modules/bigquery/package.json
@@ -17,11 +17,5 @@
     "aws-sdk": "^2.1692.0",
     "google-auth-library": "^9.15.0",
     "zod": "catalog:"
-  },
-  "devDependencies": {
-    "@types/jest": "^29.5.14",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.3.2",
-    "typescript": "catalog:"
   }
 }

--- a/modules/bigquery/package.json
+++ b/modules/bigquery/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
-    "ts-jest": "^29.3.2"
+    "ts-jest": "^29.3.2",
+    "typescript": "catalog:"
   }
 }

--- a/modules/logger/src/aroundAsync.ts
+++ b/modules/logger/src/aroundAsync.ts
@@ -28,10 +28,10 @@ export function aroundAsync<
 		const context = hooks.before(args);
 
 		try {
-		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- required because generic function implementations erase concrete return typing
-		const result = (await fn(...args)) as Awaited<ReturnType<TFn>>;
-		hooks.after(result, context);
-		return result;
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- required because generic function implementations erase concrete return typing
+			const result = (await fn(...args)) as Awaited<ReturnType<TFn>>;
+			hooks.after(result, context);
+			return result;
 		} catch (error) {
 			hooks.onError(error, context);
 			throw error;

--- a/modules/logger/src/aroundAsync.ts
+++ b/modules/logger/src/aroundAsync.ts
@@ -28,11 +28,10 @@ export function aroundAsync<
 		const context = hooks.before(args);
 
 		try {
-			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- required because generic function implementations erase concrete return typing
-			const result = (await fn(...args)) as Awaited<ReturnType<TFn>>;
-			hooks.after(result, context);
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return -- generic implementation preserves type via the cast above
-			return result;
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- required because generic function implementations erase concrete return typing
+		const result = (await fn(...args)) as Awaited<ReturnType<TFn>>;
+		hooks.after(result, context);
+		return result;
 		} catch (error) {
 			hooks.onError(error, context);
 			throw error;

--- a/modules/product-catalog/package.json
+++ b/modules/product-catalog/package.json
@@ -30,7 +30,6 @@
     "tsx": "^4.21.0",
     "tsconfig-paths": "catalog:",
     "zod": "catalog:",
-    "eslint-plugin-sort-keys-fix": "^1.1.2",
-    "typescript": "catalog:"
+    "eslint-plugin-sort-keys-fix": "^1.1.2"
   }
 }

--- a/modules/salesforce/package.json
+++ b/modules/salesforce/package.json
@@ -15,11 +15,5 @@
     "zod": "catalog:",
     "secrets-manager": "workspace:*",
     "zuora": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/jest": "^29.5.14",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.3.2",
-    "typescript": "catalog:"
   }
 }

--- a/modules/salesforce/package.json
+++ b/modules/salesforce/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
-    "ts-jest": "^29.3.2"
+    "ts-jest": "^29.3.2",
+    "typescript": "catalog:"
   }
 }

--- a/modules/zuora/test/createSubscriptionIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionIntegration.test.ts
@@ -290,8 +290,7 @@ describe('createSubscription integration', () => {
 		expect(
 			digitalPackInvoiceItems.every(
 				(item) =>
-					firstDigitalPackItem !== undefined &&
-					item.amountWithoutTax === firstDigitalPackItem.amountWithoutTax,
+			item.amountWithoutTax === firstDigitalPackItem?.amountWithoutTax,
 			),
 		).toBe(true);
 	});

--- a/modules/zuora/test/createSubscriptionIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionIntegration.test.ts
@@ -290,7 +290,7 @@ describe('createSubscription integration', () => {
 		expect(
 			digitalPackInvoiceItems.every(
 				(item) =>
-			item.amountWithoutTax === firstDigitalPackItem?.amountWithoutTax,
+					item.amountWithoutTax === firstDigitalPackItem?.amountWithoutTax,
 			),
 		).toBe(true);
 	});

--- a/modules/zuora/test/invoice.test.ts
+++ b/modules/zuora/test/invoice.test.ts
@@ -5,10 +5,7 @@ import {
 	getInvoiceItems,
 	writeOffInvoice,
 } from '@modules/zuora/invoice';
-import type {
-	InvoiceItemAdjustmentSourceType,
-	InvoiceItemAdjustmentType,
-} from '@modules/zuora/types';
+import type { InvoiceItemAdjustmentType } from '@modules/zuora/types';
 import {
 	getInvoiceItemsSchema,
 	getInvoiceSchema,
@@ -81,7 +78,7 @@ describe('invoice', () => {
 				'SRC-123',
 				50.0,
 				'Increase' as InvoiceItemAdjustmentType,
-				'InvoiceDetail' as InvoiceItemAdjustmentSourceType,
+				'InvoiceDetail',
 				'Test adjustment',
 				'REASON-01',
 			);

--- a/modules/zuora/test/restClient.test.ts
+++ b/modules/zuora/test/restClient.test.ts
@@ -4,7 +4,7 @@ import { RestClient, RestClientError } from '../src/restClient';
 
 class TestRestClient extends RestClient {
 	constructor(baseUrl: string, authHeaders: Record<string, string> = {}) {
-		const mockTokenProvider: jest.Mocked<BearerTokenProvider> = {
+		const mockTokenProvider = {
 			getAuthorisation: jest
 				.fn()
 				.mockResolvedValue({ baseUrl, authHeaders } satisfies Authorisation),

--- a/modules/zuora/test/zuoraClient.test.ts
+++ b/modules/zuora/test/zuoraClient.test.ts
@@ -36,7 +36,7 @@ describe('ZuoraClient fetch method error handling', () => {
 				baseUrl: '',
 				authHeaders: { Authorization: 'Bearer test_token' },
 			} satisfies Authorisation),
-		} as unknown as jest.Mocked<BearerTokenProvider>;
+		};
 
 		zuoraClient = new ZuoraClient(mockTokenProvider);
 	});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"typescript-eslint": "^8.46.2",
+			"typescript-eslint": "^8.63.0",
 			"micromatch>braces": "^3.0.3",
 			"cross-spawn": "^7.0.6",
 			"@babel/helpers@<7.26.10": ">=7.26.10",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"prettier": "^3.3.3",
 		"ts-jest": "^29.4.11",
 		"typescript": "catalog:",
+		"@typescript/native": "catalog:",
 		"zod": "catalog:"
 	},
 	"pnpm": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"build": "pnpm --stream -r run build",
 		"package": "pnpm --stream -r run package",
-		"type-check": "tsc --noEmit",
+		"type-check": "pnpm --stream -r run type-check",
 		"lint": "pnpm --stream -r run lint",
 		"clean": "rm -rf .parcel-cache && pnpm -r run clean",
 		"test": "pnpm --stream -r run test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  typescript-eslint: ^8.46.2
+  typescript-eslint: ^8.63.0
   micromatch>braces: ^3.0.3
   cross-spawn: ^7.0.6
   '@babel/helpers@<7.26.10': '>=7.26.10'
@@ -40,7 +40,7 @@ importers:
     devDependencies:
       '@guardian/eslint-config':
         specifier: ^11.0.0
-        version: 11.0.0(@typescript/typescript6@6.0.2)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
+        version: 11.0.0(@typescript/typescript6@6.0.2)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       '@guardian/prettier':
         specifier: ^8.0.1
         version: 8.0.2(prettier@3.8.3)(tslib@2.8.1)
@@ -1002,10 +1002,13 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       ts-jest:
         specifier: ^29.3.2
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)))(typescript@7.0.2)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)))
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
 
   modules/email:
     dependencies:
@@ -1212,10 +1215,13 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       ts-jest:
         specifier: ^29.3.2
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)))(typescript@7.0.2)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)))
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
 
   modules/secrets-manager:
     dependencies:
@@ -2151,8 +2157,18 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/config-array@0.21.2':
@@ -2822,20 +2838,20 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@typescript-eslint/eslint-plugin@8.46.2':
-    resolution: {integrity: sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==}
+  '@typescript-eslint/eslint-plugin@8.63.0':
+    resolution: {integrity: sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.46.2
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': ^8.63.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.46.2':
-    resolution: {integrity: sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==}
+  '@typescript-eslint/parser@8.63.0':
+    resolution: {integrity: sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/project-service@8.46.2':
     resolution: {integrity: sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==}
@@ -2843,8 +2859,18 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.63.0':
+    resolution: {integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.46.2':
     resolution: {integrity: sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.63.0':
+    resolution: {integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.46.2':
@@ -2853,15 +2879,25 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/type-utils@8.46.2':
-    resolution: {integrity: sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==}
+  '@typescript-eslint/tsconfig-utils@8.63.0':
+    resolution: {integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.63.0':
+    resolution: {integrity: sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/types@8.46.2':
     resolution: {integrity: sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.63.0':
+    resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.46.2':
@@ -2870,6 +2906,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/typescript-estree@8.63.0':
+    resolution: {integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@8.46.2':
     resolution: {integrity: sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2877,8 +2919,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.63.0':
+    resolution: {integrity: sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.46.2':
     resolution: {integrity: sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -3829,6 +3882,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3933,6 +3990,15 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: 4.0.4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fetch-mock@11.1.5:
     resolution: {integrity: sha512-KHmZDnZ1ry0pCTrX4YG5DtThHi0MH+GNI9caESnzX/nMJBrvppUHMvLx47M0WY9oAtKOMiPfZDRpxhlHg89BOA==}
@@ -4110,9 +4176,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   gtoken@7.1.0:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
@@ -5689,6 +5752,10 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   title-case@2.1.1:
     resolution: {integrity: sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==}
 
@@ -5707,6 +5774,12 @@ packages:
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -5830,12 +5903,12 @@ packages:
     resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.46.2:
-    resolution: {integrity: sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==}
+  typescript-eslint@8.63.0:
+    resolution: {integrity: sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -7123,7 +7196,14 @@ snapshots:
       eslint: 9.39.4
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.2':
     dependencies:
@@ -7229,14 +7309,14 @@ snapshots:
       read-pkg-up: 7.0.1
       yargs: 17.7.2
 
-  '@guardian/eslint-config@11.0.0(@typescript/typescript6@6.0.2)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)':
+  '@guardian/eslint-config@11.0.0(@typescript/typescript6@6.0.2)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.39.4)
       '@eslint/js': 9.19.0
       '@stylistic/eslint-plugin': 2.11.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
       eslint-config-prettier: 9.1.0(eslint@9.39.4)
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-import-x: 4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
       eslint-plugin-react: 7.37.2(eslint@9.39.4)
@@ -7244,7 +7324,7 @@ snapshots:
       eslint-plugin-storybook: 0.11.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       globals: 15.14.0
       read-package-up: 11.0.0
-      typescript-eslint: 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      typescript-eslint: 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
     transitivePeerDependencies:
       - eslint-plugin-import
       - supports-color
@@ -7324,7 +7404,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -7338,7 +7418,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -8191,29 +8271,28 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
-      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
-      '@typescript-eslint/visitor-keys': 8.46.2
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/type-utils': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/utils': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/visitor-keys': 8.63.0
       eslint: 9.39.4
-      graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(@typescript/typescript6@6.0.2)
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
+  '@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(@typescript/typescript6@6.0.2)
-      '@typescript-eslint/visitor-keys': 8.46.2
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.63.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4
       typescript: '@typescript/typescript6@6.0.2'
@@ -8229,28 +8308,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.63.0(@typescript/typescript6@6.0.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/types': 8.63.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.46.2':
     dependencies:
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/visitor-keys': 8.46.2
 
+  '@typescript-eslint/scope-manager@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+
   '@typescript-eslint/tsconfig-utils@8.46.2(@typescript/typescript6@6.0.2)':
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/type-utils@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
+  '@typescript-eslint/tsconfig-utils@8.63.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(@typescript/typescript6@6.0.2)
-      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      typescript: '@typescript/typescript6@6.0.2'
+
+  '@typescript-eslint/type-utils@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4
-      ts-api-utils: 2.1.0(@typescript/typescript6@6.0.2)
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.46.2': {}
+
+  '@typescript-eslint/types@8.63.0': {}
 
   '@typescript-eslint/typescript-estree@8.46.2(@typescript/typescript6@6.0.2)':
     dependencies:
@@ -8268,6 +8367,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.63.0(@typescript/typescript6@6.0.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.63.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.5
+      semver: 7.8.1
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.4)
@@ -8279,10 +8393,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(@typescript/typescript6@6.0.2)
+      eslint: 9.39.4
+      typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.46.2':
     dependencies:
       '@typescript-eslint/types': 8.46.2
       eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      eslint-visitor-keys: 5.0.1
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -8932,13 +9062,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)):
+  create-jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -9359,7 +9489,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import-x@4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import-x@4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -9371,16 +9501,16 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-import-x: 4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/parser': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
@@ -9407,7 +9537,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
@@ -9417,7 +9547,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9428,7 +9558,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/parser': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9507,6 +9637,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.4:
     dependencies:
@@ -9657,6 +9789,10 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fetch-mock@11.1.5:
     dependencies:
@@ -9869,8 +10005,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  graphemer@1.4.0: {}
 
   gtoken@7.1.0:
     dependencies:
@@ -10293,16 +10427,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)):
+  jest-cli@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+      create-jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -10374,7 +10508,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)):
+  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@babel/core': 7.28.3
       '@jest/test-sequencer': 29.7.0
@@ -10400,7 +10534,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.1
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@7.0.2)
+      ts-node: 10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -10730,12 +10864,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)):
+  jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+      jest-cli: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11913,6 +12047,11 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   title-case@2.1.1:
     dependencies:
       no-case: 2.3.2
@@ -11929,6 +12068,10 @@ snapshots:
   ts-algebra@1.2.2: {}
 
   ts-api-utils@2.1.0(@typescript/typescript6@6.0.2):
+    dependencies:
+      typescript: '@typescript/typescript6@6.0.2'
+
+  ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
@@ -11955,18 +12098,18 @@ snapshots:
       esbuild: 0.25.12
       jest-util: 30.4.1
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)))(typescript@7.0.2):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
+      jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.8.1
       type-fest: 4.41.0
-      typescript: 7.0.2
+      typescript: '@typescript/typescript6@6.0.2'
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.7
@@ -11995,7 +12138,7 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2):
+  ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -12009,7 +12152,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 7.0.2
+      typescript: '@typescript/typescript6@6.0.2'
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -12103,12 +12246,12 @@ snapshots:
       reflect.getprototypeof: 1.0.10
     optional: true
 
-  typescript-eslint@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4):
+  typescript-eslint@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)
-      '@typescript-eslint/parser': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
-      '@typescript-eslint/typescript-estree': 8.46.2(@typescript/typescript6@6.0.2)
-      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/parser': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/typescript-estree': 8.63.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -996,19 +996,6 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
-    devDependencies:
-      '@types/jest':
-        specifier: ^29.5.14
-        version: 29.5.14
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
-      ts-jest:
-        specifier: ^29.3.2
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)))
-      typescript:
-        specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
 
   modules/email:
     dependencies:
@@ -1145,9 +1132,6 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.22.4
-      typescript:
-        specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1209,19 +1193,6 @@ importers:
       zuora:
         specifier: workspace:*
         version: link:../zuora
-    devDependencies:
-      '@types/jest':
-        specifier: ^29.5.14
-        version: 29.5.14
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
-      ts-jest:
-        specifier: ^29.3.2
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)))
-      typescript:
-        specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
 
   modules/secrets-manager:
     dependencies:
@@ -7404,41 +7375,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 25.9.1
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/diff-sequences@30.4.0': {}
 
   '@jest/environment@29.7.0':
@@ -8701,20 +8637,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@7.29.7):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/transform': 29.7.0
-      '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.29.7)
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -8785,13 +8707,6 @@ snapshots:
       '@babel/core': 7.28.3
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.3)
-
-  babel-preset-jest@29.6.3(@babel/core@7.29.7):
-    dependencies:
-      '@babel/core': 7.29.7
-      babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
-    optional: true
 
   balanced-match@1.0.2: {}
 
@@ -9054,21 +8969,6 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10427,25 +10327,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@babel/core': 7.28.3
@@ -10504,37 +10385,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
       ts-node: 10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)):
-    dependencies:
-      '@babel/core': 7.28.3
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.3)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.9.1
-      ts-node: 10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -10858,18 +10708,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12098,27 +11936,6 @@ snapshots:
       esbuild: 0.25.12
       jest-util: 30.4.1
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.9
-      jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.8.1
-      type-fest: 4.41.0
-      typescript: '@typescript/typescript6@6.0.2'
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.7
-      '@jest/transform': 30.4.1
-      '@jest/types': 30.4.1
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      esbuild: 0.25.12
-      jest-util: 30.4.1
-
   ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -12127,25 +11944,6 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.19.19
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: '@typescript/typescript6@6.0.2'
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@25.9.1)(@typescript/typescript6@6.0.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.9.1
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,15 @@ settings:
 
 catalogs:
   default:
+    '@typescript/native':
+      specifier: npm:typescript@^7.0.2
+      version: 7.0.2
     tsconfig-paths:
       specifier: ^4.2.0
       version: 4.2.0
     typescript:
-      specifier: ^5.6.3
-      version: 5.9.2
+      specifier: npm:@typescript/typescript6@^6.0.2
+      version: 6.0.2
     zod:
       specifier: ^4.4.3
       version: 4.4.3
@@ -37,7 +40,7 @@ importers:
     devDependencies:
       '@guardian/eslint-config':
         specifier: ^11.0.0
-        version: 11.0.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint@9.39.4))(eslint@9.39.4)(typescript@5.9.2)
+        version: 11.0.0(@typescript/typescript6@6.0.2)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       '@guardian/prettier':
         specifier: ^8.0.1
         version: 8.0.2(prettier@3.8.3)(tslib@2.8.1)
@@ -47,6 +50,9 @@ importers:
       '@types/node':
         specifier: ^22.14.1
         version: 22.19.19
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       esbuild:
         specifier: ^0.25.4
         version: 0.25.12
@@ -64,7 +70,7 @@ importers:
         version: 6.2.11
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+        version: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
       jest-runner-groups:
         specifier: ^2.2.0
         version: 2.2.0(jest-docblock@29.7.0)(jest-runner@29.7.0)
@@ -73,10 +79,10 @@ importers:
         version: 3.8.3
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.28.3)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)))(typescript@5.9.2)
+        version: 29.4.11(@babel/core@7.28.3)(@jest/transform@30.4.1)(@jest/types@30.4.1)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)))
       typescript:
         specifier: 'catalog:'
-        version: 5.9.2
+        version: '@typescript/typescript6@6.0.2'
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -996,10 +1002,10 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       ts-jest:
         specifier: ^29.3.2
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)))(typescript@7.0.2)
 
   modules/email:
     dependencies:
@@ -1138,7 +1144,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.2
+        version: '@typescript/typescript6@6.0.2'
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1206,10 +1212,10 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       ts-jest:
         specifier: ^29.3.2
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)))(typescript@7.0.2)
 
   modules/secrets-manager:
     dependencies:
@@ -2874,6 +2880,130 @@ packages:
   '@typescript-eslint/visitor-keys@8.46.2':
     resolution: {integrity: sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -5707,14 +5837,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uglify-js@3.19.3:
@@ -7094,22 +7229,22 @@ snapshots:
       read-pkg-up: 7.0.1
       yargs: 17.7.2
 
-  '@guardian/eslint-config@11.0.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint@9.39.4))(eslint@9.39.4)(typescript@5.9.2)':
+  '@guardian/eslint-config@11.0.0(@typescript/typescript6@6.0.2)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.39.4)
       '@eslint/js': 9.19.0
-      '@stylistic/eslint-plugin': 2.11.0(eslint@9.39.4)(typescript@5.9.2)
+      '@stylistic/eslint-plugin': 2.11.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
       eslint-config-prettier: 9.1.0(eslint@9.39.4)
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.6.1(eslint@9.39.4)(typescript@5.9.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint@9.39.4))(eslint@9.39.4)
-      eslint-plugin-import-x: 4.6.1(eslint@9.39.4)(typescript@5.9.2)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-plugin-import-x: 4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
       eslint-plugin-react: 7.37.2(eslint@9.39.4)
       eslint-plugin-react-hooks: 5.1.0(eslint@9.39.4)
-      eslint-plugin-storybook: 0.11.1(eslint@9.39.4)(typescript@5.9.2)
+      eslint-plugin-storybook: 0.11.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       globals: 15.14.0
       read-package-up: 11.0.0
-      typescript-eslint: 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      typescript-eslint: 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
     transitivePeerDependencies:
       - eslint-plugin-import
       - supports-color
@@ -7154,7 +7289,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -7168,7 +7303,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -7189,7 +7324,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -7203,7 +7338,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -7904,9 +8039,9 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  '@stylistic/eslint-plugin@2.11.0(eslint@9.39.4)(typescript@5.9.2)':
+  '@stylistic/eslint-plugin@2.11.0(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -8056,41 +8191,41 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint@9.39.4)(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       '@typescript-eslint/visitor-keys': 8.46.2
       eslint: 9.39.4
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.1.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.46.2(@typescript/typescript6@6.0.2)
       '@typescript-eslint/visitor-keys': 8.46.2
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4
-      typescript: 5.9.2
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.46.2(typescript@5.9.2)':
+  '@typescript-eslint/project-service@8.46.2(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.46.2(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.46.2
       debug: 4.4.3(supports-color@8.1.1)
-      typescript: 5.9.2
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -8099,28 +8234,28 @@ snapshots:
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/visitor-keys': 8.46.2
 
-  '@typescript-eslint/tsconfig-utils@8.46.2(typescript@5.9.2)':
+  '@typescript-eslint/tsconfig-utils@8.46.2(@typescript/typescript6@6.0.2)':
     dependencies:
-      typescript: 5.9.2
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/type-utils@8.46.2(eslint@9.39.4)(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.46.2(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.1.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.46.2': {}
 
-  '@typescript-eslint/typescript-estree@8.46.2(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@8.46.2(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.46.2(typescript@5.9.2)
-      '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.9.2)
+      '@typescript-eslint/project-service': 8.46.2(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.46.2(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/visitor-keys': 8.46.2
       debug: 4.4.3(supports-color@8.1.1)
@@ -8128,19 +8263,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.9
       semver: 7.8.1
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.1.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.2(eslint@9.39.4)(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.46.2(@typescript/typescript6@6.0.2)
       eslint: 9.39.4
-      typescript: 5.9.2
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -8148,6 +8283,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.46.2
       eslint-visitor-keys: 4.2.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -8718,13 +8917,13 @@ snapshots:
 
   core-js@3.49.0: {}
 
-  create-jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
+  create-jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -8733,13 +8932,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -9160,7 +9359,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import-x@4.6.1(eslint@9.39.4)(typescript@5.9.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import-x@4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -9172,27 +9371,27 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint@9.39.4)
-      eslint-plugin-import-x: 4.6.1(eslint@9.39.4)(typescript@5.9.2)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4)
+      eslint-plugin-import-x: 4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  eslint-plugin-import-x@4.6.1(eslint@9.39.4)(typescript@5.9.2):
+  eslint-plugin-import-x@4.6.1(@typescript/typescript6@6.0.2)(eslint@9.39.4):
     dependencies:
       '@types/doctrine': 0.0.9
       '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       debug: 4.4.3(supports-color@8.1.1)
       doctrine: 3.0.0
       enhanced-resolve: 5.18.3
@@ -9208,7 +9407,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint@9.39.4):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
@@ -9218,7 +9417,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9229,7 +9428,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9288,10 +9487,10 @@ snapshots:
       natural-compare: 1.4.0
       requireindex: 1.2.0
 
-  eslint-plugin-storybook@0.11.1(eslint@9.39.4)(typescript@5.9.2):
+  eslint-plugin-storybook@0.11.1(@typescript/typescript6@6.0.2)(eslint@9.39.4):
     dependencies:
       '@storybook/csf': 0.1.13
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -10075,16 +10274,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
+  jest-cli@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      create-jest: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -10094,16 +10293,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -10113,7 +10312,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
+  jest-config@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@babel/core': 7.28.3
       '@jest/test-sequencer': 29.7.0
@@ -10139,12 +10338,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.19
-      ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.2)
+      ts-node: 10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
+  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@babel/core': 7.28.3
       '@jest/test-sequencer': 29.7.0
@@ -10170,12 +10369,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.1
-      ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.2)
+      ts-node: 10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)):
     dependencies:
       '@babel/core': 7.28.3
       '@jest/test-sequencer': 29.7.0
@@ -10201,7 +10400,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.1
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@7.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -10519,24 +10718,24 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
+  jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      jest-cli: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11729,24 +11928,24 @@ snapshots:
 
   ts-algebra@1.2.2: {}
 
-  ts-api-utils@2.1.0(typescript@5.9.2):
+  ts-api-utils@2.1.0(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 5.9.2
+      typescript: '@typescript/typescript6@6.0.2'
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.4.11(@babel/core@7.28.3)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)))(typescript@5.9.2):
+  ts-jest@29.4.11(@babel/core@7.28.3)(@jest/transform@30.4.1)(@jest/types@30.4.1)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      jest: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.8.1
       type-fest: 4.41.0
-      typescript: 5.9.2
+      typescript: '@typescript/typescript6@6.0.2'
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.28.3
@@ -11756,18 +11955,18 @@ snapshots:
       esbuild: 0.25.12
       jest-util: 30.4.1
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2)))(typescript@7.0.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.8.1
       type-fest: 4.41.0
-      typescript: 5.9.3
+      typescript: 7.0.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.7
@@ -11777,7 +11976,7 @@ snapshots:
       esbuild: 0.25.12
       jest-util: 30.4.1
 
-  ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2):
+  ts-node@10.9.2(@types/node@22.19.19)(@typescript/typescript6@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -11791,12 +11990,12 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.2
+      typescript: '@typescript/typescript6@6.0.2'
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@25.9.1)(typescript@7.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -11810,7 +12009,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 7.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -11904,20 +12103,43 @@ snapshots:
       reflect.getprototypeof: 1.0.10
     optional: true
 
-  typescript-eslint@8.46.2(eslint@9.39.4)(typescript@5.9.2):
+  typescript-eslint@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.2))(eslint@9.39.4)(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.39.4)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/parser': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/typescript-estree': 8.46.2(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.46.2(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
-      typescript: 5.9.2
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.2: {}
-
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uglify-js@3.19.3:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ packages:
 
 catalog:
   zod: ^4.4.3
-  typescript: ^5.6.3
+  typescript: "npm:@typescript/typescript6@^6.0.2"
+  "@typescript/native": "npm:typescript@^7.0.2"
   "@aws-sdk/client-ssm": ^3.848.0,
   tsconfig-paths: ^4.2.0


### PR DESCRIPTION
TS 7 is released which is supposed to be a lot quicker in terms of tooling and compile times.

https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/

Since we had nothing to lose I thought I'd have a go using copilot and see if there are any blockers - seemingly everything works with minor changes, mostly due to the linter being updated.  Copilot did chuck in some unnecessary seeming changes which I manually removed or simplified.

In terms of build speed theres not bad improvement (althoug not representative as it was just a single run before and after)
<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/c6c216b4-00fe-45a7-b21c-4b8828224f11" />

We will find out over time whether the improvements in local dev are significant, but it's good to keep up with the version anyway (we were on v5 before)

See inline comments for more.

Tested in CODE, product-switch-api deployed fine and seems to work 
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fproduct-switch-api-CODE/log-events/2026$252F07$252F09$252F$255B$2524LATEST$255D126380cccc2145d184bc73fba366b43f