### PR TITLE
Migrate product move cancellation to Zuora Orders API

### DIFF
--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/Handler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/Handler.scala
@@ -137,7 +137,7 @@ class TestContext() extends Context {
 
   override def getClientContext: ClientContext = ???
 
-  override def getRemainingTimeInMillis: Int = ???
+  override def getRemainingTimeInMillis: Int = 300000
 
   override def getMemoryLimitInMB: Int = ???
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpoint.scala
@@ -24,7 +24,6 @@ import com.gu.productmove.invoicingapi.InvoicingApiRefund.RefundResponse
 import com.gu.productmove.invoicingapi.{InvoicingApiRefund, InvoicingApiRefundLive}
 import com.gu.productmove.zuora.rest.*
 import com.gu.productmove.zuora.{
-  CancellationResponse,
   CreditBalanceAdjustment,
   CreditBalanceAdjustmentLive,
   GetAccount,

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointSteps.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/endpoint/cancel/SubscriptionCancelEndpointSteps.scala
@@ -74,10 +74,10 @@ class SubscriptionCancelEndpointSteps(
       )
       supporterPlusCharge <- getSupporterPlusCharge(charges, zuoraIds.supporterPlusZuoraIds)
 
-      today <- Clock.currentDateTime.map(_.toLocalDate)
+      currentDate <- Clock.currentDateTime.map(_.toLocalDate)
 
       // check whether the sub is within the first 14 days of purchase - if it is then the subscriber is entitled to a refund
-      shouldBeRefundedDate = getRefundDateIfEligibile(today, subscription.LastPlanAddedDate__c)
+      shouldBeRefundedDate = getRefundDateIfEligibile(currentDate, subscription.LastPlanAddedDate__c)
       _ <- ZIO.log(s"Backdated refund effective date is $shouldBeRefundedDate")
 
       cancellationDate <- ZIO
@@ -91,7 +91,7 @@ class SubscriptionCancelEndpointSteps(
       _ <- ZIO.log(s"Cancellation date is $cancellationDate")
 
       _ <- ZIO.log(s"Attempting to cancel sub")
-      cancellationResponse <- zuoraCancel.cancel(subscriptionName, cancellationDate)
+      _ <- zuoraCancel.cancel(subscription.accountNumber, subscriptionName, cancellationDate, today)
       _ <- ZIO.log("Sub cancelled as of: " + cancellationDate)
 
       _ <- ZIO.log(
@@ -100,7 +100,7 @@ class SubscriptionCancelEndpointSteps(
       )
       _ <-
         if (shouldBeRefundedDate.isDefined)
-          sqs.queueRefund(RefundInput(subscriptionName, account.basicInfo.id, today))
+          sqs.queueRefund(RefundInput(subscriptionName, account.basicInfo.id, currentDate))
         else
           ZIO.succeed(())
 

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/framework/LambdaRemainingTime.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/framework/LambdaRemainingTime.scala
@@ -1,0 +1,20 @@
+package com.gu.productmove.framework
+
+import com.amazonaws.services.lambda.runtime.Context
+import zio.{FiberRef, Task, UIO, Unsafe}
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+/** Makes the Lambda context available to services without adding it to every Tapir endpoint signature.
+  */
+object LambdaRemainingTime {
+  private val remainingTimeInMillis = Unsafe.unsafe { implicit unsafe => FiberRef.unsafe.make[() => Int](() => 0) }
+
+  def withContext[A](context: Context)(effect: Task[A]): Task[A] =
+    withRemainingTime(() => context.getRemainingTimeInMillis)(effect)
+
+  def withRemainingTime[A](getRemainingTimeInMillis: () => Int)(effect: Task[A]): Task[A] =
+    remainingTimeInMillis.locally(getRemainingTimeInMillis)(effect)
+
+  def remaining: UIO[FiniteDuration] = remainingTimeInMillis.get.map(_.apply().millis)
+}

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/framework/ZIOApiGatewayRequestHandler.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/framework/ZIOApiGatewayRequestHandler.scala
@@ -57,7 +57,9 @@ abstract class ZIOApiGatewayRequestHandler(val server: List[ServerEndpoint[Any, 
             str = new String(allBytes, StandardCharsets.UTF_8)
             _ <- ZIO.log("input: " + str)
             loggedOutputStream = new ByteArrayOutputStream()
-            _ <- handler.process[AwsRequestV1](new ByteArrayInputStream(allBytes), loggedOutputStream)
+            _ <- LambdaRemainingTime.withContext(context) {
+              handler.process[AwsRequestV1](new ByteArrayInputStream(allBytes), loggedOutputStream)
+            }
             _ <- ZIO.log("output: " + new String(loggedOutputStream.toByteArray, StandardCharsets.UTF_8))
             _ = output.write(loggedOutputStream.toByteArray)
             _ = output.close()

--- a/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/ZuoraCancel.scala
+++ b/handlers/product-move-api/src/main/scala/com/gu/productmove/zuora/ZuoraCancel.scala
@@ -1,67 +1,293 @@
 package com.gu.productmove.zuora
 
-import com.gu.productmove.AwsS3
-import com.gu.productmove.GuStageLive.Stage
-import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.ErrorResponse
-import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
-import com.gu.productmove.zuora.model.SubscriptionName
-import com.gu.productmove.zuora.rest.ZuoraGet
-import com.gu.productmove.zuora.*
-import sttp.capabilities.zio.ZioStreams
-import sttp.capabilities.{Effect, WebSockets}
-import sttp.client3.*
-import sttp.client3.httpclient.zio.HttpClientZioBackend
-import sttp.client3.ziojson.*
-import sttp.model.Uri
+import com.gu.productmove.zuora.model.{AccountNumber, SubscriptionName}
+import com.gu.productmove.zuora.rest.{ZuoraClient, ZuoraRestBody}
+import com.gu.productmove.framework.LambdaRemainingTime
+import sttp.client3.{basicRequest, UriContext}
 import zio.json.*
-import zio.{Clock, IO, RIO, Task, UIO, URLayer, ZIO, ZLayer}
+import zio.{Clock, Duration, Task, URLayer, ZIO, ZLayer}
 
 import java.time.LocalDate
+import scala.concurrent.duration.{DurationInt, FiniteDuration, NANOSECONDS}
 
 trait ZuoraCancel {
   def cancel(
+      accountNumber: AccountNumber,
       subscriptionName: SubscriptionName,
       cancellationEffectiveDate: LocalDate,
-  ): Task[CancellationResponse]
+      orderDate: LocalDate,
+  ): Task[Unit]
 }
 
 object ZuoraCancelLive {
-  val layer: URLayer[ZuoraGet, ZuoraCancel] = ZLayer.fromFunction(ZuoraCancelLive(_))
+  val layer: URLayer[ZuoraClient, ZuoraCancel] = ZLayer.fromFunction(ZuoraCancelLive(_))
 }
 
-private class ZuoraCancelLive(zuoraGet: ZuoraGet) extends ZuoraCancel {
+private class ZuoraCancelLive(zuoraClient: ZuoraClient) extends ZuoraCancel {
   override def cancel(
+      accountNumber: AccountNumber,
       subscriptionName: SubscriptionName,
       cancellationEffectiveDate: LocalDate,
-  ): Task[CancellationResponse] = {
-    val cancellationRequest = CancellationRequest(cancellationEffectiveDate)
+      orderDate: LocalDate,
+  ): Task[Unit] =
+    for {
+      remainingTime <- LambdaRemainingTime.remaining
+      maximumOrderDuration <- ZIO
+        .fromOption(ZuoraCancel.orderDuration(remainingTime))
+        .orElseFail(new Throwable("Not enough Lambda time remains to safely submit the Zuora cancellation order"))
+      deadline <- Clock.nanoTime.map(_ + maximumOrderDuration.toNanos)
+      request = CancellationOrderRequest.forSubscription(
+        accountNumber,
+        subscriptionName,
+        cancellationEffectiveDate,
+        orderDate,
+      )
+      _ <- createOrder(request, subscriptionName, deadline).catchSome { case failure: LockingContention =>
+        retryAfterLockingContention(request, subscriptionName, deadline, failure)
+      }
+    } yield ()
 
-    zuoraGet.put[CancellationRequest, CancellationResponse](
-      uri"subscriptions/${subscriptionName.value}/cancel",
-      cancellationRequest,
-    )
-  }
+  private def createOrder(
+      request: CancellationOrderRequest,
+      subscriptionName: SubscriptionName,
+      deadline: Long,
+  ): Task[Unit] =
+    for {
+      submissionTimeout <- readTimeout(deadline)
+      jobId <- submit(request, submissionTimeout)
+      _ <- ZIO.log(s"Submitted cancellation order job $jobId for ${subscriptionName.value}")
+      _ <- waitForCompletion(jobId, deadline)
+      _ <- ZIO.log(s"Cancellation order job $jobId completed for ${subscriptionName.value}")
+    } yield ()
+
+  private def retryAfterLockingContention(
+      request: CancellationOrderRequest,
+      subscriptionName: SubscriptionName,
+      deadline: Long,
+      failure: LockingContention,
+  ): Task[Unit] =
+    remainingDuration(deadline).flatMap {
+      case Some(remaining) if remaining > ZuoraCancel.LockingContentionRetryDelay + ZuoraCancel.MinimumOrderDuration =>
+        ZIO.logWarning(
+          s"Retrying cancellation for ${subscriptionName.value} after locking contention: ${failure.getMessage}",
+        ) *> ZIO.sleep(Duration.fromScala(ZuoraCancel.LockingContentionRetryDelay)) *> createOrder(
+          request,
+          subscriptionName,
+          deadline,
+        )
+      case _ => ZIO.fail(failure)
+    }
+
+  /** https://developer.zuora.com/v1-api-reference/api/orders/post_createorderasynchronously */
+  private def submit(request: CancellationOrderRequest, timeout: FiniteDuration): Task[String] =
+    for {
+      body <- zuoraClient.send(
+        basicRequest
+          .contentType("application/json")
+          .body(request.toJson)
+          .readTimeout(timeout)
+          .post(uri"async/orders"),
+      )
+      submission <- ZIO.fromEither(
+        ZuoraRestBody.parseIfSuccessful[AsyncJobSubmission](body, ZuoraRestBody.ZuoraSuccessCheck.SuccessCheckLowercase),
+      )
+      jobId <- submission match {
+        case AsyncJobSubmission.Accepted(value) => ZIO.succeed(value)
+        case AsyncJobSubmission.Rejected => ZIO.fail(new Throwable("Zuora did not accept the cancellation order"))
+      }
+    } yield jobId
+
+  /** https://developer.zuora.com/v1-api-reference/api/orders/get_jobstatusandresponse */
+  private def getJobReport(jobId: String, timeout: FiniteDuration): Task[AsyncJobReport] =
+    for {
+      body <- zuoraClient.send(basicRequest.readTimeout(timeout).get(uri"async-jobs/$jobId"))
+      report <- ZIO.fromEither(
+        ZuoraRestBody.parseIfSuccessful[AsyncJobReport](body, ZuoraRestBody.ZuoraSuccessCheck.SuccessCheckLowercase),
+      )
+    } yield report
+
+  private def waitForCompletion(jobId: String, deadline: Long): Task[Unit] =
+    readTimeout(deadline).flatMap { timeout =>
+      getJobReport(jobId, timeout).either.flatMap {
+        case Left(failure) =>
+          ZIO.logWarning(s"Could not read cancellation order job $jobId: ${failure.getMessage}. Retrying.") *>
+            pauseBeforeNextPoll(deadline) *> waitForCompletion(jobId, deadline)
+        case Right(AsyncJobReport(AsyncJobStatus.Processing, _, _)) =>
+          pauseBeforeNextPoll(deadline) *> waitForCompletion(jobId, deadline)
+        case Right(AsyncJobReport(AsyncJobStatus.Failed, errors, _))
+            if errors.exists(
+              _.contains(ZuoraCancel.LockingContentionCode),
+            ) =>
+          ZIO.fail(LockingContention(s"Cancellation order job $jobId failed: ${errors.get}"))
+        case Right(AsyncJobReport(AsyncJobStatus.Failed, errors, _)) =>
+          ZIO.fail(new Throwable(s"Cancellation order job $jobId failed: ${errors.getOrElse("no reason returned")}"))
+        case Right(AsyncJobReport(AsyncJobStatus.Completed, _, Some(AsyncOrderResult(OrderStatus.Completed)))) =>
+          ZIO.unit
+        case Right(AsyncJobReport(AsyncJobStatus.Completed, _, result)) =>
+          ZIO.fail(
+            new Throwable(
+              s"Cancellation order job $jobId completed with order status ${result.map(_.status.value).getOrElse("missing")}",
+            ),
+          )
+      }
+    }
+
+  private def pauseBeforeNextPoll(deadline: Long): Task[Unit] =
+    remainingDuration(deadline).flatMap {
+      case Some(remaining) =>
+        ZIO.sleep(Duration.fromScala(if remaining < ZuoraCancel.PollInterval then remaining
+        else ZuoraCancel.PollInterval))
+      case None => ZIO.fail(new Throwable("Timed out waiting for the cancellation order"))
+    }
+
+  private def readTimeout(deadline: Long): Task[FiniteDuration] =
+    remainingDuration(deadline).flatMap {
+      case Some(remaining) =>
+        ZIO.succeed(if remaining < ZuoraCancel.RequestReadTimeout then remaining else ZuoraCancel.RequestReadTimeout)
+      case None => ZIO.fail(new Throwable("Timed out waiting for the cancellation order"))
+    }
+
+  private def remainingDuration(deadline: Long): zio.UIO[Option[FiniteDuration]] =
+    Clock.nanoTime.map(now => Option.when(deadline > now)(FiniteDuration(deadline - now, NANOSECONDS)))
 }
 
 object ZuoraCancel {
-  def cancel(
-      subscriptionName: SubscriptionName,
-      cancellationEffectiveDate: LocalDate,
-  ): RIO[ZuoraCancel, CancellationResponse] =
-    ZIO.serviceWithZIO[ZuoraCancel](_.cancel(subscriptionName, cancellationEffectiveDate))
+  private[zuora] val PollInterval = 2.seconds
+  private[zuora] val RequestReadTimeout = 2.minutes
+  private[zuora] val MaximumOrderDuration = 3.minutes
+  private[zuora] val PostOrderWorkBuffer = 2.minutes
+  private[zuora] val MinimumOrderDuration = 10.seconds
+  private[zuora] val LockingContentionRetryDelay = 1.minute
+  private[zuora] val LockingContentionCode = "[40000050]"
+
+  private[zuora] def orderDuration(remainingTime: FiniteDuration): Option[FiniteDuration] = {
+    val availableDuration = remainingTime - PostOrderWorkBuffer
+    Option.when(availableDuration >= MinimumOrderDuration) {
+      if availableDuration < MaximumOrderDuration then availableDuration else MaximumOrderDuration
+    }
+  }
 }
 
-case class CancellationRequest(
-    cancellationEffectiveDate: LocalDate,
-    runBilling: Boolean = false,
-    cancellationPolicy: String = "SpecificDate",
-)
+case class CancellationOrderRequest(
+    orderDate: LocalDate,
+    existingAccountNumber: String,
+    subscriptions: List[OrderSubscription],
+    processingOptions: ProcessingOptions,
+) derives JsonEncoder
 
-given JsonEncoder[CancellationRequest] = DeriveJsonEncoder.gen[CancellationRequest]
+object CancellationOrderRequest {
+  def forSubscription(
+      accountNumber: AccountNumber,
+      subscriptionName: SubscriptionName,
+      cancellationEffectiveDate: LocalDate,
+      orderDate: LocalDate,
+  ): CancellationOrderRequest =
+    CancellationOrderRequest(
+      orderDate = orderDate,
+      existingAccountNumber = accountNumber.value,
+      subscriptions = List(
+        OrderSubscription(
+          subscriptionNumber = subscriptionName.value,
+          orderActions = List(
+            CancelSubscriptionOrderAction(
+              triggerDates = List(TriggerDate(TriggerDateName.ContractEffective, cancellationEffectiveDate)),
+              cancelSubscription = Cancellation(CancellationPolicy.SpecificDate, cancellationEffectiveDate),
+            ),
+          ),
+        ),
+      ),
+      processingOptions = ProcessingOptions(runBilling = false, collectPayment = false),
+    )
+}
 
-case class CancellationResponse(
-    subscriptionId: String,
-    cancelledDate: LocalDate,
-)
+case class OrderSubscription(subscriptionNumber: String, orderActions: List[CancelSubscriptionOrderAction])
+    derives JsonEncoder
 
-given JsonDecoder[CancellationResponse] = DeriveJsonDecoder.gen[CancellationResponse]
+case class CancelSubscriptionOrderAction(
+    `type`: String = "CancelSubscription",
+    triggerDates: List[TriggerDate],
+    cancelSubscription: Cancellation,
+) derives JsonEncoder
+
+case class TriggerDate(name: TriggerDateName, triggerDate: LocalDate) derives JsonEncoder
+
+enum TriggerDateName(val value: String) {
+  case ContractEffective extends TriggerDateName("ContractEffective")
+}
+
+object TriggerDateName {
+  given JsonEncoder[TriggerDateName] = JsonEncoder.string.contramap(_.value)
+}
+
+case class Cancellation(cancellationPolicy: CancellationPolicy, cancellationEffectiveDate: LocalDate)
+    derives JsonEncoder
+
+enum CancellationPolicy(val value: String) {
+  case SpecificDate extends CancellationPolicy("SpecificDate")
+}
+
+object CancellationPolicy {
+  given JsonEncoder[CancellationPolicy] = JsonEncoder.string.contramap(_.value)
+}
+
+case class ProcessingOptions(runBilling: Boolean, collectPayment: Boolean) derives JsonEncoder
+
+sealed trait AsyncJobSubmission
+
+object AsyncJobSubmission {
+  case class Accepted(jobId: String) extends AsyncJobSubmission
+  case object Rejected extends AsyncJobSubmission
+
+  private case class Response(success: Boolean, jobId: Option[String]) derives JsonDecoder
+
+  given JsonDecoder[AsyncJobSubmission] = JsonDecoder[Response].mapOrFail {
+    case Response(true, Some(jobId)) => Right(Accepted(jobId))
+    case Response(true, None) => Left("Zuora accepted the cancellation order without returning a job ID")
+    case Response(false, _) => Right(Rejected)
+  }
+}
+
+case class AsyncJobReport(status: AsyncJobStatus, errors: Option[String], result: Option[AsyncOrderResult])
+    derives JsonDecoder
+
+case class AsyncOrderResult(status: OrderStatus) derives JsonDecoder
+
+enum AsyncJobStatus(val value: String) {
+  case Processing extends AsyncJobStatus("Processing")
+  case Failed extends AsyncJobStatus("Failed")
+  case Completed extends AsyncJobStatus("Completed")
+}
+
+object AsyncJobStatus {
+  given JsonDecoder[AsyncJobStatus] = JsonDecoder[String].mapOrFail {
+    case "Processing" => Right(AsyncJobStatus.Processing)
+    case "Failed" => Right(AsyncJobStatus.Failed)
+    case "Completed" => Right(AsyncJobStatus.Completed)
+    case status => Left(s"Unknown Zuora async job status: $status")
+  }
+}
+
+enum OrderStatus(val value: String) {
+  case Draft extends OrderStatus("Draft")
+  case Pending extends OrderStatus("Pending")
+  case Completed extends OrderStatus("Completed")
+  case Cancelled extends OrderStatus("Cancelled")
+  case Scheduled extends OrderStatus("Scheduled")
+  case Executing extends OrderStatus("Executing")
+  case Failed extends OrderStatus("Failed")
+}
+
+object OrderStatus {
+  given JsonDecoder[OrderStatus] = JsonDecoder[String].mapOrFail {
+    case "Draft" => Right(OrderStatus.Draft)
+    case "Pending" => Right(OrderStatus.Pending)
+    case "Completed" => Right(OrderStatus.Completed)
+    case "Cancelled" => Right(OrderStatus.Cancelled)
+    case "Scheduled" => Right(OrderStatus.Scheduled)
+    case "Executing" => Right(OrderStatus.Executing)
+    case "Failed" => Right(OrderStatus.Failed)
+    case status => Left(s"Unknown Zuora order status: $status")
+  }
+}
+
+private case class LockingContention(reason: String) extends Throwable(reason)

--- a/handlers/product-move-api/src/test/resources/zuoraResponses/CancellationResponse1.json
+++ b/handlers/product-move-api/src/test/resources/zuoraResponses/CancellationResponse1.json
@@ -1,8 +1,0 @@
-{
-  "success": true,
-  "subscriptionId":"8ad08d29860bd93e0186127£052a6414",
-  "cancelledDate": "2023-02-02",
-  "totalDeltaMrr": 0.000000000,
-  "totalDeltaTcv": -119.341954027,
-  "invoiceId":"Sad08d29860bd93e0186127f060e6444"
-}

--- a/handlers/product-move-api/src/test/resources/zuoraResponses/CancellationResponse2.json
+++ b/handlers/product-move-api/src/test/resources/zuoraResponses/CancellationResponse2.json
@@ -1,7 +1,0 @@
-{
-  "success" : true,
-  "subscriptionId" : "8a129cc3861a835d01862248d8ee5c9d",
-  "cancelledDate" : "2023-02-19",
-  "totalDeltaMrr" : 0.000000000,
-  "totalDeltaTcv" : -130.000000000
-}

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/HandlerSpec.scala
@@ -567,10 +567,7 @@ object HandlerSpec extends ZIOSpecDefault {
         val mockGetSubscriptionToCancel =
           new MockGetSubscriptionToCancel(Map(subscriptionName -> getSubscriptionForCancelResponse))
         val mockZuoraCancel = new MockZuoraCancel(
-          Map(
-            (subscriptionName, LocalDate.of(2022, 9, 29)) ->
-              CancellationResponse(subscriptionName.value, LocalDate.of(2022, 9, 29)),
-          ),
+          Set((subscriptionName, LocalDate.of(2022, 9, 29))),
         )
         val mockSQS = new MockSQS(Map(emailMessage -> ()))
         (for {
@@ -593,7 +590,18 @@ object HandlerSpec extends ZIOSpecDefault {
             equalTo(ProductMoveEndpointTypes.Success("Subscription A-S00339056 was successfully cancelled")),
           ) &&
           assert(mockGetSubscriptionToCancel.requests)(equalTo(List(subscriptionName))) &&
-          assert(mockZuoraCancel.requests)(equalTo(List((subscriptionName, LocalDate.of(2022, 9, 29))))) &&
+          assert(mockZuoraCancel.requests)(
+            equalTo(
+              List(
+                (
+                  AccountNumber("anAccountNumber"),
+                  subscriptionName,
+                  LocalDate.of(2022, 9, 29),
+                  LocalDate.ofInstant(time, zoneOffset),
+                ),
+              ),
+            ),
+          ) &&
           assert(mockSQS.requests)(hasSameElements(List(emailMessage)))
         })
       },

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/Stubs.scala
@@ -276,15 +276,6 @@ val directDebitGetAccountResponse = GetAccountResponse(
 )
 
 //-----------------------------------------------------
-// Stubs for ZuoraCancel service
-//-----------------------------------------------------
-
-val cancellationResponse2 = CancellationResponse(
-  "8a129cc3861a835d01862248d8ee5c9d",
-  cancelledDate = LocalDate.of(2023, 2, 19),
-)
-
-//-----------------------------------------------------
 // Stubs for Dynamo service
 //-----------------------------------------------------
 

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/JsonCodecSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/JsonCodecSpec.scala
@@ -3,6 +3,7 @@ package com.gu.productmove.zuora
 import com.gu.productmove.*
 import com.gu.productmove.endpoint.available.Currency
 import com.gu.productmove.endpoint.zuora.GetSubscriptionToCancel.GetSubscriptionToCancelResponse
+import com.gu.productmove.zuora.model.{AccountNumber, SubscriptionName}
 import com.gu.productmove.zuora.GetAccount.BasicInfo
 import com.gu.productmove.zuora.GetSubscription.GetSubscriptionResponse
 import org.scalatest.*
@@ -99,10 +100,32 @@ class JsonCodecSpec extends AnyFlatSpec {
     assert(json.fromJson[GetSubscriptionResponse].getOrElse("") == getSubscriptionResponse2)
   }
 
-  it should "Correctly decode PUT (/v1/subscriptions/$subscriptionNumber/cancel) response without a negative invoice attached" in {
-    val json = Source.fromResource("zuoraResponses/CancellationResponse2.json").mkString
+  it should "encode a cancellation Order with today as its order date" in {
+    val request = CancellationOrderRequest.forSubscription(
+      AccountNumber("A0123456"),
+      SubscriptionName("A-S0123456"),
+      LocalDate.of(2026, 9, 1),
+      LocalDate.of(2026, 8, 19),
+    )
 
-    assert(json.fromJson[CancellationResponse].getOrElse("") == cancellationResponse2)
+    assert(
+      request.toJson ==
+        """{"orderDate":"2026-08-19","existingAccountNumber":"A0123456","subscriptions":[{"subscriptionNumber":"A-S0123456","orderActions":[{"type":"CancelSubscription","triggerDates":[{"name":"ContractEffective","triggerDate":"2026-09-01"}],"cancelSubscription":{"cancellationPolicy":"SpecificDate","cancellationEffectiveDate":"2026-09-01"}}]}],"processingOptions":{"runBilling":false,"collectPayment":false}}""",
+    )
+  }
+
+  it should "keep a backdated cancellation effective date separate from the order date" in {
+    val request = CancellationOrderRequest.forSubscription(
+      AccountNumber("A0123456"),
+      SubscriptionName("A-S0123456"),
+      LocalDate.of(2026, 8, 1),
+      LocalDate.of(2026, 8, 19),
+    )
+
+    assert(
+      request.toJson ==
+        """{"orderDate":"2026-08-19","existingAccountNumber":"A0123456","subscriptions":[{"subscriptionNumber":"A-S0123456","orderActions":[{"type":"CancelSubscription","triggerDates":[{"name":"ContractEffective","triggerDate":"2026-08-01"}],"cancelSubscription":{"cancellationPolicy":"SpecificDate","cancellationEffectiveDate":"2026-08-01"}}]}],"processingOptions":{"runBilling":false,"collectPayment":false}}""",
+    )
   }
 
   it should "Correctly decode PUT (/v1/subscriptions/$subscriptionNumber) response where user made payment on switch" in {

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockZuoraCancel.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/MockZuoraCancel.scala
@@ -1,26 +1,29 @@
 package com.gu.productmove.zuora
 
 import com.gu.productmove.endpoint.move.ProductMoveEndpointTypes.{ErrorResponse, InternalServerError}
-import com.gu.productmove.zuora.model.SubscriptionName
+import com.gu.productmove.zuora.model.{AccountNumber, SubscriptionName}
 import zio.*
 
 import java.time.LocalDate
 
-class MockZuoraCancel(responses: Map[(SubscriptionName, LocalDate), CancellationResponse]) extends ZuoraCancel {
+class MockZuoraCancel(responses: Set[(SubscriptionName, LocalDate)]) extends ZuoraCancel {
 
-  private var mutableStore: List[(SubscriptionName, LocalDate)] = Nil // we need to remember the side effects
+  private var mutableStore: List[(AccountNumber, SubscriptionName, LocalDate, LocalDate)] =
+    Nil // we need to remember the side effects
 
   def requests = mutableStore.reverse
 
   override def cancel(
+      accountNumber: AccountNumber,
       subscriptionName: SubscriptionName,
       chargedThroughDate: LocalDate,
-  ): Task[CancellationResponse] = {
-    mutableStore = (subscriptionName, chargedThroughDate) :: mutableStore
+      orderDate: LocalDate,
+  ): Task[Unit] = {
+    mutableStore = (accountNumber, subscriptionName, chargedThroughDate, orderDate) :: mutableStore
 
-    responses.get((subscriptionName, chargedThroughDate)) match {
-      case Some(stubbedResponse) => ZIO.succeed(stubbedResponse)
-      case None =>
+    responses.contains((subscriptionName, chargedThroughDate)) match {
+      case true => ZIO.unit
+      case false =>
         ZIO.fail(
           new Throwable(
             s"MockZuoraCancel: no response stubbed for parameters: (${subscriptionName.value}, $chargedThroughDate)",
@@ -31,6 +34,6 @@ class MockZuoraCancel(responses: Map[(SubscriptionName, LocalDate), Cancellation
 }
 
 object MockZuoraCancel {
-  def requests: ZIO[MockZuoraCancel, Nothing, List[(SubscriptionName, LocalDate)]] =
+  def requests: ZIO[MockZuoraCancel, Nothing, List[(AccountNumber, SubscriptionName, LocalDate, LocalDate)]] =
     ZIO.serviceWith[MockZuoraCancel](_.requests)
 }

--- a/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ZuoraCancelSpec.scala
+++ b/handlers/product-move-api/src/test/scala/com/gu/productmove/zuora/ZuoraCancelSpec.scala
@@ -1,0 +1,142 @@
+package com.gu.productmove.zuora
+
+import com.gu.productmove.zuora.model.{AccountNumber, SubscriptionName}
+import com.gu.productmove.zuora.rest.ZuoraClient
+import com.gu.productmove.framework.LambdaRemainingTime
+import sttp.client3.Request
+import zio.*
+import zio.test.*
+
+import java.time.LocalDate
+
+object ZuoraCancelSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("ZuoraCancel")(
+      test("waits for both the job and its Order to complete") {
+        for {
+          client <- SequencedZuoraClient.make(
+            List(
+              Right("""{"success":true,"jobId":"job-123"}"""),
+              Right("""{"success":true,"status":"Completed","errors":null,"result":{"status":"Completed"}}"""),
+            ),
+          )
+          _ <- cancel(client)
+          paths <- client.paths
+        } yield assertTrue(paths == List("async/orders", "async-jobs/job-123"))
+      },
+      test("does not treat a completed job with a pending Order as success") {
+        for {
+          client <- SequencedZuoraClient.make(
+            List(
+              Right("""{"success":true,"jobId":"job-123"}"""),
+              Right("""{"success":true,"status":"Completed","errors":null,"result":{"status":"Pending"}}"""),
+            ),
+          )
+          result <- cancel(client).either
+          paths <- client.paths
+        } yield assertTrue(result.isLeft, paths == List("async/orders", "async-jobs/job-123"))
+      },
+      test("does not resubmit an Order when submission fails") {
+        for {
+          client <- SequencedZuoraClient.make(List(Left(new RuntimeException("connection reset"))))
+          result <- cancel(client).either
+          paths <- client.paths
+        } yield assertTrue(result.isLeft, paths == List("async/orders"))
+      },
+      test("does not submit an Order when the Lambda needs its remaining time for later work") {
+        for {
+          client <- SequencedZuoraClient.make(Nil)
+          result <- cancel(client, remainingTimeInMillis = 10000).either
+          paths <- client.paths
+        } yield assertTrue(result.isLeft, paths.isEmpty)
+      },
+      test("retries a temporary job status read without resubmitting the Order") {
+        for {
+          client <- SequencedZuoraClient.make(
+            List(
+              Right("""{"success":true,"jobId":"job-123"}"""),
+              Left(new RuntimeException("temporary network error")),
+              Right("""{"success":true,"status":"Completed","errors":null,"result":{"status":"Completed"}}"""),
+            ),
+          )
+          fiber <- cancel(client).fork
+          _ <- TestClock.adjust(Duration.fromSeconds(2))
+          _ <- fiber.join
+          paths <- client.paths
+        } yield assertTrue(paths == List("async/orders", "async-jobs/job-123", "async-jobs/job-123"))
+      },
+      test("retries one Order after Zuora confirms locking contention") {
+        for {
+          client <- SequencedZuoraClient.make(
+            List(
+              Right("""{"success":true,"jobId":"job-123"}"""),
+              Right(
+                """{"success":true,"status":"Failed","errors":"[40000050] Operation failed due to a lock competition","result":null}""",
+              ),
+              Right("""{"success":true,"jobId":"job-456"}"""),
+              Right("""{"success":true,"status":"Completed","errors":null,"result":{"status":"Completed"}}"""),
+            ),
+          )
+          fiber <- cancel(client).fork
+          _ <- TestClock.adjust(Duration.fromSeconds(60))
+          _ <- fiber.join
+          paths <- client.paths
+        } yield assertTrue(
+          paths == List("async/orders", "async-jobs/job-123", "async/orders", "async-jobs/job-456"),
+        )
+      },
+      test("polls a processing job until both statuses complete") {
+        for {
+          client <- SequencedZuoraClient.make(
+            List(
+              Right("""{"success":true,"jobId":"job-123"}"""),
+              Right("""{"success":true,"status":"Processing","errors":null,"result":null}"""),
+              Right("""{"success":true,"status":"Completed","errors":null,"result":{"status":"Completed"}}"""),
+            ),
+          )
+          fiber <- cancel(client).fork
+          _ <- TestClock.adjust(Duration.fromSeconds(2))
+          _ <- fiber.join
+          paths <- client.paths
+        } yield assertTrue(paths == List("async/orders", "async-jobs/job-123", "async-jobs/job-123"))
+      },
+    )
+
+  private def cancel(client: ZuoraClient, remainingTimeInMillis: Int = 300000): Task[Unit] =
+    LambdaRemainingTime.withRemainingTime(() => remainingTimeInMillis) {
+      ZIO
+        .serviceWithZIO[ZuoraCancel](
+          _.cancel(
+            AccountNumber("A0123456"),
+            SubscriptionName("A-S0123456"),
+            LocalDate.of(2026, 9, 1),
+            LocalDate.of(2026, 8, 19),
+          ),
+        )
+        .provide(ZuoraCancelLive.layer, ZLayer.succeed(client))
+    }
+
+  private final class SequencedZuoraClient(
+      responses: Ref[List[Either[Throwable, String]]],
+      requestPaths: Ref[List[String]],
+  ) extends ZuoraClient {
+    override def send(request: Request[Either[String, String], Any]): Task[String] =
+      requestPaths.update(_ :+ request.uri.toString) *>
+        responses
+          .modify {
+            case response :: remaining => (response, remaining)
+            case Nil => (Left(new RuntimeException("No Zuora response was configured")), Nil)
+          }
+          .flatMap(ZIO.fromEither)
+
+    def paths: UIO[List[String]] = requestPaths.get
+  }
+
+  private object SequencedZuoraClient {
+    def make(responses: List[Either[Throwable, String]]): UIO[SequencedZuoraClient] =
+      for {
+        responseQueue <- Ref.make(responses)
+        requestPaths <- Ref.make(List.empty[String])
+      } yield new SequencedZuoraClient(responseQueue, requestPaths)
+  }
+}


### PR DESCRIPTION
## What does this change?

This replaces the legacy subscription cancellation amendment in product-move-api with an asynchronous Zuora Order. It preserves the existing effective cancellation date, including the backdated refund case, while using the submission date as `orderDate`.

The Order is only treated as complete once both the async job and its nested Order report `Completed`. A failed status read is retried within the Lambda remaining time. An ambiguous submission is not retried, while confirmed Zuora locking contention is retried once after one minute.

The cancellation Order has this shape:

```json
{
  "orderDate": "2026-08-19",
  "existingAccountNumber": "A0123456",
  "subscriptions": [
    {
      "subscriptionNumber": "A-S0123456",
      "orderActions": [
        {
          "type": "CancelSubscription",
          "triggerDates": [
            {
              "name": "ContractEffective",
              "triggerDate": "2026-09-01"
            }
          ],
          "cancelSubscription": {
            "cancellationPolicy": "SpecificDate",
            "cancellationEffectiveDate": "2026-09-01"
          }
        }
      ]
    }
  ],
  "processingOptions": {
    "runBilling": false,
    "collectPayment": false
  }
}
```

## How has this change been tested?

`product-move-api` formatting, unit tests and assembly all pass locally. The new tests cover the Order payload, completed and incomplete async results, temporary job-read failures, ambiguous submission failures, locking contention, polling, and the Lambda time budget.

The branch was deployed to CODE and a Supporter Plus cancellation completed through the API gateway. Zuora reported both the async job and its nested Order as `Completed`; the existing cancellation reason and email flow then completed.

## How can we measure success?

A controlled cancellation in CODE creates a completed Zuora Order with the existing cancellation effective date. The cancellation reason, refund flow and email then follow the existing path.

## Have we considered potential risks?

The Order polling window is capped at three minutes so two minutes remain for the existing refund, cancellation reason and email work. If the submission response is lost, the processor fails rather than risking a duplicate cancellation. A confirmed Zuora locking contention is the only case retried, once.
