### PR TITLE
Udpate timestamps on invitation record to be iso datetime

### DIFF
--- a/handlers/multiple-account-api/README.md
+++ b/handlers/multiple-account-api/README.md
@@ -104,7 +104,7 @@ Example path: /subscriptions/A-S00974337/secondary-users
       "subscriptionName": "A-S00974337",
       "secondaryIdentityId": "30067890",
       "primaryIdentityId": "20012345",
-      "acceptedDate": "2026-06-12"
+      "acceptedDate": "2026-06-12T00:00:00.000Z"
     }
   ]
 }

--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -569,7 +569,8 @@ components:
           example: '30067890'
         invitedDate:
           type: string
-          example: '2026-06-12'
+          format: date-time
+          example: '2026-06-12T00:00:00.000Z'
         expiryDate:
           type: number
           example: 1781222400000
@@ -614,7 +615,8 @@ components:
           example: '20012345'
         acceptedDate:
           type: string
-          example: '2026-06-12'
+          format: date-time
+          example: '2026-06-12T00:00:00.000Z'
     SecondaryUserWithName:
       type: object
       additionalProperties: false
@@ -639,7 +641,8 @@ components:
           example: '20012345'
         acceptedDate:
           type: string
-          example: '2026-06-12'
+          format: date-time
+          example: '2026-06-12T00:00:00.000Z'
         displayName:
           type: string
           example: jsmith92

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -13,7 +13,6 @@ import {
 } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import { getSupporterRatePlan } from '@modules/supporter-product-data/supporterProductData';
-import { zuoraDateFormat } from '@modules/zuora/utils';
 import { sendAcceptInvitationEmail } from './emails/acceptInvitationEmail';
 import type { InvitationRepository } from './invitationRepository';
 

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -55,7 +55,7 @@ export const acceptInvitationEndpoint = async (
 			subscriptionName,
 			secondaryIdentityId,
 			primaryIdentityId,
-			acceptedDate: zuoraDateFormat(today),
+			acceptedDate: today.toISOString(),
 			expiryDate: secondaryUserTTLFromPrimarySubscriptionTTL(
 				parentSupporterProductDataRecord.termEndDate,
 			),

--- a/handlers/multiple-account-api/src/createInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/createInvitationEndpoint.ts
@@ -12,7 +12,6 @@ import type {
 	ZuoraAccount,
 	ZuoraSubscription,
 } from '@modules/zuora/types/objects';
-import { zuoraDateFormat } from '@modules/zuora/utils';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import type { InvitationRepository } from './invitationRepository';
@@ -82,7 +81,7 @@ export const createInvitationEndpoint =
 			primaryUserEmail: account.billToContact.workEmail,
 			secondaryUserEmail: body.secondaryUserEmail,
 			secondaryIdentityId,
-			invitedDate: zuoraDateFormat(now),
+			invitedDate: now.toISOString(),
 			expiryDate: now.add(1, 'month').toDate().getTime(),
 		});
 

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -31,7 +31,7 @@ export const nonCancelledInvitationRecordSchema = z.object({
 	primaryUserEmail: z.string(),
 	secondaryUserEmail: z.string(),
 	secondaryIdentityId: z.string(),
-	invitedDate: z.string(),
+	invitedDate: z.iso.datetime(),
 	expiryDate: z.number(),
 });
 

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -20,7 +20,7 @@ const makeSecondaryUser = (
 	subscriptionName,
 	secondaryIdentityId,
 	primaryIdentityId,
-	acceptedDate: '2026-06-12',
+	acceptedDate: '2026-06-12T00:00:00.000Z',
 	expiryDate: 1781218800,
 	invitationCode: 'RpwR62kMnAxe',
 	...overrides,

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -8,7 +8,6 @@ import type {
 	ZuoraSubscription,
 } from '@modules/zuora/types/objects';
 import { zuoraSubscriptionSchema } from '@modules/zuora/types/objects';
-import { zuoraDateFormat } from '@modules/zuora/utils';
 import { zuoraCatalogSchema } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import code from '../../../modules/zuora-catalog/test/fixtures/catalog-code.json';
 import { createInvitationEndpoint } from '../src/createInvitationEndpoint';
@@ -56,7 +55,7 @@ const mockInvitations: InvitationRecord[] = [
 		primaryUserEmail: 'integration-test-joe@thegulocal.com',
 		secondaryUserEmail: 'integration-test@thegulocal.com',
 		secondaryIdentityId: '8888888',
-		invitedDate: zuoraDateFormat(testDay),
+		invitedDate: testDay.toISOString(),
 		expiryDate: dayjs(testDay).add(1, 'month').toDate().getTime(),
 	},
 ];
