### PR TITLE
Add cancelledBy field to multiple accounts invitations

### DIFF
--- a/handlers/multiple-account-api/README.md
+++ b/handlers/multiple-account-api/README.md
@@ -123,3 +123,29 @@ Example path: /subscriptions/A-S00974337/secondary-users/30067890
 #### Response:
 
 `204 No Content`
+
+### Delete (reject/cancel) an invitation
+
+#### Request:
+
+DELETE /invitation/{invitationCode}
+
+Headers: 'x-identity-id' - the identity id of the user cancelling/rejecting the
+invitation. This is required and must match either the `primaryIdentityId` or
+the `secondaryIdentityId` of the invitation.
+
+Example path: /invitation/RpwR62kMnAxe
+
+The invitation is soft deleted: the record is retained for two weeks (via the
+DynamoDB TTL `expiryDate`) with a `cancelledBy` value derived from the identity
+id - `primary` when it matches the primary user, `secondary` when it matches the
+secondary user.
+
+#### Response:
+
+`204 No Content`
+
+If the `x-identity-id` header is missing, or does not match either user on the
+invitation, a `400 Bad Request` is returned.
+
+

--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -314,7 +314,8 @@ paths:
         'x-identity-id' header is required and must match either the primary or
         secondary user of the invitation. Whether the invitation was cancelled
         by the primary or rejected by the secondary is derived from which of the
-        two the identity id matches.
+        two the identity id matches. An invitation that has already been
+        cancelled is treated as not found and cannot be cancelled again.
       security:
         - apiKey: []
       parameters:
@@ -347,7 +348,9 @@ paths:
                 type: string
                 example: The x-identity-id header is required
         '404':
-          description: Invitation not found.
+          description: >-
+            Invitation not found. Also returned when the invitation has already
+            been cancelled.
           content:
             text/plain:
               schema:
@@ -364,7 +367,10 @@ paths:
     post:
       operationId: acceptInvitation
       summary: Accept invitation
-      description: Accepts an invitation for the signed-in secondary user, linking them to the subscription.
+      description: >-
+        Accepts an invitation for the signed-in secondary user, linking them to
+        the subscription. An invitation that has already been cancelled cannot
+        be accepted.
       security:
         - bearerAuth: []
       parameters:
@@ -384,10 +390,16 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: false
+                $ref: '#/components/schemas/AcceptInvitationResponse'
+              examples:
+                default:
+                  value:
+                    identityId: '30067890'
+                    secondarySubscriptionName: A-S00974338
         '400':
-          description: Invalid request or the signed-in user does not match the invited user.
+          description: >-
+            Invalid request, the signed-in user does not match the invited user,
+            or the invitation has already been cancelled.
           content:
             text/plain:
               schema:
@@ -395,6 +407,8 @@ paths:
               examples:
                 incorrectUser:
                   value: Incorrect user
+                cancelled:
+                  value: Invitation has been cancelled by the primary user
             application/json:
               schema:
                 $ref: '#/components/schemas/ParserError'
@@ -480,6 +494,21 @@ components:
           pattern: '^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{12}$'
           description: 12-character Base58 invitation code.
           example: RpwR62kMnAxe
+    AcceptInvitationResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - identityId
+        - secondarySubscriptionName
+      properties:
+        identityId:
+          type: string
+          description: Identity id of the secondary user who accepted the invitation.
+          example: '30067890'
+        secondarySubscriptionName:
+          type: string
+          description: Zuora subscription number created for the secondary user.
+          example: A-S00974338
     Invitation:
       type: object
       additionalProperties: false

--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -543,6 +543,17 @@ components:
         expiryDate:
           type: number
           example: 1781222400000
+        cancelledBy:
+          type: string
+          enum:
+            - primary
+            - secondary
+          description: >-
+            Present in the list-invitations response when the invitation has
+            been cancelled by the primary user or rejected by the secondary
+            user. Absent for pending invitations, and never returned by the
+            mma-primary summary (which excludes cancelled invitations).
+          example: primary
     ListInvitationsResponse:
       type: object
       additionalProperties: false

