### PR TITLE
Store the invitation code on the secondary user

### DIFF
--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -58,6 +58,7 @@ export const acceptInvitationEndpoint = async (
 			expiryDate: secondaryUserTTLFromPrimarySubscriptionTTL(
 				parentSupporterProductDataRecord.termEndDate,
 			),
+			invitationCode,
 		};
 
 		const createSecondaryUserTransaction =

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -22,6 +22,7 @@ const makeSecondaryUser = (
 	primaryIdentityId,
 	acceptedDate: '2026-06-12',
 	expiryDate: 1781218800,
+	invitationCode: 'RpwR62kMnAxe',
 	...overrides,
 });
 

--- a/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
@@ -13,6 +13,7 @@ describe('listSecondaryUsersEndpoint', () => {
 				primaryIdentityId: 'primary-id',
 				acceptedDate: '2026-06-12',
 				expiryDate: 1781218800,
+				invitationCode: 'RpwR62kMnAxe',
 			},
 		];
 		const mockListNonCancelled = jest

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -41,6 +41,7 @@ describe('secondaryUserMeEndpoint', () => {
 		primaryIdentityId: 'primary-id',
 		acceptedDate: '2026-06-12',
 		expiryDate: 1781218800,
+		invitationCode: 'RpwR62kMnAxe',
 	});
 
 	const makeRepository = (

--- a/handlers/supporter-product-data-lambdas/test/processSupporterRatePlanItemLambda.test.ts
+++ b/handlers/supporter-product-data-lambdas/test/processSupporterRatePlanItemLambda.test.ts
@@ -108,6 +108,7 @@ describe('processSupporterRatePlanItemLambda', () => {
 				primaryIdentityId: 'primary-id-1',
 				acceptedDate: '2026-01-01',
 				expiryDate: dayjs('2026-01-01').add(2, 'weeks').unix(),
+				invitationCode: 'invitation-code-1',
 			},
 			{
 				subscriptionName: 'sub-1',
@@ -115,6 +116,7 @@ describe('processSupporterRatePlanItemLambda', () => {
 				primaryIdentityId: 'primary-id-1',
 				acceptedDate: '2026-01-02',
 				expiryDate: dayjs('2026-01-02').add(2, 'weeks').unix(),
+				invitationCode: 'invitation-code-2',
 			},
 		];
 		const getSecondaryUsers = jest.fn(() => Promise.resolve(secondaryUsers));

--- a/modules/multiple-account/src/secondaryUserRepository.ts
+++ b/modules/multiple-account/src/secondaryUserRepository.ts
@@ -25,6 +25,7 @@ export const secondaryUserRecordSchema = z.object({
 	expiryDate: z.number(),
 	cancelledBy: cancelledBySchema.optional(),
 	cancelledDate: z.iso.datetime().optional(),
+	invitationCode: z.string(),
 });
 
 export function secondaryUserTTLFromPrimarySubscriptionTTL(primaryTTL: Dayjs) {

--- a/modules/multiple-account/test/secondaryUserRepositoryIntegration.test.ts
+++ b/modules/multiple-account/test/secondaryUserRepositoryIntegration.test.ts
@@ -19,6 +19,7 @@ const testRecord = {
 	primaryIdentityId: '12345678',
 	acceptedDate: new Date().toISOString(),
 	expiryDate: dayjs().add(10, 'seconds').toDate().getTime(),
+	invitationCode: 'it-test-invitation-code',
 };
 
 const repo = new SecondaryUserRepository(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The data design team have asked us to add the invitation code as an additional field on a secondary user record. This is so that they can distinguish between records if the user is removed and then reinvited.

## [Asana Ticket](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1217280945466071)