### PR TITLE
Fix sales-tax-api integration test

### DIFF
--- a/handlers/sales-tax-api/test/fixtures.ts
+++ b/handlers/sales-tax-api/test/fixtures.ts
@@ -46,7 +46,7 @@ export const canadianCountryStates: TaxRatesResponse = {
 	NU: 0.05,
 	ON: 0.13,
 	PE: 0.15,
-	QC: 0.1475,
+	QC: 0.14975,
 	SK: 0.11,
 	YT: 0.05,
 };


### PR DESCRIPTION
## What does this change?

Update the Quebec sales tax rate in the fixture to match Zuora, which fixes a currently broken integration test.