### PR TITLE
Send invitation redeem confirmation email

### DIFF
--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -13,10 +13,7 @@ import {
 } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import { getSupporterRatePlan } from '@modules/supporter-product-data/supporterProductData';
-import { getAccount } from '@modules/zuora/account';
-import { getSubscription } from '@modules/zuora/subscription';
 import { zuoraDateFormat } from '@modules/zuora/utils';
-import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { sendAcceptInvitationEmail } from './emails/acceptInvitationEmail';
 import type { InvitationRepository } from './invitationRepository';
 
@@ -25,7 +22,6 @@ export const acceptInvitationEndpoint = async (
 	invitationRepository: InvitationRepository,
 	secondaryUserRepository: SecondaryUserRepository,
 	dynamoClient: DynamoDBClient,
-	zuoraClient: ZuoraClient,
 	signedInUserId: string,
 	invitationCode: string,
 ) => {
@@ -93,20 +89,10 @@ export const acceptInvitationEndpoint = async (
 			today,
 		);
 
-		const zuoraSubscription = await getSubscription(
-			zuoraClient,
-			invitation.subscriptionName,
-		);
-		const account = await getAccount(
-			zuoraClient,
-			zuoraSubscription.accountNumber,
-		);
-
 		await sendAcceptInvitationEmail(
 			stage,
-			account.billToContact.firstName,
-			account.billToContact.workEmail,
-			invitation.secondaryUserFirstName,
+			invitation.primaryUserFirstName,
+			invitation.primaryUserEmail,
 			invitation.secondaryUserEmail,
 			invitation.secondaryIdentityId,
 		);

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -13,7 +13,11 @@ import {
 } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import { getSupporterRatePlan } from '@modules/supporter-product-data/supporterProductData';
+import { getAccount } from '@modules/zuora/account';
+import { getSubscription } from '@modules/zuora/subscription';
 import { zuoraDateFormat } from '@modules/zuora/utils';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { sendAcceptInvitationEmail } from './emails/acceptInvitationEmail';
 import type { InvitationRepository } from './invitationRepository';
 
 export const acceptInvitationEndpoint = async (
@@ -21,6 +25,7 @@ export const acceptInvitationEndpoint = async (
 	invitationRepository: InvitationRepository,
 	secondaryUserRepository: SecondaryUserRepository,
 	dynamoClient: DynamoDBClient,
+	zuoraClient: ZuoraClient,
 	signedInUserId: string,
 	invitationCode: string,
 ) => {
@@ -88,7 +93,23 @@ export const acceptInvitationEndpoint = async (
 			today,
 		);
 
-		// TODO: email?
+		const zuoraSubscription = await getSubscription(
+			zuoraClient,
+			invitation.subscriptionName,
+		);
+		const account = await getAccount(
+			zuoraClient,
+			zuoraSubscription.accountNumber,
+		);
+
+		await sendAcceptInvitationEmail(
+			stage,
+			account.billToContact.firstName,
+			account.billToContact.workEmail,
+			invitation.secondaryUserFirstName,
+			invitation.secondaryUserEmail,
+			invitation.secondaryIdentityId,
+		);
 		return ok({
 			identityId: secondaryIdentityId,
 			secondarySubscriptionName,

--- a/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
+++ b/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
@@ -1,0 +1,29 @@
+import {
+	buildEmailMessage,
+	DataExtensionNames,
+	sendEmail,
+} from '@modules/email/email';
+import type { Stage } from '@modules/stage';
+
+export async function sendAcceptInvitationEmail(
+	stage: Stage,
+	primaryUserFirstName: string,
+	primaryUserEmail: string,
+	secondaryUserFirstName: string,
+	secondaryUserEmail: string,
+	secondaryUserIdentityId: string,
+) {
+	const dataAttributes = {
+		primary_user_first_name: primaryUserFirstName,
+		primary_user_email: primaryUserEmail,
+		secondary_user_first_name: secondaryUserFirstName,
+	};
+
+	const emailMessage = buildEmailMessage(
+		secondaryUserEmail,
+		DataExtensionNames.multipleAccountEmails.secondaryUser.invitationRedeemed,
+		dataAttributes,
+		{ IdentityUserId: secondaryUserIdentityId },
+	);
+	await sendEmail(stage, emailMessage);
+}

--- a/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
+++ b/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
@@ -9,14 +9,12 @@ export async function sendAcceptInvitationEmail(
 	stage: Stage,
 	primaryUserFirstName: string,
 	primaryUserEmail: string,
-	secondaryUserFirstName: string,
 	secondaryUserEmail: string,
 	secondaryUserIdentityId: string,
 ) {
 	const dataAttributes = {
 		primary_user_first_name: primaryUserFirstName,
 		primary_user_email: primaryUserEmail,
-		secondary_user_first_name: secondaryUserFirstName,
 	};
 
 	const emailMessage = buildEmailMessage(

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -114,6 +114,7 @@ export const handler: Handler = Router([
 				invitationRepository,
 				secondaryUserRepository,
 				dynamoClient,
+				await lazyZuoraClient.get(),
 				maybeAuthenticatedEvent.userDetails.identityId,
 				path.invitationCode,
 			);

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -114,7 +114,6 @@ export const handler: Handler = Router([
 				invitationRepository,
 				secondaryUserRepository,
 				dynamoClient,
-				await lazyZuoraClient.get(),
 				maybeAuthenticatedEvent.userDetails.identityId,
 				path.invitationCode,
 			);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Sends a redeem confirmation email after invitation acceptance to the secondary user.


## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

Currently this email can't be tested  because it is not completely set up in Braze.