### PR TITLE
Changes to prevent the Zuora extract file being committed to source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ project/project/
 node_modules/
 *.zip
 handlers/*/coverage
+# PII query result downloads from supporter-product-data-lambdas download-query-results
+select-active-rate-plans-*.csv

--- a/handlers/supporter-product-data-lambdas/src/downloadQueryResultsCommand.ts
+++ b/handlers/supporter-product-data-lambdas/src/downloadQueryResultsCommand.ts
@@ -1,4 +1,5 @@
 import { createWriteStream, existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -171,10 +172,19 @@ void (async function () {
 		return;
 	}
 
-	// Default to the current directory; a filename is generated inside
-	// downloadQueryResults when the path is a directory.
-	const outputPath = process.argv[4] ?? '.';
+	// The downloaded file contains PII, so default to the OS temp directory
+	// rather than the current working directory. This keeps it out of the git
+	// working tree (avoiding accidental commits) and lets the OS clean it up
+	// automatically. Pass an explicit outputPath to override.
+	let outputPath = process.argv[4];
+	if (outputPath === undefined) {
+		console.log(`Defaulting outputPath to the OS temp directory: ${tmpdir()}`);
+		outputPath = tmpdir();
+	}
 
 	const resolvedPath = await downloadQueryResults(stage, queryType, outputPath);
 	console.log(`Results written to ${resolvedPath}`);
+	console.log(
+		'This file contains PII - delete it when you are done and never commit it to source control.',
+	);
 })();


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR follows on from #3710 which added a script to run the supporter product data Zuora Aqua query locally. 

Because the file downloaded contains PII it is better if this is not written into a git directory to reduce the chance of it being committed to source control. This PR changes the default download directory to the OS temp directory ensuring that it is not in source control and also that it will be deleted automatically by the operating system after a period of time.

I have also added a line in the .gitignore to match the output file in case a user overrides the default path.
