### PR TITLE
Multiple accounts: Soft delete secondary users

### DIFF
--- a/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
@@ -1126,6 +1126,10 @@ exports[`The Multiple account api stack matches the snapshot 1`] = `
             "Value": "CODE",
           },
         ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "expiryDate",
+          "Enabled": true,
+        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Delete",
@@ -2421,6 +2425,10 @@ exports[`The Multiple account api stack matches the snapshot 2`] = `
             "Value": "PROD",
           },
         ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "expiryDate",
+          "Enabled": true,
+        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",

--- a/cdk/lib/multiple-account-api.ts
+++ b/cdk/lib/multiple-account-api.ts
@@ -76,6 +76,7 @@ export class MultipleAccountApi extends SrStack {
 			billingMode: BillingMode.PAY_PER_REQUEST,
 			partitionKey: { name: 'subscriptionName', type: AttributeType.STRING },
 			sortKey: { name: 'secondaryIdentityId', type: AttributeType.STRING },
+			timeToLiveAttribute: 'expiryDate',
 			encryption: TableEncryption.AWS_MANAGED,
 			stream: StreamViewType.NEW_AND_OLD_IMAGES,
 			removalPolicy:

--- a/handlers/multiple-account-api/README.md
+++ b/handlers/multiple-account-api/README.md
@@ -116,13 +116,25 @@ Example path: /subscriptions/A-S00974337/secondary-users
 
 DELETE /subscriptions/{subscriptionName}/secondary-users/{secondaryIdentityId}
 
-Headers: 'x-identity-id' - the identity id of the primary user
+Headers: 'x-identity-id' - the identity id of the user removing the secondary
+user. This is required and must match either the `primaryIdentityId` (the
+primary removing the secondary user) or the `secondaryIdentityId` (the secondary
+user removing themselves) of the secondary user record.
 
 Example path: /subscriptions/A-S00974337/secondary-users/30067890
+
+The secondary user record is soft deleted: the record is retained for two weeks
+(via the DynamoDB TTL `expiryDate`) with a `cancelledBy` value derived from the
+identity id - `primary` when it matches the primary user, `secondary` when it
+matches the secondary user. The associated supporter product data record (the
+benefit) is deleted immediately.
 
 #### Response:
 
 `204 No Content`
+
+If the `x-identity-id` header is missing, or does not match either user on the
+secondary user record, a `400 Bad Request` is returned.
 
 ### Delete (reject/cancel) an invitation
 
@@ -147,5 +159,3 @@ secondary user.
 
 If the `x-identity-id` header is missing, or does not match either user on the
 invitation, a `400 Bad Request` is returned.
-
-

--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -16,7 +16,7 @@ paths:
       description: Creates a new invitation for a subscription and returns an invitation code.
       security:
         - identityId: []
-        -  apiKey: []
+        - apiKey: []
       requestBody:
         required: true
         content:
@@ -161,7 +161,16 @@ paths:
     delete:
       operationId: deleteSecondaryUser
       summary: Delete secondary user
-      description: Removes a secondary user from a primary subscription.
+      description: >-
+        Removes (soft deletes) a secondary user from a primary subscription. The
+        'x-identity-id' header is required and must match either the primary
+        user (removing the secondary user) or the secondary user (removing
+        themselves). Whether the removal was carried out by the primary or the
+        secondary is derived from which of the two the identity id matches. The
+        secondary user record is retained for two weeks via a DynamoDB TTL with
+        a 'cancelledBy' value, while the associated supporter product data record
+        (the benefit) is deleted immediately. A secondary user record that has
+        already been cancelled is treated as not found.
       security:
         - identityId: []
         - apiKey: []
@@ -180,11 +189,32 @@ paths:
             type: string
           description: Identity ID of the secondary user to remove.
           example: '30067890'
+        - name: x-identity-id
+          in: header
+          required: true
+          schema:
+            type: string
+          description: >-
+            The identity id of the primary or secondary user of the secondary
+            user record. When it matches the primary user the removal is recorded
+            as 'primary'; when it matches the secondary user it is recorded as
+            'secondary'.
       responses:
         '204':
           description: Secondary user deleted.
+        '400':
+          description: >-
+            Missing 'x-identity-id' header, or the identity id does not match
+            the primary or secondary user of the secondary user record.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: The x-identity-id header is required
         '404':
-          description: Route not found.
+          description: >-
+            Secondary user not found. Also returned when the secondary user has
+            already been cancelled.
           content:
             text/plain:
               schema:
@@ -691,5 +721,3 @@ components:
             - Invalid request path
         details:
           description: Parser-specific error details.
-
-

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -7,7 +7,11 @@ import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
 import { secondarySubscriptionName } from '@modules/multiple-account/secondarySubscription';
 import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
-import { buildErrorResponse } from '@modules/routing/apiGatewayResponses';
+import {
+	badRequest,
+	buildErrorResponse,
+	notFound,
+} from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import { getDeleteSupporterRatePlanTransaction } from '@modules/supporter-product-data/supporterProductData';
 
@@ -24,24 +28,51 @@ export const deleteSecondaryUserEndpoint = async (
 	stage: Stage,
 	secondaryUserRepository: SecondaryUserRepository,
 	dynamoClient: DynamoDBClient,
-	path: DeleteSecondaryUserPath,
+	subscriptionName: string,
+	secondaryIdentityId: string,
+	loggedInUserIdentityId: string,
 ): Promise<APIGatewayProxyResult> => {
 	try {
-		const { subscriptionName, secondaryIdentityId } = path;
 		const composedSubscriptionName = secondarySubscriptionName(
 			subscriptionName,
 			secondaryIdentityId,
 		);
 		logger.mutableAddContext(composedSubscriptionName);
 
-		// Carry out the secondary user deletion and deletion of the support product data record
-		// in a transaction to keep them atomic
+		const secondaryUser = await secondaryUserRepository.getFromSubscription(
+			secondaryIdentityId,
+			subscriptionName,
+		);
+
+		if (!secondaryUser || secondaryUser.cancelledBy !== undefined) {
+			return notFound();
+		}
+
+		if (
+			loggedInUserIdentityId !== secondaryUser.primaryIdentityId &&
+			loggedInUserIdentityId !== secondaryUser.secondaryIdentityId
+		) {
+			return badRequest(
+				'The x-identity-id does not match the primary or secondary user of this subscription',
+			);
+		}
+
+		const cancelledBy =
+			loggedInUserIdentityId === secondaryUser.primaryIdentityId
+				? 'primary'
+				: 'secondary';
+
+		// Soft delete the secondary user record (retaining it so we can tell who
+		// removed it, until DynamoDB's TTL removes it) but hard delete the
+		// supporter product data record so the benefit is removed immediately.
+		// These are carried out in a transaction to keep them atomic.
 		await dynamoClient.send(
 			new TransactWriteItemsCommand({
 				TransactItems: [
-					secondaryUserRepository.getDeleteTransaction(
+					secondaryUserRepository.getSoftDeleteTransaction(
 						subscriptionName,
 						secondaryIdentityId,
+						cancelledBy,
 					),
 					getDeleteSupporterRatePlanTransaction(
 						stage,

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -39,12 +39,13 @@ export const deleteSecondaryUserEndpoint = async (
 		);
 		logger.mutableAddContext(composedSubscriptionName);
 
-		const secondaryUser = await secondaryUserRepository.getFromSubscription(
-			secondaryIdentityId,
-			subscriptionName,
-		);
+		const secondaryUser =
+			await secondaryUserRepository.getNonCancelledBySubscriptionAndIdentity(
+				subscriptionName,
+				secondaryIdentityId,
+			);
 
-		if (!secondaryUser || secondaryUser.cancelledBy !== undefined) {
+		if (!secondaryUser) {
 			return notFound();
 		}
 

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -155,17 +155,24 @@ export const handler: Handler = Router([
 		path: '/subscriptions/{subscriptionName}/secondary-users/{secondaryIdentityId}',
 		handler: withPathParser(
 			deleteSecondaryUserPathSchema,
-			withMMAIdentityCheck(
-				stage,
-				async (_body, _zuoraClient, subscription, _account, path) =>
-					deleteSecondaryUserEndpoint(
-						stage,
-						secondaryUserRepository,
-						dynamoClient,
-						path,
-					),
-				({ path }) => path.subscriptionName,
-			),
+			async (event, path) => {
+				// Both the primary (removing a secondary user) and the secondary
+				// user (removing themselves) send their identity id in the
+				// 'x-identity-id' header.
+				const loggedInUserIdentityId = event.headers['x-identity-id'];
+				if (!loggedInUserIdentityId) {
+					return badRequest('The x-identity-id header is required');
+				}
+				const { subscriptionName, secondaryIdentityId } = path;
+				return deleteSecondaryUserEndpoint(
+					stage,
+					secondaryUserRepository,
+					dynamoClient,
+					subscriptionName,
+					secondaryIdentityId,
+					loggedInUserIdentityId,
+				);
+			},
 		),
 	},
 	{

--- a/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
+++ b/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
@@ -8,7 +8,8 @@ export const listSecondaryUsersEndpoint = async (
 ) => {
 	try {
 		logger.mutableAddContext(subscriptionName);
-		const secondaryUsers = await secondaryUserRepository.list(subscriptionName);
+		const secondaryUsers =
+			await secondaryUserRepository.listNonCancelled(subscriptionName);
 		return ok({ secondaryUsers });
 	} catch (error) {
 		return buildErrorResponse(error);

--- a/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
+++ b/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
@@ -9,7 +9,9 @@ export const listSecondaryUsersEndpoint = async (
 	try {
 		logger.mutableAddContext(subscriptionName);
 		const secondaryUsers =
-			await secondaryUserRepository.listNonCancelled(subscriptionName);
+			await secondaryUserRepository.listNonCancelledBySubscription(
+				subscriptionName,
+			);
 		return ok({ secondaryUsers });
 	} catch (error) {
 		return buildErrorResponse(error);

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -38,14 +38,18 @@ export const mmaPrimarySummaryEndpoint = async (
 		const nonCancelledInvitations =
 			await invitationRepository.listNonCancelled(subscriptionName);
 
-		const secondaryUsers = await getSecondaryUserListWithNames(
-			subscriptionName,
-			secondaryUserRepository,
-			identityClient,
-		);
+		const nonCancelledSecondaryUsers =
+			await getNonCancelledSecondaryUserListWithNames(
+				subscriptionName,
+				secondaryUserRepository,
+				identityClient,
+			);
 
 		return ok(
-			{ invitations: nonCancelledInvitations, secondaryUsers },
+			{
+				invitations: nonCancelledInvitations,
+				secondaryUsers: nonCancelledSecondaryUsers,
+			},
 			mmaPrimarySummaryResponseSchema,
 		);
 	} catch (error) {
@@ -53,12 +57,13 @@ export const mmaPrimarySummaryEndpoint = async (
 	}
 };
 
-const getSecondaryUserListWithNames = async (
+const getNonCancelledSecondaryUserListWithNames = async (
 	subscriptionName: string,
 	secondaryUserRepository: SecondaryUserRepository,
 	identityClient: IdentityClient,
 ) => {
-	const secondaryUsers = await secondaryUserRepository.list(subscriptionName);
+	const secondaryUsers =
+		await secondaryUserRepository.listNonCancelled(subscriptionName);
 
 	return Promise.all(
 		secondaryUsers.map(async (secondaryUser) =>

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -63,7 +63,9 @@ const getNonCancelledSecondaryUserListWithNames = async (
 	identityClient: IdentityClient,
 ) => {
 	const secondaryUsers =
-		await secondaryUserRepository.listNonCancelled(subscriptionName);
+		await secondaryUserRepository.listNonCancelledBySubscription(
+			subscriptionName,
+		);
 
 	return Promise.all(
 		secondaryUsers.map(async (secondaryUser) =>

--- a/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
+++ b/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
@@ -25,9 +25,8 @@ export async function secondaryUserMeEndpoint(
 	secondaryUserRepository: SecondaryUserRepository,
 	zuoraClient: ZuoraClient,
 ): Promise<APIGatewayProxyResult> {
-	const secondaryUsers: SecondaryUserRecord[] = (
-		await secondaryUserRepository.get(identityId)
-	).filter((secondaryUser) => secondaryUser.cancelledBy === undefined);
+	const secondaryUsers: SecondaryUserRecord[] =
+		await secondaryUserRepository.listNonCancelledByIdentity(identityId);
 
 	const primaryUsers = await Promise.all(
 		secondaryUsers.map(async (secondaryUser) =>

--- a/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
+++ b/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
@@ -25,8 +25,9 @@ export async function secondaryUserMeEndpoint(
 	secondaryUserRepository: SecondaryUserRepository,
 	zuoraClient: ZuoraClient,
 ): Promise<APIGatewayProxyResult> {
-	const secondaryUsers: SecondaryUserRecord[] =
-		await secondaryUserRepository.get(identityId);
+	const secondaryUsers: SecondaryUserRecord[] = (
+		await secondaryUserRepository.get(identityId)
+	).filter((secondaryUser) => secondaryUser.cancelledBy === undefined);
 
 	const primaryUsers = await Promise.all(
 		secondaryUsers.map(async (secondaryUser) =>

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -107,7 +107,8 @@ test('acceptInvitationEndpoint accepts an invitation and creates a secondary use
 	expect(invitation).toBeUndefined();
 
 	// A secondary user record should have been created
-	const secondaryUsers = await secondaryUserRepository.get(secondaryIdentityId);
+	const secondaryUsers =
+		await secondaryUserRepository.listByIdentity(secondaryIdentityId);
 	expect(secondaryUsers).toHaveLength(1);
 	expect(secondaryUsers[0]?.subscriptionName).toBe(subscriptionName);
 	expect(secondaryUsers[0]?.secondaryIdentityId).toBe(secondaryIdentityId);

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -1,0 +1,189 @@
+import { TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
+import type {
+	DynamoDBClient,
+	TransactWriteItem,
+} from '@aws-sdk/client-dynamodb';
+import type {
+	SecondaryUserRecord,
+	SecondaryUserRepository,
+} from '@modules/multiple-account/secondaryUserRepository';
+import { deleteSecondaryUserEndpoint } from '../src/deleteSecondaryUserEndpoint';
+
+const stage = 'CODE';
+const subscriptionName = 'A-S00974337';
+const secondaryIdentityId = 'secondary-id';
+const primaryIdentityId = 'primary-id';
+
+const makeSecondaryUser = (
+	overrides: Partial<SecondaryUserRecord> = {},
+): SecondaryUserRecord => ({
+	subscriptionName,
+	secondaryIdentityId,
+	primaryIdentityId,
+	acceptedDate: '2026-06-12',
+	expiryDate: 1781218800,
+	...overrides,
+});
+
+const softDeleteTransaction: TransactWriteItem = {
+	Update: {
+		TableName: 'multiple-account-secondary-user-CODE',
+		Key: {
+			subscriptionName: { S: subscriptionName },
+			secondaryIdentityId: { S: secondaryIdentityId },
+		},
+		UpdateExpression: 'SET cancelledBy = :cancelledBy',
+	},
+};
+
+const makeRepository = (
+	users: SecondaryUserRecord[],
+): {
+	repository: SecondaryUserRepository;
+	mockGet: jest.Mock<Promise<SecondaryUserRecord[]>, [string]>;
+	mockGetSoftDeleteTransaction: jest.Mock;
+} => {
+	const mockGet = jest
+		.fn<Promise<SecondaryUserRecord[]>, [string]>()
+		.mockResolvedValue(users);
+	const mockGetSoftDeleteTransaction = jest
+		.fn()
+		.mockReturnValue(softDeleteTransaction);
+	const repository = {
+		get: mockGet,
+		getSoftDeleteTransaction: mockGetSoftDeleteTransaction,
+	} as unknown as SecondaryUserRepository;
+	return { repository, mockGet, mockGetSoftDeleteTransaction };
+};
+
+const makeDynamoClient = (): {
+	client: DynamoDBClient;
+	mockSend: jest.Mock<Promise<unknown>, [TransactWriteItemsCommand]>;
+} => {
+	const mockSend = jest
+		.fn<Promise<unknown>, [TransactWriteItemsCommand]>()
+		.mockResolvedValue({});
+	const client = { send: mockSend } as unknown as DynamoDBClient;
+	return { client, mockSend };
+};
+
+describe('deleteSecondaryUserEndpoint', () => {
+	it('soft deletes with cancelledBy "primary" when the primary user deletes', async () => {
+		const { repository, mockGetSoftDeleteTransaction } = makeRepository([
+			makeSecondaryUser(),
+		]);
+		const { client, mockSend } = makeDynamoClient();
+
+		const result = await deleteSecondaryUserEndpoint(
+			stage,
+			repository,
+			client,
+			{ subscriptionName, secondaryIdentityId },
+			primaryIdentityId,
+		);
+
+		expect(result.statusCode).toBe(204);
+		expect(mockGetSoftDeleteTransaction).toHaveBeenCalledWith(
+			subscriptionName,
+			secondaryIdentityId,
+			'primary',
+		);
+		expect(mockSend).toHaveBeenCalledWith(
+			expect.any(TransactWriteItemsCommand),
+		);
+		const command = mockSend.mock.calls[0]?.[0];
+		expect(command?.input.TransactItems).toHaveLength(2);
+		expect(command?.input.TransactItems?.[0]).toBe(softDeleteTransaction);
+		expect(command?.input.TransactItems?.[1]).toEqual({
+			Delete: {
+				TableName: 'SupporterProductData-CODE',
+				Key: {
+					subscriptionName: {
+						S: `${subscriptionName}-${secondaryIdentityId}`,
+					},
+					identityId: { S: secondaryIdentityId },
+				},
+			},
+		});
+	});
+
+	it('soft deletes with cancelledBy "secondary" when the secondary user deletes', async () => {
+		const { repository, mockGetSoftDeleteTransaction } = makeRepository([
+			makeSecondaryUser(),
+		]);
+		const { client } = makeDynamoClient();
+
+		const result = await deleteSecondaryUserEndpoint(
+			stage,
+			repository,
+			client,
+			{ subscriptionName, secondaryIdentityId },
+			secondaryIdentityId,
+		);
+
+		expect(result.statusCode).toBe(204);
+		expect(mockGetSoftDeleteTransaction).toHaveBeenCalledWith(
+			subscriptionName,
+			secondaryIdentityId,
+			'secondary',
+		);
+	});
+
+	it('returns 404 when the secondary user record is not found', async () => {
+		const { repository, mockGetSoftDeleteTransaction } = makeRepository([]);
+		const { client, mockSend } = makeDynamoClient();
+
+		const result = await deleteSecondaryUserEndpoint(
+			stage,
+			repository,
+			client,
+			{ subscriptionName, secondaryIdentityId },
+			primaryIdentityId,
+		);
+
+		expect(result.statusCode).toBe(404);
+		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('returns 404 when the secondary user record is already cancelled', async () => {
+		const { repository, mockGetSoftDeleteTransaction } = makeRepository([
+			makeSecondaryUser({
+				cancelledBy: 'primary',
+				cancelledDate: '2026-07-29T00:00:00.000Z',
+			}),
+		]);
+		const { client, mockSend } = makeDynamoClient();
+
+		const result = await deleteSecondaryUserEndpoint(
+			stage,
+			repository,
+			client,
+			{ subscriptionName, secondaryIdentityId },
+			primaryIdentityId,
+		);
+
+		expect(result.statusCode).toBe(404);
+		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('returns 400 when the identity id matches neither user', async () => {
+		const { repository, mockGetSoftDeleteTransaction } = makeRepository([
+			makeSecondaryUser(),
+		]);
+		const { client, mockSend } = makeDynamoClient();
+
+		const result = await deleteSecondaryUserEndpoint(
+			stage,
+			repository,
+			client,
+			{ subscriptionName, secondaryIdentityId },
+			'someone-else',
+		);
+
+		expect(result.statusCode).toBe(400);
+		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+});

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -25,7 +25,7 @@ const makeSecondaryUser = (
 	...overrides,
 });
 
-const softDeleteTransaction: TransactWriteItem = {
+const softDeleteTransactItem: TransactWriteItem = {
 	Update: {
 		TableName: 'multiple-account-secondary-user-CODE',
 		Key: {
@@ -37,23 +37,30 @@ const softDeleteTransaction: TransactWriteItem = {
 };
 
 const makeRepository = (
-	users: SecondaryUserRecord[],
+	secondaryUser: SecondaryUserRecord | undefined,
 ): {
 	repository: SecondaryUserRepository;
-	mockGet: jest.Mock<Promise<SecondaryUserRecord[]>, [string]>;
-	mockGetSoftDeleteTransaction: jest.Mock;
+	mockGetBySubscriptionAndIdentity: jest.Mock<
+		Promise<SecondaryUserRecord | undefined>,
+		[string, string]
+	>;
+	mockSoftDeleteTransactItem: jest.Mock;
 } => {
-	const mockGet = jest
-		.fn<Promise<SecondaryUserRecord[]>, [string]>()
-		.mockResolvedValue(users);
-	const mockGetSoftDeleteTransaction = jest
+	const mockGetBySubscriptionAndIdentity = jest
+		.fn<Promise<SecondaryUserRecord | undefined>, [string, string]>()
+		.mockResolvedValue(secondaryUser);
+	const mockSoftDeleteTransactItem = jest
 		.fn()
-		.mockReturnValue(softDeleteTransaction);
+		.mockReturnValue(softDeleteTransactItem);
 	const repository = {
-		get: mockGet,
-		getSoftDeleteTransaction: mockGetSoftDeleteTransaction,
+		getBySubscriptionAndIdentity: mockGetBySubscriptionAndIdentity,
+		softDeleteTransactItem: mockSoftDeleteTransactItem,
 	} as unknown as SecondaryUserRepository;
-	return { repository, mockGet, mockGetSoftDeleteTransaction };
+	return {
+		repository,
+		mockGetBySubscriptionAndIdentity,
+		mockSoftDeleteTransactItem,
+	};
 };
 
 const makeDynamoClient = (): {
@@ -69,21 +76,21 @@ const makeDynamoClient = (): {
 
 describe('deleteSecondaryUserEndpoint', () => {
 	it('soft deletes with cancelledBy "primary" when the primary user deletes', async () => {
-		const { repository, mockGetSoftDeleteTransaction } = makeRepository([
-			makeSecondaryUser(),
-		]);
+		const { repository, mockSoftDeleteTransactItem } =
+			makeRepository(makeSecondaryUser());
 		const { client, mockSend } = makeDynamoClient();
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
-			{ subscriptionName, secondaryIdentityId },
+			subscriptionName,
+			secondaryIdentityId,
 			primaryIdentityId,
 		);
 
 		expect(result.statusCode).toBe(204);
-		expect(mockGetSoftDeleteTransaction).toHaveBeenCalledWith(
+		expect(mockSoftDeleteTransactItem).toHaveBeenCalledWith(
 			subscriptionName,
 			secondaryIdentityId,
 			'primary',
@@ -93,7 +100,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 		);
 		const command = mockSend.mock.calls[0]?.[0];
 		expect(command?.input.TransactItems).toHaveLength(2);
-		expect(command?.input.TransactItems?.[0]).toBe(softDeleteTransaction);
+		expect(command?.input.TransactItems?.[0]).toBe(softDeleteTransactItem);
 		expect(command?.input.TransactItems?.[1]).toEqual({
 			Delete: {
 				TableName: 'SupporterProductData-CODE',
@@ -108,21 +115,21 @@ describe('deleteSecondaryUserEndpoint', () => {
 	});
 
 	it('soft deletes with cancelledBy "secondary" when the secondary user deletes', async () => {
-		const { repository, mockGetSoftDeleteTransaction } = makeRepository([
-			makeSecondaryUser(),
-		]);
+		const { repository, mockSoftDeleteTransactItem } =
+			makeRepository(makeSecondaryUser());
 		const { client } = makeDynamoClient();
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
-			{ subscriptionName, secondaryIdentityId },
+			subscriptionName,
+			secondaryIdentityId,
 			secondaryIdentityId,
 		);
 
 		expect(result.statusCode).toBe(204);
-		expect(mockGetSoftDeleteTransaction).toHaveBeenCalledWith(
+		expect(mockSoftDeleteTransactItem).toHaveBeenCalledWith(
 			subscriptionName,
 			secondaryIdentityId,
 			'secondary',
@@ -130,60 +137,63 @@ describe('deleteSecondaryUserEndpoint', () => {
 	});
 
 	it('returns 404 when the secondary user record is not found', async () => {
-		const { repository, mockGetSoftDeleteTransaction } = makeRepository([]);
+		const { repository, mockSoftDeleteTransactItem } =
+			makeRepository(undefined);
 		const { client, mockSend } = makeDynamoClient();
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
-			{ subscriptionName, secondaryIdentityId },
+			subscriptionName,
+			secondaryIdentityId,
 			primaryIdentityId,
 		);
 
 		expect(result.statusCode).toBe(404);
-		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
+		expect(mockSoftDeleteTransactItem).not.toHaveBeenCalled();
 		expect(mockSend).not.toHaveBeenCalled();
 	});
 
 	it('returns 404 when the secondary user record is already cancelled', async () => {
-		const { repository, mockGetSoftDeleteTransaction } = makeRepository([
+		const { repository, mockSoftDeleteTransactItem } = makeRepository(
 			makeSecondaryUser({
 				cancelledBy: 'primary',
 				cancelledDate: '2026-07-29T00:00:00.000Z',
 			}),
-		]);
+		);
 		const { client, mockSend } = makeDynamoClient();
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
-			{ subscriptionName, secondaryIdentityId },
+			subscriptionName,
+			secondaryIdentityId,
 			primaryIdentityId,
 		);
 
 		expect(result.statusCode).toBe(404);
-		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
+		expect(mockSoftDeleteTransactItem).not.toHaveBeenCalled();
 		expect(mockSend).not.toHaveBeenCalled();
 	});
 
 	it('returns 400 when the identity id matches neither user', async () => {
-		const { repository, mockGetSoftDeleteTransaction } = makeRepository([
-			makeSecondaryUser(),
-		]);
+		const { repository, mockSoftDeleteTransactItem } =
+			makeRepository(makeSecondaryUser());
 		const { client, mockSend } = makeDynamoClient();
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
-			{ subscriptionName, secondaryIdentityId },
+			subscriptionName,
+			secondaryIdentityId,
 			'someone-else',
 		);
 
 		expect(result.statusCode).toBe(400);
-		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
+		expect(mockSoftDeleteTransactItem).not.toHaveBeenCalled();
 		expect(mockSend).not.toHaveBeenCalled();
 	});
 });

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -40,26 +40,27 @@ const makeRepository = (
 	secondaryUser: SecondaryUserRecord | undefined,
 ): {
 	repository: SecondaryUserRepository;
-	mockGetBySubscriptionAndIdentity: jest.Mock<
+	mockGetNonCancelledBySubscriptionAndIdentity: jest.Mock<
 		Promise<SecondaryUserRecord | undefined>,
 		[string, string]
 	>;
-	mockSoftDeleteTransactItem: jest.Mock;
+	mockGetSoftDeleteTransaction: jest.Mock;
 } => {
-	const mockGetBySubscriptionAndIdentity = jest
+	const mockGetNonCancelledBySubscriptionAndIdentity = jest
 		.fn<Promise<SecondaryUserRecord | undefined>, [string, string]>()
 		.mockResolvedValue(secondaryUser);
-	const mockSoftDeleteTransactItem = jest
+	const mockGetSoftDeleteTransaction = jest
 		.fn()
 		.mockReturnValue(softDeleteTransactItem);
 	const repository = {
-		getBySubscriptionAndIdentity: mockGetBySubscriptionAndIdentity,
-		softDeleteTransactItem: mockSoftDeleteTransactItem,
+		getNonCancelledBySubscriptionAndIdentity:
+			mockGetNonCancelledBySubscriptionAndIdentity,
+		getSoftDeleteTransaction: mockGetSoftDeleteTransaction,
 	} as unknown as SecondaryUserRepository;
 	return {
 		repository,
-		mockGetBySubscriptionAndIdentity,
-		mockSoftDeleteTransactItem,
+		mockGetNonCancelledBySubscriptionAndIdentity,
+		mockGetSoftDeleteTransaction,
 	};
 };
 
@@ -76,7 +77,7 @@ const makeDynamoClient = (): {
 
 describe('deleteSecondaryUserEndpoint', () => {
 	it('soft deletes with cancelledBy "primary" when the primary user deletes', async () => {
-		const { repository, mockSoftDeleteTransactItem } =
+		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client, mockSend } = makeDynamoClient();
 
@@ -90,7 +91,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 		);
 
 		expect(result.statusCode).toBe(204);
-		expect(mockSoftDeleteTransactItem).toHaveBeenCalledWith(
+		expect(mockGetSoftDeleteTransaction).toHaveBeenCalledWith(
 			subscriptionName,
 			secondaryIdentityId,
 			'primary',
@@ -115,7 +116,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 	});
 
 	it('soft deletes with cancelledBy "secondary" when the secondary user deletes', async () => {
-		const { repository, mockSoftDeleteTransactItem } =
+		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client } = makeDynamoClient();
 
@@ -129,7 +130,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 		);
 
 		expect(result.statusCode).toBe(204);
-		expect(mockSoftDeleteTransactItem).toHaveBeenCalledWith(
+		expect(mockGetSoftDeleteTransaction).toHaveBeenCalledWith(
 			subscriptionName,
 			secondaryIdentityId,
 			'secondary',
@@ -137,7 +138,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 	});
 
 	it('returns 404 when the secondary user record is not found', async () => {
-		const { repository, mockSoftDeleteTransactItem } =
+		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(undefined);
 		const { client, mockSend } = makeDynamoClient();
 
@@ -151,17 +152,15 @@ describe('deleteSecondaryUserEndpoint', () => {
 		);
 
 		expect(result.statusCode).toBe(404);
-		expect(mockSoftDeleteTransactItem).not.toHaveBeenCalled();
+		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
 		expect(mockSend).not.toHaveBeenCalled();
 	});
 
 	it('returns 404 when the secondary user record is already cancelled', async () => {
-		const { repository, mockSoftDeleteTransactItem } = makeRepository(
-			makeSecondaryUser({
-				cancelledBy: 'primary',
-				cancelledDate: '2026-07-29T00:00:00.000Z',
-			}),
-		);
+		// The repository's getNonCancelledBySubscriptionAndIdentity filters out
+		// cancelled records, so it resolves undefined for an already-cancelled user.
+		const { repository, mockGetSoftDeleteTransaction } =
+			makeRepository(undefined);
 		const { client, mockSend } = makeDynamoClient();
 
 		const result = await deleteSecondaryUserEndpoint(
@@ -174,12 +173,12 @@ describe('deleteSecondaryUserEndpoint', () => {
 		);
 
 		expect(result.statusCode).toBe(404);
-		expect(mockSoftDeleteTransactItem).not.toHaveBeenCalled();
+		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
 		expect(mockSend).not.toHaveBeenCalled();
 	});
 
 	it('returns 400 when the identity id matches neither user', async () => {
-		const { repository, mockSoftDeleteTransactItem } =
+		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client, mockSend } = makeDynamoClient();
 
@@ -193,7 +192,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 		);
 
 		expect(result.statusCode).toBe(400);
-		expect(mockSoftDeleteTransactItem).not.toHaveBeenCalled();
+		expect(mockGetSoftDeleteTransaction).not.toHaveBeenCalled();
 		expect(mockSend).not.toHaveBeenCalled();
 	});
 });

--- a/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
@@ -106,7 +106,7 @@ afterEach(async () => {
 	}
 });
 
-test('deleteSecondaryUserEndpoint deletes secondary user and supporter product data records', async () => {
+test('deleteSecondaryUserEndpoint soft deletes the secondary user and removes the supporter product data record', async () => {
 	const secondaryUsersBeforeDelete =
 		await secondaryUserRepository.get(secondaryIdentityId);
 	const matchingSecondaryUserBeforeDelete = secondaryUsersBeforeDelete.find(
@@ -128,21 +128,25 @@ test('deleteSecondaryUserEndpoint deletes secondary user and supporter product d
 		stage,
 		secondaryUserRepository,
 		dynamoClient,
-		{
-			subscriptionName,
-			secondaryIdentityId,
-		},
+		subscriptionName,
+		secondaryIdentityId,
+		secondaryIdentityId,
 	);
 
 	expect(result.statusCode).toBe(204);
 
+	// The secondary user record is retained (soft deleted) with cancellation
+	// metadata rather than hard deleted.
 	const secondaryUsersAfterDelete =
 		await secondaryUserRepository.get(secondaryIdentityId);
 	const matchingSecondaryUserAfterDelete = secondaryUsersAfterDelete.find(
 		(record) => record.subscriptionName === subscriptionName,
 	);
-	expect(matchingSecondaryUserAfterDelete).toBeUndefined();
+	expect(matchingSecondaryUserAfterDelete).toBeDefined();
+	expect(matchingSecondaryUserAfterDelete?.cancelledBy).toBe('secondary');
+	expect(matchingSecondaryUserAfterDelete?.cancelledDate).toBeDefined();
 
+	// The supporter product data record (the benefit) is removed immediately.
 	const supporterProductDataRecordsAfterDelete =
 		(await getSupporterRatePlans(stage, secondaryIdentityId)) ?? [];
 	const subscriptionRecordAfterDelete =

--- a/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
@@ -108,7 +108,7 @@ afterEach(async () => {
 
 test('deleteSecondaryUserEndpoint soft deletes the secondary user and removes the supporter product data record', async () => {
 	const secondaryUsersBeforeDelete =
-		await secondaryUserRepository.get(secondaryIdentityId);
+		await secondaryUserRepository.listByIdentity(secondaryIdentityId);
 	const matchingSecondaryUserBeforeDelete = secondaryUsersBeforeDelete.find(
 		(record) => record.subscriptionName === subscriptionName,
 	);
@@ -138,7 +138,7 @@ test('deleteSecondaryUserEndpoint soft deletes the secondary user and removes th
 	// The secondary user record is retained (soft deleted) with cancellation
 	// metadata rather than hard deleted.
 	const secondaryUsersAfterDelete =
-		await secondaryUserRepository.get(secondaryIdentityId);
+		await secondaryUserRepository.listByIdentity(secondaryIdentityId);
 	const matchingSecondaryUserAfterDelete = secondaryUsersAfterDelete.find(
 		(record) => record.subscriptionName === subscriptionName,
 	);

--- a/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
@@ -19,7 +19,7 @@ describe('listSecondaryUsersEndpoint', () => {
 			.fn<Promise<SecondaryUserRecord[]>, [string]>()
 			.mockResolvedValue(secondaryUsers);
 		const secondaryUserRepository = {
-			listNonCancelled: mockListNonCancelled,
+			listNonCancelledBySubscription: mockListNonCancelled,
 		} as unknown as SecondaryUserRepository;
 
 		const result = await listSecondaryUsersEndpoint(
@@ -37,7 +37,7 @@ describe('listSecondaryUsersEndpoint', () => {
 			.fn<Promise<SecondaryUserRecord[]>, [string]>()
 			.mockRejectedValue(new Error('dynamodb error'));
 		const secondaryUserRepository = {
-			listNonCancelled: mockListNonCancelled,
+			listNonCancelledBySubscription: mockListNonCancelled,
 		} as unknown as SecondaryUserRepository;
 
 		const result = await listSecondaryUsersEndpoint(

--- a/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
@@ -5,7 +5,7 @@ import type {
 import { listSecondaryUsersEndpoint } from '../src/listSecondaryUsersEndpoint';
 
 describe('listSecondaryUsersEndpoint', () => {
-	it('returns all secondary users for the subscription', async () => {
+	it('returns all non-cancelled secondary users for the subscription', async () => {
 		const secondaryUsers: SecondaryUserRecord[] = [
 			{
 				subscriptionName: 'A-S00974337',
@@ -15,11 +15,11 @@ describe('listSecondaryUsersEndpoint', () => {
 				expiryDate: 1781218800,
 			},
 		];
-		const mockList = jest
+		const mockListNonCancelled = jest
 			.fn<Promise<SecondaryUserRecord[]>, [string]>()
 			.mockResolvedValue(secondaryUsers);
 		const secondaryUserRepository = {
-			list: mockList,
+			listNonCancelled: mockListNonCancelled,
 		} as unknown as SecondaryUserRepository;
 
 		const result = await listSecondaryUsersEndpoint(
@@ -29,15 +29,15 @@ describe('listSecondaryUsersEndpoint', () => {
 
 		expect(result.statusCode).toBe(200);
 		expect(JSON.parse(result.body)).toEqual({ secondaryUsers });
-		expect(mockList).toHaveBeenCalledWith('A-S00974337');
+		expect(mockListNonCancelled).toHaveBeenCalledWith('A-S00974337');
 	});
 
 	it('returns a 500 response when listing fails', async () => {
-		const mockList = jest
+		const mockListNonCancelled = jest
 			.fn<Promise<SecondaryUserRecord[]>, [string]>()
 			.mockRejectedValue(new Error('dynamodb error'));
 		const secondaryUserRepository = {
-			list: mockList,
+			listNonCancelled: mockListNonCancelled,
 		} as unknown as SecondaryUserRepository;
 
 		const result = await listSecondaryUsersEndpoint(

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -47,7 +47,7 @@ describe('secondaryUserMeEndpoint', () => {
 		users: SecondaryUserRecord[],
 	): SecondaryUserRepository =>
 		({
-			listByIdentity: jest
+			listNonCancelledByIdentity: jest
 				.fn<Promise<SecondaryUserRecord[]>, [string]>()
 				.mockResolvedValue(users),
 		}) as unknown as SecondaryUserRepository;
@@ -114,13 +114,8 @@ describe('secondaryUserMeEndpoint', () => {
 		expect(mockGetAccount).not.toHaveBeenCalled();
 	});
 
-	it('excludes cancelled secondary user records', async () => {
+	it('only requests details for the non-cancelled records returned by the repository', async () => {
 		const activeUser = makeSecondaryUser('A-S00000001');
-		const cancelledUser: SecondaryUserRecord = {
-			...makeSecondaryUser('A-S00000002'),
-			cancelledBy: 'primary',
-			cancelledDate: '2026-07-29T00:00:00.000Z',
-		};
 		mockGetSubscription.mockResolvedValueOnce(makeSubscription('A00000001'));
 		mockGetAccount.mockResolvedValueOnce(
 			makeAccount('Ada', 'Lovelace', 'ada@example.com'),
@@ -128,7 +123,7 @@ describe('secondaryUserMeEndpoint', () => {
 
 		const result = await secondaryUserMeEndpoint(
 			'secondary-id',
-			makeRepository([activeUser, cancelledUser]),
+			makeRepository([activeUser]),
 			zuoraClient,
 		);
 

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -47,7 +47,7 @@ describe('secondaryUserMeEndpoint', () => {
 		users: SecondaryUserRecord[],
 	): SecondaryUserRepository =>
 		({
-			get: jest
+			listByIdentity: jest
 				.fn<Promise<SecondaryUserRecord[]>, [string]>()
 				.mockResolvedValue(users),
 		}) as unknown as SecondaryUserRepository;

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -114,6 +114,41 @@ describe('secondaryUserMeEndpoint', () => {
 		expect(mockGetAccount).not.toHaveBeenCalled();
 	});
 
+	it('excludes cancelled secondary user records', async () => {
+		const activeUser = makeSecondaryUser('A-S00000001');
+		const cancelledUser: SecondaryUserRecord = {
+			...makeSecondaryUser('A-S00000002'),
+			cancelledBy: 'primary',
+			cancelledDate: '2026-07-29T00:00:00.000Z',
+		};
+		mockGetSubscription.mockResolvedValueOnce(makeSubscription('A00000001'));
+		mockGetAccount.mockResolvedValueOnce(
+			makeAccount('Ada', 'Lovelace', 'ada@example.com'),
+		);
+
+		const result = await secondaryUserMeEndpoint(
+			'secondary-id',
+			makeRepository([activeUser, cancelledUser]),
+			zuoraClient,
+		);
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({
+			primaryUsers: [
+				{
+					firstName: 'Ada',
+					lastName: 'Lovelace',
+					workEmail: 'ada@example.com',
+				},
+			],
+		});
+		expect(mockGetSubscription).toHaveBeenCalledTimes(1);
+		expect(mockGetSubscription).toHaveBeenCalledWith(
+			zuoraClient,
+			'A-S00000001',
+		);
+	});
+
 	it('propagates errors thrown while fetching from Zuora', async () => {
 		mockGetSubscription.mockRejectedValue(new Error('Zuora unavailable'));
 

--- a/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItemLambda.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItemLambda.ts
@@ -42,7 +42,7 @@ const buildDependencies = async (): Promise<ProcessItemDependencies> => {
 			subscriptionService.getSubscription(subscriptionName),
 		writePrimaryItem: (item) => dynamoService.writeItem(item),
 		getSecondaryUsers: (subscriptionName) =>
-			secondaryUserRepository.listNonCancelled(subscriptionName),
+			secondaryUserRepository.listNonCancelledBySubscription(subscriptionName),
 		writeSecondaryItem: async (primaryItem, secondaryUser) => {
 			// Create is an upsert, so if the secondary subscription already exists it will be updated
 			await createSecondarySubscription(

--- a/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItemLambda.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItemLambda.ts
@@ -42,7 +42,7 @@ const buildDependencies = async (): Promise<ProcessItemDependencies> => {
 			subscriptionService.getSubscription(subscriptionName),
 		writePrimaryItem: (item) => dynamoService.writeItem(item),
 		getSecondaryUsers: (subscriptionName) =>
-			secondaryUserRepository.list(subscriptionName),
+			secondaryUserRepository.listNonCancelled(subscriptionName),
 		writeSecondaryItem: async (primaryItem, secondaryUser) => {
 			// Create is an upsert, so if the secondary subscription already exists it will be updated
 			await createSecondarySubscription(

--- a/modules/multiple-account/src/secondaryUserRepository.ts
+++ b/modules/multiple-account/src/secondaryUserRepository.ts
@@ -1,6 +1,7 @@
 import {
 	DeleteItemCommand,
 	DynamoDBClient,
+	GetItemCommand,
 	PutItemCommand,
 	QueryCommand,
 	type TransactWriteItem,
@@ -61,7 +62,9 @@ export class SecondaryUserRepository {
 		);
 	}
 
-	async get(secondaryIdentityId: string): Promise<SecondaryUserRecord[]> {
+	async listByIdentity(
+		secondaryIdentityId: string,
+	): Promise<SecondaryUserRecord[]> {
 		const result = await this.client.send(
 			new QueryCommand({
 				TableName: this.tableName,
@@ -77,30 +80,50 @@ export class SecondaryUserRepository {
 		);
 	}
 
-	async getFromSubscription(
+	async listNonCancelledByIdentity(
 		secondaryIdentityId: string,
-		subscriptionName: string,
-	): Promise<SecondaryUserRecord | undefined> {
-		const result = await this.client.send(
-			new QueryCommand({
-				TableName: this.tableName,
-				KeyConditionExpression:
-					'secondaryIdentityId = :secondaryIdentityId AND subscriptionName = :subscriptionName',
-				ExpressionAttributeValues: {
-					':secondaryIdentityId': { S: secondaryIdentityId },
-					':subscriptionName': { S: subscriptionName },
-				},
-			}),
-		);
-		const allSecondaryUsers = (result.Items ?? []).map((item) =>
-			secondaryUserRecordSchema.parse(unmarshall(item)),
-		);
-		return allSecondaryUsers.find(
-			(record) => record.subscriptionName === subscriptionName,
+	): Promise<SecondaryUserRecord[]> {
+		return (await this.listByIdentity(secondaryIdentityId)).filter(
+			(secondaryUser) => secondaryUser.cancelledBy === undefined,
 		);
 	}
 
-	async list(subscriptionName: string): Promise<SecondaryUserRecord[]> {
+	async getBySubscriptionAndIdentity(
+		subscriptionName: string,
+		secondaryIdentityId: string,
+	): Promise<SecondaryUserRecord | undefined> {
+		const result = await this.client.send(
+			new GetItemCommand({
+				TableName: this.tableName,
+				Key: {
+					subscriptionName: { S: subscriptionName },
+					secondaryIdentityId: { S: secondaryIdentityId },
+				},
+			}),
+		);
+		if (!result.Item) {
+			return undefined;
+		}
+		return secondaryUserRecordSchema.parse(unmarshall(result.Item));
+	}
+
+	async getNonCancelledBySubscriptionAndIdentity(
+		subscriptionName: string,
+		secondaryIdentityId: string,
+	): Promise<SecondaryUserRecord | undefined> {
+		const secondaryUser = await this.getBySubscriptionAndIdentity(
+			subscriptionName,
+			secondaryIdentityId,
+		);
+		if (!secondaryUser || secondaryUser.cancelledBy !== undefined) {
+			return undefined;
+		}
+		return secondaryUser;
+	}
+
+	async listBySubscription(
+		subscriptionName: string,
+	): Promise<SecondaryUserRecord[]> {
 		logger.log(
 			`Querying secondary users for primary subscription ${subscriptionName}`,
 		);
@@ -118,10 +141,10 @@ export class SecondaryUserRepository {
 		);
 	}
 
-	async listNonCancelled(
+	async listNonCancelledBySubscription(
 		subscriptionName: string,
 	): Promise<SecondaryUserRecord[]> {
-		return (await this.list(subscriptionName)).filter(
+		return (await this.listBySubscription(subscriptionName)).filter(
 			(secondaryUser) => secondaryUser.cancelledBy === undefined,
 		);
 	}

--- a/modules/multiple-account/src/secondaryUserRepository.ts
+++ b/modules/multiple-account/src/secondaryUserRepository.ts
@@ -7,10 +7,13 @@ import {
 	UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import type { Dayjs } from 'dayjs';
+import dayjs, { type Dayjs } from 'dayjs';
 import { z } from 'zod';
 import { logger } from '@modules/logger/logger';
-import { cancelledBySchema } from '@modules/multiple-account/cancelledBySchema';
+import {
+	type CancelledBy,
+	cancelledBySchema,
+} from '@modules/multiple-account/cancelledBySchema';
 import type { Stage } from '@modules/stage';
 
 export const secondaryUserRecordSchema = z.object({
@@ -20,10 +23,18 @@ export const secondaryUserRecordSchema = z.object({
 	acceptedDate: z.string(),
 	expiryDate: z.number(),
 	cancelledBy: cancelledBySchema.optional(),
+	cancelledDate: z.iso.datetime().optional(),
 });
 
 export function secondaryUserTTLFromPrimarySubscriptionTTL(primaryTTL: Dayjs) {
 	return primaryTTL.add(2, 'weeks').unix();
+}
+
+// When a secondary user is removed we keep the record for a short period
+// (rather than hard deleting it) so we can tell who cancelled it, then let
+// DynamoDB's TTL (expiryDate) remove it automatically.
+export function secondaryUserCancellationTTL(): number {
+	return dayjs().add(2, 'weeks').unix();
 }
 
 export type SecondaryUserRecord = z.infer<typeof secondaryUserRecordSchema>;
@@ -66,6 +77,29 @@ export class SecondaryUserRepository {
 		);
 	}
 
+	async getFromSubscription(
+		secondaryIdentityId: string,
+		subscriptionName: string,
+	): Promise<SecondaryUserRecord | undefined> {
+		const result = await this.client.send(
+			new QueryCommand({
+				TableName: this.tableName,
+				KeyConditionExpression:
+					'secondaryIdentityId = :secondaryIdentityId AND subscriptionName = :subscriptionName',
+				ExpressionAttributeValues: {
+					':secondaryIdentityId': { S: secondaryIdentityId },
+					':subscriptionName': { S: subscriptionName },
+				},
+			}),
+		);
+		const allSecondaryUsers = (result.Items ?? []).map((item) =>
+			secondaryUserRecordSchema.parse(unmarshall(item)),
+		);
+		return allSecondaryUsers.find(
+			(record) => record.subscriptionName === subscriptionName,
+		);
+	}
+
 	async list(subscriptionName: string): Promise<SecondaryUserRecord[]> {
 		logger.log(
 			`Querying secondary users for primary subscription ${subscriptionName}`,
@@ -81,6 +115,14 @@ export class SecondaryUserRepository {
 		);
 		return (result.Items ?? []).map((item) =>
 			secondaryUserRecordSchema.parse(unmarshall(item)),
+		);
+	}
+
+	async listNonCancelled(
+		subscriptionName: string,
+	): Promise<SecondaryUserRecord[]> {
+		return (await this.list(subscriptionName)).filter(
+			(secondaryUser) => secondaryUser.cancelledBy === undefined,
 		);
 	}
 
@@ -109,6 +151,29 @@ export class SecondaryUserRepository {
 				Key: {
 					subscriptionName: { S: subscriptionName },
 					secondaryIdentityId: { S: secondaryIdentityId },
+				},
+			},
+		};
+	}
+
+	getSoftDeleteTransaction(
+		subscriptionName: string,
+		secondaryIdentityId: string,
+		cancelledBy: CancelledBy,
+	): TransactWriteItem {
+		return {
+			Update: {
+				TableName: this.tableName,
+				Key: {
+					subscriptionName: { S: subscriptionName },
+					secondaryIdentityId: { S: secondaryIdentityId },
+				},
+				UpdateExpression:
+					'SET expiryDate = :expiryDate, cancelledBy = :cancelledBy, cancelledDate = :cancelledDate',
+				ExpressionAttributeValues: {
+					':expiryDate': { N: secondaryUserCancellationTTL().toString() },
+					':cancelledBy': { S: cancelledBy },
+					':cancelledDate': { S: dayjs().toISOString() },
 				},
 			},
 		};

--- a/modules/multiple-account/test/secondaryUserRepositoryIntegration.test.ts
+++ b/modules/multiple-account/test/secondaryUserRepositoryIntegration.test.ts
@@ -36,7 +36,7 @@ afterEach(async () => {
 test('SecondaryUserRepository saves and retrieves a record from DynamoDB', async () => {
 	await repo.save(testRecord);
 
-	const saved = await repo.get(testRecord.secondaryIdentityId);
+	const saved = await repo.listByIdentity(testRecord.secondaryIdentityId);
 
 	expect(saved).toEqual([testRecord]);
 });
@@ -51,7 +51,7 @@ test('SecondaryUserRepository updateTTL updates the expiryDate without overwriti
 		newExpiryDate,
 	);
 
-	const saved = await repo.get(testRecord.secondaryIdentityId);
+	const saved = await repo.listByIdentity(testRecord.secondaryIdentityId);
 
 	expect(saved).toEqual([{ ...testRecord, expiryDate: newExpiryDate }]);
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds soft deletion to secondary users in the multiple accounts API.
It follows on from https://github.com/guardian/support-service-lambdas/pull/3715 which did the same for invitations.

## Details
Secondary users can be removed from a subscription with multiple accounts benefits in two ways;
either the primary user may remove them, or they may remove themselves. 

Previously when this happened the secondary user record was hard deleted from the data store, but this made it hard for the data team to provide analysis on which user had removed the record. 

To solve this we are introducing soft deletes for secondary users. When they are removed from the subscription now, the record is not deleted, instead a `cancelledBy` field is set to `primary` or `secondary` and a `cancelledDate` field is set to the current date time in ISO 8601 format. 

We also set the expiryDate field to now + 2 weeks, this is a Dynamo TTL field, meaning that the record will be hard deleted automatically on this date, meaning that we don't need to worry about retaining PII beyond that point but the data team have sufficient time to record the identity of the user who deleted the record.

The diff is slightly bigger than it would otherwise be because I refactored some names on the secondaryUserRepository class to make them consistent. Mostly ensuring that 'get' methods return a single items and 'list' methods return an array of items.

### [Asana Card](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216303741013593)

## Testing - all carried out on CODE
### Create a new invitation
Request:

```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/invitation' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 112809589' \ # primary user
--header 'Content-Type: application/json' \
--header 'Authorization: ••••••' \
--data-raw '{
  "subscriptionName": "A-S00974337",
  "secondaryUserEmail": "test@thegulocal.com"
}'
```

Response:
`200`
```json
{
    "invitationCode": "FRcCyefqP3qf"
}
```

### Accept that invitation as the secondary user
Request:
```shell
curl --location --request POST 'https://multiple-account-api-code.support.guardianapis.com/invitation/twT95D1SFKBd/accept' \
--header 'x-api-key: [API_KEY]' \
--header 'Authorization: ••••••' # secondary user authenticated with Okta
```

Response:
```json
{
    "identityId": "21841960",
    "secondarySubscriptionName": "A-S00974337-21841960"
}
```

### Delete the invitation as the primary user
Request:
```shell
curl --location --request DELETE 'https://multiple-account-api-code.support.guardianapis.com/subscriptions/A-S00974337/secondary-users/21841960' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 112809589' # primary user
```

Response: `204 No Content` 

### Try to get the invitation
Request:
```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/invitation/twT95D1SFKBd' \
--header 'x-api-key: [API_KEY]' 
```

Response
`404`
```json
{
    "message": "Not Found"
}
```

### View the secondary user list as the primary user
Request:
```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/subscriptions/A-S00974337/mma-primary' \
--header 'x-api-key: [API_KEY]' \
--header 'x-identity-id: 112809589'
```

Request:
`200`
```Json
{
    "invitations": [],
    "secondaryUsers": []
}
```
Cancelled secondary users should not show up in the MMA response.