### PR TITLE
Add primary user data to invitation table

### DIFF
--- a/handlers/multiple-account-api/src/createInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/createInvitationEndpoint.ts
@@ -78,6 +78,8 @@ export const createInvitationEndpoint =
 			subscriptionName: zuoraSubscription.subscriptionNumber,
 			invitationCode,
 			primaryIdentityId: account.basicInfo.identityId,
+			primaryUserFirstName: account.billToContact.firstName,
+			primiaryUserEmail: account.billToContact.workEmail,
 			secondaryUserEmail: body.secondaryUserEmail,
 			secondaryIdentityId,
 			invitedDate: zuoraDateFormat(now),

--- a/handlers/multiple-account-api/src/createInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/createInvitationEndpoint.ts
@@ -79,7 +79,7 @@ export const createInvitationEndpoint =
 			invitationCode,
 			primaryIdentityId: account.basicInfo.identityId,
 			primaryUserFirstName: account.billToContact.firstName,
-			primiaryUserEmail: account.billToContact.workEmail,
+			primaryUserEmail: account.billToContact.workEmail,
 			secondaryUserEmail: body.secondaryUserEmail,
 			secondaryIdentityId,
 			invitedDate: zuoraDateFormat(now),

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -28,7 +28,7 @@ export const nonCancelledInvitationRecordSchema = z.object({
 	invitationCode: z.string(),
 	primaryIdentityId: z.string(),
 	primaryUserFirstName: z.string(),
-	primiaryUserEmail: z.string(),
+	primaryUserEmail: z.string(),
 	secondaryUserEmail: z.string(),
 	secondaryIdentityId: z.string(),
 	invitedDate: z.string(),

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -27,6 +27,8 @@ export const nonCancelledInvitationRecordSchema = z.object({
 	subscriptionName: z.string(),
 	invitationCode: z.string(),
 	primaryIdentityId: z.string(),
+	primaryUserFirstName: z.string(),
+	primiaryUserEmail: z.string(),
 	secondaryUserEmail: z.string(),
 	secondaryIdentityId: z.string(),
 	invitedDate: z.string(),

--- a/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteInvitationIntegration.test.ts
@@ -30,6 +30,8 @@ const buildRecord = (
 	subscriptionName,
 	invitationCode,
 	primaryIdentityId: '12345678',
+	primaryUserFirstName: 'Joe',
+	primaryUserEmail: 'integration-test-joe@thegulocal.com',
 	secondaryUserEmail: 'integration-test@thegulocal.com',
 	secondaryIdentityId: '87654321',
 	invitedDate: new Date().toISOString(),

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -52,6 +52,8 @@ const mockInvitations: InvitationRecord[] = [
 		subscriptionName: 'A-S12345',
 		invitationCode: 'invitation-code',
 		primaryIdentityId: '99999999',
+		primaryUserFirstName: 'Joe',
+		primaryUserEmail: 'integration-test-joe@thegulocal.com',
 		secondaryUserEmail: 'integration-test@thegulocal.com',
 		secondaryIdentityId: '8888888',
 		invitedDate: zuoraDateFormat(testDay),

--- a/handlers/multiple-account-api/test/invitationRepositoryIntegration.test.ts
+++ b/handlers/multiple-account-api/test/invitationRepositoryIntegration.test.ts
@@ -18,6 +18,8 @@ const testRecord: InvitationRecord = {
 	subscriptionName: 'A-S00099999',
 	invitationCode: 'it-test-code',
 	primaryIdentityId: '12345678',
+	primaryUserFirstName: 'Joe',
+	primiaryUserEmail: 'integration-test-joe@thegulocal.com',
 	secondaryUserEmail: 'integration-test@thegulocal.com',
 	secondaryIdentityId: '87654321',
 	invitedDate: new Date().toISOString(),

--- a/handlers/multiple-account-api/test/invitationRepositoryIntegration.test.ts
+++ b/handlers/multiple-account-api/test/invitationRepositoryIntegration.test.ts
@@ -19,7 +19,7 @@ const testRecord: InvitationRecord = {
 	invitationCode: 'it-test-code',
 	primaryIdentityId: '12345678',
 	primaryUserFirstName: 'Joe',
-	primiaryUserEmail: 'integration-test-joe@thegulocal.com',
+	primaryUserEmail: 'integration-test-joe@thegulocal.com',
 	secondaryUserEmail: 'integration-test@thegulocal.com',
 	secondaryIdentityId: '87654321',
 	invitedDate: new Date().toISOString(),

--- a/handlers/multiple-account-api/test/listInvitationsEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listInvitationsEndpoint.test.ts
@@ -11,6 +11,8 @@ describe('listInvitationsEndpoint', () => {
 				subscriptionName: 'A-S00974337',
 				invitationCode: 'RpwR62kMnAxe',
 				primaryIdentityId: 'primary-id',
+				primaryUserFirstName: 'Joe',
+				primaryUserEmail: 'integration-test-joe@thegulocal.com',
 				secondaryUserEmail: 'integration-test@thegulocal.com',
 				secondaryIdentityId: 'secondary-id',
 				invitedDate: '2026-06-12',


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add two new fields to invitation record so we don't have to make further  requests to Zuora:
- Primary user first name
- Primary user email
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
Create a invitation and check dynamoDB table to see new fields being stored.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Since invitation records only last for 1 month, we do not expect this to be an issue.