### PR TITLE
Local development permissions for payment-api

### DIFF
--- a/cdk/lib/__snapshots__/iam-policies.test.ts.snap
+++ b/cdk/lib/__snapshots__/iam-policies.test.ts.snap
@@ -79,6 +79,102 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
                     ],
                   ],
                 },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/app-config/dev/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/stripe-config/test/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/contributions-store-queue/test/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/email-config/test/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/identity-config/test/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/recaptcha-config/test/",
+                    ],
+                  ],
+                },
               ],
             },
             {
@@ -450,6 +546,102 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
                         "Ref": "AWS::AccountId",
                       },
                       ":parameter/support/frontend/DEV",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/app-config/dev/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/stripe-config/test/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/contributions-store-queue/test/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/email-config/test/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/identity-config/test/",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/payment-api/recaptcha-config/test/",
                     ],
                   ],
                 },

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -60,6 +60,13 @@ class AllowCodeParameterStoreReadPolicy extends PolicyStatement {
 				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/DEV/*`,
 				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/CODE/*`,
 				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/support/frontend/DEV`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/payment-api/app-config/dev/`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/payment-api/stripe-config/test/`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/payment-api/contributions-store-queue/test/`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/payment-api/email-config/test/`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/payment-api/identity-config/test/`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/payment-api/recaptcha-config/test/`,
+				`arn:aws:ssm:${scope.region}:${scope.account}:parameter/payment-api/stripe-config/test/`,
 			],
 		});
 	}


### PR DESCRIPTION
following on from https://github.com/guardian/support-service-lambdas/pull/3718
and the original PR https://github.com/guardian/support-service-lambdas/pull/3731

## What does this change?

This PR adds the relevant permissions needed to run payment-api locally to the iam-policies stack.

## How has this change been tested?

Using the CODE iam-policies permission and running payment-api locally.