### PR TITLE
Show the amount without tax in day 0 emails (for tax exclusive rate plans)

### DIFF
--- a/handlers/discount-api/test/getNextPaymentDate.test.ts
+++ b/handlers/discount-api/test/getNextPaymentDate.test.ts
@@ -4,9 +4,24 @@ import { zuoraDateFormat } from '@modules/zuora/utils';
 
 test('getNextNonFreePaymentDate fails if all payments are free', () => {
 	const items = [
-		{ date: new Date('2020-02-01'), amount: 0 },
-		{ date: new Date('2020-01-01'), amount: 0 },
-		{ date: new Date('2020-01-01'), amount: 0 },
+		{
+			date: new Date('2020-02-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-01-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-01-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
 	];
 
 	const actual = () => getNextNonFreePaymentDate(items);
@@ -18,9 +33,24 @@ test('getNextNonFreePaymentDate fails if all payments are free', () => {
 
 test('getNextNonFreePaymentDate finds the relevant payment', () => {
 	const items = [
-		{ date: new Date('2020-01-01'), amount: 0 },
-		{ date: new Date('2020-02-01'), amount: 10 },
-		{ date: new Date('2020-03-01'), amount: 10 },
+		{
+			date: new Date('2020-01-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-03-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
 	];
 
 	const actual = getNextNonFreePaymentDate(items);
@@ -30,9 +60,24 @@ test('getNextNonFreePaymentDate finds the relevant payment', () => {
 
 test('getNextNonFreePaymentDate finds the relevant payment in reverse order', () => {
 	const items = [
-		{ date: new Date('2020-03-01'), amount: 10 },
-		{ date: new Date('2020-02-01'), amount: 10 },
-		{ date: new Date('2020-01-01'), amount: 0 },
+		{
+			date: new Date('2020-03-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-01-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
 	];
 
 	const actual = getNextNonFreePaymentDate(items);
@@ -42,10 +87,30 @@ test('getNextNonFreePaymentDate finds the relevant payment in reverse order', ()
 
 test('getNextNonFreePaymentDate finds the relevant payment even if theres duplicates', () => {
 	const items = [
-		{ date: new Date('2020-01-01'), amount: 0 },
-		{ date: new Date('2020-02-01'), amount: 0 },
-		{ date: new Date('2020-02-01'), amount: 10 },
-		{ date: new Date('2020-03-01'), amount: 10 },
+		{
+			date: new Date('2020-01-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-03-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
 	];
 
 	const actual = getNextNonFreePaymentDate(items);
@@ -55,10 +120,30 @@ test('getNextNonFreePaymentDate finds the relevant payment even if theres duplic
 
 test('getNextNonFreePaymentDate finds the relevant payment in reverse order even if theres duplicates', () => {
 	const items = [
-		{ date: new Date('2020-03-01'), amount: 10 },
-		{ date: new Date('2020-02-01'), amount: 10 },
-		{ date: new Date('2020-02-01'), amount: 0 },
-		{ date: new Date('2020-01-01'), amount: 0 },
+		{
+			date: new Date('2020-03-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-01-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
 	];
 
 	const actual = getNextNonFreePaymentDate(items);

--- a/handlers/discount-api/test/getOrderedInvoiceTotals.test.ts
+++ b/handlers/discount-api/test/getOrderedInvoiceTotals.test.ts
@@ -2,50 +2,150 @@ import { getOrderedInvoiceTotals } from '@modules/zuora/billingPreview';
 
 test('getOrderedInvoiceTotals doesnt affect if theyre already in order', () => {
 	const items = [
-		{ date: new Date('2020-01-01'), amount: 0 },
-		{ date: new Date('2020-02-01'), amount: 10 },
-		{ date: new Date('2020-03-01'), amount: 10 },
+		{
+			date: new Date('2020-01-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-03-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
 	];
 
 	const actual = getOrderedInvoiceTotals(items);
 
 	expect(actual).toEqual([
-		{ date: new Date('2020-01-01'), total: 0 },
-		{ date: new Date('2020-02-01'), total: 10 },
-		{ date: new Date('2020-03-01'), total: 10 },
+		{
+			date: new Date('2020-01-01'),
+			total: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-02-01'),
+			total: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-03-01'),
+			total: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
 	]);
 });
 
 test('getOrderedInvoiceTotals reorders them if theyre NOT in order', () => {
 	const items = [
-		{ date: new Date('2020-02-01'), amount: 10 },
-		{ date: new Date('2020-01-01'), amount: 0 },
-		{ date: new Date('2020-03-01'), amount: 10 },
+		{
+			date: new Date('2020-02-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-01-01'),
+			amount: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-03-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
 	];
 
 	const actual = getOrderedInvoiceTotals(items);
 
 	expect(actual).toEqual([
-		{ date: new Date('2020-01-01'), total: 0 },
-		{ date: new Date('2020-02-01'), total: 10 },
-		{ date: new Date('2020-03-01'), total: 10 },
+		{
+			date: new Date('2020-01-01'),
+			total: 0,
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-02-01'),
+			total: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-03-01'),
+			total: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
 	]);
 });
 
 test('getOrderedInvoiceTotals adds them up and reorders them', () => {
 	const items = [
-		{ date: new Date('2020-01-01'), amount: 1 },
-		{ date: new Date('2020-02-01'), amount: 10 },
-		{ date: new Date('2020-03-01'), amount: 100 },
-		{ date: new Date('2020-02-01'), amount: 20 },
-		{ date: new Date('2020-01-01'), amount: 2 },
+		{
+			date: new Date('2020-01-01'),
+			amount: 1,
+			amountWithoutTax: 1,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 10,
+			amountWithoutTax: 8,
+			taxAmount: 2,
+		},
+		{
+			date: new Date('2020-03-01'),
+			amount: 100,
+			amountWithoutTax: 80,
+			taxAmount: 20,
+		},
+		{
+			date: new Date('2020-02-01'),
+			amount: 20,
+			amountWithoutTax: 16,
+			taxAmount: 4,
+		},
+		{
+			date: new Date('2020-01-01'),
+			amount: 2,
+			amountWithoutTax: 2,
+			taxAmount: 0,
+		},
 	];
 
 	const actual = getOrderedInvoiceTotals(items);
 
 	expect(actual).toEqual([
-		{ date: new Date('2020-01-01'), total: 3 },
-		{ date: new Date('2020-02-01'), total: 30 },
-		{ date: new Date('2020-03-01'), total: 100 },
+		{
+			date: new Date('2020-01-01'),
+			total: 3,
+			amountWithoutTax: 3,
+			taxAmount: 0,
+		},
+		{
+			date: new Date('2020-02-01'),
+			total: 30,
+			amountWithoutTax: 24,
+			taxAmount: 6,
+		},
+		{
+			date: new Date('2020-03-01'),
+			total: 100,
+			amountWithoutTax: 80,
+			taxAmount: 20,
+		},
 	]);
 });

--- a/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
+++ b/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
@@ -25,14 +25,20 @@ export const buildEmailMessage = (
 
 	const subscriptionRate = describePayments(
 		{
-			payments: paymentSchedule.map(({ date, total }) => ({
-				date,
-				amount: total,
-			})),
+			payments: paymentSchedule.map(
+				({ date, total, amountWithoutTax, taxAmount }) => ({
+					date,
+					amount: total,
+					amountWithoutTax,
+					taxAmount,
+				}),
+			),
 		},
 		productRatePlanKey,
 		currency,
 		false,
+		// TODO: make this dynamic
+		'TaxInclusive',
 	);
 	const nextPaymentDate = paymentSchedule[0]?.date;
 

--- a/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
+++ b/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
@@ -37,8 +37,7 @@ export const buildEmailMessage = (
 		productRatePlanKey,
 		currency,
 		false,
-		// TODO: make this dynamic
-		'TaxInclusive',
+		switchInformation.target.taxMode,
 	);
 	const nextPaymentDate = paymentSchedule[0]?.date;
 

--- a/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
@@ -5,6 +5,7 @@ import type {
 	GuardianCatalogKeys,
 	ProductCatalogHelper,
 	ProductKey,
+	TaxMode,
 } from '@modules/product-catalog/productCatalog';
 import type { ProductSwitchTargetBody, SwitchMode } from '../schemas';
 import type { Discount } from '../switchDefinition/discounts';
@@ -25,7 +26,7 @@ export type TargetInformation = {
 	subscriptionChargeId: string; // adjust invoice, build response // used to find the price and service end date (next payment date) from the preview invoice, also to find and adjust out any charge less than 0.50
 	contributionCharge?: TargetContribution; // order // used to find the price from the preview invoice as above, also to do the chargeOverrides in the order to set the additional amount to take
 	discount?: Discount; // order (product rate plan id), return to client
-	taxMode: 'TaxExclusive' | 'TaxInclusive' | null | undefined;
+	taxMode: TaxMode;
 };
 
 export type TargetContribution = {

--- a/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
@@ -25,6 +25,7 @@ export type TargetInformation = {
 	subscriptionChargeId: string; // adjust invoice, build response // used to find the price and service end date (next payment date) from the preview invoice, also to find and adjust out any charge less than 0.50
 	contributionCharge?: TargetContribution; // order // used to find the price from the preview invoice as above, also to do the chargeOverrides in the order to set the additional amount to take
 	discount?: Discount; // order (product rate plan id), return to client
+	taxMode: 'TaxExclusive' | 'TaxInclusive' | null | undefined;
 };
 
 export type TargetContribution = {

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/digitalSubscriptionTargetInformation.ts
@@ -43,6 +43,7 @@ export const digitalSubscriptionTargetInformation: SwitchTargetInformation<
 			contributionCharge: undefined,
 			subscriptionChargeId: productRatePlan.charges.Subscription.id,
 			dataExtensionName: DataExtensionNames.supporterPlusToDigitalPlusSwitch,
+			taxMode: productRatePlan.taxMode,
 		} satisfies TargetInformation;
 	},
 };

--- a/handlers/product-switch-api/src/changePlan/switchDefinition/supporterPlusTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/supporterPlusTargetInformation.ts
@@ -78,6 +78,7 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 			discount,
 			dataExtensionName:
 				DataExtensionNames.recurringContributionToSupporterPlusSwitch,
+			taxMode: productRatePlan.taxMode,
 		} satisfies TargetInformation;
 	},
 };

--- a/handlers/product-switch-api/test/changePlan/action/email.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/email.test.ts
@@ -9,8 +9,18 @@ import type { TargetInformation } from '../../../src/changePlan/prepare/targetIn
 
 test('Email message body is correct', () => {
 	const testPaymentSchedule = [
-		{ date: new Date(2026, 5, 29), total: 12.21 },
-		{ date: new Date(2027, 5, 29), total: 12.21 },
+		{
+			date: new Date(2026, 5, 29),
+			total: 12.21,
+			amountWithoutTax: 10,
+			taxAmount: 2.21,
+		},
+		{
+			date: new Date(2027, 5, 29),
+			total: 12.21,
+			amountWithoutTax: 10,
+			taxAmount: 2.21,
+		},
 	];
 
 	const dateOfFirstPayment = dayjs('2024-04-16');
@@ -47,8 +57,18 @@ test('Email message body is correct', () => {
 
 test('Email subscription_rate is correct during a discount', () => {
 	const testDiscountedPaymentSchedule = [
-		{ date: new Date(2026, 5, 29), total: 8.21 },
-		{ date: new Date(2027, 5, 29), total: 12.21 },
+		{
+			date: new Date(2026, 5, 29),
+			total: 8.21,
+			amountWithoutTax: 7,
+			taxAmount: 1.21,
+		},
+		{
+			date: new Date(2027, 5, 29),
+			total: 12.21,
+			amountWithoutTax: 10,
+			taxAmount: 2.21,
+		},
 	];
 
 	const dateOfFirstPayment = dayjs('2024-04-16');

--- a/handlers/product-switch-api/test/changePlan/action/email.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/email.test.ts
@@ -121,6 +121,7 @@ const testTargetInformation: TargetInformation = {
 	productRatePlanId: '',
 	ratePlanName: '',
 	subscriptionChargeId: '',
+	taxMode: 'TaxInclusive',
 };
 
 const testSwitchInformation: SwitchInformation = {

--- a/handlers/product-switch-api/test/changePlan/action/switch/switchAction.test.ts
+++ b/handlers/product-switch-api/test/changePlan/action/switch/switchAction.test.ts
@@ -94,6 +94,8 @@ describe('DoSwitchAction', () => {
 		const callOrder: string[] = [];
 		const nextPaymentDate = new Date(2026, 10, 16); // 16 November 2026
 		const nextPaymentTotal = 95.5;
+		const nextPaymentWithoutTax = 90.0;
+		const nextPaymentTaxAmount = 5.5;
 
 		mockZuoraClient.get.mockResolvedValueOnce(zeroAmountInvoice);
 
@@ -111,10 +113,14 @@ describe('DoSwitchAction', () => {
 					{
 						date: nextPaymentDate,
 						total: nextPaymentTotal,
+						amountWithoutTax: nextPaymentWithoutTax,
+						taxAmount: nextPaymentTaxAmount,
 					},
 					{
 						date: dayjs(nextPaymentDate).add(1, 'year').toDate(),
 						total: nextPaymentTotal,
+						amountWithoutTax: nextPaymentWithoutTax,
+						taxAmount: nextPaymentTaxAmount,
 					},
 				]);
 			}),

--- a/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
+++ b/handlers/product-switch-api/test/changePlan/prepare/targetInformation.test.ts
@@ -76,6 +76,7 @@ describe('getTargetInformation', () => {
 			discount: undefined,
 			dataExtensionName:
 				DataExtensionNames.recurringContributionToSupporterPlusSwitch,
+			taxMode: 'TaxInclusive',
 		} satisfies TargetInformation);
 	});
 

--- a/handlers/product-switch-api/test/salesforceTracking.test.ts
+++ b/handlers/product-switch-api/test/salesforceTracking.test.ts
@@ -15,6 +15,7 @@ test('salesforce tracking data is serialised to the queue correctly', () => {
 		productRatePlanId: '',
 		ratePlanName: 'Supporter Plus V2 - Monthly',
 		subscriptionChargeId: '',
+		taxMode: 'TaxInclusive',
 	};
 	const subscriptionInformation: SubscriptionInformation = {
 		accountNumber: '',

--- a/handlers/product-switch-api/test/supporterProductDataIntegration.test.ts
+++ b/handlers/product-switch-api/test/supporterProductDataIntegration.test.ts
@@ -40,6 +40,7 @@ test('supporter product data', async () => {
 			ratePlanName: 'Supporter Plus V2 - Monthly',
 			dataExtensionName:
 				DataExtensionNames.recurringContributionToSupporterPlusSwitch,
+			taxMode: 'TaxInclusive',
 		},
 	};
 

--- a/handlers/product-switch-api/test/supporterRatePlanItem.test.ts
+++ b/handlers/product-switch-api/test/supporterRatePlanItem.test.ts
@@ -32,6 +32,7 @@ const getSwitchInformation = (): SwitchInformation => ({
 		ratePlanName: 'Supporter Plus V2 - Monthly',
 		dataExtensionName:
 			DataExtensionNames.recurringContributionToSupporterPlusSwitch,
+		taxMode: 'TaxInclusive',
 	},
 });
 

--- a/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
@@ -31,7 +31,7 @@ export function buildContributionEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
@@ -2,13 +2,13 @@ import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
 	EmailBillingPeriod,
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 export function buildContributionEmailFields({

--- a/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
@@ -20,6 +20,7 @@ export function buildContributionEmailFields({
 	paymentSchedule,
 	paymentMethod,
 	mandateId,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -30,6 +31,7 @@ export function buildContributionEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
+	taxMode: string | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,
@@ -41,6 +43,7 @@ export function buildContributionEmailFields({
 		paymentSchedule,
 		mandateId,
 		isFixedTerm: false, // There are no fixed term contribution rate plans
+		taxMode,
 	});
 
 	const productFields = {

--- a/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
@@ -8,6 +8,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 export function buildContributionEmailFields({
@@ -31,7 +32,7 @@ export function buildContributionEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
@@ -8,6 +8,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 type DeliveryFields = {
@@ -41,7 +42,7 @@ export function buildDeliveryEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	isFixedTerm: boolean;
 	mandateId?: string;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): DeliveryEmailFields {
 	const nonDeliveryFields: NonDeliveryEmailFields = buildNonDeliveryEmailFields(
 		{

--- a/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
@@ -1,6 +1,7 @@
 import type { Dayjs } from 'dayjs';
 import { getCountryNameByCode } from '@modules/internationalisation/country';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { NonDeliveryEmailFields } from './emailFields';
 import { buildNonDeliveryEmailFields } from './emailFields';
 import type {
@@ -8,7 +9,6 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 type DeliveryFields = {

--- a/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
@@ -30,6 +30,7 @@ export function buildDeliveryEmailFields({
 	paymentSchedule,
 	isFixedTerm,
 	mandateId,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -40,6 +41,7 @@ export function buildDeliveryEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	isFixedTerm: boolean;
 	mandateId?: string;
+	taxMode: string | undefined | null;
 }): DeliveryEmailFields {
 	const nonDeliveryFields: NonDeliveryEmailFields = buildNonDeliveryEmailFields(
 		{
@@ -52,6 +54,7 @@ export function buildDeliveryEmailFields({
 			paymentSchedule: paymentSchedule,
 			isFixedTerm: isFixedTerm,
 			mandateId: mandateId,
+			taxMode,
 		},
 	);
 

--- a/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
@@ -41,7 +41,7 @@ export function buildDeliveryEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	isFixedTerm: boolean;
 	mandateId?: string;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): DeliveryEmailFields {
 	const nonDeliveryFields: NonDeliveryEmailFields = buildNonDeliveryEmailFields(
 		{

--- a/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
@@ -2,13 +2,13 @@ import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
 	EmailBillingPeriod,
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 export function buildDigitalSubscriptionEmailFields({

--- a/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
@@ -29,7 +29,7 @@ export function buildDigitalSubscriptionEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
@@ -8,6 +8,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 export function buildDigitalSubscriptionEmailFields({
@@ -29,7 +30,7 @@ export function buildDigitalSubscriptionEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
@@ -19,6 +19,7 @@ export function buildDigitalSubscriptionEmailFields({
 	paymentSchedule,
 	paymentMethod,
 	mandateId,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -28,6 +29,7 @@ export function buildDigitalSubscriptionEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
+	taxMode: string | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,
@@ -39,6 +41,7 @@ export function buildDigitalSubscriptionEmailFields({
 		paymentSchedule,
 		mandateId,
 		isFixedTerm: false, // There are no fixed term Digital subscription rate plans
+		taxMode,
 	});
 
 	const productFields = {

--- a/modules/email/src/dataFields/dayZero/emailFields.ts
+++ b/modules/email/src/dataFields/dayZero/emailFields.ts
@@ -13,6 +13,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 type EmailCommonFields = {
@@ -45,7 +46,7 @@ export function buildNonDeliveryEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	isFixedTerm: boolean;
 	mandateId?: string;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): NonDeliveryEmailFields {
 	const paymentFields = getPaymentFields(
 		today,

--- a/modules/email/src/dataFields/dayZero/emailFields.ts
+++ b/modules/email/src/dataFields/dayZero/emailFields.ts
@@ -45,7 +45,7 @@ export function buildNonDeliveryEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	isFixedTerm: boolean;
 	mandateId?: string;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): NonDeliveryEmailFields {
 	const paymentFields = getPaymentFields(
 		today,

--- a/modules/email/src/dataFields/dayZero/emailFields.ts
+++ b/modules/email/src/dataFields/dayZero/emailFields.ts
@@ -5,6 +5,7 @@ import type {
 	EmailMessageWithIdentityUserId,
 } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { describePayments, firstPayment } from './paymentDescription';
 import type { EmailPaymentFields } from './paymentEmailFields';
 import { getPaymentFields } from './paymentEmailFields';
@@ -13,7 +14,6 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 type EmailCommonFields = {

--- a/modules/email/src/dataFields/dayZero/emailFields.ts
+++ b/modules/email/src/dataFields/dayZero/emailFields.ts
@@ -34,6 +34,7 @@ export function buildNonDeliveryEmailFields({
 	paymentSchedule,
 	isFixedTerm,
 	mandateId,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -44,6 +45,7 @@ export function buildNonDeliveryEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	isFixedTerm: boolean;
 	mandateId?: string;
+	taxMode: string | undefined | null;
 }): NonDeliveryEmailFields {
 	const paymentFields = getPaymentFields(
 		today,
@@ -56,6 +58,7 @@ export function buildNonDeliveryEmailFields({
 		billingPeriod,
 		currency,
 		isFixedTerm,
+		taxMode,
 	);
 	return {
 		first_name: user.firstName,

--- a/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
@@ -7,6 +7,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 export function buildGuardianAdLiteEmailFields({
@@ -26,7 +27,7 @@ export function buildGuardianAdLiteEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	paymentSchedule: EmailPaymentSchedule;
 	mandateId?: string;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
@@ -26,7 +26,7 @@ export function buildGuardianAdLiteEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	paymentSchedule: EmailPaymentSchedule;
 	mandateId?: string;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
@@ -2,12 +2,12 @@ import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 export function buildGuardianAdLiteEmailFields({

--- a/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
@@ -17,6 +17,7 @@ export function buildGuardianAdLiteEmailFields({
 	paymentMethod,
 	paymentSchedule,
 	mandateId,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -25,6 +26,7 @@ export function buildGuardianAdLiteEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	paymentSchedule: EmailPaymentSchedule;
 	mandateId?: string;
+	taxMode: string | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,
@@ -36,6 +38,7 @@ export function buildGuardianAdLiteEmailFields({
 		paymentSchedule,
 		mandateId: mandateId,
 		isFixedTerm: false, // Guardian Ad-Lite has no fixed term rate plans
+		taxMode,
 	});
 
 	return buildEmailFields(

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
@@ -31,6 +31,7 @@ export function buildGuardianWeeklyEmailFields({
 	isFixedTerm,
 	mandateId,
 	giftRecipient,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -42,6 +43,7 @@ export function buildGuardianWeeklyEmailFields({
 	isFixedTerm: boolean;
 	mandateId?: string;
 	giftRecipient?: EmailGiftRecipient;
+	taxMode: string | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const gifteeFields = giftRecipient
 		? {
@@ -68,6 +70,7 @@ export function buildGuardianWeeklyEmailFields({
 		paymentSchedule: paymentSchedule,
 		isFixedTerm: isFixedTerm,
 		mandateId: mandateId,
+		taxMode,
 	});
 	const productFields = {
 		...secondPaymentFields,

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
@@ -43,7 +43,7 @@ export function buildGuardianWeeklyEmailFields({
 	isFixedTerm: boolean;
 	mandateId?: string;
 	giftRecipient?: EmailGiftRecipient;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const gifteeFields = giftRecipient
 		? {

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
@@ -13,6 +13,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 export type GuardianWeeklyProductPurchase = Extract<
@@ -43,7 +44,7 @@ export function buildGuardianWeeklyEmailFields({
 	isFixedTerm: boolean;
 	mandateId?: string;
 	giftRecipient?: EmailGiftRecipient;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): EmailMessageWithIdentityUserId {
 	const gifteeFields = giftRecipient
 		? {

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
 import { buildEmailFields } from './emailFields';
@@ -13,7 +14,6 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 export type GuardianWeeklyProductPurchase = Extract<

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
@@ -2,6 +2,7 @@ import type { Dayjs } from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
 import { buildEmailFields } from './emailFields';
@@ -10,7 +11,6 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 export type GuardianWeeklyProductPurchase = Extract<

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
@@ -38,7 +38,7 @@ export function buildGuardianWeeklyPlusEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	isFixedTerm: boolean;
 	mandateId?: string;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const deliveryFields = buildDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
@@ -10,6 +10,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 export type GuardianWeeklyProductPurchase = Extract<
@@ -38,7 +39,7 @@ export function buildGuardianWeeklyPlusEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	isFixedTerm: boolean;
 	mandateId?: string;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): EmailMessageWithIdentityUserId {
 	const deliveryFields = buildDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
@@ -27,6 +27,7 @@ export function buildGuardianWeeklyPlusEmailFields({
 	paymentMethod,
 	isFixedTerm,
 	mandateId,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -37,6 +38,7 @@ export function buildGuardianWeeklyPlusEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	isFixedTerm: boolean;
 	mandateId?: string;
+	taxMode: string | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const deliveryFields = buildDeliveryEmailFields({
 		today: today,
@@ -48,6 +50,7 @@ export function buildGuardianWeeklyPlusEmailFields({
 		paymentSchedule: paymentSchedule,
 		isFixedTerm: isFixedTerm,
 		mandateId: mandateId,
+		taxMode,
 	});
 
 	return buildEmailFields(

--- a/modules/email/src/dataFields/dayZero/paperEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paperEmailFields.ts
@@ -30,6 +30,7 @@ export function buildPaperEmailFields({
 	mandateId,
 	productInformation,
 	deliveryAgentDetails,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -40,6 +41,7 @@ export function buildPaperEmailFields({
 	mandateId?: string;
 	productInformation: PaperProductPurchase;
 	deliveryAgentDetails?: EmailDeliveryAgentDetails;
+	taxMode: string | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const deliveryAgentFields =
 		productInformation.product === 'NationalDelivery' && deliveryAgentDetails
@@ -65,6 +67,7 @@ export function buildPaperEmailFields({
 		paymentSchedule: paymentSchedule,
 		isFixedTerm: false, // There are no fixed term paper rate plans
 		mandateId: mandateId,
+		taxMode,
 	});
 	const productFields = {
 		package: productInformation.ratePlan,

--- a/modules/email/src/dataFields/dayZero/paperEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paperEmailFields.ts
@@ -41,7 +41,7 @@ export function buildPaperEmailFields({
 	mandateId?: string;
 	productInformation: PaperProductPurchase;
 	deliveryAgentDetails?: EmailDeliveryAgentDetails;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const deliveryAgentFields =
 		productInformation.product === 'NationalDelivery' && deliveryAgentDetails

--- a/modules/email/src/dataFields/dayZero/paperEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paperEmailFields.ts
@@ -5,6 +5,7 @@ import type {
 	EmailMessageWithIdentityUserId,
 } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
 import { buildEmailFields } from './emailFields';
@@ -13,7 +14,6 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 export type PaperProductPurchase = Extract<

--- a/modules/email/src/dataFields/dayZero/paperEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paperEmailFields.ts
@@ -13,6 +13,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 export type PaperProductPurchase = Extract<
@@ -41,7 +42,7 @@ export function buildPaperEmailFields({
 	mandateId?: string;
 	productInformation: PaperProductPurchase;
 	deliveryAgentDetails?: EmailDeliveryAgentDetails;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): EmailMessageWithIdentityUserId {
 	const deliveryAgentFields =
 		productInformation.product === 'NationalDelivery' && deliveryAgentDetails

--- a/modules/email/src/dataFields/dayZero/paymentDescription.ts
+++ b/modules/email/src/dataFields/dayZero/paymentDescription.ts
@@ -3,11 +3,8 @@ import { partition } from '@modules/arrayFunctions';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getCurrencyInfo } from '@modules/internationalisation/currency';
 import { getNonEmptyOrThrow, isNonEmpty } from '@modules/nullAndUndefined';
-import type {
-	EmailBillingPeriod,
-	EmailPaymentSchedule,
-	TaxMode,
-} from './types';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
+import type { EmailBillingPeriod, EmailPaymentSchedule } from './types';
 
 type Payment = EmailPaymentSchedule['payments'][number];
 

--- a/modules/email/src/dataFields/dayZero/paymentDescription.ts
+++ b/modules/email/src/dataFields/dayZero/paymentDescription.ts
@@ -75,8 +75,13 @@ function monthsBetween(start: Date, end: Date): number {
 	return endD.diff(startD, 'month');
 }
 
-function getRelevantAmountFromPayment(taxMode: string | undefined | null, payment: Payment) {
-	return taxMode === "TaxExclusive" ? payment.amountWithoutTax : payment.amount;
+function getRelevantAmountFromPayment(
+	taxMode: string | undefined | null,
+	payment: Payment,
+) {
+	return taxMode === 'TaxExclusive'
+		? payment.amountWithoutTax
+		: payment.amountWithoutTax + payment.taxAmount;
 }
 
 export function describePayments(
@@ -86,11 +91,15 @@ export function describePayments(
 	isFixedTerm: boolean,
 	taxMode: string | undefined | null,
 ): string {
-	const initialPrice = getRelevantAmountFromPayment(taxMode, firstPayment(paymentSchedule));
+	const initialPrice = getRelevantAmountFromPayment(
+		taxMode,
+		firstPayment(paymentSchedule),
+	);
 
 	const [paymentsWithInitialPrice, paymentsWithDifferentPrice] = partition(
 		paymentSchedule.payments,
-		(payment) => getRelevantAmountFromPayment(taxMode, payment) === initialPrice,
+		(payment) =>
+			getRelevantAmountFromPayment(taxMode, payment) === initialPrice,
 	);
 
 	const noun = billingPeriodNoun(billingPeriod);
@@ -194,6 +203,9 @@ function descriptionWithMultipleIntroductoryPeriods(
 		billingPeriod,
 	)} for ${timespan}, then ${priceWithCurrency(
 		currency,
-		getRelevantAmountFromPayment(taxMode, earliestPayment(paymentsWithDifferentPrice)),
+		getRelevantAmountFromPayment(
+			taxMode,
+			earliestPayment(paymentsWithDifferentPrice),
+		),
 	)} every ${billingPeriodNoun(billingPeriod)}`;
 }

--- a/modules/email/src/dataFields/dayZero/paymentDescription.ts
+++ b/modules/email/src/dataFields/dayZero/paymentDescription.ts
@@ -76,7 +76,7 @@ function monthsBetween(start: Date, end: Date): number {
 }
 
 function getRelevantAmountFromPayment(
-	taxMode: string | undefined | null,
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null,
 	payment: Payment,
 ) {
 	return taxMode === 'TaxExclusive'
@@ -89,7 +89,7 @@ export function describePayments(
 	billingPeriod: EmailBillingPeriod,
 	currency: IsoCurrency,
 	isFixedTerm: boolean,
-	taxMode: string | undefined | null,
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null,
 ): string {
 	const initialPrice = getRelevantAmountFromPayment(
 		taxMode,
@@ -148,7 +148,7 @@ function descriptionWithSingleIntroductoryPeriod(
 	currency: IsoCurrency,
 	initialPrice: number,
 	billingPeriod: EmailBillingPeriod,
-	taxMode: string | undefined | null,
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null,
 ) {
 	const firstDifferent = paymentsWithDifferentPrice[0];
 	return `${priceWithCurrency(
@@ -168,7 +168,7 @@ function descriptionWithMultipleIntroductoryPeriods(
 	currency: IsoCurrency,
 	initialPrice: number,
 	billingPeriod: EmailBillingPeriod,
-	taxMode: string | undefined | null,
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null,
 ) {
 	const firstIntroductoryPayment = earliestPayment(paymentsWithInitialPrice);
 	const firstDifferentPayment = earliestPayment(paymentsWithDifferentPrice);

--- a/modules/email/src/dataFields/dayZero/paymentDescription.ts
+++ b/modules/email/src/dataFields/dayZero/paymentDescription.ts
@@ -75,17 +75,22 @@ function monthsBetween(start: Date, end: Date): number {
 	return endD.diff(startD, 'month');
 }
 
+function getRelevantAmountFromPayment(taxMode: string | undefined | null, payment: Payment) {
+	return taxMode === "TaxExclusive" ? payment.amountWithoutTax : payment.amount;
+}
+
 export function describePayments(
 	paymentSchedule: EmailPaymentSchedule,
 	billingPeriod: EmailBillingPeriod,
 	currency: IsoCurrency,
 	isFixedTerm: boolean,
+	taxMode: string | undefined | null,
 ): string {
-	const initialPrice = firstPayment(paymentSchedule).amount;
+	const initialPrice = getRelevantAmountFromPayment(taxMode, firstPayment(paymentSchedule));
 
 	const [paymentsWithInitialPrice, paymentsWithDifferentPrice] = partition(
 		paymentSchedule.payments,
-		(payment) => payment.amount === initialPrice,
+		(payment) => getRelevantAmountFromPayment(taxMode, payment) === initialPrice,
 	);
 
 	const noun = billingPeriodNoun(billingPeriod);
@@ -110,6 +115,7 @@ export function describePayments(
 			currency,
 			initialPrice,
 			billingPeriod,
+			taxMode,
 		);
 	}
 	return descriptionWithMultipleIntroductoryPeriods(
@@ -124,6 +130,7 @@ export function describePayments(
 		currency,
 		initialPrice,
 		billingPeriod,
+		taxMode,
 	);
 }
 
@@ -132,6 +139,7 @@ function descriptionWithSingleIntroductoryPeriod(
 	currency: IsoCurrency,
 	initialPrice: number,
 	billingPeriod: EmailBillingPeriod,
+	taxMode: string | undefined | null,
 ) {
 	const firstDifferent = paymentsWithDifferentPrice[0];
 	return `${priceWithCurrency(
@@ -141,7 +149,7 @@ function descriptionWithSingleIntroductoryPeriod(
 		billingPeriod,
 	)}, then ${priceWithCurrency(
 		currency,
-		firstDifferent.amount,
+		getRelevantAmountFromPayment(taxMode, firstDifferent),
 	)} every ${billingPeriodNoun(billingPeriod)}`;
 }
 
@@ -151,6 +159,7 @@ function descriptionWithMultipleIntroductoryPeriods(
 	currency: IsoCurrency,
 	initialPrice: number,
 	billingPeriod: EmailBillingPeriod,
+	taxMode: string | undefined | null,
 ) {
 	const firstIntroductoryPayment = earliestPayment(paymentsWithInitialPrice);
 	const firstDifferentPayment = earliestPayment(paymentsWithDifferentPrice);
@@ -185,6 +194,6 @@ function descriptionWithMultipleIntroductoryPeriods(
 		billingPeriod,
 	)} for ${timespan}, then ${priceWithCurrency(
 		currency,
-		earliestPayment(paymentsWithDifferentPrice).amount,
+		getRelevantAmountFromPayment(taxMode, earliestPayment(paymentsWithDifferentPrice)),
 	)} every ${billingPeriodNoun(billingPeriod)}`;
 }

--- a/modules/email/src/dataFields/dayZero/paymentDescription.ts
+++ b/modules/email/src/dataFields/dayZero/paymentDescription.ts
@@ -3,7 +3,11 @@ import { partition } from '@modules/arrayFunctions';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getCurrencyInfo } from '@modules/internationalisation/currency';
 import { getNonEmptyOrThrow, isNonEmpty } from '@modules/nullAndUndefined';
-import type { EmailBillingPeriod, EmailPaymentSchedule } from './types';
+import type {
+	EmailBillingPeriod,
+	EmailPaymentSchedule,
+	TaxMode,
+} from './types';
 
 type Payment = EmailPaymentSchedule['payments'][number];
 
@@ -75,10 +79,7 @@ function monthsBetween(start: Date, end: Date): number {
 	return endD.diff(startD, 'month');
 }
 
-function getRelevantAmountFromPayment(
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null,
-	payment: Payment,
-) {
+function getRelevantAmountFromPayment(taxMode: TaxMode, payment: Payment) {
 	return taxMode === 'TaxExclusive'
 		? payment.amountWithoutTax
 		: payment.amountWithoutTax + payment.taxAmount;
@@ -89,7 +90,7 @@ export function describePayments(
 	billingPeriod: EmailBillingPeriod,
 	currency: IsoCurrency,
 	isFixedTerm: boolean,
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null,
+	taxMode: TaxMode,
 ): string {
 	const initialPrice = getRelevantAmountFromPayment(
 		taxMode,
@@ -148,7 +149,7 @@ function descriptionWithSingleIntroductoryPeriod(
 	currency: IsoCurrency,
 	initialPrice: number,
 	billingPeriod: EmailBillingPeriod,
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null,
+	taxMode: TaxMode,
 ) {
 	const firstDifferent = paymentsWithDifferentPrice[0];
 	return `${priceWithCurrency(
@@ -168,7 +169,7 @@ function descriptionWithMultipleIntroductoryPeriods(
 	currency: IsoCurrency,
 	initialPrice: number,
 	billingPeriod: EmailBillingPeriod,
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null,
+	taxMode: TaxMode,
 ) {
 	const firstIntroductoryPayment = earliestPayment(paymentsWithInitialPrice);
 	const firstDifferentPayment = earliestPayment(paymentsWithDifferentPrice);

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -8,6 +8,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 export function buildSupporterPlusEmailFields({
@@ -31,7 +32,7 @@ export function buildSupporterPlusEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	isFixedTerm: boolean;
 	mandateId?: string;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }) {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -20,6 +20,7 @@ export function buildSupporterPlusEmailFields({
 	paymentMethod,
 	isFixedTerm,
 	mandateId,
+	taxMode,
 }: {
 	today: dayjs.Dayjs;
 	user: EmailUser;
@@ -30,6 +31,7 @@ export function buildSupporterPlusEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	isFixedTerm: boolean;
 	mandateId?: string;
+	taxMode: string | undefined | null;
 }) {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,
@@ -41,6 +43,7 @@ export function buildSupporterPlusEmailFields({
 		paymentSchedule,
 		mandateId,
 		isFixedTerm,
+		taxMode,
 	});
 	const oldNonStandardPaymentFields = getPaymentMethodFieldsSupporterPlus(
 		paymentMethod,

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -31,7 +31,7 @@ export function buildSupporterPlusEmailFields({
 	paymentMethod: EmailPaymentMethod;
 	isFixedTerm: boolean;
 	mandateId?: string;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }) {
 	const nonDeliveryEmailFields = buildNonDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -1,6 +1,7 @@
 import type dayjs from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import { getPaymentMethodFieldsSupporterPlus } from './paymentEmailFields';
 import type {
@@ -8,7 +9,6 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 export function buildSupporterPlusEmailFields({

--- a/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
@@ -2,6 +2,7 @@ import type { Dayjs } from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
 import { buildEmailFields } from './emailFields';
@@ -10,7 +11,6 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
-	TaxMode,
 } from './types';
 
 export type TierThreeProductPurchase = Extract<

--- a/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
@@ -10,6 +10,7 @@ import type {
 	EmailPaymentMethod,
 	EmailPaymentSchedule,
 	EmailUser,
+	TaxMode,
 } from './types';
 
 export type TierThreeProductPurchase = Extract<
@@ -36,7 +37,7 @@ export function buildTierThreeEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
-	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+	taxMode: TaxMode;
 }): EmailMessageWithIdentityUserId {
 	const deliveryFields = buildDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
@@ -26,6 +26,7 @@ export function buildTierThreeEmailFields({
 	paymentSchedule,
 	paymentMethod,
 	mandateId,
+	taxMode,
 }: {
 	today: Dayjs;
 	user: EmailUser;
@@ -35,6 +36,7 @@ export function buildTierThreeEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
+	taxMode: string | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const deliveryFields = buildDeliveryEmailFields({
 		today: today,
@@ -46,6 +48,7 @@ export function buildTierThreeEmailFields({
 		paymentSchedule: paymentSchedule,
 		isFixedTerm: false,
 		mandateId: mandateId,
+		taxMode,
 	});
 	const additionalFields: Record<string, string> = {
 		billing_period: billingPeriod.toLowerCase(),

--- a/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
@@ -36,7 +36,7 @@ export function buildTierThreeEmailFields({
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;
 	mandateId?: string;
-	taxMode: string | undefined | null;
+	taxMode: 'TaxInclusive' | 'TaxExclusive' | undefined | null;
 }): EmailMessageWithIdentityUserId {
 	const deliveryFields = buildDeliveryEmailFields({
 		today: today,

--- a/modules/email/src/dataFields/dayZero/types.ts
+++ b/modules/email/src/dataFields/dayZero/types.ts
@@ -33,8 +33,12 @@ export type EmailPaymentMethod =
 			Type: 'PayPal';
 	  };
 
+export type Payment = {
+	date: Date; amount: number; amountWithoutTax: number; taxAmount: number;
+}
+
 export type EmailPaymentSchedule = {
-	payments: Array<{ date: Date; amount: number }>;
+	payments: Payment[];
 };
 
 export type EmailGiftRecipient = {

--- a/modules/email/src/dataFields/dayZero/types.ts
+++ b/modules/email/src/dataFields/dayZero/types.ts
@@ -2,6 +2,8 @@ import type { CountryCode } from '@modules/internationalisation/country';
 
 export type EmailBillingPeriod = 'Annual' | 'Monthly' | 'Quarterly';
 
+export type TaxMode = 'TaxInclusive' | 'TaxExclusive' | undefined | null;
+
 export type PostalAddress = {
 	lineOne?: string;
 	lineTwo?: string;

--- a/modules/email/src/dataFields/dayZero/types.ts
+++ b/modules/email/src/dataFields/dayZero/types.ts
@@ -34,8 +34,11 @@ export type EmailPaymentMethod =
 	  };
 
 export type Payment = {
-	date: Date; amount: number; amountWithoutTax: number; taxAmount: number;
-}
+	date: Date;
+	amount: number;
+	amountWithoutTax: number;
+	taxAmount: number;
+};
 
 export type EmailPaymentSchedule = {
 	payments: Payment[];

--- a/modules/email/src/dataFields/dayZero/types.ts
+++ b/modules/email/src/dataFields/dayZero/types.ts
@@ -2,8 +2,6 @@ import type { CountryCode } from '@modules/internationalisation/country';
 
 export type EmailBillingPeriod = 'Annual' | 'Monthly' | 'Quarterly';
 
-export type TaxMode = 'TaxInclusive' | 'TaxExclusive' | undefined | null;
-
 export type PostalAddress = {
 	lineOne?: string;
 	lineTwo?: string;

--- a/modules/email/test/dataFields/dayZero/contributionEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/contributionEmailFields.test.ts
@@ -20,12 +20,23 @@ describe('contributionEmailFields', () => {
 			subscriptionNumber: 'SUBSCRIPTION123',
 			paymentSchedule: {
 				payments: [
-					{ date: new Date('2025-11-21'), amount: 5 },
-					{ date: new Date('2025-12-21'), amount: 5 },
+					{
+						date: new Date('2025-11-21'),
+						amount: 5,
+						amountWithoutTax: 5,
+						taxAmount: 0,
+					},
+					{
+						date: new Date('2025-12-21'),
+						amount: 5,
+						amountWithoutTax: 5,
+						taxAmount: 0,
+					},
 				],
 			},
 			paymentMethod: directDebitPaymentMethod,
 			mandateId: mandateId,
+			taxMode: 'TaxInclusive',
 		});
 		const expected = {
 			To: {

--- a/modules/email/test/dataFields/dayZero/digitalSubscriptionEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/digitalSubscriptionEmailFields.test.ts
@@ -19,10 +19,18 @@ describe('digitalSubscriptionEmailFields', () => {
 			billingPeriod: 'Annual',
 			subscriptionNumber: subscriptionNumber,
 			paymentSchedule: {
-				payments: [{ date: new Date('2025-11-11'), amount: 119.9 }],
+				payments: [
+					{
+						date: new Date('2025-11-11'),
+						amount: 119.9,
+						amountWithoutTax: 110,
+						taxAmount: 9.9,
+					},
+				],
 			},
 			paymentMethod: directDebitPaymentMethod,
 			mandateId: mandateId,
+			taxMode: 'TaxInclusive',
 		});
 		const expected = {
 			To: {

--- a/modules/email/test/dataFields/dayZero/guardianAdLiteEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/guardianAdLiteEmailFields.test.ts
@@ -18,11 +18,22 @@ describe('guardianAdLiteEmailFields', () => {
 			subscriptionNumber: subscriptionNumber,
 			paymentSchedule: {
 				payments: [
-					{ date: new Date('2025-11-11'), amount: 10 },
-					{ date: new Date('2025-12-11'), amount: 10 },
+					{
+						date: new Date('2025-11-11'),
+						amount: 10,
+						amountWithoutTax: 8,
+						taxAmount: 2,
+					},
+					{
+						date: new Date('2025-12-11'),
+						amount: 10,
+						amountWithoutTax: 8,
+						taxAmount: 2,
+					},
 				],
 			},
 			paymentMethod: creditCardPaymentMethod,
+			taxMode: 'TaxInclusive',
 		});
 		const expected = {
 			To: {

--- a/modules/email/test/dataFields/dayZero/guardianWeeklyEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/guardianWeeklyEmailFields.test.ts
@@ -25,6 +25,7 @@ describe('Guardian weekly thank you email fields', () => {
 			paymentMethod: creditCardPaymentMethod,
 			isFixedTerm: false,
 			mandateId: undefined,
+			taxMode: 'TaxInclusive',
 		});
 
 		const expected = {
@@ -71,6 +72,7 @@ describe('Guardian weekly thank you email fields', () => {
 			isFixedTerm: true,
 			mandateId: undefined,
 			giftRecipient: giftRecipient,
+			taxMode: 'TaxInclusive',
 		});
 		const expected = {
 			To: {

--- a/modules/email/test/dataFields/dayZero/paperEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/paperEmailFields.test.ts
@@ -68,6 +68,7 @@ describe('Paper email fields', () => {
 				deliveryInstructions: '',
 				deliveryContact: deliveryContact,
 			},
+			taxMode: 'TaxInclusive',
 		});
 
 		expect(emailFields).toStrictEqual(expected);
@@ -90,6 +91,7 @@ describe('Paper email fields', () => {
 				deliveryAgent: 123,
 			},
 			deliveryAgentDetails: deliveryAgentDetails,
+			taxMode: 'TaxInclusive',
 		});
 
 		expect(emailFields.To.ContactAttributes.SubscriberAttributes).toMatchObject(

--- a/modules/email/test/dataFields/dayZero/paymentDescription.test.ts
+++ b/modules/email/test/dataFields/dayZero/paymentDescription.test.ts
@@ -1,8 +1,8 @@
 import { describePayments as describeSchedule } from '@modules/email/dataFields/dayZero/paymentDescription';
-import type { EmailPaymentSchedule } from '@modules/email/dataFields/dayZero/types';
-
-type Payment = { date: Date; amount: number };
-type PaymentSchedule = EmailPaymentSchedule;
+import type {
+	EmailPaymentSchedule,
+	Payment,
+} from '@modules/email/dataFields/dayZero/types';
 
 function addMonths(date: Date, months: number): Date {
 	const d = new Date(date.getTime());
@@ -14,6 +14,8 @@ function payments(original: Payment, subsequentMonths: number[]): Payment[] {
 	const subsequentPayments = subsequentMonths.map((m) => ({
 		date: addMonths(original.date, m),
 		amount: original.amount,
+		amountWithoutTax: original.amountWithoutTax,
+		taxAmount: original.taxAmount,
 	}));
 	return [original, ...subsequentPayments];
 }
@@ -25,119 +27,186 @@ describe('paymentDescription.describe', () => {
 		const standardDigitalPackPayment: Payment = {
 			date: referenceDate,
 			amount: 119.9,
+			taxAmount: 19.9,
+			amountWithoutTax: 100,
 		};
 		const scheduleList = payments(standardDigitalPackPayment, [12]);
-		const schedule: PaymentSchedule = { payments: scheduleList };
+		const schedule: EmailPaymentSchedule = { payments: scheduleList };
 		const expected = '£119.90 every year';
-		expect(describeSchedule(schedule, 'Annual', 'GBP', false)).toBe(expected);
+		expect(
+			describeSchedule(schedule, 'Annual', 'GBP', false, 'TaxInclusive'),
+		).toBe(expected);
+	});
+
+	test('explains a simple annual tax exclusive payment schedule correctly', () => {
+		const standardDigitalPackPayment: Payment = {
+			date: referenceDate,
+			amount: 119.9,
+			taxAmount: 19.9,
+			amountWithoutTax: 100,
+		};
+		const scheduleList = payments(standardDigitalPackPayment, [12]);
+		const schedule: EmailPaymentSchedule = { payments: scheduleList };
+		const expected = '£100.00 every year';
+		expect(
+			describeSchedule(schedule, 'Annual', 'GBP', false, 'TaxExclusive'),
+		).toBe(expected);
 	});
 
 	test('explains a simple quarterly payment schedule correctly', () => {
 		const standardDigitalPackPayment: Payment = {
 			date: referenceDate,
 			amount: 57.5,
+			taxAmount: 7.5,
+			amountWithoutTax: 50,
 		};
 		const scheduleList = payments(standardDigitalPackPayment, [3, 6, 9]);
-		const schedule: PaymentSchedule = { payments: scheduleList };
+		const schedule: EmailPaymentSchedule = { payments: scheduleList };
 		const expected = '$57.50 every quarter';
-		expect(describeSchedule(schedule, 'Quarterly', 'USD', false)).toBe(
-			expected,
-		);
+		expect(
+			describeSchedule(schedule, 'Quarterly', 'USD', false, 'TaxInclusive'),
+		).toBe(expected);
 	});
 
 	test('explains a simple monthly payment schedule correctly', () => {
 		const standardDigitalPackPayment: Payment = {
 			date: referenceDate,
 			amount: 11.99,
+			taxAmount: 2.99,
+			amountWithoutTax: 9.0,
 		};
 		const scheduleList = payments(
 			standardDigitalPackPayment,
 			[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
 		);
-		const schedule: PaymentSchedule = { payments: scheduleList };
+		const schedule: EmailPaymentSchedule = { payments: scheduleList };
 		const expected = '€11.99 every month';
-		expect(describeSchedule(schedule, 'Monthly', 'EUR', false)).toBe(expected);
+		expect(
+			describeSchedule(schedule, 'Monthly', 'EUR', false, 'TaxInclusive'),
+		).toBe(expected);
 	});
 
 	test('explains a payment schedule truthfully if we only get information about the first payment', () => {
 		const discountedDigitalPackPayment: Payment = {
 			date: referenceDate,
 			amount: 100.9,
+			taxAmount: 5.9,
+			amountWithoutTax: 95.0,
 		};
-		const schedule: PaymentSchedule = {
+		const schedule: EmailPaymentSchedule = {
 			payments: [discountedDigitalPackPayment],
 		};
 		const expected = '£100.90 for the first year';
-		expect(describeSchedule(schedule, 'Annual', 'GBP', false)).toBe(expected);
+		expect(
+			describeSchedule(schedule, 'Annual', 'GBP', false, 'TaxInclusive'),
+		).toBe(expected);
 	});
 
 	test('explains a payment schedule correctly if the first 3 months are discounted', () => {
 		const firstDiscountedPayment: Payment = {
 			date: referenceDate,
 			amount: 5.99,
+			taxAmount: 0.99,
+			amountWithoutTax: 5.0,
 		};
 		const firstFullPricePayment: Payment = {
 			date: addMonths(referenceDate, 3),
 			amount: 11.99,
+			taxAmount: 1.99,
+			amountWithoutTax: 9.0,
 		};
 		const scheduleList: Payment[] = [
 			...payments(firstDiscountedPayment, [1, 2]),
 			...payments(firstFullPricePayment, [1, 2, 3, 4, 5, 6, 7, 8, 9]),
 		];
-		const schedule: PaymentSchedule = { payments: scheduleList };
+		const schedule: EmailPaymentSchedule = { payments: scheduleList };
 		const expected = '£5.99 every month for 3 months, then £11.99 every month';
-		expect(describeSchedule(schedule, 'Monthly', 'GBP', false)).toBe(expected);
+		expect(
+			describeSchedule(schedule, 'Monthly', 'GBP', false, 'TaxInclusive'),
+		).toBe(expected);
 	});
 
 	test('explains a payment schedule correctly for an annual subscription', () => {
 		const firstDiscountedPayment: Payment = {
 			date: referenceDate,
 			amount: 59.76,
+			taxAmount: 9.76,
+			amountWithoutTax: 50.0,
 		};
 		const firstFullPricePayment: Payment = {
 			date: addMonths(referenceDate, 12),
 			amount: 95.0,
+			taxAmount: 5.0,
+			amountWithoutTax: 90.0,
 		};
-		const schedule: PaymentSchedule = {
+		const schedule: EmailPaymentSchedule = {
 			payments: [firstDiscountedPayment, firstFullPricePayment],
 		};
 		const expected = '£59.76 for the first year, then £95.00 every year';
-		expect(describeSchedule(schedule, 'Annual', 'GBP', false)).toBe(expected);
+		expect(
+			describeSchedule(schedule, 'Annual', 'GBP', false, 'TaxInclusive'),
+		).toBe(expected);
 	});
 
 	test('explains a payment schedule correctly if the first 2 quarters are discounted', () => {
 		const firstDiscountedPayment: Payment = {
 			date: referenceDate,
 			amount: 30.0,
+			taxAmount: 2.0,
+			amountWithoutTax: 28.0,
 		};
 		const firstFullPricePayment: Payment = {
 			date: addMonths(referenceDate, 6),
 			amount: 37.5,
+			taxAmount: 2.5,
+			amountWithoutTax: 35.0,
 		};
 		const scheduleList: Payment[] = [
 			...payments(firstDiscountedPayment, [3]),
 			...payments(firstFullPricePayment, [3, 6]),
 		];
-		const schedule: PaymentSchedule = { payments: scheduleList };
+		const schedule: EmailPaymentSchedule = { payments: scheduleList };
 		const expected =
 			'£30.00 every quarter for 2 quarters, then £37.50 every quarter';
-		expect(describeSchedule(schedule, 'Quarterly', 'GBP', false)).toBe(
-			expected,
-		);
+		expect(
+			describeSchedule(schedule, 'Quarterly', 'GBP', false, 'TaxInclusive'),
+		).toBe(expected);
 	});
 
 	test('correctly formats zero amounts with multiple zero amounts in the payment schedule', () => {
-		const zeroPayment: Payment = { date: referenceDate, amount: 0.0 };
+		const zeroPayment: Payment = {
+			date: referenceDate,
+			amount: 0.0,
+			taxAmount: 0.0,
+			amountWithoutTax: 0.0,
+		};
 		const scheduleList: Payment[] = payments(zeroPayment, [10]);
-		const schedule: PaymentSchedule = { payments: scheduleList };
-		const got = describeSchedule(schedule, 'Monthly', 'AUD', false);
+		const schedule: EmailPaymentSchedule = { payments: scheduleList };
+		const got = describeSchedule(
+			schedule,
+			'Monthly',
+			'AUD',
+			false,
+			'TaxInclusive',
+		);
 		expect(got).toBe('$0.00 every month');
 	});
 
 	test('correctly formats zero amounts with a single zero amount in the payment schedule', () => {
-		const zeroPayment: Payment = { date: referenceDate, amount: 0.0 };
-		const schedule: PaymentSchedule = { payments: [zeroPayment] };
-		const got = describeSchedule(schedule, 'Monthly', 'AUD', false);
+		const zeroPayment: Payment = {
+			date: referenceDate,
+			amount: 0.0,
+			taxAmount: 0.0,
+			amountWithoutTax: 0.0,
+		};
+		const schedule: EmailPaymentSchedule = { payments: [zeroPayment] };
+		const got = describeSchedule(
+			schedule,
+			'Monthly',
+			'AUD',
+			false,
+			'TaxInclusive',
+		);
 		expect(got).toBe('$0.00 for the first month');
 	});
 });

--- a/modules/email/test/dataFields/dayZero/paymentDescription.test.ts
+++ b/modules/email/test/dataFields/dayZero/paymentDescription.test.ts
@@ -113,7 +113,7 @@ describe('paymentDescription.describe', () => {
 			date: addMonths(referenceDate, 3),
 			amount: 11.99,
 			taxAmount: 1.99,
-			amountWithoutTax: 9.0,
+			amountWithoutTax: 10.0,
 		};
 		const scheduleList: Payment[] = [
 			...payments(firstDiscountedPayment, [1, 2]),

--- a/modules/email/test/dataFields/dayZero/supporterPlusEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/supporterPlusEmailFields.test.ts
@@ -26,6 +26,7 @@ describe('Supporter plus thank you email fields', () => {
 			paymentMethod: directDebitPaymentMethod,
 			isFixedTerm: false,
 			mandateId: mandateId,
+			taxMode: 'TaxInclusive',
 		});
 
 		const expected = {
@@ -80,6 +81,7 @@ describe('Supporter plus thank you email fields', () => {
 			paymentSchedule: paymentSchedule,
 			paymentMethod: creditCardPaymentMethod,
 			isFixedTerm: false,
+			taxMode: 'TaxInclusive',
 		});
 		const expected = {
 			To: {
@@ -116,6 +118,7 @@ describe('Supporter plus thank you email fields', () => {
 			paymentMethod: directDebitPaymentMethod,
 			isFixedTerm: true,
 			mandateId: '65HK26E',
+			taxMode: 'TaxInclusive',
 		});
 
 		const expected = {

--- a/modules/email/test/dataFields/dayZero/supporterPlusEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/supporterPlusEmailFields.test.ts
@@ -151,4 +151,43 @@ describe('Supporter plus thank you email fields', () => {
 		};
 		expect(emailFields).toStrictEqual(expected);
 	});
+
+	it('should build correct email fields for tax exclusive monthly supporter plus', () => {
+		const emailFields = buildSupporterPlusEmailFields({
+			today: dayjs(today),
+			user: emailUser,
+			currency: 'CAD',
+			billingPeriod: 'Monthly',
+			subscriptionNumber: subscriptionNumber,
+			paymentSchedule: paymentSchedule,
+			paymentMethod: creditCardPaymentMethod,
+			isFixedTerm: false,
+			mandateId: mandateId,
+			taxMode: 'TaxExclusive',
+		});
+
+		const expected = {
+			To: {
+				Address: emailAddress,
+				ContactAttributes: {
+					SubscriberAttributes: {
+						first_name: emailUser.firstName,
+						payment_method: 'Credit/Debit Card',
+						first_payment_date: 'Thursday, 11 December 2025',
+						last_name: emailUser.lastName,
+						currency: 'CAD',
+						billing_period: 'monthly',
+						is_fixed_term: 'false',
+						subscriber_id: subscriptionNumber,
+						subscription_rate:
+							'$8.00 for the first month, then $10.00 every month',
+					},
+				},
+			},
+			DataExtensionName: DataExtensionNames.day0Emails.supporterPlus,
+			IdentityUserId: '1234',
+		};
+
+		expect(emailFields).toStrictEqual(expected);
+	});
 });

--- a/modules/email/test/dataFields/dayZero/tierThreeEmailFields.test.ts
+++ b/modules/email/test/dataFields/dayZero/tierThreeEmailFields.test.ts
@@ -23,6 +23,7 @@ describe('Tier three thank you email fields', () => {
 			paymentSchedule: paperPaymentSchedule,
 			paymentMethod: creditCardPaymentMethod,
 			mandateId: undefined,
+			taxMode: 'TaxInclusive',
 		});
 
 		const expected = {

--- a/modules/email/test/dataFields/fixtures/emailFieldsTestData.ts
+++ b/modules/email/test/dataFields/fixtures/emailFieldsTestData.ts
@@ -61,10 +61,14 @@ export const paymentSchedule = {
 		{
 			date: dayjs('2025-12-11').toDate(),
 			amount: 10.0,
+			amountWithoutTax: 8.0,
+			taxAmount: 2.0,
 		},
 		{
 			date: dayjs('2026-01-11').toDate(),
 			amount: 12.0,
+			amountWithoutTax: 8.0,
+			taxAmount: 2.0,
 		},
 	],
 };
@@ -74,6 +78,8 @@ export const fixedTermPaymentSchedule = {
 		{
 			date: dayjs('2025-12-11').toDate(),
 			amount: 9,
+			amountWithoutTax: 8.0,
+			taxAmount: 1.0,
 		},
 	],
 };
@@ -83,10 +89,14 @@ export const paperPaymentSchedule = {
 		{
 			date: dayjs('2025-11-18').toDate(),
 			amount: 10.0,
+			amountWithoutTax: 8,
+			taxAmount: 2,
 		},
 		{
 			date: dayjs('2025-12-18').toDate(),
 			amount: 10.0,
+			amountWithoutTax: 8,
+			taxAmount: 2,
 		},
 	],
 };

--- a/modules/email/test/dataFields/fixtures/emailFieldsTestData.ts
+++ b/modules/email/test/dataFields/fixtures/emailFieldsTestData.ts
@@ -67,7 +67,7 @@ export const paymentSchedule = {
 		{
 			date: dayjs('2026-01-11').toDate(),
 			amount: 12.0,
-			amountWithoutTax: 8.0,
+			amountWithoutTax: 10.0,
 			taxAmount: 2.0,
 		},
 	],

--- a/modules/product-catalog/src/productCatalog.ts
+++ b/modules/product-catalog/src/productCatalog.ts
@@ -245,3 +245,5 @@ export class ProductCatalogHelper {
 		return productRatePlanKey in ratePlans;
 	}
 }
+
+export type TaxMode = 'TaxInclusive' | 'TaxExclusive' | null | undefined;

--- a/modules/zuora/src/billingPreview.ts
+++ b/modules/zuora/src/billingPreview.ts
@@ -28,9 +28,19 @@ export const itemsForSubscription =
 			(item) => item.subscriptionNumber === subscriptionNumber,
 		);
 
-export type SimpleInvoiceItem = { date: Date; amount: number };
+export type SimpleInvoiceItem = {
+	date: Date;
+	amount: number;
+	amountWithoutTax: number;
+	taxAmount: number;
+};
 
-export type SimpleInvoiceTotal = { date: Date; total: number };
+export type SimpleInvoiceTotal = {
+	date: Date;
+	total: number;
+	amountWithoutTax: number;
+	taxAmount: number;
+};
 
 export function getNextInvoiceTotal(invoiceItems: SimpleInvoiceItem[]) {
 	return convertItemsToTotal(getNextInvoice(invoiceItems)).total;
@@ -95,6 +105,8 @@ const convertItemsToTotal = ({
 	({
 		date: new Date(date),
 		total: sumNumbers(items.map((item) => item.amount)),
+		amountWithoutTax: sumNumbers(items.map((item) => item.amountWithoutTax)),
+		taxAmount: sumNumbers(items.map((item) => item.taxAmount)),
 	}) satisfies SimpleInvoiceTotal;
 
 export const toSimpleInvoiceItems = (
@@ -103,4 +115,6 @@ export const toSimpleInvoiceItems = (
 	billingPreviewAfter.map((entry) => ({
 		date: entry.serviceStartDate,
 		amount: entry.chargeAmount + entry.taxAmount,
+		amountWithoutTax: entry.chargeAmount,
+		taxAmount: entry.taxAmount,
 	}));


### PR DESCRIPTION
## What does this change?

Before this change, we always use the total amount from the payment schedule (`amount`) in day 0 emails. For tax exclusive rate plans this isn't what we want, we want the amount without taxes. Separate fields were added in guardian/support-frontend#8104 to facilitate this.

We'd like to remove `amount` from the payment schedule as it duplicates other data (it can be derived from `amountWithoutTax` and `taxAmount` by summing them). So start doing this in some places instead of using `amount`.

There are some use cases outside of the support-workers day 0 email which have been affected by the change to the payment schedule, for example the product switch email confirmation. I might need some help testing these.

## How has this change been tested?

The day 0 email changes have been tested by taking out tax exclusive rate plans in CODE (see screenshots on guardian/support-frontend#8107). For example this is for a CAD tax exclusive rate plan:

<img width="553" height="259" alt="Screenshot 2026-07-20 at 14 41 55" src="https://github.com/user-attachments/assets/3c515567-dd0d-470d-b824-1d0d108ac727" />
