### PR TITLE
IAM policies: Additions for local support-frontend development

### DIFF
--- a/cdk/lib/__snapshots__/iam-policies.test.ts.snap
+++ b/cdk/lib/__snapshots__/iam-policies.test.ts.snap
@@ -313,6 +313,48 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
               },
             },
             {
+              "Action": [
+                "states:StartExecution",
+                "states:GetExecutionHistory",
+                "states:DescribeStateMachine",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:states:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stateMachine:support-workers-CODE",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:states:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":execution:support-workers-CODE:*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
               "Action": "cloudwatch:PutMetricData",
               "Effect": "Allow",
               "Resource": "*",
@@ -643,6 +685,48 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
                   ],
                 ],
               },
+            },
+            {
+              "Action": [
+                "states:StartExecution",
+                "states:GetExecutionHistory",
+                "states:DescribeStateMachine",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:states:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stateMachine:support-workers-CODE",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:states:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":execution:support-workers-CODE:*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": "cloudwatch:PutMetricData",

--- a/cdk/lib/__snapshots__/iam-policies.test.ts.snap
+++ b/cdk/lib/__snapshots__/iam-policies.test.ts.snap
@@ -293,6 +293,26 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
               },
             },
             {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:lambda:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":function:stripe-intent-CODE",
+                  ],
+                ],
+              },
+            },
+            {
               "Action": "cloudwatch:PutMetricData",
               "Effect": "Allow",
               "Resource": "*",
@@ -595,6 +615,26 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
                       "Ref": "AWS::AccountId",
                     },
                     ":*/CODE/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:lambda:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":function:stripe-intent-CODE",
                   ],
                 ],
               },

--- a/cdk/lib/__snapshots__/iam-policies.test.ts.snap
+++ b/cdk/lib/__snapshots__/iam-policies.test.ts.snap
@@ -317,6 +317,11 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
               "Effect": "Allow",
               "Resource": "*",
             },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::contributions-ticker/CODE/*",
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -643,6 +648,11 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
               "Action": "cloudwatch:PutMetricData",
               "Effect": "Allow",
               "Resource": "*",
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::contributions-ticker/CODE/*",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -28,6 +28,7 @@ export class IamPolicies extends SrStack {
 				getSupportAdminConsoleBucketPolicy(),
 				new AllowDynamoTableFullAccessPolicy(this),
 				...getManageFrontendPolicies(this.region, this.account),
+				...getSupportFrontendPolicies(this.region, this.account),
 				new PolicyStatement({
 					actions: ['cloudwatch:PutMetricData'],
 					resources: ['*'],
@@ -124,6 +125,16 @@ function getManageFrontendPolicies(region: string, account: string) {
 		actions: ['execute-api:Invoke'],
 		resources: [`arn:aws:execute-api:${region}:${account}:*/CODE/*`],
 	});
+
+	return [
+		fulfilmentDatesBucketPolicy,
+		allowListStackResources,
+		unsafeAllowGetAllApiKeys,
+		allowInvokeApi,
+	];
+}
+
+function getSupportFrontendPolicies(region: string, account: string) {
 	const allowInvokeLambda = new PolicyStatement({
 		actions: ['lambda:InvokeFunction'],
 		resources: [
@@ -131,13 +142,7 @@ function getManageFrontendPolicies(region: string, account: string) {
 		],
 	});
 
-	return [
-		fulfilmentDatesBucketPolicy,
-		allowListStackResources,
-		unsafeAllowGetAllApiKeys,
-		allowInvokeApi,
-		allowInvokeLambda,
-	];
+	return [allowInvokeLambda];
 }
 
 function getSupportAdminConsoleBucketPolicy() {

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -33,6 +33,7 @@ export class IamPolicies extends SrStack {
 					actions: ['cloudwatch:PutMetricData'],
 					resources: ['*'],
 				}),
+				new AllowS3GetPolicy('contributions-ticker', ['CODE/*']),
 			],
 		});
 	}

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -143,7 +143,19 @@ function getSupportFrontendPolicies(region: string, account: string) {
 		],
 	});
 
-	return [allowInvokeLambda];
+	const stateMachinePolicy = new PolicyStatement({
+		actions: [
+			'states:StartExecution',
+			'states:GetExecutionHistory',
+			'states:DescribeStateMachine',
+		],
+		resources: [
+			`arn:aws:states:${region}:${account}:stateMachine:support-workers-CODE`,
+			`arn:aws:states:${region}:${account}:execution:support-workers-CODE:*`,
+		],
+	});
+
+	return [allowInvokeLambda, stateMachinePolicy];
 }
 
 function getSupportAdminConsoleBucketPolicy() {

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -120,15 +120,22 @@ function getManageFrontendPolicies(region: string, account: string) {
 		actions: ['apigateway:GET'],
 		resources: [`arn:aws:apigateway:${region}::/apikeys/*`], // FIXME only CODE ones
 	});
-	const allowInvokeLambda = new PolicyStatement({
+	const allowInvokeApi = new PolicyStatement({
 		actions: ['execute-api:Invoke'],
 		resources: [`arn:aws:execute-api:${region}:${account}:*/CODE/*`],
+	});
+	const allowInvokeLambda = new PolicyStatement({
+		actions: ['lambda:InvokeFunction'],
+		resources: [
+			`arn:aws:lambda:${region}:${account}:function:stripe-intent-CODE`,
+		],
 	});
 
 	return [
 		fulfilmentDatesBucketPolicy,
 		allowListStackResources,
 		unsafeAllowGetAllApiKeys,
+		allowInvokeApi,
 		allowInvokeLambda,
 	];
 }


### PR DESCRIPTION
following on from the intial PR https://github.com/guardian/support-service-lambdas/pull/3718

## What does this change?

Adds some additional policies required to run support-frontend locally.

## How has this change been tested?

Tested by deploying iam-policies to CODE and using the CODE credentials from Janus. With this set of permissions I was able to put through a transaction in my locally running support frontend.