### PR TITLE
Allow sending emails with local dev role

### DIFF
--- a/cdk/lib/__snapshots__/iam-policies.test.ts.snap
+++ b/cdk/lib/__snapshots__/iam-policies.test.ts.snap
@@ -364,6 +364,29 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
               "Effect": "Allow",
               "Resource": "arn:aws:s3:::contributions-ticker/CODE/*",
             },
+            {
+              "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:SendMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sqs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":braze-emails-CODE",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -737,6 +760,29 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
               "Action": "s3:GetObject",
               "Effect": "Allow",
               "Resource": "arn:aws:s3:::contributions-ticker/CODE/*",
+            },
+            {
+              "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:SendMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sqs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":braze-emails-CODE",
+                  ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -2,6 +2,7 @@ import type { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuDeveloperPolicyExperimental } from '@guardian/cdk/lib/experimental/constructs/iam/policies';
 import { type App } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import type { SrQueueName } from './cdk/policies';
 import type { SrStageNames } from './cdk/SrStack';
 import { SrStack } from './cdk/SrStack';
 
@@ -34,6 +35,18 @@ export class IamPolicies extends SrStack {
 					resources: ['*'],
 				}),
 				new AllowS3GetPolicy('contributions-ticker', ['CODE/*']),
+				new AllowSqsSendPolicy(this, 'braze-emails'),
+			],
+		});
+	}
+}
+
+class AllowSqsSendPolicy extends PolicyStatement {
+	constructor(scope: GuStack, queueName: SrQueueName) {
+		super({
+			actions: ['sqs:GetQueueUrl', 'sqs:SendMessage'],
+			resources: [
+				`arn:aws:sqs:${scope.region}:${scope.account}:${queueName}-CODE`,
 			],
 		});
 	}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The local development role used to run membership applications locally needs permission to access the braze emails SQS queue if we are going to be able to test sending emails locally.