### PR TITLE
Send leave subscription email to secondary user

### DIFF
--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -4,9 +4,11 @@ import {
 } from '@aws-sdk/client-dynamodb';
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { z } from 'zod';
+import { getUserByIdentityId } from '@modules/identity/idapi';
+import type { IdentityClient } from '@modules/identity/identityClient';
 import { logger } from '@modules/logger/logger';
 import { secondarySubscriptionName } from '@modules/multiple-account/secondarySubscription';
-import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
+import { type SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import {
 	badRequest,
 	buildErrorResponse,
@@ -16,6 +18,7 @@ import type { Stage } from '@modules/stage';
 import { getDeleteSupporterRatePlanTransaction } from '@modules/supporter-product-data/supporterProductData';
 import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
+import type { ZuoraAccount } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { sendLeaveSubscriptionEmail } from './emails/leaveSubcriptionEmail';
 
@@ -28,11 +31,24 @@ export type DeleteSecondaryUserPath = z.infer<
 	typeof deleteSecondaryUserPathSchema
 >;
 
+const getZuoraAccount = async (
+	zuoraClient: ZuoraClient,
+	subscriptionName: string,
+): Promise<ZuoraAccount> => {
+	const zuoraSubscription = await getSubscription(
+		zuoraClient,
+		subscriptionName,
+	);
+
+	return getAccount(zuoraClient, zuoraSubscription.accountNumber);
+};
+
 export const deleteSecondaryUserEndpoint = async (
 	stage: Stage,
 	secondaryUserRepository: SecondaryUserRepository,
 	dynamoClient: DynamoDBClient,
 	zuoraClient: ZuoraClient,
+	identityClient: IdentityClient,
 	subscriptionName: string,
 	secondaryIdentityId: string,
 	loggedInUserIdentityId: string,
@@ -90,20 +106,20 @@ export const deleteSecondaryUserEndpoint = async (
 		);
 
 		if (cancelledBy === 'secondary') {
-			const zuoraSubscription = await getSubscription(
-				zuoraClient,
-				subscriptionName,
-			);
-			const account = await getAccount(
-				zuoraClient,
-				zuoraSubscription.accountNumber,
-			);
+			const [account, secondaryUserDetails] = await Promise.all([
+				getZuoraAccount(zuoraClient, subscriptionName),
+				getUserByIdentityId(identityClient, secondaryIdentityId),
+			]);
+
+			if (!secondaryUserDetails?.primaryEmailAddress) {
+				throw new Error('Secondary user does not have email address');
+			}
 
 			await sendLeaveSubscriptionEmail(
 				stage,
 				account.billToContact.firstName,
 				account.billToContact.workEmail,
-				secondaryUser.secondaryEmail,
+				secondaryUserDetails.primaryEmailAddress,
 				secondaryIdentityId,
 			);
 		}

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -88,16 +88,17 @@ export const deleteSecondaryUserEndpoint = async (
 				],
 			}),
 		);
