### PR TITLE
Internationalisation refactor: Standardise currency naming

### DIFF
--- a/handlers/new-subscription-api/src/requestSchema.ts
+++ b/handlers/new-subscription-api/src/requestSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { isoCurrencySchema } from '@modules/internationalisation/schemas';
+import { currencyCodeSchema } from '@modules/internationalisation/schemas';
 import { productPurchaseSchema } from '@modules/product-catalog/productPurchaseSchema';
 import { existingPaymentMethodInputSchema } from '@modules/zuora/createSubscription/createSubscriptionWithExistingPaymentMethod';
 import { giftRecipientSchema } from '@modules/zuora/createSubscription/giftRecipient';
@@ -25,7 +25,7 @@ export const createSubscriptionRequestSchema = z.object({
 	salesforceAccountId: z.string(),
 	salesforceContactId: z.string(),
 	identityId: z.string(),
-	currency: isoCurrencySchema,
+	currency: currencyCodeSchema,
 	paymentGateway: paymentGatewaySchema,
 	existingPaymentMethod: existingPaymentMethodInputSchema,
 	billToContact: contactSchema,

--- a/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
+++ b/handlers/product-switch-api/src/changePlan/action/productSwitchEmail.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { describePayments } from '@modules/email/dataFields/dayZero/paymentDescription';
 import type { EmailMessageWithUserId } from '@modules/email/email';
-import { getCurrencyInfo } from '@modules/internationalisation/currency';
+import { getCurrencyByCode } from '@modules/internationalisation/currency';
 import type { SimpleInvoiceTotal } from '@modules/zuora/billingPreview';
 import type { PaymentMethodType } from '../prepare/accountInformation';
 import type { SwitchInformation } from '../prepare/switchInformation';
@@ -52,7 +52,7 @@ export const buildEmailMessage = (
 				SubscriberAttributes: {
 					first_name: firstName,
 					last_name: lastName,
-					currency: getCurrencyInfo(currency).extendedGlyph,
+					currency: getCurrencyByCode(currency).extendedGlyph,
 					first_payment_amount: firstPaymentAmount.toFixed(2),
 					date_of_first_payment: today.format('DD MMMM YYYY'),
 					date_of_next_payment:

--- a/handlers/product-switch-api/src/changePlan/prepare/accountInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/accountInformation.ts
@@ -1,4 +1,4 @@
-import { type IsoCurrency } from '@modules/internationalisation/currency';
+import { type CurrencyCode } from '@modules/internationalisation/currency';
 import type { ZuoraAccount } from '@modules/zuora/types';
 
 export type PaymentMethodType =
@@ -12,7 +12,7 @@ export type AccountInformation = {
 	emailAddress: string; // email
 	firstName: string; // email
 	lastName: string; // email
-	currency: IsoCurrency; // email
+	currency: CurrencyCode; // email
 	defaultPaymentMethodId: string; // create payment
 	paymentMethodType: PaymentMethodType; // email
 };

--- a/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
+++ b/handlers/product-switch-api/src/changePlan/prepare/targetInformation.ts
@@ -1,6 +1,6 @@
 import type { DataExtensionName } from '@modules/email/email';
 import type { GuardianRatePlan } from '@modules/guardian-subscription/reprocessRatePlans/guardianRatePlanBuilder';
-import { type IsoCurrency } from '@modules/internationalisation/currency';
+import { type CurrencyCode } from '@modules/internationalisation/currency';
 import type {
 	GuardianCatalogKeys,
 	ProductCatalogHelper,
@@ -39,7 +39,7 @@ export type TargetContribution = {
  */
 export type SwitchActionData = {
 	mode: SwitchMode;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 } & (
 	| {
 			mode: 'switchToBasePrice' | 'save';
@@ -59,7 +59,7 @@ export type SwitchActionData = {
 export const getTargetInformation = (
 	input: ProductSwitchTargetBody,
 	productCatalogKeys: GuardianRatePlan,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	previousAmount: number,
 	includesContribution: boolean,
 	productCatalogHelper: ProductCatalogHelper,

--- a/handlers/product-switch-api/src/frequencySwitchEmail.ts
+++ b/handlers/product-switch-api/src/frequencySwitchEmail.ts
@@ -1,8 +1,8 @@
 import type dayjs from 'dayjs';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { DataExtensionNames, sendEmail } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
-import { getCurrencyInfo } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
+import { getCurrencyByCode } from '@modules/internationalisation/currency';
 import type { Stage } from '@modules/stage';
 import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
 
@@ -26,7 +26,7 @@ export const buildFrequencySwitchEmailMessage = (
 	lastName: string,
 	identityId: string,
 	subscriptionNumber: string,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	newAnnualPrice: number,
 	nextPaymentDate: dayjs.Dayjs,
 ): EmailMessageWithUserId => {
@@ -38,7 +38,7 @@ export const buildFrequencySwitchEmailMessage = (
 					first_name: firstName,
 					last_name: lastName,
 					first_discounted_payment_date: nextPaymentDate.format('DD MMMM YYYY'),
-					currency: getCurrencyInfo(currency).extendedGlyph,
+					currency: getCurrencyByCode(currency).extendedGlyph,
 					new_price: newAnnualPrice.toFixed(2),
 					payment_frequency: 'Annually',
 					subscription_id: subscriptionNumber,
@@ -59,6 +59,7 @@ export const buildFrequencySwitchEmailMessage = (
  * @param stage The environment stage (CODE/PROD)
  * @param subscription The Zuora subscription
  * @param account The Zuora account
+ * @param currency The currency on the subscription
  * @param newAnnualPrice The new annual price
  * @param effectiveDate The date when the switch takes effect (next payment date)
  * @returns Promise that resolves when the email is sent
@@ -67,7 +68,7 @@ export const sendFrequencySwitchConfirmationEmail = async (
 	stage: Stage,
 	subscription: ZuoraSubscription,
 	account: ZuoraAccount,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	newAnnualPrice: number,
 	effectiveDate: dayjs.Dayjs,
 ): Promise<void> => {

--- a/handlers/product-switch-api/src/frequencySwitchEndpoint.ts
+++ b/handlers/product-switch-api/src/frequencySwitchEndpoint.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { ValidationError } from '@modules/errors';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
-import { isoCurrencySchema } from '@modules/internationalisation/schemas';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
+import { currencyCodeSchema } from '@modules/internationalisation/schemas';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
@@ -228,7 +228,7 @@ export async function selectCandidateSubscriptionCharge(
 interface FrequencySwitchInfo {
 	targetRatePlanId: string;
 	targetPrice: number;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	orderActions: OrderAction[];
 }
 
@@ -254,7 +254,7 @@ function prepareFrequencySwitchInfo(
 	const targetRatePlanId = getTargetRatePlanId(productCatalog, currentRatePlan);
 
 	// Frequency switches are Supporter Plus specific, so directly access the Annual rate plan
-	const currency = isoCurrencySchema.parse(currentCharge.currency);
+	const currency = currencyCodeSchema.parse(currentCharge.currency);
 	const targetPrice =
 		productCatalog.SupporterPlus.ratePlans.Annual.pricing[currency];
 

--- a/handlers/product-switch-api/src/frequencySwitchSchemas.ts
+++ b/handlers/product-switch-api/src/frequencySwitchSchemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { isoCurrencySchema } from '@modules/internationalisation/schemas';
+import { currencyCodeSchema } from '@modules/internationalisation/schemas';
 
 export const frequencySwitchRequestSchema = z.object({
 	preview: z.boolean(),
@@ -30,7 +30,7 @@ const priceObjectSchema = z.object({
 });
 
 export const frequencySwitchPreviewSuccessResponseSchema = z.object({
-	currency: isoCurrencySchema,
+	currency: currencyCodeSchema,
 	savings: priceObjectSchema,
 	newPrice: priceObjectSchema,
 	currentContribution: priceObjectSchema,

--- a/handlers/product-switch-api/test/frequencySwitch.test.ts
+++ b/handlers/product-switch-api/test/frequencySwitch.test.ts
@@ -3,7 +3,7 @@
  * Tests the candidate selection logic and edge cases without external API calls.
  */
 import dayjs from 'dayjs';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type {
 	RatePlanCharge,
 	ZuoraAccount,
@@ -45,7 +45,7 @@ function makeMockZuoraClient(): ZuoraClient {
 function makeAccount(overrides?: {
 	totalInvoiceBalance?: number;
 	creditBalance?: number;
-	currency?: IsoCurrency;
+	currency?: CurrencyCode;
 }): ZuoraAccount {
 	return {
 		basicInfo: {

--- a/handlers/supporter-product-data-lambdas/src/services/zuoraSubscriptionService.ts
+++ b/handlers/supporter-product-data-lambdas/src/services/zuoraSubscriptionService.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
-import { isoCurrencySchema } from '@modules/internationalisation/schemas';
+import { currencyCodeSchema } from '@modules/internationalisation/schemas';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 
 const ratePlanChargeSchema = z.object({
 	price: z.number().nullable(),
-	currency: isoCurrencySchema,
+	currency: currencyCodeSchema,
 });
 
 const ratePlanSchema = z.object({

--- a/handlers/update-supporter-plus-amount/src/sendEmail.ts
+++ b/handlers/update-supporter-plus-amount/src/sendEmail.ts
@@ -1,7 +1,7 @@
 import type dayjs from 'dayjs';
 import type { EmailMessageWithUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { ProductBillingPeriod } from '@modules/product-catalog/productBillingPeriods';
 
 export type EmailFields = {
@@ -9,7 +9,7 @@ export type EmailFields = {
 	emailAddress: string;
 	firstName: string;
 	lastName: string;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	newAmount: number;
 	billingPeriod: ProductBillingPeriod<'SupporterPlus'>;
 	identityId: string;

--- a/handlers/update-supporter-plus-amount/src/supporterPlusAmountBands.ts
+++ b/handlers/update-supporter-plus-amount/src/supporterPlusAmountBands.ts
@@ -1,8 +1,8 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { ProductBillingPeriod } from '@modules/product-catalog/productBillingPeriods';
 
 export const supporterPlusAmountBands: Record<
-	IsoCurrency,
+	CurrencyCode,
 	Record<ProductBillingPeriod<'SupporterPlus'>, { min: number; max: number }>
 > = {
 	GBP: {

--- a/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
+++ b/handlers/update-supporter-plus-amount/src/updateSupporterPlusAmount.ts
@@ -2,7 +2,7 @@ import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import { getSingleOrThrow } from '@modules/arrayFunctions';
 import { ValidationError } from '@modules/errors';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import { isSupportedCurrency } from '@modules/internationalisation/currency';
 import { logger } from '@modules/logger/logger';
 import { getIfDefined } from '@modules/nullAndUndefined';
@@ -143,7 +143,7 @@ export const getSupporterPlusData = (
 
 const validateNewAmount = (
 	newAmount: number,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	billingPeriod: ProductBillingPeriod<'SupporterPlus'>,
 ): void => {
 	const amountBand = supporterPlusAmountBands[currency][billingPeriod];

--- a/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/contributionEmailFields.ts
@@ -1,7 +1,7 @@
 import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
@@ -26,7 +26,7 @@ export function buildContributionEmailFields({
 	today: Dayjs;
 	user: EmailUser;
 	amount: number;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	billingPeriod: EmailBillingPeriod;
 	subscriptionNumber: string;
 	paymentSchedule: EmailPaymentSchedule;

--- a/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/deliveryEmailFields.ts
@@ -1,6 +1,6 @@
 import type { Dayjs } from 'dayjs';
 import { getCountryNameByCode } from '@modules/internationalisation/country';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { NonDeliveryEmailFields } from './emailFields';
 import { buildNonDeliveryEmailFields } from './emailFields';
@@ -36,7 +36,7 @@ export function buildDeliveryEmailFields({
 	today: Dayjs;
 	user: EmailUser;
 	subscriptionNumber: string;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	billingPeriod: EmailBillingPeriod;
 	paymentMethod: EmailPaymentMethod;
 	paymentSchedule: EmailPaymentSchedule;

--- a/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/digitalSubscriptionEmailFields.ts
@@ -1,7 +1,7 @@
 import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
@@ -24,7 +24,7 @@ export function buildDigitalSubscriptionEmailFields({
 }: {
 	today: Dayjs;
 	user: EmailUser;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	billingPeriod: EmailBillingPeriod;
 	subscriptionNumber: string;
 	paymentSchedule: EmailPaymentSchedule;

--- a/modules/email/src/dataFields/dayZero/emailFields.ts
+++ b/modules/email/src/dataFields/dayZero/emailFields.ts
@@ -4,7 +4,7 @@ import type {
 	DataExtensionName,
 	EmailMessageWithIdentityUserId,
 } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { describePayments, firstPayment } from './paymentDescription';
 import type { EmailPaymentFields } from './paymentEmailFields';
@@ -40,7 +40,7 @@ export function buildNonDeliveryEmailFields({
 	today: Dayjs;
 	user: EmailUser;
 	subscriptionNumber: string;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	billingPeriod: EmailBillingPeriod;
 	paymentMethod: EmailPaymentMethod;
 	paymentSchedule: EmailPaymentSchedule;

--- a/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianAdLiteEmailFields.ts
@@ -1,7 +1,7 @@
 import type { Dayjs } from 'dayjs';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
 import { DataExtensionNames } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import type {
@@ -23,7 +23,7 @@ export function buildGuardianAdLiteEmailFields({
 	today: Dayjs;
 	user: EmailUser;
 	subscriptionNumber: string;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	paymentMethod: EmailPaymentMethod;
 	paymentSchedule: EmailPaymentSchedule;
 	mandateId?: string;

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyEmailFields.ts
@@ -2,7 +2,7 @@ import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
@@ -36,7 +36,7 @@ export function buildGuardianWeeklyEmailFields({
 }: {
 	today: Dayjs;
 	user: EmailUser;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	billingPeriod: EmailBillingPeriod;
 	subscriptionNumber: string;
 	paymentSchedule: EmailPaymentSchedule;

--- a/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/guardianWeeklyPlusEmailFields.ts
@@ -1,7 +1,7 @@
 import type { Dayjs } from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
@@ -32,7 +32,7 @@ export function buildGuardianWeeklyPlusEmailFields({
 }: {
 	today: Dayjs;
 	user: EmailUser;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	billingPeriod: EmailBillingPeriod;
 	subscriptionNumber: string;
 	paymentSchedule: EmailPaymentSchedule;

--- a/modules/email/src/dataFields/dayZero/paperEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/paperEmailFields.ts
@@ -4,7 +4,7 @@ import type {
 	DataExtensionName,
 	EmailMessageWithIdentityUserId,
 } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
@@ -35,7 +35,7 @@ export function buildPaperEmailFields({
 }: {
 	today: Dayjs;
 	user: EmailUser;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	subscriptionNumber: string;
 	paymentSchedule: EmailPaymentSchedule;
 	paymentMethod: EmailPaymentMethod;

--- a/modules/email/src/dataFields/dayZero/paymentDescription.ts
+++ b/modules/email/src/dataFields/dayZero/paymentDescription.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { partition } from '@modules/arrayFunctions';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
-import { getCurrencyInfo } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
+import { getCurrencyByCode } from '@modules/internationalisation/currency';
 import { getNonEmptyOrThrow, isNonEmpty } from '@modules/nullAndUndefined';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { EmailBillingPeriod, EmailPaymentSchedule } from './types';
@@ -24,10 +24,10 @@ export function formatPrice(amount: number): string {
 }
 
 export function priceWithCurrency(
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	amount: number,
 ): string {
-	return `${getCurrencyInfo(currency).glyph}${formatPrice(amount)}`;
+	return `${getCurrencyByCode(currency).glyph}${formatPrice(amount)}`;
 }
 
 export function firstPayment(paymentSchedule: EmailPaymentSchedule): Payment {
@@ -85,7 +85,7 @@ function getRelevantAmountFromPayment(taxMode: TaxMode, payment: Payment) {
 export function describePayments(
 	paymentSchedule: EmailPaymentSchedule,
 	billingPeriod: EmailBillingPeriod,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	isFixedTerm: boolean,
 	taxMode: TaxMode,
 ): string {
@@ -143,7 +143,7 @@ export function describePayments(
 
 function descriptionWithSingleIntroductoryPeriod(
 	paymentsWithDifferentPrice: [Payment, ...Payment[]],
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	initialPrice: number,
 	billingPeriod: EmailBillingPeriod,
 	taxMode: TaxMode,
@@ -163,7 +163,7 @@ function descriptionWithSingleIntroductoryPeriod(
 function descriptionWithMultipleIntroductoryPeriods(
 	paymentsWithInitialPrice: [Payment, ...Payment[]],
 	paymentsWithDifferentPrice: [Payment, ...Payment[]],
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	initialPrice: number,
 	billingPeriod: EmailBillingPeriod,
 	taxMode: TaxMode,

--- a/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/supporterPlusEmailFields.ts
@@ -1,6 +1,6 @@
 import type dayjs from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import { buildEmailFields, buildNonDeliveryEmailFields } from './emailFields';
 import { getPaymentMethodFieldsSupporterPlus } from './paymentEmailFields';
@@ -25,7 +25,7 @@ export function buildSupporterPlusEmailFields({
 }: {
 	today: dayjs.Dayjs;
 	user: EmailUser;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	billingPeriod: EmailBillingPeriod;
 	subscriptionNumber: string;
 	paymentSchedule: EmailPaymentSchedule;

--- a/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
+++ b/modules/email/src/dataFields/dayZero/tierThreeEmailFields.ts
@@ -1,7 +1,7 @@
 import type { Dayjs } from 'dayjs';
 import { DataExtensionNames } from '@modules/email/email';
 import type { EmailMessageWithIdentityUserId } from '@modules/email/email';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { TaxMode } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import { buildDeliveryEmailFields } from './deliveryEmailFields';
@@ -31,7 +31,7 @@ export function buildTierThreeEmailFields({
 }: {
 	today: Dayjs;
 	user: EmailUser;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	billingPeriod: EmailBillingPeriod;
 	subscriptionNumber: string;
 	paymentSchedule: EmailPaymentSchedule;

--- a/modules/internationalisation/src/countryGroup.ts
+++ b/modules/internationalisation/src/countryGroup.ts
@@ -1,5 +1,5 @@
 import type { CountryCode } from '@modules/internationalisation/country';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 
 // ----- Types ----- //
 export const GBPCountries = 'GBPCountries';
@@ -40,7 +40,7 @@ export enum SupportRegionId {
 
 export type CountryGroup = {
 	name: CountryGroupName;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	countries: CountryCode[];
 	supportRegionId: SupportRegionId;
 };

--- a/modules/internationalisation/src/currency.ts
+++ b/modules/internationalisation/src/currency.ts
@@ -1,6 +1,4 @@
-import { isInList } from '@modules/arrayFunctions';
-
-export const CurrencyValues = [
+export const currencyCodes = [
 	'GBP',
 	'EUR',
 	'AUD',
@@ -9,15 +7,15 @@ export const CurrencyValues = [
 	'NZD',
 ] as const;
 
-export type IsoCurrency = (typeof CurrencyValues)[number];
+export type CurrencyCode = (typeof currencyCodes)[number];
 
-export type CurrencyInfo = {
+export type Currency = {
 	glyph: string;
 	extendedGlyph: string;
 	spokenCurrency: string;
 };
 
-const currencies: Record<IsoCurrency, CurrencyInfo> = {
+const currencies: Record<CurrencyCode, Currency> = {
 	GBP: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -50,7 +48,14 @@ const currencies: Record<IsoCurrency, CurrencyInfo> = {
 	},
 };
 
-export const isSupportedCurrency = isInList(CurrencyValues);
+const currencySet: Set<string> = new Set(currencyCodes);
 
-export const getCurrencyInfo = (currency: IsoCurrency): CurrencyInfo =>
-	currencies[currency];
+export function isSupportedCurrency(
+	maybeCurrency: string,
+): maybeCurrency is CurrencyCode {
+	return currencySet.has(maybeCurrency);
+}
+
+export function getCurrencyByCode(currencyCode: CurrencyCode): Currency {
+	return currencies[currencyCode];
+}

--- a/modules/internationalisation/src/schemas.ts
+++ b/modules/internationalisation/src/schemas.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { countryCodes } from '@modules/internationalisation/country';
 import { SupportRegionId } from '@modules/internationalisation/countryGroup';
-import { CurrencyValues } from '@modules/internationalisation/currency';
+import { currencyCodes } from '@modules/internationalisation/currency';
 
-export const isoCurrencySchema = z.enum(CurrencyValues);
+export const currencyCodeSchema = z.enum(currencyCodes);
 export const countryCodeSchema = z.enum(countryCodes);
 export const supportRegionSchema = z.nativeEnum(SupportRegionId);

--- a/modules/zuora/src/createSubscription/chargeOverride.ts
+++ b/modules/zuora/src/createSubscription/chargeOverride.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '@modules/errors';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { objectEntries } from '@modules/objectFunctions';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
@@ -9,7 +9,7 @@ import { getProductRatePlan } from '@modules/zuora/createSubscription/getProduct
 export const getChargeOverride = (
 	productCatalog: ProductCatalog,
 	productPurchase: ProductPurchase,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 ): { productRatePlanChargeId: string; overrideAmount: number } | undefined => {
 	if (productPurchase.product === 'Contribution') {
 		const chargeId =
@@ -50,7 +50,7 @@ export const getChargeOverride = (
 function getBaseProductPrice(
 	productCatalog: ProductCatalog,
 	productPurchase: ProductPurchase,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 ) {
 	return getIfDefined(
 		objectEntries(

--- a/modules/zuora/src/createSubscription/createSubscription.ts
+++ b/modules/zuora/src/createSubscription/createSubscription.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 import { z } from 'zod';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import type {
 	ProductCatalog,
@@ -53,7 +53,7 @@ export type CreateSubscriptionInputFields<T extends PaymentMethod> = {
 	salesforceAccountId: string;
 	salesforceContactId: string;
 	identityId: string;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	paymentGateway: PaymentGateway<T>;
 	paymentMethod: T | ClonedPaymentMethod;
 	billToContact: Contact;
@@ -119,7 +119,7 @@ export function getReaderType(
 export function buildSubscriptionOrderAction(
 	productCatalog: ProductCatalog,
 	productPurchase: ProductPurchase,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	appliedPromotion: AppliedPromotion | undefined,
 	promotion: Promo | undefined,
 ): {

--- a/modules/zuora/src/createSubscription/previewCreateSubscription.ts
+++ b/modules/zuora/src/createSubscription/previewCreateSubscription.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import { z } from 'zod';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
 import type { AppliedPromotion, Promo } from '@modules/promotions/v2/schema';
@@ -19,7 +19,7 @@ import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 export type PreviewCreateSubscriptionInputFields = {
 	stage: Stage;
 	accountNumber: string;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	productPurchase: ProductPurchase;
 	appliedPromotion?: AppliedPromotion;
 };

--- a/modules/zuora/src/orders/newAccount.ts
+++ b/modules/zuora/src/orders/newAccount.ts
@@ -1,4 +1,4 @@
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { PaymentGateway } from '@modules/zuora/orders/paymentGateways';
 import type { AnyPaymentMethod } from '@modules/zuora/orders/paymentMethods';
 
@@ -19,7 +19,7 @@ export type Contact = {
 
 type NewAccountBase<T extends AnyPaymentMethod> = {
 	name: string;
-	currency: IsoCurrency;
+	currency: CurrencyCode;
 	crmId: string; // Salesforce accountId
 	customFields: {
 		sfContactId__c: string; // Salesforce contactId

--- a/modules/zuora/src/types/objects/account.ts
+++ b/modules/zuora/src/types/objects/account.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { CurrencyValues } from '@modules/internationalisation/currency';
+import { currencyCodeSchema } from '@modules/internationalisation/schemas';
 import { zuoraSubscriptionSchema } from './subscription';
 
 export const zuoraAccountBasicInfoSchema = z
@@ -14,7 +14,7 @@ export const zuoraAccountBasicInfoSchema = z
 
 export const metricsSchema = z.object({
 	totalInvoiceBalance: z.number(),
-	currency: z.enum(CurrencyValues),
+	currency: currencyCodeSchema,
 	creditBalance: z.number(),
 });
 export const billToContactSchema = z.object({

--- a/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
+++ b/modules/zuora/test/buildCreateSubscriptionRequest.test.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import { SupportRegionId } from '@modules/internationalisation/countryGroup';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { AppliedPromotion, Promo } from '@modules/promotions/v2/schema';
 import type { Stage } from '@modules/stage';
@@ -66,7 +66,7 @@ const baseStripeInput = {
 	salesforceAccountId: 'sf-acc-1',
 	salesforceContactId: 'sf-con-1',
 	identityId: 'id-1',
-	currency: 'GBP' as IsoCurrency,
+	currency: 'GBP' as CurrencyCode,
 	paymentGateway:
 		'Stripe PaymentIntents GNM Membership' as PaymentGateway<CreditCardReferenceTransaction>,
 	paymentMethod: paymentMethod,

--- a/modules/zuora/test/createSubscriptionIntegration.test.ts
+++ b/modules/zuora/test/createSubscriptionIntegration.test.ts
@@ -7,7 +7,7 @@
 import dayjs from 'dayjs';
 import { z } from 'zod';
 import { SupportRegionId } from '@modules/internationalisation/countryGroup';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import { getIfDefined } from '@modules/nullAndUndefined';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type { ProductPurchase } from '@modules/product-catalog/productPurchaseSchema';
@@ -31,7 +31,7 @@ import code from '../../zuora-catalog/test/fixtures/catalog-code.json';
 
 describe('createSubscription integration', () => {
 	const productCatalog = generateProductCatalog(zuoraCatalogSchema.parse(code));
-	const currency: IsoCurrency = 'GBP';
+	const currency: CurrencyCode = 'GBP';
 	const contact = {
 		firstName: 'John',
 		lastName: 'Doe',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR is part of the work to standardise naming and code structure in the internationalisation module, it follows on from #3700 and refactors the currency Type.

## Changes
Renames several types functions and consts:

| Old Name | New Name | Kind |
| --- | --- | --- |
| `IsoCurrency` | `CurrencyCode` | `Type` |
| `CurrencyInfo` | `Currency` | `Type` |
| `CurrencyValues` | `currencyCodes` | `Const` |
| `getCurrencyInfo` | `getCurrencyByCode` | `Function` |
| `isoCurrencySchema` | `currencyCodeSchema` | `Zod schema` |