### PR TITLE
add permission to send email for multiple-accounts-api

### DIFF
--- a/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
@@ -1030,22 +1030,40 @@ exports[`The Multiple account api stack matches the snapshot 1`] = `
                 "sqs:SendMessage",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:sqs:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":supporter-product-data-CODE",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":supporter-product-data-CODE",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":braze-emails-CODE",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -2329,22 +2347,40 @@ exports[`The Multiple account api stack matches the snapshot 2`] = `
                 "sqs:SendMessage",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:sqs:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":supporter-product-data-PROD",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":supporter-product-data-PROD",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":braze-emails-PROD",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/multiple-account-api.ts
+++ b/cdk/lib/multiple-account-api.ts
@@ -49,8 +49,7 @@ export class MultipleAccountApi extends SrStack {
 		lambda.addPolicies(new AllowSupporterProductDataQueryPolicy(this));
 		lambda.addPolicies(new AllowSupporterProductDataDeletePolicy(this));
 		lambda.addPolicies(
-			AllowSqsSendPolicy.create(this, 'supporter-product-data'),
-			AllowSqsSendPolicy.create(this, `braze-emails`),
+			AllowSqsSendPolicy.create(this, 'supporter-product-data', 'braze-emails'),
 		);
 
 		const invitationTable = new Table(this, 'InvitationTable', {

--- a/cdk/lib/multiple-account-api.ts
+++ b/cdk/lib/multiple-account-api.ts
@@ -50,6 +50,7 @@ export class MultipleAccountApi extends SrStack {
 		lambda.addPolicies(new AllowSupporterProductDataDeletePolicy(this));
 		lambda.addPolicies(
 			AllowSqsSendPolicy.create(this, 'supporter-product-data'),
+			AllowSqsSendPolicy.create(this, `braze-emails`),
 		);
 
 		const invitationTable = new Table(this, 'InvitationTable', {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds `braze-emails` to SQSSendPolicy in order to send email from multiple-accounts-api.
  
## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

Tested on CODE and no errors were thrown. Got a 200 Status Code  with invitation code in the response and received the email. 