### PR TITLE
use logger for 500 error catches

### DIFF
--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { z } from 'zod';
 import { ValidationError } from '@modules/errors';
-import { prettyPrint } from '@modules/prettyPrint';
+import { logger } from '@modules/logger/logger';
 import { stringify } from '@modules/stringify';
 
 function jsonResponse(message: string, statusCode: number) {
@@ -64,13 +64,9 @@ export function created<T extends Record<string, unknown>>(
 
 export function buildErrorResponse(error: unknown): APIGatewayProxyResult {
 	if (error instanceof ValidationError) {
-		console.log(
-			`Handler returned 400 response due to validation error: ${prettyPrint(error)}`,
-		);
+		logger.log(`Handler returned 400 response due to validation error`, error);
 		return badRequest(error.message);
 	}
-	console.log(
-		`Handler returned 500 response due to unexpected error: ${prettyPrint(error)}`,
-	);
+	logger.log(`Handler returned 500 response due to unexpected error`, error);
 	return internalServerError();
 }


### PR DESCRIPTION
I noticed the product-switch-api is failing with 500 errors with no information on the caught exception

e.g. https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fproduct-switch-api-PROD/log-events$3Fstart$3D1785792420000$26filterPattern$3D$26end$3D1785792540000
<img width="2745" height="662" alt="image" src="https://github.com/user-attachments/assets/1b94698d-5eb6-413c-be52-3bbfe2fcdda2" />

Unfortunately that's no use for debugging.
It uses the `prettyPrint` module in common which just stringifys the object.
https://github.com/guardian/support-service-lambdas/blob/6aad4999eb4c799edacaee24a47774083843626b/modules/prettyPrint.ts#L1-L3

This PR changes it to use the logger, which handles Error more carefully and would hopefully produce some useful output in this case:
https://github.com/guardian/support-service-lambdas/blob/79fe5c96bf5bac8226f166198a4ccace0a88894a/modules/logger/src/prettyPrint.ts#L5-L12

This will also give us proper line number and context information (i.e. A-S number) for each log message.