--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -157,7 +157,7 @@ paths:
               schema:
                 type: string
                 example: Internal server error
-    /subscriptions/{subscriptionName}/secondary-users/{secondaryIdentityId}:
+  /subscriptions/{subscriptionName}/secondary-users/{secondaryIdentityId}:
     delete:
       operationId: deleteSecondaryUser
       summary: Delete secondary user
@@ -309,7 +309,12 @@ paths:
     delete:
       operationId: deleteInvitation
       summary: Delete invitation
-      description: Deletes an invitation by invitation code.
+      description: >-
+        Deletes (soft deletes) an invitation by invitation code. The
+        'x-identity-id' header is required and must match either the primary or
+        secondary user of the invitation. Whether the invitation was cancelled
+        by the primary or rejected by the secondary is derived from which of the
+        two the identity id matches.
       security:
         - apiKey: []
       parameters:
@@ -319,17 +324,28 @@ paths:
           schema:
             type: string
           description: The invitation code to delete.
+        - name: x-identity-id
+          in: header
+          required: true
+          schema:
+            type: string
+          description: >-
+            The identity id of the primary or secondary user of the invitation.
+            When it matches the primary user the cancellation is recorded as
+            'primary'; when it matches the secondary user it is recorded as
+            'secondary'.
       responses:
         '204':
           description: Invitation deleted.
+        '400':
+          description: >-
+            Missing 'x-identity-id' header, or the identity id does not match
+            the primary or secondary user of the invitation.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/DeleteInvitationResponse'
-              examples:
-                default:
-                  value:
-                    message: Deleted
+                type: string
+                example: The x-identity-id header is required
         '404':
           description: Invitation not found.
           content:
@@ -464,15 +480,6 @@ components:
           pattern: '^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{12}$'
           description: 12-character Base58 invitation code.
           example: RpwR62kMnAxe
-    DeleteInvitationResponse:
-      type: object
-      additionalProperties: false
-      required:
-        - message
-      properties:
-        message:
-          type: string
-          example: Deleted
     Invitation:
       type: object
       additionalProperties: false

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -40,6 +40,12 @@ export const acceptInvitationEndpoint = async (
 			return badRequest('Incorrect user');
 		}
 
+		if (invitation.cancelledBy !== undefined) {
+			return badRequest(
+				`Invitation has been cancelled by the ${invitation.cancelledBy} user`,
+			);
+		}
+
 		const { subscriptionName, secondaryIdentityId, primaryIdentityId } =
 			invitation;
 

--- a/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
@@ -2,6 +2,7 @@ import type { APIGatewayProxyResult } from 'aws-lambda';
 import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import {
+	badRequest,
 	internalServerError,
 	notFound,
 } from '@modules/routing/apiGatewayResponses';
@@ -11,12 +12,12 @@ export const deleteInvitationPathSchema = z.object({
 	invitationCode: z.string(),
 });
 
-export type DeleteInvitationPath = z.infer<typeof deleteInvitationPathSchema>;
-
 export const deleteInvitationEndpoint =
 	(invitationRepository: InvitationRepository) =>
