### PR TITLE
Add subscription name to secondary-user/me endpoint

### DIFF
--- a/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
+++ b/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
@@ -10,14 +10,19 @@ import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraAccount } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 
+const subscriptionWithPrimaryUserInformationSchema = z.object({
+	subscriptionName: z.string(),
+	firstName: z.string(),
+	lastName: z.string(),
+	workEmail: z.string(),
+});
+
+type SubscriptionWithPrimaryUserInformation = z.infer<
+	typeof subscriptionWithPrimaryUserInformationSchema
+>;
+
 const responseSchema = z.object({
-	primaryUsers: z
-		.object({
-			firstName: z.string(),
-			lastName: z.string(),
-			workEmail: z.string(),
-		})
-		.array(),
+	subscriptions: z.array(subscriptionWithPrimaryUserInformationSchema),
 });
 
 export async function secondaryUserMeEndpoint(
@@ -28,28 +33,32 @@ export async function secondaryUserMeEndpoint(
 	const secondaryUsers: SecondaryUserRecord[] =
 		await secondaryUserRepository.listNonCancelledByIdentity(identityId);
 
-	const primaryUsers = await Promise.all(
+	const subscriptionsWithPrimaryUserInformation = await Promise.all(
 		secondaryUsers.map(async (secondaryUser) =>
-			getPrimaryUserInformationForSubscription(
+			getSubscriptionWithPrimaryUserInformation(
 				zuoraClient,
 				secondaryUser.subscriptionName,
 			),
 		),
 	);
-	return ok({ primaryUsers }, responseSchema);
+	return ok(
+		{ subscriptions: subscriptionsWithPrimaryUserInformation },
+		responseSchema,
+	);
 }
 
-async function getPrimaryUserInformationForSubscription(
+async function getSubscriptionWithPrimaryUserInformation(
 	zuoraClient: ZuoraClient,
 	subscriptionName: string,
-) {
+): Promise<SubscriptionWithPrimaryUserInformation> {
 	const subscription = await getSubscription(zuoraClient, subscriptionName);
 	const account: ZuoraAccount = await getAccount(
 		zuoraClient,
 		subscription.accountNumber,
 	);
-	const { zipCode, ...billToContactWithoutZipCode } = account.billToContact;
+	const { zipCode, ...firstNameLastNameAndEmail } = account.billToContact;
 	return {
-		...billToContactWithoutZipCode,
+		subscriptionName,
+		...firstNameLastNameAndEmail,
 	};
 }

--- a/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
+++ b/handlers/multiple-account-api/src/secondaryUserMeEndpoint.ts
@@ -56,9 +56,11 @@ async function getSubscriptionWithPrimaryUserInformation(
 		zuoraClient,
 		subscription.accountNumber,
 	);
-	const { zipCode, ...firstNameLastNameAndEmail } = account.billToContact;
+	const { firstName, lastName, workEmail } = account.billToContact;
 	return {
 		subscriptionName,
-		...firstNameLastNameAndEmail,
+		firstName,
+		lastName,
+		workEmail,
 	};
 }

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -76,13 +76,15 @@ describe('secondaryUserMeEndpoint', () => {
 
 		expect(result.statusCode).toBe(200);
 		expect(JSON.parse(result.body)).toEqual({
-			primaryUsers: [
+			subscriptions: [
 				{
+					subscriptionName: 'A-S00000001',
 					firstName: 'Ada',
 					lastName: 'Lovelace',
 					workEmail: 'ada@example.com',
 				},
 				{
+					subscriptionName: 'A-S00000002',
 					firstName: 'Alan',
 					lastName: 'Turing',
 					workEmail: 'alan@example.com',
@@ -109,7 +111,7 @@ describe('secondaryUserMeEndpoint', () => {
 		);
 
 		expect(result.statusCode).toBe(200);
-		expect(JSON.parse(result.body)).toEqual({ primaryUsers: [] });
+		expect(JSON.parse(result.body)).toEqual({ subscriptions: [] });
 		expect(mockGetSubscription).not.toHaveBeenCalled();
 		expect(mockGetAccount).not.toHaveBeenCalled();
 	});
@@ -129,8 +131,9 @@ describe('secondaryUserMeEndpoint', () => {
 
 		expect(result.statusCode).toBe(200);
 		expect(JSON.parse(result.body)).toEqual({
-			primaryUsers: [
+			subscriptions: [
 				{
+					subscriptionName: 'A-S00000001',
 					firstName: 'Ada',
 					lastName: 'Lovelace',
 					workEmail: 'ada@example.com',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR changes the structure of the response from the /secondary-users/me endpoint which was first introduced in: https://github.com/guardian/support-service-lambdas/pull/3697

Manage-frontend needs the subscription name (number) of the subscription which a secondary user belongs to so that it can remove them from it if needed. This field wasn't present in the previous response but this PR adds it.

## Authentication 
Authentication has not changed in this PR, it is via an Okta JWT token in the Authorization header. This is to prevent enumeration of identity ids - the signed in user will only be able to retrieve a list for their own identity id.

## Testing
Testing this endpoint is a little more complicated than some others because it requires an Okta Authorization header. 

To get one of these follow the steps in [this README](https://github.com/guardian/identity/tree/main/docs/generating_tokens_locally) to generate a header in Postman or Hopscotch. 

You can then make your request to secondary users endpoint:
```
## Example request 

```shell
curl --location --request GET 'https://multiple-account-api-code.support.guardianapis.com/secondary-user/me' \
--header 'x-api-key: [API_KEY]' \
--header 'Content-Type: application/json' \
--header 'Authorization: ••••••' \
```

The **OLD** version of this would have returned:

```json
{
    "primaryUsers": [
        {
            "firstName": "Test",
            "lastName": "User"
            "workEmail": "test.user@thegulocal.com"
        }
    ]
}
```

The **NEW** version returns:
```json
{
    "subscriptions": [
        {
            "subscriptionName": "A-S00000001",
            "firstName": "Test",
            "lastName": "User",
            "workEmail": "test.user@thegulocal.com"
        }
    ]
}
```

