### PR TITLE
Remove name fields from mma-primary endpoint

### DIFF
--- a/handlers/braze-acquisition-events-sync/src/services.ts
+++ b/handlers/braze-acquisition-events-sync/src/services.ts
@@ -49,6 +49,12 @@ export const defaultDeps: RuntimeDeps = {
 			);
 			return undefined;
 		}
+		if (!user.privateFields) {
+			logger.log(
+				`User found in IDAPI for identityId ${identityId} missing privateFields`,
+			);
+			return undefined;
+		}
 		const parsedPrivateFields = privateFieldsSchema.safeParse(
 			user.privateFields,
 		);

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -19,9 +19,6 @@ export const mmaPrimarySummaryResponseSchema = z.object({
 	secondaryUsers: z.array(
 		secondaryUserRecordSchema.extend({
 			email: z.string().optional(),
-			displayName: z.string().optional(),
-			firstName: z.string().optional(),
-			lastName: z.string().optional(),
 		}),
 	),
 });
@@ -69,12 +66,12 @@ const getNonCancelledSecondaryUserListWithNames = async (
 
 	return Promise.all(
 		secondaryUsers.map(async (secondaryUser) =>
-			getSecondaryUserWithName(identityClient, secondaryUser),
+			getSecondaryUserWithEmail(identityClient, secondaryUser),
 		),
 	);
 };
 
-const getSecondaryUserWithName = async (
+const getSecondaryUserWithEmail = async (
 	identityClient: IdentityClient,
 	secondaryUser: SecondaryUserRecord,
 ) => {
@@ -91,9 +88,6 @@ const getSecondaryUserWithName = async (
 
 	return {
 		...secondaryUser,
-		displayName: userDetails.publicFields.displayName,
-		firstName: userDetails.privateFields.firstName,
-		lastName: userDetails.privateFields.secondName,
 		email: userDetails.primaryEmailAddress,
 	};
 };

--- a/modules/identity/src/idapi.ts
+++ b/modules/identity/src/idapi.ts
@@ -15,6 +15,13 @@ const identityUserByIdSchema = z.object({
 	id: z.string(),
 	primaryEmailAddress: z.string().optional(),
 	publicFields: z.object({ displayName: z.string() }),
+	privateFields: z
+		.object({
+			brazeUuid: z.string().optional(),
+			firstName: z.string().optional(),
+			secondName: z.string().optional(),
+		})
+		.optional(),
 });
 
 type IdentityUserById = z.infer<typeof identityUserByIdSchema>;

--- a/modules/identity/src/idapi.ts
+++ b/modules/identity/src/idapi.ts
@@ -3,38 +3,31 @@ import { z } from 'zod';
 import { RestClientError } from '@modules/zuora/restClient';
 import type { IdentityClient } from './identityClient';
 
-const identityUserSchema = z.object({
+const identityUserByEmailSchema = z.object({
 	id: z.string(),
 	primaryEmailAddress: z.string(),
 	publicFields: z.object({ displayName: z.string() }),
 });
 
-const identityUserWithPrivateFieldsSchema = z.object({
+type IdentityUserByEmail = z.infer<typeof identityUserByEmailSchema>;
+
+const identityUserByIdSchema = z.object({
 	id: z.string(),
 	primaryEmailAddress: z.string().optional(),
 	publicFields: z.object({ displayName: z.string() }),
-	privateFields: z.object({
-		brazeUuid: z.string().optional(),
-		firstName: z.string().optional(),
-		secondName: z.string().optional(),
-	}),
 });
 
-type IdentityUser = z.infer<typeof identityUserSchema>;
+type IdentityUserById = z.infer<typeof identityUserByIdSchema>;
 
 const userByEmailResponseSchema = z.object({
 	status: z.literal('ok'),
-	user: identityUserSchema,
+	user: identityUserByEmailSchema,
 });
 
 const userByIdentityIdResponseSchema = z.object({
 	status: z.literal('ok'),
-	user: identityUserWithPrivateFieldsSchema,
+	user: identityUserByIdSchema,
 });
-
-type IdentityUserWithPrivateFields = z.infer<
-	typeof identityUserWithPrivateFieldsSchema
->;
 
 const guestAccountResponseSchema = z.object({
 	status: z.literal('ok'),
@@ -46,7 +39,7 @@ const guestAccountResponseSchema = z.object({
 export const getUserByEmail = async (
 	client: IdentityClient,
 	email: string,
-): Promise<IdentityUser | undefined> => {
+): Promise<IdentityUserByEmail | undefined> => {
 	try {
 		const response = await client.get(
 			`/user?emailAddress=${encodeURIComponent(email)}`,
@@ -67,7 +60,7 @@ export const getUserByEmail = async (
 export const getUserByIdentityId = async (
 	client: IdentityClient,
 	identityId: string,
-): Promise<IdentityUserWithPrivateFields | undefined> => {
+): Promise<IdentityUserById | undefined> => {
 	try {
 		const response = await client.get(
 			`/user/${encodeURIComponent(identityId)}`,


### PR DESCRIPTION
## What does this change?

This PR removes `firstName`, `lastName` and `displayName` from the `secondaryUsers` list in the response from the mma-primary endpoint.  

This is for privacy reasons. Actually this behaviour was broken already because the token we use to auth with IDAPI does not allow inclusion of the privateFields property, which `firstName` and `lastName` are nested under.

Note: includes a change to update the IDAPI user response schema to make the `privateFields` property optional. I think this is the right way to model this since it may or may not be there depending on the permissions of the access token used to auth with IDAPI. This had one small knock on effect in braze-acquisition-events-sync, so I'll ask MarTech to check that to make sure they're happy.

## How has this change been tested?

This has been deployed to CODE and verified by calling the endpoint from MMA. Previously this was broken when the response contained secondary users who had accepted an invitiation.