-	async (path: DeleteInvitationPath): Promise<APIGatewayProxyResult> => {
-		const { invitationCode } = path;
+	async (
+		invitationCode: string,
+		identityId: string,
+	): Promise<APIGatewayProxyResult> => {
 		logger.mutableAddContext(invitationCode);
 
 		try {
@@ -26,9 +27,22 @@ export const deleteInvitationEndpoint =
 				return notFound();
 			}
 
-			await invitationRepository.delete(
+			if (
+				identityId != invitation.primaryIdentityId &&
+				identityId != invitation.secondaryIdentityId
+			) {
+				return badRequest(
+					'The x-identity-id does not match the primary or secondary user of this invitation',
+				);
+			}
+
+			const cancelledBy =
+				identityId === invitation.primaryIdentityId ? 'primary' : 'secondary';
+
+			await invitationRepository.softDelete(
 				invitation.subscriptionName,
 				invitationCode,
+				cancelledBy,
 			);
 
 			return {

--- a/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
@@ -23,7 +23,7 @@ export const deleteInvitationEndpoint =
 		try {
 			const invitation = await invitationRepository.get(invitationCode);
 
-			if (!invitation) {
+			if (!invitation || invitation.cancelledBy !== undefined) {
 				return notFound();
 			}
 

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -6,6 +6,7 @@ import { IdentityClient } from '@modules/identity/identityClient';
 import { Lazy } from '@modules/lazy';
 import { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
+import { badRequest } from '@modules/routing/apiGatewayResponses';
 import { Router } from '@modules/routing/router';
 import { withMMAIdentityCheck } from '@modules/routing/withMMAIdentityCheck';
 import { withBodyParser, withPathParser } from '@modules/routing/withParsers';
@@ -86,9 +87,18 @@ export const handler: Handler = Router([
 	{
 		httpMethod: 'DELETE',
 		path: '/invitation/{invitationCode}',
-		handler: withPathParser(deleteInvitationPathSchema, async (_event, path) =>
-			deleteInvitationEndpoint(invitationRepository)(path),
-		),
+		handler: withPathParser(deleteInvitationPathSchema, async (event, path) => {
+			// Both the primary (cancelling) and secondary (rejecting) users send
+			// their identity id in the 'x-identity-id' header.
+			const identityId = event.headers['x-identity-id'];
+			if (!identityId) {
+				return badRequest('The x-identity-id header is required');
+			}
+			return deleteInvitationEndpoint(invitationRepository)(
+				path.invitationCode,
+				identityId,
+			);
+		}),
 	},
 	{
 		httpMethod: 'POST',

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -99,6 +99,12 @@ export class InvitationRepository {
 		);
 	}
 
+	async listNonCancelled(subscriptionName: string) {
+		return (await this.list(subscriptionName)).filter(
+			(invitation) => invitation.cancelledBy === undefined,
+		);
+	}
+
 	async delete(
 		subscriptionName: string,
 		invitationCode: string,

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -32,6 +32,7 @@ export const invitationRecordSchema = z.object({
 	invitedDate: z.string(),
 	expiryDate: z.number(),
 	cancelledBy: cancelledBySchema.optional(),
+	cancelledDate: z.iso.datetime().optional(),
 });
 
 export type InvitationRecord = z.infer<typeof invitationRecordSchema>;
@@ -126,10 +127,11 @@ export class InvitationRepository {
 					invitationCode: { S: invitationCode },
 				},
 				UpdateExpression:
-					'SET expiryDate = :expiryDate, cancelledBy = :cancelledBy',
+					'SET expiryDate = :expiryDate, cancelledBy = :cancelledBy, cancelledDate = :cancelledDate',
 				ExpressionAttributeValues: {
 					':expiryDate': { N: invitationCancellationTTL().toString() },
 					':cancelledBy': { S: cancelledBy },
+					':cancelledDate': { S: dayjs().toISOString() },
 				},
 			}),
 		);

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -8,6 +8,7 @@ import {
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { z } from 'zod';
 import { getMaybeSingleOrThrow } from '@modules/arrayFunctions';
+import { cancelledBySchema } from '@modules/multiple-account/cancelledBySchema';
 import type { Stage } from '@modules/stage';
 
 export const invitationRecordSchema = z.object({
@@ -18,6 +19,7 @@ export const invitationRecordSchema = z.object({
 	secondaryIdentityId: z.string(),
 	invitedDate: z.string(),
 	expiryDate: z.number(),
+	cancelledBy: cancelledBySchema.optional(),
 });
 
 export type InvitationRecord = z.infer<typeof invitationRecordSchema>;

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -4,12 +4,24 @@ import {
 	PutItemCommand,
 	QueryCommand,
 	type TransactWriteItem,
+	UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import dayjs from 'dayjs';
 import { z } from 'zod';
 import { getMaybeSingleOrThrow } from '@modules/arrayFunctions';
-import { cancelledBySchema } from '@modules/multiple-account/cancelledBySchema';
+import {
+	type CancelledBy,
+	cancelledBySchema,
+} from '@modules/multiple-account/cancelledBySchema';
 import type { Stage } from '@modules/stage';
+
+// When an invitation is cancelled/rejected we keep the
+// record for a short period (rather than hard deleting it) so we can tell who
+// cancelled it, then let DynamoDB's TTL (expiryDate) remove it automatically.
+export function invitationCancellationTTL(): number {
+	return dayjs().add(2, 'weeks').unix();
+}
 
 export const invitationRecordSchema = z.object({
 	subscriptionName: z.string(),
@@ -96,6 +108,28 @@ export class InvitationRepository {
 				Key: {
 					subscriptionName: { S: subscriptionName },
 					invitationCode: { S: invitationCode },
+				},
+			}),
+		);
+	}
+
+	async softDelete(
+		subscriptionName: string,
+		invitationCode: string,
+		cancelledBy: CancelledBy,
+	): Promise<void> {
+		await this.client.send(
+			new UpdateItemCommand({
+				TableName: this.tableName,
+				Key: {
+					subscriptionName: { S: subscriptionName },
+					invitationCode: { S: invitationCode },
+				},
+				UpdateExpression:
+					'SET expiryDate = :expiryDate, cancelledBy = :cancelledBy',
+				ExpressionAttributeValues: {
+					':expiryDate': { N: invitationCancellationTTL().toString() },
+					':cancelledBy': { S: cancelledBy },
 				},
 			}),
 		);

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -16,7 +16,7 @@ import {
 import type { ListSecondaryUsersBody } from './listSecondaryUsersEndpoint';
 
 export const mmaPrimarySummaryResponseSchema = z.object({
-	invitations: z.array(invitationRecordSchema),
+	invitations: z.array(invitationRecordSchema.omit({ cancelledBy: true })),
 	secondaryUsers: z.array(
 		secondaryUserRecordSchema.extend({
 			email: z.string().optional(),
@@ -36,7 +36,11 @@ export const mmaPrimarySummaryEndpoint =
 	async ({ subscriptionName }: ListSecondaryUsersBody) => {
 		try {
 			logger.mutableAddContext(subscriptionName);
-			const invitations = await invitationRepository.list(subscriptionName);
+
+			const nonCancelledInvitations = (
+				await invitationRepository.list(subscriptionName)
+			).filter((invitation) => !invitation.cancelledBy);
+
 			const secondaryUsers = await getSecondaryUserListWithNames(
 				subscriptionName,
 				secondaryUserRepository,
@@ -44,7 +48,7 @@ export const mmaPrimarySummaryEndpoint =
 			);
 
 			return ok(
-				{ invitations, secondaryUsers },
+				{ invitations: nonCancelledInvitations, secondaryUsers },
 				mmaPrimarySummaryResponseSchema,
 			);
 		} catch (error) {

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -39,9 +39,8 @@ export const mmaPrimarySummaryEndpoint =
 		try {
 			logger.mutableAddContext(subscriptionName);
 
-			const nonCancelledInvitations = (
-				await invitationRepository.list(subscriptionName)
-			).filter((invitation) => !invitation.cancelledBy);
+			const nonCancelledInvitations =
+				await invitationRepository.listNonCancelled(subscriptionName);
 
 			const secondaryUsers = await getSecondaryUserListWithNames(
 				subscriptionName,

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -16,7 +16,9 @@ import {
 import type { ListSecondaryUsersBody } from './listSecondaryUsersEndpoint';
 
 export const mmaPrimarySummaryResponseSchema = z.object({
-	invitations: z.array(invitationRecordSchema.omit({ cancelledBy: true })),
+	invitations: z.array(
+		invitationRecordSchema.omit({ cancelledBy: true, cancelledDate: true }),
+	),
 	secondaryUsers: z.array(
 		secondaryUserRecordSchema.extend({
 			email: z.string().optional(),

--- a/handlers/multiple-account-api/src/validation.ts
+++ b/handlers/multiple-account-api/src/validation.ts
@@ -48,10 +48,10 @@ export async function validateInvitationInformation(
 ) {
 	logger.log('Validating invitation information');
 
-	const currentInvites = await repo.list(subscriptionName);
+	const nonCancelledInvites = await repo.listNonCancelled(subscriptionName);
 
 	// Check the secondary user has not been invited already
-	const inviteAlreadyExistsForUser = currentInvites.find(
+	const inviteAlreadyExistsForUser = nonCancelledInvites.find(
 		(invite) => invite.secondaryIdentityId === secondaryIdentityId,
 	);
 
@@ -63,7 +63,7 @@ export async function validateInvitationInformation(
 
 	// Check the subscription still has free invites
 	const subscriptionHasAvailableInvites =
-		currentInvites.length < MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION;
+		nonCancelledInvites.length < MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION;
 
 	if (!subscriptionHasAvailableInvites) {
 		throw new ValidationError(

--- a/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
@@ -61,10 +61,12 @@ test('deleteInvitationEndpoint soft deletes invitation and returns 204', async (
 
 	expect(result.statusCode).toBe(204);
 
-	// The record is soft deleted: it still exists but now has cancelledBy set
-	// and an updated TTL (expiryDate) roughly 2 weeks in the future.
+	// The record is soft deleted: it still exists but now has cancelledBy and
+	// cancelledDate set and an updated TTL (expiryDate) roughly 2 weeks in the future.
 	const softDeleted = await repo.get(invitationCode);
 	expect(softDeleted?.cancelledBy).toBe('primary');
+	expect(softDeleted?.cancelledDate).toBeDefined();
+	expect(dayjs(softDeleted?.cancelledDate).isValid()).toBe(true);
 	expect(softDeleted?.expiryDate).toBeGreaterThan(
 		dayjs().add(13, 'days').unix(),
 	);
@@ -82,6 +84,8 @@ test('deleteInvitationEndpoint records cancelledBy as secondary when the seconda
 
 	const softDeleted = await repo.get(invitationCode);
 	expect(softDeleted?.cancelledBy).toBe('secondary');
+	expect(softDeleted?.cancelledDate).toBeDefined();
+	expect(dayjs(softDeleted?.cancelledDate).isValid()).toBe(true);
 });
 
 test('deleteInvitationEndpoint returns 400 when the identity id matches neither user', async () => {

--- a/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
@@ -51,21 +51,53 @@ afterEach(async () => {
 	);
 });
 
-test('deleteInvitationEndpoint deletes invitation and returns 204', async () => {
+test('deleteInvitationEndpoint soft deletes invitation and returns 204', async () => {
 	const invitationCode = `it-delete-${Date.now()}`;
 	const record = buildRecord('A-S00099999', invitationCode);
 	await saveRecord(record);
 
 	const endpoint = deleteInvitationEndpoint(repo);
-	const result = await endpoint({ invitationCode });
+	const result = await endpoint(invitationCode, record.primaryIdentityId);
 
 	expect(result.statusCode).toBe(204);
-	await expect(repo.get(record.invitationCode)).resolves.toBeUndefined();
+
+	// The record is soft deleted: it still exists but now has cancelledBy set
+	// and an updated TTL (expiryDate) roughly 2 weeks in the future.
+	const softDeleted = await repo.get(invitationCode);
+	expect(softDeleted?.cancelledBy).toBe('primary');
+	expect(softDeleted?.expiryDate).toBeGreaterThan(
+		dayjs().add(13, 'days').unix(),
+	);
+});
+
+test('deleteInvitationEndpoint records cancelledBy as secondary when the secondary user rejects', async () => {
+	const invitationCode = `it-delete-secondary-${Date.now()}`;
+	const record = buildRecord('A-S00099999', invitationCode);
+	await saveRecord(record);
+
+	const endpoint = deleteInvitationEndpoint(repo);
+	const result = await endpoint(invitationCode, record.secondaryIdentityId);
+
+	expect(result.statusCode).toBe(204);
+
+	const softDeleted = await repo.get(invitationCode);
+	expect(softDeleted?.cancelledBy).toBe('secondary');
+});
+
+test('deleteInvitationEndpoint returns 400 when the identity id matches neither user', async () => {
+	const invitationCode = `it-delete-badrequest-${Date.now()}`;
+	const record = buildRecord('A-S00099999', invitationCode);
+	await saveRecord(record);
+
+	const endpoint = deleteInvitationEndpoint(repo);
+	const result = await endpoint(invitationCode, 'not-a-matching-id');
+
+	expect(result.statusCode).toBe(400);
 });
 
 test('deleteInvitationEndpoint returns 404 when invitation is not found', async () => {
 	const endpoint = deleteInvitationEndpoint(repo);
-	const result = await endpoint({ invitationCode: `it-missing-${Date.now()}` });
+	const result = await endpoint(`it-missing-${Date.now()}`, '12345678');
 
 	expect(result.statusCode).toBe(404);
 });

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -58,9 +58,14 @@ const mockList = jest
 	.fn<Promise<InvitationRecord[]>, [string]>()
 	.mockResolvedValue(mockInvitations);
 
+const mockListNonCancelled = jest
+	.fn<Promise<InvitationRecord[]>, [string]>()
+	.mockResolvedValue(mockInvitations);
+
 const mockRepo: InvitationRepository = {
 	save: mockSave,
 	list: mockList,
+	listNonCancelled: mockListNonCancelled,
 } as unknown as InvitationRepository;
 
 const mockIdentityClient = {} as IdentityClient;
@@ -70,6 +75,7 @@ describe('createInvitationHandler', () => {
 		jest.clearAllMocks();
 		mockSave.mockResolvedValue(undefined);
 		mockList.mockResolvedValue(mockInvitations);
+		mockListNonCancelled.mockResolvedValue(mockInvitations);
 	});
 
 	it('saves an invitation record and returns 201 with invitationCode', async () => {

--- a/modules/multiple-account/src/cancelledBySchema.ts
+++ b/modules/multiple-account/src/cancelledBySchema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const cancelledBySchema = z.union([
+	z.literal('primary'),
+	z.literal('secondary'),
+]);

--- a/modules/multiple-account/src/cancelledBySchema.ts
+++ b/modules/multiple-account/src/cancelledBySchema.ts
@@ -4,3 +4,5 @@ export const cancelledBySchema = z.union([
 	z.literal('primary'),
 	z.literal('secondary'),
 ]);
+
+export type CancelledBy = z.infer<typeof cancelledBySchema>;

--- a/modules/multiple-account/src/secondaryUserRepository.ts
+++ b/modules/multiple-account/src/secondaryUserRepository.ts
@@ -10,6 +10,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import type { Dayjs } from 'dayjs';
 import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
+import { cancelledBySchema } from '@modules/multiple-account/cancelledBySchema';
 import type { Stage } from '@modules/stage';
 
 export const secondaryUserRecordSchema = z.object({
@@ -18,6 +19,7 @@ export const secondaryUserRecordSchema = z.object({
 	primaryIdentityId: z.string(),
 	acceptedDate: z.string(),
 	expiryDate: z.number(),
+	cancelledBy: cancelledBySchema.optional(),
 });
 
 export function secondaryUserTTLFromPrimarySubscriptionTTL(primaryTTL: Dayjs) {

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -1,10 +1,13 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { z } from 'zod';
 import { ValidationError } from '@modules/errors';
-import { prettyPrint } from '@modules/prettyPrint';
+import { logger } from '@modules/logger/logger';
 import { stringify } from '@modules/stringify';
 
 function jsonResponse(message: string, statusCode: number) {
+	logger.log(
+		`Handler returned ${statusCode} response with message: ${message}`,
+	);
 	return {
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ message }),
@@ -64,13 +67,7 @@ export function created<T extends Record<string, unknown>>(
 
 export function buildErrorResponse(error: unknown): APIGatewayProxyResult {
 	if (error instanceof ValidationError) {
-		console.log(
-			`Handler returned 400 response due to validation error: ${prettyPrint(error)}`,
-		);
 		return badRequest(error.message);
 	}
-	console.log(
-		`Handler returned 500 response due to unexpected error: ${prettyPrint(error)}`,
-	);
 	return internalServerError();
 }

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -1,13 +1,10 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { z } from 'zod';
 import { ValidationError } from '@modules/errors';
-import { logger } from '@modules/logger/logger';
+import { prettyPrint } from '@modules/prettyPrint';
 import { stringify } from '@modules/stringify';
 
 function jsonResponse(message: string, statusCode: number) {
-	logger.log(
-		`Handler returned ${statusCode} response with message: ${message}`,
-	);
 	return {
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ message }),
@@ -67,7 +64,13 @@ export function created<T extends Record<string, unknown>>(
 
 export function buildErrorResponse(error: unknown): APIGatewayProxyResult {
 	if (error instanceof ValidationError) {
+		console.log(
+			`Handler returned 400 response due to validation error: ${prettyPrint(error)}`,
+		);
 		return badRequest(error.message);
 	}
+	console.log(
+		`Handler returned 500 response due to unexpected error: ${prettyPrint(error)}`,
+	);
 	return internalServerError();
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds two new optional fields to multiple accounts Invitation records - `cancelledBy` and `cancelledDate` will be set when the invitation is either cancelled via MMA by the primary user or rejected by the secondary user.

The value will be determined in the delete invitation endpoint from the `x-identity-id` header which should match either the primary or secondary user identity id on the invitation record. If this header is not present the response will be a 400 bad request.

## Testing - all carried out on CODE
### Create a new invitation
Request:

```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/invitation' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 112809589' \ # primary user
--header 'Content-Type: application/json' \
--header 'Authorization: ••••••' \
--data-raw '{
  "subscriptionName": "A-S00974337",
  "secondaryUserEmail": "test@thegulocal.com"
}'
```

Response:
`200`
```json
{
    "invitationCode": "FRcCyefqP3qf"
}
```

### Delete that invitation as the secondary user
Request:
```shell
curl --location --request DELETE 'https://multiple-account-api-code.support.guardianapis.com/invitation/FRcCyefqP3qf' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 21841960' # secondary user
```

Response:
`204 No Content`

### Try to delete the invitation again
Request:
```shell
curl --location --request DELETE 'https://multiple-account-api-code.support.guardianapis.com/invitation/FRcCyefqP3qf' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 21841960' # secondary user
```

Response:
`404`
```json
{
    "message": "Not Found"
}
```

### Try to accept the invitation
Request:
```shell
curl --location --request POST 'https://multiple-account-api-code.support.guardianapis.com/invitation/FRcCyefqP3qf/accept' \
--header 'x-api-key: [API_KEY]' \
--header 'Authorization: ••••••'
```

Response
`400`
```json
{
    "message": "Invitation has been cancelled by the secondary user"
}
```

### View the invitation list as the primary user
Request:
```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/subscriptions/A-S00974337/mma-primary' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 112809589'
```

Request:
`200`
```Json
{
    "invitations": [],
    "secondaryUsers": []
}
```
Cancelled invitations should not show up in the MMA response

## [Asana card](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216361629156782)