### PR TITLE
Turn off dry run for the scrub job

### DIFF
--- a/cdk/lib/__snapshots__/scrub-non-tokenised-payment-methods.test.ts.snap
+++ b/cdk/lib/__snapshots__/scrub-non-tokenised-payment-methods.test.ts.snap
@@ -1502,7 +1502,7 @@ exports[`The ScrubNonTokenisedPaymentMethods stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "scrub-non-tokenised-payment-methods",
-            "DRY_RUN": "true",
+            "DRY_RUN": "false",
             "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "PROD",
@@ -1761,7 +1761,7 @@ exports[`The ScrubNonTokenisedPaymentMethods stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "scrub-non-tokenised-payment-methods",
-            "DRY_RUN": "true",
+            "DRY_RUN": "false",
             "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "PROD",
@@ -2616,7 +2616,7 @@ exports[`The ScrubNonTokenisedPaymentMethods stack matches the snapshot 2`] = `
         "Environment": {
           "Variables": {
             "APP": "scrub-non-tokenised-payment-methods",
-            "DRY_RUN": "true",
+            "DRY_RUN": "false",
             "NODE_OPTIONS": "--enable-source-maps",
             "STACK": "support",
             "STAGE": "PROD",

--- a/cdk/lib/scrub-non-tokenised-payment-methods.ts
+++ b/cdk/lib/scrub-non-tokenised-payment-methods.ts
@@ -55,6 +55,13 @@ export class ScrubNonTokenisedPaymentMethods extends SrStack {
 		);
 
 		/*
+		 * The work list, the map's result files, the lifecycle rule and the two
+		 * policies that grant access to them only work together while they all
+		 * name the same prefix, so it is named once.
+		 */
+		const executionsPrefix = 'executions';
+
+		/*
 		 * The other buckets in this repo rewrite the same file every run, so they
 		 * never grow. This one keys everything on the execution start time, which
 		 * is what makes a past run findable from the console, and that means a new
@@ -67,7 +74,7 @@ export class ScrubNonTokenisedPaymentMethods extends SrStack {
 			lifecycleRules: [
 				{
 					id: 'expire-execution-files',
-					prefix: 'executions/',
+					prefix: `${executionsPrefix}/`,
 					expiration: Duration.days(90),
 				},
 			],
@@ -76,6 +83,16 @@ export class ScrubNonTokenisedPaymentMethods extends SrStack {
 		const snsTopicArn = `arn:aws:sns:${this.region}:${this.account}:alarms-handler-topic-${this.stage}`;
 
 		const paymentMethodsFileName = 'payment-methods-to-scrub.json';
+
+		/*
+		 * The map reads back the file the first lambda writes, so the two have to
+		 * agree on the key down to the character. Building it once is what stops
+		 * them drifting apart.
+		 */
+		const paymentMethodsFileKey = JsonPath.format(
+			`${executionsPrefix}/{}/${paymentMethodsFileName}`,
+			JsonPath.stringAt('$$.Execution.StartTime'),
+		);
 
 		/*
 		 * This lambda is given an explicit role only so its name stays short
@@ -105,7 +122,7 @@ export class ScrubNonTokenisedPaymentMethods extends SrStack {
 		lambdaRole.addToPolicy(
 			new PolicyStatement({
 				actions: ['s3:PutObject'],
-				resources: [bucket.arnForObjects('executions/*')],
+				resources: [bucket.arnForObjects(`${executionsPrefix}/*`)],
 			}),
 		);
 
@@ -140,10 +157,7 @@ export class ScrubNonTokenisedPaymentMethods extends SrStack {
 			{
 				lambdaFunction: getPaymentMethodsToScrubLambda,
 				payload: TaskInput.fromObject({
-					filePath: JsonPath.format(
-						`executions/{}/${paymentMethodsFileName}`,
-						JsonPath.stringAt('$$.Execution.StartTime'),
-					),
+					filePath: paymentMethodsFileKey,
 				}),
 			},
 		);
@@ -187,7 +201,7 @@ export class ScrubNonTokenisedPaymentMethods extends SrStack {
 		checkRunMadeProgressLambda.addPolicies(
 			new GuGetS3ObjectsPolicy(this, 'ReadMapRunResults', {
 				bucketName: bucketName(stage),
-				paths: ['executions/*'],
+				paths: [`${executionsPrefix}/*`],
 			}),
 		);
 
@@ -200,16 +214,13 @@ export class ScrubNonTokenisedPaymentMethods extends SrStack {
 				toleratedFailurePercentage: 100,
 				itemReader: new S3JsonItemReader({
 					bucket,
-					key: JsonPath.format(
-						`executions/{}/${paymentMethodsFileName}`,
-						JsonPath.stringAt('$$.Execution.StartTime'),
-					),
+					key: paymentMethodsFileKey,
 				}),
 				itemBatcher: new ItemBatcher({ maxItemsPerBatch: 1 }),
 				resultWriterV2: new ResultWriterV2({
 					bucket,
 					prefix: JsonPath.format(
-						`executions/{}`,
+						`${executionsPrefix}/{}`,
 						JsonPath.stringAt('$$.Execution.StartTime'),
 					),
 				}),

--- a/cdk/lib/scrub-non-tokenised-payment-methods.ts
+++ b/cdk/lib/scrub-non-tokenised-payment-methods.ts
@@ -130,11 +130,15 @@ export class ScrubNonTokenisedPaymentMethods extends SrStack {
 			architecture: Architecture.ARM_64,
 			timeout: Duration.minutes(3),
 			environment: {
-				// Log what would happen without touching Zuora. Both lambdas read it:
-				// the first one skips its no-progress check, which would otherwise
-				// fire every day since a dry run never changes the work list.
-				// Flip to false in a follow-up once a PROD run has been eyeballed.
-				DRY_RUN: 'true',
+				// Logs what would happen without touching Zuora. It also turns off
+				// the no-progress check, which would otherwise fire every day, since
+				// a dry run never changes the work list.
+				//
+				// CODE can only ever dry run: the work list is read from the mirror
+				// of PROD, so none of it exists in the CODE Zuora tenant and every
+				// item is skipped. Left live there, the no-progress check would fail
+				// every run for a reason that says nothing about the code.
+				DRY_RUN: String(this.stage !== 'PROD'),
 			},
 		};
 


### PR DESCRIPTION
### What does this change?

The scrub job has been in dry run since it was deployed. The first PROD run went out this morning and got through all 500 payment methods: 500 would have been scrubbed, none skipped, none failed. So this turns dry run off and lets it do the work.

CODE stays in dry run. The work list is read from the mirror of PROD, so none of it exists in the CODE Zuora tenant and every item is skipped there. Left live, the no-progress check would fail every CODE run for a reason that says nothing about the code.

There is also the tidy-up John asked for on #3748. The executions prefix was written out six times and the key the map reads back was built twice, so both are named once now. That is the first commit, and it is worth reading on its own: it changes no snapshot at all.

### How has this change been tested?

Gates pass locally. The synthesised template says the rest better than I can. The only difference in PROD is DRY_RUN on the three lambdas, and CODE is byte for byte unchanged, which is what makes the prefix change a pure rename.

### How can we measure success?

Tomorrow's run should scrub 500, and the backlog should drop from 19,612 as it stood this morning to around 19,112. Scrubbed cards stop coming back from the query, so if that number does not move, the no-progress check fails the run and the alarm fires.

At 500 a day against 4 to 6 becoming eligible, the backlog should clear in about 40 days.

### Have we considered potential risks?

This is the first time the no-progress check is live, since it is skipped in dry run. It has never actually run, so tomorrow morning is its first real exercise.

The scrub is not reversible. What limits it is that every item is re-read from Zuora before it is touched, and the run is capped at 500 a day, so a bad day costs 500 rows rather than the whole backlog.