-		const zuoraSubscription = await getSubscription(
-			zuoraClient,
-			subscriptionName,
-		);
-		const account = await getAccount(
-			zuoraClient,
-			zuoraSubscription.accountNumber,
-		);
 
 		if (cancelledBy === 'secondary') {
+			const zuoraSubscription = await getSubscription(
+				zuoraClient,
+				subscriptionName,
+			);
+			const account = await getAccount(
+				zuoraClient,
+				zuoraSubscription.accountNumber,
+			);
+
 			await sendLeaveSubscriptionEmail(
 				stage,
 				account.billToContact.firstName,

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -14,6 +14,10 @@ import {
 } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import { getDeleteSupporterRatePlanTransaction } from '@modules/supporter-product-data/supporterProductData';
+import { getAccount } from '@modules/zuora/account';
+import { getSubscription } from '@modules/zuora/subscription';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { sendLeaveSubscriptionEmail } from './emails/leaveSubcriptionEmail';
 
 export const deleteSecondaryUserPathSchema = z.object({
 	subscriptionName: z.string(),
@@ -28,6 +32,7 @@ export const deleteSecondaryUserEndpoint = async (
 	stage: Stage,
 	secondaryUserRepository: SecondaryUserRepository,
 	dynamoClient: DynamoDBClient,
+	zuoraClient: ZuoraClient,
 	subscriptionName: string,
 	secondaryIdentityId: string,
 	loggedInUserIdentityId: string,
@@ -83,6 +88,24 @@ export const deleteSecondaryUserEndpoint = async (
 				],
 			}),
 		);
+		const zuoraSubscription = await getSubscription(
+			zuoraClient,
+			subscriptionName,
+		);
+		const account = await getAccount(
+			zuoraClient,
+			zuoraSubscription.accountNumber,
+		);
+
+		if (cancelledBy === 'secondary') {
+			await sendLeaveSubscriptionEmail(
+				stage,
+				account.billToContact.firstName,
+				account.billToContact.workEmail,
+				secondaryUser.secondaryEmail,
+				secondaryIdentityId,
+			);
+		}
 
 		return {
 			statusCode: 204,

--- a/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
+++ b/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
@@ -1,0 +1,28 @@
+import {
+	buildEmailMessage,
+	DataExtensionNames,
+	sendEmail,
+} from '@modules/email/email';
+import type { Stage } from '@modules/stage';
+
+export async function sendLeaveSubscriptionEmail(
+	stage: Stage,
+	primaryUserFirstName: string,
+	primaryUserEmail: string,
+	secondaryUserEmail: string,
+	secondaryUserIdentityId: string,
+) {
+	const dataAttributes = {
+		primary_user_first_name: primaryUserFirstName,
+		primary_user_email: primaryUserEmail,
+		secondary_user_email: secondaryUserEmail,
+	};
+
+	const emailMessage = buildEmailMessage(
+		secondaryUserEmail,
+		DataExtensionNames.multipleAccountEmails.secondaryUser.leaveSubscription,
+		dataAttributes,
+		{ IdentityUserId: secondaryUserIdentityId },
+	);
+	await sendEmail(stage, emailMessage);
+}

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -174,6 +174,7 @@ export const handler: Handler = Router([
 					secondaryUserRepository,
 					dynamoClient,
 					await lazyZuoraClient.get(),
+					await identityClientPromise,
 					subscriptionName,
 					secondaryIdentityId,
 					loggedInUserIdentityId,

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -173,6 +173,7 @@ export const handler: Handler = Router([
 					stage,
 					secondaryUserRepository,
 					dynamoClient,
+					await lazyZuoraClient.get(),
 					subscriptionName,
 					secondaryIdentityId,
 					loggedInUserIdentityId,

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -104,9 +104,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client, mockSend } = makeDynamoClient();
-		// TODO: mock responses from these clients
 		const zuoraClient = {} as unknown as ZuoraClient;
-		// TODO: this should return a thegulocal.com email address so that membership-workflow knows to ignore it
 		const identityClient = {} as unknown as IdentityClient;
 		jest
 			.mocked(getSubscription)

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -13,6 +13,7 @@ import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { deleteSecondaryUserEndpoint } from '../src/deleteSecondaryUserEndpoint';
+import { sendLeaveSubscriptionEmail } from '../src/emails/leaveSubcriptionEmail';
 import { makeAccount, makeSubscription } from './helpers';
 
 jest.mock('@modules/zuora/subscription', () => ({
@@ -25,6 +26,10 @@ jest.mock('@modules/zuora/account', () => ({
 
 jest.mock('@modules/identity/idapi', () => ({
 	getUserByIdentityId: jest.fn(),
+}));
+
+jest.mock('../src/emails/leaveSubcriptionEmail', () => ({
+	sendLeaveSubscriptionEmail: jest.fn(),
 }));
 
 const stage = 'CODE';
@@ -155,12 +160,15 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const zuoraClient = {} as unknown as ZuoraClient;
 		const identityClient = {} as unknown as IdentityClient;
 		const secondaryEmail = 'secondary@thegulocal.com';
+		const primaryEmail = 'primary@thegulocal.com';
 		jest
 			.mocked(getSubscription)
 			.mockResolvedValue(makeSubscription(subscriptionName));
 		jest
 			.mocked(getAccount)
-			.mockResolvedValue(makeAccount('Firstname', 'Lastname', secondaryEmail));
+			.mockResolvedValue(
+				makeAccount('PrimaryFirstName', 'PrimaryLastName', primaryEmail),
+			);
 		jest.mocked(getUserByIdentityId).mockResolvedValue({
 			id: '123456',
 			primaryEmailAddress: secondaryEmail,
@@ -185,6 +193,13 @@ describe('deleteSecondaryUserEndpoint', () => {
 			subscriptionName,
 			secondaryIdentityId,
 			'secondary',
+		);
+		expect(sendLeaveSubscriptionEmail).toHaveBeenCalledWith(
+			stage,
+			'PrimaryFirstName',
+			primaryEmail,
+			secondaryEmail,
+			secondaryIdentityId,
 		);
 	});
 

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -83,7 +83,9 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client, mockSend } = makeDynamoClient();
+		// TODO: mock responses from these clients
 		const zuoraClient = {} as unknown as ZuoraClient;
+		// TODO: this should return a thegulocal.com email address so that membership-workflow knows to ignore it
 		const identityClient = {} as unknown as IdentityClient;
 
 		const result = await deleteSecondaryUserEndpoint(

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -3,10 +3,12 @@ import type {
 	DynamoDBClient,
 	TransactWriteItem,
 } from '@aws-sdk/client-dynamodb';
+import type { IdentityClient } from '@modules/identity/identityClient';
 import type {
 	SecondaryUserRecord,
 	SecondaryUserRepository,
 } from '@modules/multiple-account/secondaryUserRepository';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { deleteSecondaryUserEndpoint } from '../src/deleteSecondaryUserEndpoint';
 
 const stage = 'CODE';
@@ -81,11 +83,15 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client, mockSend } = makeDynamoClient();
+		const zuoraClient = {} as unknown as ZuoraClient;
+		const identityClient = {} as unknown as IdentityClient;
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
+			zuoraClient,
+			identityClient,
 			subscriptionName,
 			secondaryIdentityId,
 			primaryIdentityId,
@@ -120,11 +126,15 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client } = makeDynamoClient();
+		const zuoraClient = {} as unknown as ZuoraClient;
+		const identityClient = {} as unknown as IdentityClient;
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
+			zuoraClient,
+			identityClient,
 			subscriptionName,
 			secondaryIdentityId,
 			secondaryIdentityId,
@@ -142,11 +152,15 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(undefined);
 		const { client, mockSend } = makeDynamoClient();
+		const zuoraClient = {} as unknown as ZuoraClient;
+		const identityClient = {} as unknown as IdentityClient;
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
+			zuoraClient,
+			identityClient,
 			subscriptionName,
 			secondaryIdentityId,
 			primaryIdentityId,
@@ -163,11 +177,15 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(undefined);
 		const { client, mockSend } = makeDynamoClient();
+		const zuoraClient = {} as unknown as ZuoraClient;
+		const identityClient = {} as unknown as IdentityClient;
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
+			zuoraClient,
+			identityClient,
 			subscriptionName,
 			secondaryIdentityId,
 			primaryIdentityId,
@@ -182,11 +200,15 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client, mockSend } = makeDynamoClient();
+		const zuoraClient = {} as unknown as ZuoraClient;
+		const identityClient = {} as unknown as IdentityClient;
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
 			repository,
 			client,
+			zuoraClient,
+			identityClient,
 			subscriptionName,
 			secondaryIdentityId,
 			'someone-else',

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -3,13 +3,29 @@ import type {
 	DynamoDBClient,
 	TransactWriteItem,
 } from '@aws-sdk/client-dynamodb';
+import { getUserByIdentityId } from '@modules/identity/idapi';
 import type { IdentityClient } from '@modules/identity/identityClient';
 import type {
 	SecondaryUserRecord,
 	SecondaryUserRepository,
 } from '@modules/multiple-account/secondaryUserRepository';
+import { getAccount } from '@modules/zuora/account';
+import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { deleteSecondaryUserEndpoint } from '../src/deleteSecondaryUserEndpoint';
+import { makeAccount, makeSubscription } from './helpers';
+
+jest.mock('@modules/zuora/subscription', () => ({
+	getSubscription: jest.fn(),
+}));
+
+jest.mock('@modules/zuora/account', () => ({
+	getAccount: jest.fn(),
+}));
+
+jest.mock('@modules/identity/idapi', () => ({
+	getUserByIdentityId: jest.fn(),
+}));
 
 const stage = 'CODE';
 const subscriptionName = 'A-S00974337';
@@ -87,6 +103,14 @@ describe('deleteSecondaryUserEndpoint', () => {
 		const zuoraClient = {} as unknown as ZuoraClient;
 		// TODO: this should return a thegulocal.com email address so that membership-workflow knows to ignore it
 		const identityClient = {} as unknown as IdentityClient;
+		jest
+			.mocked(getSubscription)
+			.mockResolvedValue(makeSubscription(subscriptionName));
+		jest
+			.mocked(getAccount)
+			.mockResolvedValue(
+				makeAccount('Firstname', 'Lastname', 'test@thegulocal.com'),
+			);
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,
@@ -124,12 +148,26 @@ describe('deleteSecondaryUserEndpoint', () => {
 		});
 	});
 
-	it('soft deletes with cancelledBy "secondary" when the secondary user deletes', async () => {
+	it('soft deletes with cancelledBy "secondary" and sends an email when the secondary user deletes', async () => {
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(makeSecondaryUser());
 		const { client } = makeDynamoClient();
 		const zuoraClient = {} as unknown as ZuoraClient;
 		const identityClient = {} as unknown as IdentityClient;
+		const secondaryEmail = 'secondary@thegulocal.com';
+		jest
+			.mocked(getSubscription)
+			.mockResolvedValue(makeSubscription(subscriptionName));
+		jest
+			.mocked(getAccount)
+			.mockResolvedValue(makeAccount('Firstname', 'Lastname', secondaryEmail));
+		jest.mocked(getUserByIdentityId).mockResolvedValue({
+			id: '123456',
+			primaryEmailAddress: secondaryEmail,
+			publicFields: {
+				displayName: 'Example',
+			},
+		});
 
 		const result = await deleteSecondaryUserEndpoint(
 			stage,

--- a/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
@@ -34,14 +34,17 @@ const dynamoClient = new DynamoDBClient({});
 
 jest.setTimeout(30000);
 
+const buildIdentityClient = () =>
+	IdentityClient.create(
+		stage,
+		`/${stage}/support/multiple-account-api/identity-client-access-token`,
+	);
+
 beforeEach(async () => {
 	const zuoraClient = await ZuoraClient.create(stage);
 	const zuoraCatalog = await getZuoraCatalogFromS3(stage);
 	const productCatalog = await getProductCatalogFromApi(stage);
-	const identityClient = await IdentityClient.create(
-		stage,
-		`/${stage}/support/multiple-account-api/identity-client-access-token`,
-	);
+	const identityClient = await buildIdentityClient();
 
 	const createEndpoint = createInvitationEndpoint(
 		stage,
@@ -125,10 +128,15 @@ test('deleteSecondaryUserEndpoint soft deletes the secondary user and removes th
 		);
 	expect(subscriptionRecordBeforeDelete).toBeDefined();
 
+	const identityClient = await buildIdentityClient();
+	const zuoraClient = await ZuoraClient.create(stage);
+
 	const result = await deleteSecondaryUserEndpoint(
 		stage,
 		secondaryUserRepository,
 		dynamoClient,
+		zuoraClient,
+		identityClient,
 		subscriptionName,
 		secondaryIdentityId,
 		secondaryIdentityId,

--- a/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
@@ -23,7 +23,7 @@ import { InvitationRepository } from '../src/invitationRepository';
 
 const stage = 'CODE';
 const subscriptionName = 'A-S00974337';
-const secondaryUserEmail = 'integration-test2+multiple-account@theguardian.com';
+const secondaryUserEmail = 'integration-test2+multiple-account@thegulocal.com';
 
 let invitationCode: string;
 let secondaryIdentityId: string;

--- a/handlers/multiple-account-api/test/helpers.ts
+++ b/handlers/multiple-account-api/test/helpers.ts
@@ -1,0 +1,15 @@
+import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
+
+export const makeSubscription = (accountNumber: string): ZuoraSubscription =>
+	({
+		accountNumber,
+	}) as unknown as ZuoraSubscription;
+
+export const makeAccount = (
+	firstName: string,
+	lastName: string,
+	workEmail: string,
+): ZuoraAccount =>
+	({
+		billToContact: { firstName, lastName, workEmail, zipCode: 'N1 9GU' },
+	}) as unknown as ZuoraAccount;

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -4,9 +4,9 @@ import type {
 } from '@modules/multiple-account/secondaryUserRepository';
 import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
-import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { secondaryUserDetailsEndpoint } from '../src/secondaryUserDetailsEndpoint';
+import { makeAccount, makeSubscription } from './helpers';
 
 jest.mock('@modules/zuora/subscription', () => ({
 	getSubscription: jest.fn(),
@@ -20,18 +20,6 @@ describe('secondaryUserMeEndpoint', () => {
 	const mockGetSubscription = jest.mocked(getSubscription);
 	const mockGetAccount = jest.mocked(getAccount);
 	const zuoraClient = {} as unknown as ZuoraClient;
-
-	const makeSubscription = (accountNumber: string): ZuoraSubscription =>
-		({ accountNumber }) as unknown as ZuoraSubscription;
-
-	const makeAccount = (
-		firstName: string,
-		lastName: string,
-		workEmail: string,
-	): ZuoraAccount =>
-		({
-			billToContact: { firstName, lastName, workEmail, zipCode: 'N1 9GU' },
-		}) as unknown as ZuoraAccount;
 
 	const makeSecondaryUser = (
 		subscriptionName: string,


### PR DESCRIPTION
## What does this change?

When a secondary user leaves a primary subscription, send a confirmation email to the secondary user.

## How has this change been tested?

New tests added to verify the behaviour.

I've trigger the email to send to my inbox by temporarily modifying the secondary user email to my own in the integration test.

[Leave Shared Subscription Confirmation - Triggered emails from Multiple account API](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1217160312683324?focus=true)