### PR TITLE
block CAD switches to S+

### DIFF
--- a/handlers/product-switch-api/src/changePlan/switchDefinition/supporterPlusTargetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/switchDefinition/supporterPlusTargetInformation.ts
@@ -17,6 +17,12 @@ export const supporterPlusTargetInformation: SwitchTargetInformation<
 		productRatePlan: ProductRatePlan<'SupporterPlus', 'Annual' | 'Monthly'>,
 		switchActionData: SwitchActionData,
 	): TargetInformation => {
+		if (switchActionData.currency === 'CAD') {
+			throw new ValidationError(
+				'cannot currently switch to CAD supporter plus rate plans',
+			);
+		}
+
 		const targetCatalogBasePrice =
 			productRatePlan.pricing[switchActionData.currency];
 


### PR DESCRIPTION
We currently switch people to the traditional tax inclusive plan regardless of currency.

Once we start selling Tax exclusive plans in CAD, we don't want to move people across onto the old plan.  This is because we want to cleanly turn off new acquisitions before the migration can happen, to avoid leaving people behind.

This PR blocks CAD switches as a temporary measure until we implement switches over to the new tax exclusive plan (along with any copy and email confirmations)