### PR TITLE
Add support-frontend parameter store read to membership local development permission

### DIFF
--- a/cdk/lib/__snapshots__/iam-policies.test.ts.snap
+++ b/cdk/lib/__snapshots__/iam-policies.test.ts.snap
@@ -62,6 +62,22 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
                     ],
                   ],
                 },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/support/frontend/DEV/*",
+                    ],
+                  ],
+                },
               ],
             },
             {
@@ -349,6 +365,22 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
                         "Ref": "AWS::AccountId",
                       },
                       ":parameter/CODE/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/support/frontend/DEV/*",
                     ],
                   ],
                 },

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -53,6 +53,7 @@ class AllowCodeParameterStoreReadPolicy extends PolicyStatement {
 			resources: [
 				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/DEV/*`,
 				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/CODE/*`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/support/frontend/DEV/*`,
 			],
 		});
 	}


### PR DESCRIPTION
## What does this change?

The new Janus local development permission currently doesn't work for support-frontend as the path used by the parameter store policy doesn't match the convention used by support-frontend.

This PR updates the policy to add the path which support-frontend uses. For some projects we'll update the app to use the convention which already exists in the policy, but that's a big migration for support-frontend so we update the policy instead.

## How has this change been tested?

TBD - I'm not sure if we can test this before it's merged.