### PR TITLE
Add "plus taxes" to tax exclusive plan descriptions in new-product-api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -19,13 +19,19 @@ object NewProductApi {
       case Annual => "every 12 months"
       case SixWeeks => "for the first six weeks"
     }
+
+    val taxesDescriptionSuffix = planPrices.taxMode match {
+      case Some(TaxMode.TaxExclusive) => " plus taxes"
+      case _ => ""
+    }
+
     planPrices.priceMinorUnits.map { case (currency, amount) =>
       currency ->
         PaymentPlan(
           currency = currency,
           amountMinorUnits = amount,
           billingPeriod = billingPeriod,
-          description = s"${currency.iso} ${amount.formatted} $billingPeriodDescription",
+          description = s"${currency.iso} ${amount.formatted} $billingPeriodDescription$taxesDescriptionSuffix",
           taxMode = planPrices.taxMode,
         )
     }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -25,6 +25,30 @@ class CatalogWireTest extends AnyFlatSpec with Matchers with ResourceLoader {
     Json.prettyPrint(Json.toJson(wireCatalog)) shouldBe Json.prettyPrint(Json.parse(expected.get))
   }
 
+  it should "append plus taxes to tax exclusive payment plan descriptions" in {
+    val wireCatalog = WireCatalog.fromCatalog(
+      NewProductApi.catalog(fakePricesFor, stubGetFirstAvailableStartDate, today),
+    )
+
+    val supporterPlus = wireCatalog.products.find(_.label == "All Access Digital (Supporter Plus)").get
+    val monthlyTaxExclusivePlan = supporterPlus.plans.find(_.id == "monthly_supporter_plus_tax_exclusive").get
+    val cadPaymentPlan = monthlyTaxExclusivePlan.paymentPlans.find(_.currencyCode == "CAD").get
+
+    cadPaymentPlan.description shouldBe "CAD 16.99 every month plus taxes"
+  }
+
+  it should "not append plus taxes when tax mode is missing" in {
+    val wireCatalog = WireCatalog.fromCatalog(
+      NewProductApi.catalog(fakePricesFor, stubGetFirstAvailableStartDate, today),
+    )
+
+    val digitalPlus = wireCatalog.products.find(_.label == "Digital Plus").get
+    val monthlyPlan = digitalPlus.plans.find(_.id == "digipack_monthly").get
+    val gbpPaymentPlan = monthlyPlan.paymentPlans.find(_.currencyCode == "GBP").get
+
+    gbpPaymentPlan.description shouldBe "GBP 55.55 every month"
+  }
+
   def gbpPrice(amount: Int): PlanPrices = PlanPrices(
     Map(Currency.GBP -> AmountMinorUnits(amount)),
     None,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/catalogWireTest.json
@@ -64,7 +64,7 @@
         "currencyCode" : "CAD",
         "amount" : 16.99,
         "billingPeriod" : "Monthly",
-        "description" : "CAD 16.99 every month",
+        "description" : "CAD 16.99 every month plus taxes",
         "taxMode" : "TaxExclusive"
       } ],
       "enabledForBillingCountries" : [ "Canada" ]
@@ -82,7 +82,7 @@
         "currencyCode" : "CAD",
         "amount" : 169.99,
         "billingPeriod" : "Annual",
-        "description" : "CAD 169.99 every 12 months",
+        "description" : "CAD 169.99 every 12 months plus taxes",
         "taxMode" : "TaxExclusive"
       } ],
       "enabledForBillingCountries" : [ "Canada" ]
@@ -149,7 +149,7 @@
         "currencyCode" : "CAD",
         "amount" : 119.99,
         "billingPeriod" : "Annual",
-        "description" : "CAD 119.99 every 12 months",
+        "description" : "CAD 119.99 every 12 months plus taxes",
         "taxMode" : "TaxExclusive"
       } ],
       "enabledForBillingCountries" : [ "Canada" ]
@@ -167,7 +167,7 @@
         "currencyCode" : "CAD",
         "amount" : 11.99,
         "billingPeriod" : "Monthly",
-        "description" : "CAD 11.99 every month",
+        "description" : "CAD 11.99 every month plus taxes",
         "taxMode" : "TaxExclusive"
       } ],
       "enabledForBillingCountries" : [ "Canada" ]


### PR DESCRIPTION
## What does this change?
This pull request updates how payment plan descriptions are generated for products with tax-exclusive pricing. Now, when a plan is marked as tax-exclusive, the description will include "plus taxes" to clarify that taxes are not included in the displayed price. The change is covered by new tests and updates to test data to ensure correct behavior.

**Enhancements to payment plan descriptions:**

* Appends "plus taxes" to the `description` field of `PaymentPlan` objects in `NewProductApi.scala` when `taxMode` is `TaxExclusive`.

**Testing improvements:**

* Adds tests in `CatalogWireTest.scala` to verify that "plus taxes" is appended for tax-exclusive plans and omitted otherwise.
* Updates expected test data in `catalogWireTest.json` to reflect the new description format for relevant plans. [[1]](diffhunk://#diff-ff31c120da0fd85d0348755519ba7492321fef4f0e4e9bbb12e60e04670156d3L67-R67) [[2]](diffhunk://#diff-ff31c120da0fd85d0348755519ba7492321fef4f0e4e9bbb12e60e04670156d3L85-R85) [[3]](diffhunk://#diff-ff31c120da0fd85d0348755519ba7492321fef4f0e4e9bbb12e60e04670156d3L152-R152) [[4]](diffhunk://#diff-ff31c120da0fd85d0348755519ba7492321fef4f0e4e9bbb12e60e04670156d3L170-R170)

## How has this change been tested?

Deploying to CODE, verify that the correct payment plan descriptions are returned from the product catalog

## How can we measure success?

The payment amount descriptions are now accurate for tax-exclusive plans.

## Have we considered potential risks?

Risk is very low, this is just a change to CSR facing plan descriptions.