@@ -126,7 +125,7 @@ describe('createInvitationHandler', () => {
 			expect.objectContaining({
 				expiryDate: testDay.add(1, 'month').toDate().getTime(),
 				invitationCode: expect.any(String) as string,
-				invitedDate: zuoraDateFormat(testDay),
+				invitedDate: testDay.toISOString(),
 				primaryIdentityId: 'primary-identity-123',
 				secondaryIdentityId: 'secondary-identity-456',
 				subscriptionName: 'A-S00974337',

--- a/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
@@ -11,7 +11,7 @@ describe('listSecondaryUsersEndpoint', () => {
 				subscriptionName: 'A-S00974337',
 				secondaryIdentityId: 'secondary-id',
 				primaryIdentityId: 'primary-id',
-				acceptedDate: '2026-06-12',
+				acceptedDate: '2026-06-12T00:00:00.000Z',
 				expiryDate: 1781218800,
 				invitationCode: 'RpwR62kMnAxe',
 			},

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -39,7 +39,7 @@ describe('secondaryUserMeEndpoint', () => {
 		subscriptionName,
 		secondaryIdentityId: 'secondary-id',
 		primaryIdentityId: 'primary-id',
-		acceptedDate: '2026-06-12',
+		acceptedDate: '2026-06-12T00:00:00.000Z',
 		expiryDate: 1781218800,
 		invitationCode: 'RpwR62kMnAxe',
 	});

--- a/modules/multiple-account/src/secondaryUserRepository.ts
+++ b/modules/multiple-account/src/secondaryUserRepository.ts
@@ -21,7 +21,7 @@ export const secondaryUserRecordSchema = z.object({
 	subscriptionName: z.string(),
 	secondaryIdentityId: z.string(),
 	primaryIdentityId: z.string(),
-	acceptedDate: z.string(),
+	acceptedDate: z.iso.datetime(),
 	expiryDate: z.number(),
 	cancelledBy: cancelledBySchema.optional(),
 	cancelledDate: z.iso.datetime().optional(),


### PR DESCRIPTION
ℹ️ Changes in this PR  were mainly AI generated.
 
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Changes the `invitedDate` field on invitation records and the `acceptedDate` field on secondary user records from loosely-typed strings to validated ISO 8601 datetime strings, consistent with the existing `cancelledDate` field on both schemas.

### Changes

**Schema**
- `invitedDate: z.string()` → `z.iso.datetime()` in `invitationRepository.ts`
- `acceptedDate: z.string()` → `z.iso.datetime()` in `secondaryUserRepository.ts`

**Write paths**
- `createInvitationEndpoint.ts`: `zuoraDateFormat(now)` → `now.toISOString()` for `invitedDate`
- `acceptInvitationEndpoint.ts`: `zuoraDateFormat(today)` → `today.toISOString()` for `acceptedDate`
- Removed now-unused `zuoraDateFormat` imports from both files and their tests

**Tests**
- Updated fixture values from `'2026-06-12'` (date-only) to `'2026-06-12T00:00:00.000Z'` (ISO datetime) in `invitation.test.ts`, `deleteSecondaryUserEndpoint.test.ts`, `listSecondaryUsersEndpoint.test.ts`, `secondaryUserMeEndpoint.test.ts`

**Docs/API contract**
- `openapi.yaml`: added `format: date-time` and updated examples for `invitedDate` and `acceptedDate` (both `SecondaryUser` and `SecondaryUserWithName` schemas)
- `README.md`: updated example JSON responses



## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->


