### PR TITLE
remove lambda error alarm braze acquisition events

### DIFF
--- a/cdk/lib/__snapshots__/braze-acquisition-events-sync.test.ts.snap
+++ b/cdk/lib/__snapshots__/braze-acquisition-events-sync.test.ts.snap
@@ -54,6 +54,28 @@ exports[`The braze acquisition events sync stack matches the snapshot 1`] = `
         },
         "Name": "braze-acquisition-events-sync-CODE",
         "State": "ENABLED",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "braze-acquisition-events-sync",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
         "Targets": [
           {
             "Arn": {
@@ -654,6 +676,9 @@ exports[`The braze acquisition events sync stack matches the snapshot 1`] = `
         "LambdaRestApiproxy22103CFD",
         "LambdaRestApiANYC3C9D364",
       ],
+      "Metadata": {
+        "aws:cdk:do-not-refactor": true,
+      },
       "Properties": {
         "Description": "API Gateway created by CDK",
         "RestApiId": {
@@ -1100,6 +1125,28 @@ exports[`The braze acquisition events sync stack matches the snapshot 2`] = `
         },
         "Name": "braze-acquisition-events-sync-PROD",
         "State": "ENABLED",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "braze-acquisition-events-sync",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
         "Targets": [
           {
             "Arn": {
@@ -1776,6 +1823,9 @@ exports[`The braze acquisition events sync stack matches the snapshot 2`] = `
         "LambdaRestApiproxy22103CFD",
         "LambdaRestApiANYC3C9D364",
       ],
+      "Metadata": {
+        "aws:cdk:do-not-refactor": true,
+      },
       "Properties": {
         "Description": "API Gateway created by CDK",
         "RestApiId": {

--- a/cdk/lib/__snapshots__/braze-acquisition-events-sync.test.ts.snap
+++ b/cdk/lib/__snapshots__/braze-acquisition-events-sync.test.ts.snap
@@ -348,6 +348,139 @@ exports[`The braze acquisition events sync stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
+    "LambdaAsyncFailureDlq947239F5": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": "braze-acquisition-events-sync-lambda-async-failure-dlq-CODE",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "braze-acquisition-events-sync",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "LambdaAsyncFailureDlqAlarm100C3781": {
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-CODE",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "braze-acquisition-events-sync failed after async Lambda retries and the event was sent to the lambda async failure DLQ. Quick triage: inspect the DLQ message payload and request context, check lambda logs for the matching request ID, then redrive once the root cause is fixed.",
+        "AlarmName": "CODE braze-acquisition-events-sync lambda retries exhausted",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "LambdaAsyncFailureDlq947239F5",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "braze-acquisition-events-sync",
+          },
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "LambdaD247545B",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "LambdaAsyncInvokeConfig14F6D2F4": {
+      "Properties": {
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": {
+              "Fn::GetAtt": [
+                "LambdaAsyncFailureDlq947239F5",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "FunctionName": {
+          "Ref": "LambdaD247545B",
+        },
+        "MaximumEventAgeInSeconds": 7200,
+        "MaximumRetryAttempts": 2,
+        "Qualifier": "$LATEST",
+      },
+      "Type": "AWS::Lambda::EventInvokeConfig",
+    },
     "LambdaD247545B": {
       "DependsOn": [
         "LambdaServiceRoleDefaultPolicyDAE46E21",
@@ -1055,6 +1188,20 @@ exports[`The braze acquisition events sync stack matches the snapshot 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "LambdaAsyncFailureDlq947239F5",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1494,6 +1641,139 @@ exports[`The braze acquisition events sync stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
+    },
+    "LambdaAsyncFailureDlq947239F5": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": "braze-acquisition-events-sync-lambda-async-failure-dlq-PROD",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "braze-acquisition-events-sync",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "LambdaAsyncFailureDlqAlarm100C3781": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "braze-acquisition-events-sync failed after async Lambda retries and the event was sent to the lambda async failure DLQ. Quick triage: inspect the DLQ message payload and request context, check lambda logs for the matching request ID, then redrive once the root cause is fixed.",
+        "AlarmName": "PROD braze-acquisition-events-sync lambda retries exhausted",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "LambdaAsyncFailureDlq947239F5",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "braze-acquisition-events-sync",
+          },
+          {
+            "Key": "DiagnosticLinks",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "lambda:",
+                  {
+                    "Ref": "LambdaD247545B",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-service-lambdas",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "LambdaAsyncInvokeConfig14F6D2F4": {
+      "Properties": {
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": {
+              "Fn::GetAtt": [
+                "LambdaAsyncFailureDlq947239F5",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "FunctionName": {
+          "Ref": "LambdaD247545B",
+        },
+        "MaximumEventAgeInSeconds": 7200,
+        "MaximumRetryAttempts": 2,
+        "Qualifier": "$LATEST",
+      },
+      "Type": "AWS::Lambda::EventInvokeConfig",
     },
     "LambdaD247545B": {
       "DependsOn": [
@@ -2199,6 +2479,20 @@ exports[`The braze acquisition events sync stack matches the snapshot 2`] = `
                     },
                     ":parameter/PROD/support/braze-acquisition-events-sync/*",
                   ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "LambdaAsyncFailureDlq947239F5",
+                  "Arn",
                 ],
               },
             },

--- a/cdk/lib/__snapshots__/braze-acquisition-events-sync.test.ts.snap
+++ b/cdk/lib/__snapshots__/braze-acquisition-events-sync.test.ts.snap
@@ -54,28 +54,6 @@ exports[`The braze acquisition events sync stack matches the snapshot 1`] = `
         },
         "Name": "braze-acquisition-events-sync-CODE",
         "State": "ENABLED",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "braze-acquisition-events-sync",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
         "Targets": [
           {
             "Arn": {
@@ -408,84 +386,6 @@ exports[`The braze acquisition events sync stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "LambdaErrorAlarm646BFA4C": {
-      "Properties": {
-        "ActionsEnabled": false,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-CODE",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "braze-acquisition-events-sync failed. Quick triage: inspect lambda logs for error stack and identityId context, check IDAPI lookup result for missing braze-uuid, and confirm Braze /users/track request and response payloads. Impact: an eligible user may not have suppression-related Braze updates applied to their profile, which may result in them receiving marketing communications they should not receive",
-        "AlarmName": "CODE braze-acquisition-events-sync lambda errors",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": {
-              "Ref": "LambdaD247545B",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Errors",
-        "Namespace": "AWS/Lambda",
-        "Period": 300,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "braze-acquisition-events-sync",
-          },
-          {
-            "Key": "DiagnosticLinks",
-            "Value": {
-              "Fn::Join": [
-                "",
-                [
-                  "lambda:",
-                  {
-                    "Ref": "LambdaD247545B",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "LambdaRestApi687C4D83": {
       "Properties": {
         "ApiKeySourceType": "HEADER",
@@ -754,9 +654,6 @@ exports[`The braze acquisition events sync stack matches the snapshot 1`] = `
         "LambdaRestApiproxy22103CFD",
         "LambdaRestApiANYC3C9D364",
       ],
-      "Metadata": {
-        "aws:cdk:do-not-refactor": true,
-      },
       "Properties": {
         "Description": "API Gateway created by CDK",
         "RestApiId": {
@@ -1203,28 +1100,6 @@ exports[`The braze acquisition events sync stack matches the snapshot 2`] = `
         },
         "Name": "braze-acquisition-events-sync-PROD",
         "State": "ENABLED",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "braze-acquisition-events-sync",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
         "Targets": [
           {
             "Arn": {
@@ -1633,84 +1508,6 @@ exports[`The braze acquisition events sync stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "LambdaErrorAlarm646BFA4C": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "braze-acquisition-events-sync failed. Quick triage: inspect lambda logs for error stack and identityId context, check IDAPI lookup result for missing braze-uuid, and confirm Braze /users/track request and response payloads. Impact: an eligible user may not have suppression-related Braze updates applied to their profile, which may result in them receiving marketing communications they should not receive",
-        "AlarmName": "PROD braze-acquisition-events-sync lambda errors",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": {
-              "Ref": "LambdaD247545B",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Errors",
-        "Namespace": "AWS/Lambda",
-        "Period": 300,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "braze-acquisition-events-sync",
-          },
-          {
-            "Key": "DiagnosticLinks",
-            "Value": {
-              "Fn::Join": [
-                "",
-                [
-                  "lambda:",
-                  {
-                    "Ref": "LambdaD247545B",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-service-lambdas",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "LambdaRestApi687C4D83": {
       "Properties": {
         "ApiKeySourceType": "HEADER",
@@ -1979,9 +1776,6 @@ exports[`The braze acquisition events sync stack matches the snapshot 2`] = `
         "LambdaRestApiproxy22103CFD",
         "LambdaRestApiANYC3C9D364",
       ],
-      "Metadata": {
-        "aws:cdk:do-not-refactor": true,
-      },
       "Properties": {
         "Description": "API Gateway created by CDK",
         "RestApiId": {

--- a/cdk/lib/braze-acquisition-events-sync.ts
+++ b/cdk/lib/braze-acquisition-events-sync.ts
@@ -65,23 +65,6 @@ export class BrazeAcquisitionEventsSync extends SrStack {
 
 		const alarmsEnabled = this.stage === 'PROD';
 
-		new SrLambdaAlarm(this, 'LambdaErrorAlarm', {
-			app: this.app,
-			alarmName: `${this.stage} braze-acquisition-events-sync lambda errors`,
-			alarmDescription:
-				'braze-acquisition-events-sync failed. Quick triage: inspect lambda logs for error stack and identityId context, check IDAPI lookup result for missing braze-uuid, and confirm Braze /users/track request and response payloads. Impact: an eligible user may not have suppression-related Braze updates applied to their profile, which may result in them receiving marketing communications they should not receive',
-			lambdaFunctionNames: lambda.functionName,
-			metric: lambda.metricErrors({
-				period: Duration.minutes(5),
-				statistic: 'Sum',
-			}),
-			threshold: 1,
-			evaluationPeriods: 1,
-			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-			treatMissingData: TreatMissingData.NOT_BREACHING,
-			actionsEnabled: alarmsEnabled,
-		});
-
 		new SrLambdaAlarm(this, 'EventBridgeDlqAlarm', {
 			app: this.app,
 			alarmName: `${this.stage} braze-acquisition-events-sync eventbridge dlq has messages`,

--- a/cdk/lib/braze-acquisition-events-sync.ts
+++ b/cdk/lib/braze-acquisition-events-sync.ts
@@ -6,6 +6,8 @@ import {
 } from 'aws-cdk-lib/aws-cloudwatch';
 import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
+import { EventInvokeConfig } from 'aws-cdk-lib/aws-lambda';
+import { SqsDestination } from 'aws-cdk-lib/aws-lambda-destinations';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { SrApiLambda } from './cdk/SrApiLambda';
 import { SrLambdaAlarm } from './cdk/SrLambdaAlarm';
@@ -47,6 +49,11 @@ export class BrazeAcquisitionEventsSync extends SrStack {
 			retentionPeriod: Duration.days(14),
 		});
 
+		const lambdaAsyncFailureDlq = new Queue(this, 'LambdaAsyncFailureDlq', {
+			queueName: `braze-acquisition-events-sync-lambda-async-failure-dlq-${this.stage}`,
+			retentionPeriod: Duration.days(14),
+		});
+
 		const acquisitionsToBrazeRule = new Rule(this, 'AcquisitionsToBrazeRule', {
 			ruleName: `braze-acquisition-events-sync-${this.stage}`,
 			eventBus: acquisitionsBus,
@@ -63,6 +70,13 @@ export class BrazeAcquisitionEventsSync extends SrStack {
 			}),
 		);
 
+		new EventInvokeConfig(this, 'LambdaAsyncInvokeConfig', {
+			function: lambda,
+			maxEventAge: Duration.hours(2),
+			retryAttempts: 2,
+			onFailure: new SqsDestination(lambdaAsyncFailureDlq),
+		});
+
 		const alarmsEnabled = this.stage === 'PROD';
 
 		new SrLambdaAlarm(this, 'EventBridgeDlqAlarm', {
@@ -72,6 +86,23 @@ export class BrazeAcquisitionEventsSync extends SrStack {
 				'EventBridge could not invoke braze-acquisition-events-sync lambda after retries. Quick triage: inspect DLQ message attributes for invoke failure reason, confirm rule event pattern matches AcquisitionsEvent payload shape, verify lambda permissions from EventBridge, and redrive once root cause is fixed.',
 			lambdaFunctionNames: lambda.functionName,
 			metric: eventBridgeToLambdaDlq.metricApproximateNumberOfMessagesVisible({
+				period: Duration.minutes(5),
+				statistic: 'Maximum',
+			}),
+			threshold: 1,
+			evaluationPeriods: 1,
+			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			treatMissingData: TreatMissingData.NOT_BREACHING,
+			actionsEnabled: alarmsEnabled,
+		});
+
+		new SrLambdaAlarm(this, 'LambdaAsyncFailureDlqAlarm', {
+			app: this.app,
+			alarmName: `${this.stage} braze-acquisition-events-sync lambda retries exhausted`,
+			alarmDescription:
+				'braze-acquisition-events-sync failed after async Lambda retries and the event was sent to the lambda async failure DLQ. Quick triage: inspect the DLQ message payload and request context, check lambda logs for the matching request ID, then redrive once the root cause is fixed.',
+			lambdaFunctionNames: lambda.functionName,
+			metric: lambdaAsyncFailureDlq.metricApproximateNumberOfMessagesVisible({
 				period: Duration.minutes(5),
 				statistic: 'Maximum',
 			}),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1216758567921382)
## What does this change?
This change removes the Lambda error alarm from braze-acquisition-events-sync.

Previously, alerts were triggered on the first failed Lambda invocation, even when subsequent EventBridge retries succeeded and the event was processed successfully. This created alert noise for transient failures.

A DLQ alarm was configured for this flow, which is a better signal of unrecovered failure because it triggers only after EventBridge retry attempts are exhausted (3 unsuccessful invocations).
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
