### PR TITLE
Multiple accounts get invitation endpoint

### DIFF
--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -1,7 +1,6 @@
-import { TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import dayjs from 'dayjs';
-import { z } from 'zod';
 import { createSecondarySubscription } from '@modules/multiple-account/secondarySubscription';
 import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { secondaryUserTTLFromPrimarySubscriptionTTL } from '@modules/multiple-account/secondaryUserRepository';
@@ -17,17 +16,13 @@ import { getSupporterRatePlan } from '@modules/supporter-product-data/supporterP
 import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { InvitationRepository } from './invitationRepository';
 
-export const acceptInvitationPathSchema = z.object({
-	invitationCode: z.string(),
-});
-
 export const acceptInvitationEndpoint = async (
 	stage: Stage,
-	signedInUserId: string,
-	invitationCode: string,
 	invitationRepository: InvitationRepository,
 	secondaryUserRepository: SecondaryUserRepository,
 	dynamoClient: DynamoDBClient,
+	signedInUserId: string,
+	invitationCode: string,
 ) => {
 	try {
 		const invitation = await invitationRepository.get(invitationCode);

--- a/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
@@ -1,5 +1,4 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
-import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import {
 	badRequest,
@@ -8,49 +7,44 @@ import {
 } from '@modules/routing/apiGatewayResponses';
 import { type InvitationRepository } from './invitationRepository';
 
-export const deleteInvitationPathSchema = z.object({
-	invitationCode: z.string(),
-});
+export const deleteInvitationEndpoint = async (
+	invitationRepository: InvitationRepository,
+	invitationCode: string,
+	identityId: string,
+): Promise<APIGatewayProxyResult> => {
+	logger.mutableAddContext(invitationCode);
 
-export const deleteInvitationEndpoint =
-	(invitationRepository: InvitationRepository) =>
-	async (
-		invitationCode: string,
-		identityId: string,
-	): Promise<APIGatewayProxyResult> => {
-		logger.mutableAddContext(invitationCode);
+	try {
+		const invitation = await invitationRepository.get(invitationCode);
 
-		try {
-			const invitation = await invitationRepository.get(invitationCode);
-
-			if (!invitation || invitation.cancelledBy !== undefined) {
-				return notFound();
-			}
-
-			if (
-				identityId != invitation.primaryIdentityId &&
-				identityId != invitation.secondaryIdentityId
-			) {
-				return badRequest(
-					'The x-identity-id does not match the primary or secondary user of this invitation',
-				);
-			}
-
-			const cancelledBy =
-				identityId === invitation.primaryIdentityId ? 'primary' : 'secondary';
-
-			await invitationRepository.softDelete(
-				invitation.subscriptionName,
-				invitationCode,
-				cancelledBy,
-			);
-
-			return {
-				body: '',
-				statusCode: 204,
-			};
-		} catch (error) {
-			logger.error('Error deleting invitation', error);
-			return internalServerError();
+		if (!invitation || invitation.cancelledBy !== undefined) {
+			return notFound();
 		}
-	};
+
+		if (
+			identityId != invitation.primaryIdentityId &&
+			identityId != invitation.secondaryIdentityId
+		) {
+			return badRequest(
+				'The x-identity-id does not match the primary or secondary user of this invitation',
+			);
+		}
+
+		const cancelledBy =
+			identityId === invitation.primaryIdentityId ? 'primary' : 'secondary';
+
+		await invitationRepository.softDelete(
+			invitation.subscriptionName,
+			invitationCode,
+			cancelledBy,
+		);
+
+		return {
+			body: '',
+			statusCode: 204,
+		};
+	} catch (error) {
+		logger.error('Error deleting invitation', error);
+		return internalServerError();
+	}
+};

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -20,44 +20,43 @@ export type DeleteSecondaryUserPath = z.infer<
 	typeof deleteSecondaryUserPathSchema
 >;
 
-export const deleteSecondaryUserEndpoint =
-	(
-		stage: Stage,
-		secondaryUserRepository: SecondaryUserRepository,
-		dynamoClient: DynamoDBClient,
-	) =>
-	async (path: DeleteSecondaryUserPath): Promise<APIGatewayProxyResult> => {
-		try {
-			const { subscriptionName, secondaryIdentityId } = path;
-			const composedSubscriptionName = secondarySubscriptionName(
-				subscriptionName,
-				secondaryIdentityId,
-			);
-			logger.mutableAddContext(composedSubscriptionName);
+export const deleteSecondaryUserEndpoint = async (
+	stage: Stage,
+	secondaryUserRepository: SecondaryUserRepository,
+	dynamoClient: DynamoDBClient,
+	path: DeleteSecondaryUserPath,
+): Promise<APIGatewayProxyResult> => {
+	try {
+		const { subscriptionName, secondaryIdentityId } = path;
+		const composedSubscriptionName = secondarySubscriptionName(
+			subscriptionName,
+			secondaryIdentityId,
+		);
+		logger.mutableAddContext(composedSubscriptionName);
 
-			// Carry out the secondary user deletion and deletion of the support product data record
-			// in a transaction to keep them atomic
-			await dynamoClient.send(
-				new TransactWriteItemsCommand({
-					TransactItems: [
-						secondaryUserRepository.getDeleteTransaction(
-							subscriptionName,
-							secondaryIdentityId,
-						),
-						getDeleteSupporterRatePlanTransaction(
-							stage,
-							secondaryIdentityId,
-							composedSubscriptionName,
-						),
-					],
-				}),
-			);
+		// Carry out the secondary user deletion and deletion of the support product data record
+		// in a transaction to keep them atomic
+		await dynamoClient.send(
+			new TransactWriteItemsCommand({
+				TransactItems: [
+					secondaryUserRepository.getDeleteTransaction(
+						subscriptionName,
+						secondaryIdentityId,
+					),
+					getDeleteSupporterRatePlanTransaction(
+						stage,
+						secondaryIdentityId,
+						composedSubscriptionName,
+					),
+				],
+			}),
+		);
 
-			return {
-				statusCode: 204,
-				body: '',
-			};
-		} catch (error) {
-			return buildErrorResponse(error);
-		}
-	};
+		return {
+			statusCode: 204,
+			body: '',
+		};
+	} catch (error) {
+		return buildErrorResponse(error);
+	}
+};

--- a/handlers/multiple-account-api/src/getInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/getInvitationEndpoint.ts
@@ -6,7 +6,10 @@ import {
 	notFound,
 	ok,
 } from '@modules/routing/apiGatewayResponses';
-import { type InvitationRepository } from './invitationRepository';
+import {
+	type InvitationRepository,
+	nonCancelledInvitationRecordSchema,
+} from './invitationRepository';
 
 export const getInvitationEndpoint = async (
 	invitationRepository: InvitationRepository,
@@ -27,7 +30,7 @@ export const getInvitationEndpoint = async (
 			);
 		}
 
-		return ok({ invitation });
+		return ok(invitation, nonCancelledInvitationRecordSchema);
 	} catch (error) {
 		logger.error('Error retrieving invitation', error);
 		return internalServerError();

--- a/handlers/multiple-account-api/src/getInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/getInvitationEndpoint.ts
@@ -1,0 +1,28 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import { logger } from '@modules/logger/logger';
+import {
+	internalServerError,
+	notFound,
+	ok,
+} from '@modules/routing/apiGatewayResponses';
+import { type InvitationRepository } from './invitationRepository';
+
+export const getInvitationEndpoint =
+	(invitationRepository: InvitationRepository) =>
+	async (path: DeleteInvitationPath): Promise<APIGatewayProxyResult> => {
+		const { invitationCode } = path;
+		logger.mutableAddContext(invitationCode);
+
+		try {
+			const invitation = await invitationRepository.get(invitationCode);
+
+			if (!invitation) {
+				return notFound();
+			}
+
+			return ok({ invitation });
+		} catch (error) {
+			logger.error('Error retrieving invitation', error);
+			return internalServerError();
+		}
+	};

--- a/handlers/multiple-account-api/src/getInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/getInvitationEndpoint.ts
@@ -1,28 +1,35 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { logger } from '@modules/logger/logger';
 import {
+	badRequest,
 	internalServerError,
 	notFound,
 	ok,
 } from '@modules/routing/apiGatewayResponses';
 import { type InvitationRepository } from './invitationRepository';
 
-export const getInvitationEndpoint =
-	(invitationRepository: InvitationRepository) =>
-	async (path: DeleteInvitationPath): Promise<APIGatewayProxyResult> => {
-		const { invitationCode } = path;
-		logger.mutableAddContext(invitationCode);
+export const getInvitationEndpoint = async (
+	invitationRepository: InvitationRepository,
+	invitationCode: string,
+): Promise<APIGatewayProxyResult> => {
+	logger.mutableAddContext(invitationCode);
 
-		try {
-			const invitation = await invitationRepository.get(invitationCode);
+	try {
+		const invitation = await invitationRepository.get(invitationCode);
 
-			if (!invitation) {
-				return notFound();
-			}
-
-			return ok({ invitation });
-		} catch (error) {
-			logger.error('Error retrieving invitation', error);
-			return internalServerError();
+		if (!invitation) {
+			return notFound();
 		}
-	};
+
+		if (invitation.cancelledBy !== undefined) {
+			return badRequest(
+				`The invitation has been cancelled by the ${invitation.cancelledBy} user`,
+			);
+		}
+
+		return ok({ invitation });
+	} catch (error) {
+		logger.error('Error retrieving invitation', error);
+		return internalServerError();
+	}
+};

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -13,33 +13,22 @@ import { withBodyParser, withPathParser } from '@modules/routing/withParsers';
 import { stageFromEnvironment } from '@modules/stage';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { getZuoraCatalogFromS3 } from '@modules/zuora-catalog/S3';
-import {
-	acceptInvitationEndpoint,
-	acceptInvitationPathSchema,
-} from './acceptInvitationEndpoint';
+import { acceptInvitationEndpoint } from './acceptInvitationEndpoint';
 import {
 	createInvitationBodySchema,
 	createInvitationEndpoint,
 } from './createInvitationEndpoint';
-import {
-	deleteInvitationEndpoint,
-	deleteInvitationPathSchema,
-} from './deleteInvitationEndpoint';
+import { deleteInvitationEndpoint } from './deleteInvitationEndpoint';
 import {
 	deleteSecondaryUserEndpoint,
 	deleteSecondaryUserPathSchema,
 } from './deleteSecondaryUserEndpoint';
 import { getInvitationEndpoint } from './getInvitationEndpoint';
 import { InvitationRepository } from './invitationRepository';
-import {
-	listInvitationsEndpoint,
-	listInvitationsPathSchema,
-} from './listInvitationsEndpoint';
-import {
-	listSecondaryUsersEndpoint,
-	listSecondaryUsersPathSchema,
-} from './listSecondaryUsersEndpoint';
+import { listInvitationsEndpoint } from './listInvitationsEndpoint';
+import { listSecondaryUsersEndpoint } from './listSecondaryUsersEndpoint';
 import { mmaPrimarySummaryEndpoint } from './mmaPrimarySummaryEndpoint';
+import { invitationPathSchema, subscriptionPathSchema } from './schemas';
 import { secondaryUserMeEndpoint } from './secondaryUserMeEndpoint';
 
 const stage = stageFromEnvironment();
@@ -88,21 +77,22 @@ export const handler: Handler = Router([
 	{
 		httpMethod: 'GET',
 		path: '/invitation/{invitationCode}',
-		handler: withPathParser(deleteInvitationPathSchema, async (_event, path) =>
-			getInvitationEndpoint(invitationRepository)(path),
+		handler: withPathParser(invitationPathSchema, async (_event, path) =>
+			getInvitationEndpoint(invitationRepository, path.invitationCode),
 		),
 	},
 	{
 		httpMethod: 'DELETE',
 		path: '/invitation/{invitationCode}',
-		handler: withPathParser(deleteInvitationPathSchema, async (event, path) => {
+		handler: withPathParser(invitationPathSchema, async (event, path) => {
 			// Both the primary (cancelling) and secondary (rejecting) users send
 			// their identity id in the 'x-identity-id' header.
 			const identityId = event.headers['x-identity-id'];
 			if (!identityId) {
 				return badRequest('The x-identity-id header is required');
 			}
-			return deleteInvitationEndpoint(invitationRepository)(
+			return deleteInvitationEndpoint(
+				invitationRepository,
 				path.invitationCode,
 				identityId,
 			);
@@ -111,7 +101,7 @@ export const handler: Handler = Router([
 	{
 		httpMethod: 'POST',
 		path: '/invitation/{invitationCode}/accept',
-		handler: withPathParser(acceptInvitationPathSchema, async (event, path) => {
+		handler: withPathParser(invitationPathSchema, async (event, path) => {
 			const maybeAuthenticatedEvent = await authenticate(event);
 
 			if (maybeAuthenticatedEvent.type === 'failure') {
@@ -120,11 +110,11 @@ export const handler: Handler = Router([
 
 			return acceptInvitationEndpoint(
 				stage,
-				maybeAuthenticatedEvent.userDetails.identityId,
-				path.invitationCode,
 				invitationRepository,
 				secondaryUserRepository,
 				dynamoClient,
+				maybeAuthenticatedEvent.userDetails.identityId,
+				path.invitationCode,
 			);
 		}),
 	},
@@ -132,13 +122,14 @@ export const handler: Handler = Router([
 		httpMethod: 'GET',
 		path: '/subscriptions/{subscriptionName}/invitations',
 		handler: withPathParser(
-			listInvitationsPathSchema,
+			subscriptionPathSchema,
 			withMMAIdentityCheck(
 				stage,
 				async (_body, _zuoraClient, subscription) =>
-					listInvitationsEndpoint(invitationRepository)({
-						subscriptionName: subscription.subscriptionNumber,
-					}),
+					listInvitationsEndpoint(
+						invitationRepository,
+						subscription.subscriptionNumber,
+					),
 				({ path }) => path.subscriptionName,
 			),
 		),
@@ -147,13 +138,14 @@ export const handler: Handler = Router([
 		httpMethod: 'GET',
 		path: '/subscriptions/{subscriptionName}/secondary-users',
 		handler: withPathParser(
-			listSecondaryUsersPathSchema,
+			subscriptionPathSchema,
 			withMMAIdentityCheck(
 				stage,
 				async (_body, _zuoraClient, subscription) =>
-					listSecondaryUsersEndpoint(secondaryUserRepository)({
-						subscriptionName: subscription.subscriptionNumber,
-					}),
+					listSecondaryUsersEndpoint(
+						secondaryUserRepository,
+						subscription.subscriptionNumber,
+					),
 				({ path }) => path.subscriptionName,
 			),
 		),
@@ -170,10 +162,8 @@ export const handler: Handler = Router([
 						stage,
 						secondaryUserRepository,
 						dynamoClient,
-					)({
-						subscriptionName: subscription.subscriptionNumber,
-						secondaryIdentityId: path.secondaryIdentityId,
-					}),
+						path,
+					),
 				({ path }) => path.subscriptionName,
 			),
 		),
@@ -182,7 +172,7 @@ export const handler: Handler = Router([
 		httpMethod: 'GET',
 		path: '/subscriptions/{subscriptionName}/mma-primary',
 		handler: withPathParser(
-			listSecondaryUsersPathSchema,
+			subscriptionPathSchema,
 			withMMAIdentityCheck(
 				stage,
 				async (_body, _zuoraClient, subscription) =>
@@ -190,9 +180,8 @@ export const handler: Handler = Router([
 						invitationRepository,
 						secondaryUserRepository,
 						await identityClientPromise,
-					)({
-						subscriptionName: subscription.subscriptionNumber,
-					}),
+						subscription.subscriptionNumber,
+					),
 				({ path }) => path.subscriptionName,
 			),
 		),

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -29,6 +29,7 @@ import {
 	deleteSecondaryUserEndpoint,
 	deleteSecondaryUserPathSchema,
 } from './deleteSecondaryUserEndpoint';
+import { getInvitationEndpoint } from './getInvitationEndpoint';
 import { InvitationRepository } from './invitationRepository';
 import {
 	listInvitationsEndpoint,
@@ -82,6 +83,13 @@ export const handler: Handler = Router([
 				},
 				({ body }) => body.subscriptionName,
 			),
+		),
+	},
+	{
+		httpMethod: 'GET',
+		path: '/invitation/{invitationCode}',
+		handler: withPathParser(deleteInvitationPathSchema, async (_event, path) =>
+			getInvitationEndpoint(invitationRepository)(path),
 		),
 	},
 	{

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -23,7 +23,7 @@ export function invitationCancellationTTL(): number {
 	return dayjs().add(2, 'weeks').unix();
 }
 
-export const invitationRecordSchema = z.object({
+export const nonCancelledInvitationRecordSchema = z.object({
 	subscriptionName: z.string(),
 	invitationCode: z.string(),
 	primaryIdentityId: z.string(),
@@ -31,9 +31,14 @@ export const invitationRecordSchema = z.object({
 	secondaryIdentityId: z.string(),
 	invitedDate: z.string(),
 	expiryDate: z.number(),
-	cancelledBy: cancelledBySchema.optional(),
-	cancelledDate: z.iso.datetime().optional(),
 });
+
+export const invitationRecordSchema = nonCancelledInvitationRecordSchema.extend(
+	{
+		cancelledBy: cancelledBySchema.optional(),
+		cancelledDate: z.iso.datetime().optional(),
+	},
+);
 
 export type InvitationRecord = z.infer<typeof invitationRecordSchema>;
 

--- a/handlers/multiple-account-api/src/listInvitationsEndpoint.ts
+++ b/handlers/multiple-account-api/src/listInvitationsEndpoint.ts
@@ -1,22 +1,16 @@
-import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
 import type { InvitationRepository } from './invitationRepository';
 
-export const listInvitationsPathSchema = z.object({
-	subscriptionName: z.string(),
-});
-
-export type ListInvitationsPath = z.infer<typeof listInvitationsPathSchema>;
-
-export const listInvitationsEndpoint =
-	(invitationRepository: InvitationRepository) =>
-	async ({ subscriptionName }: ListInvitationsPath) => {
-		try {
-			logger.mutableAddContext(subscriptionName);
-			const invitations = await invitationRepository.list(subscriptionName);
-			return ok({ invitations });
-		} catch (error) {
-			return buildErrorResponse(error);
-		}
-	};
+export const listInvitationsEndpoint = async (
+	invitationRepository: InvitationRepository,
+	subscriptionName: string,
+) => {
+	try {
+		logger.mutableAddContext(subscriptionName);
+		const invitations = await invitationRepository.list(subscriptionName);
+		return ok({ invitations });
+	} catch (error) {
+		return buildErrorResponse(error);
+	}
+};

--- a/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
+++ b/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
@@ -1,25 +1,16 @@
-import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
 
-export const listSecondaryUsersPathSchema = z.object({
-	subscriptionName: z.string(),
-});
-
-export type ListSecondaryUsersBody = z.infer<
-	typeof listSecondaryUsersPathSchema
->;
-
-export const listSecondaryUsersEndpoint =
-	(secondaryUserRepository: SecondaryUserRepository) =>
-	async ({ subscriptionName }: ListSecondaryUsersBody) => {
-		try {
-			logger.mutableAddContext(subscriptionName);
-			const secondaryUsers =
-				await secondaryUserRepository.list(subscriptionName);
-			return ok({ secondaryUsers });
-		} catch (error) {
-			return buildErrorResponse(error);
-		}
-	};
+export const listSecondaryUsersEndpoint = async (
+	secondaryUserRepository: SecondaryUserRepository,
+	subscriptionName: string,
+) => {
+	try {
+		logger.mutableAddContext(subscriptionName);
+		const secondaryUsers = await secondaryUserRepository.list(subscriptionName);
+		return ok({ secondaryUsers });
+	} catch (error) {
+		return buildErrorResponse(error);
+	}
+};

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -10,14 +10,12 @@ import { secondaryUserRecordSchema } from '@modules/multiple-account/secondaryUs
 import { prettyPrint } from '@modules/prettyPrint';
 import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
 import {
-	invitationRecordSchema,
 	type InvitationRepository,
+	nonCancelledInvitationRecordSchema,
 } from './invitationRepository';
 
 export const mmaPrimarySummaryResponseSchema = z.object({
-	invitations: z.array(
-		invitationRecordSchema.omit({ cancelledBy: true, cancelledDate: true }),
-	),
+	invitations: z.array(nonCancelledInvitationRecordSchema),
 	secondaryUsers: z.array(
 		secondaryUserRecordSchema.extend({
 			email: z.string().optional(),

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -13,7 +13,6 @@ import {
 	invitationRecordSchema,
 	type InvitationRepository,
 } from './invitationRepository';
-import type { ListSecondaryUsersBody } from './listSecondaryUsersEndpoint';
 
 export const mmaPrimarySummaryResponseSchema = z.object({
 	invitations: z.array(
@@ -29,33 +28,32 @@ export const mmaPrimarySummaryResponseSchema = z.object({
 	),
 });
 
-export const mmaPrimarySummaryEndpoint =
-	(
-		invitationRepository: InvitationRepository,
-		secondaryUserRepository: SecondaryUserRepository,
-		identityClient: IdentityClient,
-	) =>
-	async ({ subscriptionName }: ListSecondaryUsersBody) => {
-		try {
-			logger.mutableAddContext(subscriptionName);
+export const mmaPrimarySummaryEndpoint = async (
+	invitationRepository: InvitationRepository,
+	secondaryUserRepository: SecondaryUserRepository,
+	identityClient: IdentityClient,
+	subscriptionName: string,
+) => {
+	try {
+		logger.mutableAddContext(subscriptionName);
 
-			const nonCancelledInvitations =
-				await invitationRepository.listNonCancelled(subscriptionName);
+		const nonCancelledInvitations =
+			await invitationRepository.listNonCancelled(subscriptionName);
 
-			const secondaryUsers = await getSecondaryUserListWithNames(
-				subscriptionName,
-				secondaryUserRepository,
-				identityClient,
-			);
+		const secondaryUsers = await getSecondaryUserListWithNames(
+			subscriptionName,
+			secondaryUserRepository,
+			identityClient,
+		);
 
-			return ok(
-				{ invitations: nonCancelledInvitations, secondaryUsers },
-				mmaPrimarySummaryResponseSchema,
-			);
-		} catch (error) {
-			return buildErrorResponse(error);
-		}
-	};
+		return ok(
+			{ invitations: nonCancelledInvitations, secondaryUsers },
+			mmaPrimarySummaryResponseSchema,
+		);
+	} catch (error) {
+		return buildErrorResponse(error);
+	}
+};
 
 const getSecondaryUserListWithNames = async (
 	subscriptionName: string,

--- a/handlers/multiple-account-api/src/schemas.ts
+++ b/handlers/multiple-account-api/src/schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const invitationPathSchema = z.object({
+	invitationCode: z.string(),
+});
+
+export const subscriptionPathSchema = z.object({
+	subscriptionName: z.string(),
+});

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -89,11 +89,11 @@ afterEach(async () => {
 test('acceptInvitationEndpoint accepts an invitation and creates a secondary user record', async () => {
 	const result = await acceptInvitationEndpoint(
 		stage,
-		secondaryIdentityId,
-		invitationCode,
 		invitationRepository,
 		secondaryUserRepository,
 		dynamoClient,
+		secondaryIdentityId,
+		invitationCode,
 	);
 
 	expect(result.statusCode).toBe(200);

--- a/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
@@ -56,8 +56,11 @@ test('deleteInvitationEndpoint soft deletes invitation and returns 204', async (
 	const record = buildRecord('A-S00099999', invitationCode);
 	await saveRecord(record);
 
-	const endpoint = deleteInvitationEndpoint(repo);
-	const result = await endpoint(invitationCode, record.primaryIdentityId);
+	const result = await deleteInvitationEndpoint(
+		repo,
+		invitationCode,
+		record.primaryIdentityId,
+	);
 
 	expect(result.statusCode).toBe(204);
 
@@ -77,8 +80,11 @@ test('deleteInvitationEndpoint records cancelledBy as secondary when the seconda
 	const record = buildRecord('A-S00099999', invitationCode);
 	await saveRecord(record);
 
-	const endpoint = deleteInvitationEndpoint(repo);
-	const result = await endpoint(invitationCode, record.secondaryIdentityId);
+	const result = await deleteInvitationEndpoint(
+		repo,
+		invitationCode,
+		record.secondaryIdentityId,
+	);
 
 	expect(result.statusCode).toBe(204);
 
@@ -93,15 +99,21 @@ test('deleteInvitationEndpoint returns 400 when the identity id matches neither 
 	const record = buildRecord('A-S00099999', invitationCode);
 	await saveRecord(record);
 
-	const endpoint = deleteInvitationEndpoint(repo);
-	const result = await endpoint(invitationCode, 'not-a-matching-id');
+	const result = await deleteInvitationEndpoint(
+		repo,
+		invitationCode,
+		'not-a-matching-id',
+	);
 
 	expect(result.statusCode).toBe(400);
 });
 
 test('deleteInvitationEndpoint returns 404 when invitation is not found', async () => {
-	const endpoint = deleteInvitationEndpoint(repo);
-	const result = await endpoint(`it-missing-${Date.now()}`, '12345678');
+	const result = await deleteInvitationEndpoint(
+		repo,
+		`it-missing-${Date.now()}`,
+		'12345678',
+	);
 
 	expect(result.statusCode).toBe(404);
 });

--- a/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
@@ -71,11 +71,11 @@ beforeEach(async () => {
 
 	const acceptResult = await acceptInvitationEndpoint(
 		stage,
-		secondaryIdentityId,
-		invitationCode,
 		invitationRepository,
 		secondaryUserRepository,
 		dynamoClient,
+		secondaryIdentityId,
+		invitationCode,
 	);
 
 	expect(acceptResult.statusCode).toBe(200);
@@ -124,16 +124,15 @@ test('deleteSecondaryUserEndpoint deletes secondary user and supporter product d
 		);
 	expect(subscriptionRecordBeforeDelete).toBeDefined();
 
-	const endpoint = deleteSecondaryUserEndpoint(
+	const result = await deleteSecondaryUserEndpoint(
 		stage,
 		secondaryUserRepository,
 		dynamoClient,
+		{
+			subscriptionName,
+			secondaryIdentityId,
+		},
 	);
-
-	const result = await endpoint({
-		subscriptionName,
-		secondaryIdentityId,
-	});
 
 	expect(result.statusCode).toBe(204);
 

--- a/handlers/multiple-account-api/test/listInvitationsEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listInvitationsEndpoint.test.ts
@@ -24,9 +24,10 @@ describe('listInvitationsEndpoint', () => {
 			list: mockList,
 		} as unknown as InvitationRepository;
 
-		const result = await listInvitationsEndpoint(invitationRepository)({
-			subscriptionName: 'A-S00974337',
-		});
+		const result = await listInvitationsEndpoint(
+			invitationRepository,
+			'A-S00974337',
+		);
 
 		expect(result.statusCode).toBe(200);
 		expect(JSON.parse(result.body)).toEqual({ invitations });
@@ -41,9 +42,10 @@ describe('listInvitationsEndpoint', () => {
 			list: mockList,
 		} as unknown as InvitationRepository;
 
-		const result = await listInvitationsEndpoint(invitationRepository)({
-			subscriptionName: 'A-S00974337',
-		});
+		const result = await listInvitationsEndpoint(
+			invitationRepository,
+			'A-S00974337',
+		);
 
 		expect(result.statusCode).toBe(500);
 		expect(JSON.parse(result.body)).toEqual({

--- a/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
@@ -22,9 +22,10 @@ describe('listSecondaryUsersEndpoint', () => {
 			list: mockList,
 		} as unknown as SecondaryUserRepository;
 
-		const result = await listSecondaryUsersEndpoint(secondaryUserRepository)({
-			subscriptionName: 'A-S00974337',
-		});
+		const result = await listSecondaryUsersEndpoint(
+			secondaryUserRepository,
+			'A-S00974337',
+		);
 
 		expect(result.statusCode).toBe(200);
 		expect(JSON.parse(result.body)).toEqual({ secondaryUsers });
@@ -39,9 +40,10 @@ describe('listSecondaryUsersEndpoint', () => {
 			list: mockList,
 		} as unknown as SecondaryUserRepository;
 
-		const result = await listSecondaryUsersEndpoint(secondaryUserRepository)({
-			subscriptionName: 'A-S00974337',
-		});
+		const result = await listSecondaryUsersEndpoint(
+			secondaryUserRepository,
+			'A-S00974337',
+		);
 
 		expect(result.statusCode).toBe(500);
 		expect(JSON.parse(result.body)).toEqual({

--- a/handlers/multiple-account-api/test/mmaPrimarySummaryIntegration.test.ts
+++ b/handlers/multiple-account-api/test/mmaPrimarySummaryIntegration.test.ts
@@ -24,13 +24,12 @@ test('mmaPrimarySummaryEndpoint returns invitations and secondary users with nam
 		`/${stage}/support/multiple-account-api/identity-client-access-token`,
 	);
 
-	const endpoint = mmaPrimarySummaryEndpoint(
+	const result = await mmaPrimarySummaryEndpoint(
 		invitationRepository,
 		secondaryUserRepository,
 		identityClient,
+		subscriptionName,
 	);
-
-	const result = await endpoint({ subscriptionName });
 
 	expect(result.statusCode).toBe(200);
 

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -1,10 +1,13 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { z } from 'zod';
 import { ValidationError } from '@modules/errors';
-import { prettyPrint } from '@modules/prettyPrint';
+import { logger } from '@modules/logger/logger';
 import { stringify } from '@modules/stringify';
 
 function jsonResponse(message: string, statusCode: number) {
+	logger.log(
+		`Handler returned ${statusCode} response with message: ${message}`,
+	);
 	return {
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ message }),
@@ -64,13 +67,7 @@ export function created<T extends Record<string, unknown>>(
 
 export function buildErrorResponse(error: unknown): APIGatewayProxyResult {
 	if (error instanceof ValidationError) {
-		console.log(
-			`Handler returned 400 response due to validation error: ${prettyPrint(error)}`,
-		);
 		return badRequest(error.message);
 	}
-	console.log(
-		`Handler returned 500 response due to unexpected error: ${prettyPrint(error)}`,
-	);
 	return internalServerError();
 }

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -1,13 +1,10 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { z } from 'zod';
 import { ValidationError } from '@modules/errors';
-import { logger } from '@modules/logger/logger';
+import { prettyPrint } from '@modules/prettyPrint';
 import { stringify } from '@modules/stringify';
 
 function jsonResponse(message: string, statusCode: number) {
-	logger.log(
-		`Handler returned ${statusCode} response with message: ${message}`,
-	);
 	return {
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ message }),
@@ -67,7 +64,13 @@ export function created<T extends Record<string, unknown>>(
 
 export function buildErrorResponse(error: unknown): APIGatewayProxyResult {
 	if (error instanceof ValidationError) {
+		console.log(
+			`Handler returned 400 response due to validation error: ${prettyPrint(error)}`,
+		);
 		return badRequest(error.message);
 	}
+	console.log(
+		`Handler returned 500 response due to unexpected error: ${prettyPrint(error)}`,
+	);
 	return internalServerError();
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a new endpoint to the multiple-accounts API which allows the retrieval of invitations from an invitation code. 

The new endpoint is a GET request to the path `/invitation/{invitationCode}` 

More details about this API are [in  this document](https://docs.google.com/document/d/1eqMn9zkg-iRK3Gi9ecmgGh8WWUYpLX6B3cOasTRYpns/edit?tab=t.0)

## Other Changes
- Add a single `invitationPathSchema` in a new file schemas.ts to replace the identical schemas defined in acceptInvitationEndpoint and deleteInvitationEndpoint, and now used in getInvitationEndpoint.
- 'Flatten' a number of the endpoints so that rather than returning a function which was immediately applied they are just regular functions. I'm not sure why they were defined the other way originally, I suspect there was a reason for it at one point but it is no longer necessary and makes them more complicated to reason about.

## Testing - all carried out on CODE
### Create a new invitation
Request:

```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/invitation' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 112809589' \ # primary user
--header 'Content-Type: application/json' \
--header 'Authorization: ••••••' \
--data-raw '{
  "subscriptionName": "A-S00974337",
  "secondaryUserEmail": "test@thegulocal.com"
}'
```

Response:
`200`
```json
{
    "invitationCode": "FRcCyefqP3qf"
}
```

### Fetch the new invitation
Request:
```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/invitation/gtEPRq2sxgHm' \
--header 'x-api-key: [API_KEY]'
```

Response:
`200`
```json
{
  "subscriptionName": "A-S00974337",
  "invitationCode": "twT95D1SFKBd",
  "primaryIdentityId": "112809589",
  "secondaryUserEmail": "test@thegulocal.com",
  "secondaryIdentityId": "21841960",
  "invitedDate": "2026-07-22",
  "expiryDate": 1787407152383
}
```

### Delete that invitation as the secondary user
Request:
```shell
curl --location --request DELETE 'https://multiple-account-api-code.support.guardianapis.com/invitation/gtEPRq2sxgHm' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 21841960' # secondary user
```

Response:
`204 No Content`

### Try to fetch the invitation again
Request:
```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/invitation/gtEPRq2sxgHm' \
--header 'x-api-key: [API_KEY]'
```

Response:
`400`
```json
{
    "message": "The invitation has been cancelled by the secondary user"
}
```

### Try to fetch an invitation with a non-existent code
Request:
```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/invitation/not-a-real-code' \
--header 'x-api-key: [API_KEY]'
```

Response:
`404`
```json
{
    "message": "Not Found"
}
```



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215938886224404