### PR TITLE
Alarm if generate-product-catalog-CODE fails

### DIFF
--- a/cdk/lib/__snapshots__/generate-product-catalog.test.ts.snap
+++ b/cdk/lib/__snapshots__/generate-product-catalog.test.ts.snap
@@ -272,7 +272,7 @@ def sort_filter_rules(json_obj):
     },
     "FailedProductCatalogLambdaAlarm543E56AB": {
       "Properties": {
-        "ActionsEnabled": false,
+        "ActionsEnabled": true,
         "AlarmActions": [
           {
             "Fn::Join": [

--- a/cdk/lib/generate-product-catalog.ts
+++ b/cdk/lib/generate-product-catalog.ts
@@ -125,6 +125,7 @@ export class GenerateProductCatalog extends SrStack {
 			errorImpact:
 				'This means the product catalog may not be up to date in S3. This lambda runs on a regular schedule so action will only be necessary if the alarm is triggered continuously',
 			lambdaFunctionName: lambda.functionName,
+			actionsEnabled: true,
 		});
 	}
 }


### PR DESCRIPTION
## What does this change?

Alarm if the generate-product-catalog lambda fails in CODE.

We often use CODE (the Zuora sandbox) as a staging area for change in prod, so if the CODE lambda ever starts failing we'd like to know in case it's related to Zuora changes we're planning on making in prod.