### PR TITLE
Update iam-policy to support support-frontend local dev

### DIFF
--- a/cdk/lib/__snapshots__/iam-policies.test.ts.snap
+++ b/cdk/lib/__snapshots__/iam-policies.test.ts.snap
@@ -27,6 +27,7 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
               "Action": [
                 "ssm:GetParameters",
                 "ssm:GetParameter",
+                "ssm:GetParametersByPath",
               ],
               "Effect": "Allow",
               "Resource": [
@@ -74,7 +75,7 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":parameter/support/frontend/DEV/*",
+                      ":parameter/support/frontend/DEV",
                     ],
                   ],
                 },
@@ -333,6 +334,7 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
               "Action": [
                 "ssm:GetParameters",
                 "ssm:GetParameter",
+                "ssm:GetParametersByPath",
               ],
               "Effect": "Allow",
               "Resource": [
@@ -380,7 +382,7 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":parameter/support/frontend/DEV/*",
+                      ":parameter/support/frontend/DEV",
                     ],
                   ],
                 },

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -49,11 +49,15 @@ class AllowS3GetPolicy extends PolicyStatement {
 class AllowCodeParameterStoreReadPolicy extends PolicyStatement {
 	constructor(scope: GuStack) {
 		super({
-			actions: ['ssm:GetParameters', 'ssm:GetParameter'],
+			actions: [
+				'ssm:GetParameters',
+				'ssm:GetParameter',
+				'ssm:GetParametersByPath',
+			],
 			resources: [
 				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/DEV/*`,
 				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/CODE/*`,
-				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/support/frontend/DEV/*`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/support/frontend/DEV`,
 			],
 		});
 	}


### PR DESCRIPTION
## What does this change?

Update `iam-policy` stack to support support-frontend local dev.

The change made in #3729 wasn't quite right, we actually need the ssm:GetParametersByPath action, we can also lose the wildcard from the path.

## How has this change been tested?

As with #3729 I'm not sure if it's possible to test in CODE.