### PR TITLE
Add notAvailableForBillingCountries field to new-product-api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -38,6 +38,7 @@ object WireModel {
       paymentPlans: List[WirePaymentPlan],
       paymentPlan: Option[String], // todo legacy field, remove once salesforce is reading from paymentPlans
       enabledForBillingCountries: Option[List[String]],
+      notAvailableForBillingCountries: Option[List[String]],
   )
 
   case class WirePaymentPlan(
@@ -143,6 +144,13 @@ object WireModel {
         case _ => None
       }
 
+      val notAvailableForBillingCountries = plan.id match {
+        case PlanId.DigipackAnnual | PlanId.DigipackMonthly | PlanId.AnnualSupporterPlus |
+            PlanId.MonthlySupporterPlus =>
+          Some(List(Country.Canada.name))
+        case _ => None
+      }
+
       WirePlanInfo(
         id = plan.id.name,
         label = plan.description.value,
@@ -150,6 +158,7 @@ object WireModel {
         paymentPlans = paymentPlans.toList,
         paymentPlan = legacyPaymentPlan,
         enabledForBillingCountries = enabledForBillingCountries,
+        notAvailableForBillingCountries = notAvailableForBillingCountries,
       )
     }
   }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
@@ -36,7 +36,8 @@
           "sizeInDays" : 1
         }
       },
-      "paymentPlans" : [ ]
+      "paymentPlans" : [ ],
+      "notAvailableForBillingCountries" : [ "Canada" ]
     }, {
       "id" : "annual_supporter_plus",
       "label" : "Annual",
@@ -47,7 +48,8 @@
           "sizeInDays" : 1
         }
       },
-      "paymentPlans" : [ ]
+      "paymentPlans" : [ ],
+      "notAvailableForBillingCountries" : [ "Canada" ]
     }, {
       "id" : "monthly_supporter_plus_tax_exclusive",
       "label" : "Monthly (Tax Exclusive)",
@@ -108,7 +110,8 @@
         "billingPeriod" : "Annual",
         "description" : "USD 666.65 every 12 months"
       } ],
-      "paymentPlan" : "GBP 666.66 every 12 months"
+      "paymentPlan" : "GBP 666.66 every 12 months",
+      "notAvailableForBillingCountries" : [ "Canada" ]
     }, {
       "id" : "digipack_monthly",
       "label" : "Monthly",
@@ -130,7 +133,8 @@
         "billingPeriod" : "Monthly",
         "description" : "USD 55.54 every month"
       } ],
-      "paymentPlan" : "GBP 55.55 every month"
+      "paymentPlan" : "GBP 55.55 every month",
+      "notAvailableForBillingCountries" : [ "Canada" ]
     }, {
       "id" : "digipack_annual_tax_exclusive",
       "label" : "Annual (Tax Exclusive)",


### PR DESCRIPTION
## What does this change?

In #3651 we added a new `enabledForBillingCountries` field to new-product-api to let us selectively show plans for specific billing countries.

This PR does the inverse, adds a `notAvailableForBillingCountries` field so that plans can be NOT shown for specific countries.

The usage of these fields is as follows:

 - If `enabledForBillingCountries` is provided then only show the plan for the listed countries
 - If `notAvailableForBillingCountries` is provided then do not show the plan for the listed countries
 - If neither are present, then plan is available for all countries

> [!NOTE]
> There is already a `enabledForDeliveryCountries` on products although this isn't used consistently.

Initially this is just applied to the new tax exclusive pricing plans that are about to be launched but this could be expanded more widely.

## How has this change been tested?

Tested on CODE, endpoint is returning new field as expected:

<img width="807" height="330" alt="Screenshot 2026-07-09 at 17 27 07" src="https://github.com/user-attachments/assets/be8e83d7-a113-410b-82d3-56985b7881b3" />

## How can we measure success?
We can selectively show the right plans for the right customers in Salesforce without fiddling around with the product catalog results in SF.

