### PR TITLE
Add supporter-product-data-CODE SQS queue to local dev policy

### DIFF
--- a/cdk/lib/__snapshots__/iam-policies.test.ts.snap
+++ b/cdk/lib/__snapshots__/iam-policies.test.ts.snap
@@ -370,22 +370,40 @@ exports[`The IamPolicies stack matches the snapshot 1`] = `
                 "sqs:SendMessage",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:sqs:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":braze-emails-CODE",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":braze-emails-CODE",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":supporter-product-data-CODE",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -767,22 +785,40 @@ exports[`The IamPolicies stack matches the snapshot 2`] = `
                 "sqs:SendMessage",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:sqs:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":braze-emails-CODE",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":braze-emails-CODE",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":supporter-product-data-CODE",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/iam-policies.ts
+++ b/cdk/lib/iam-policies.ts
@@ -35,19 +35,23 @@ export class IamPolicies extends SrStack {
 					resources: ['*'],
 				}),
 				new AllowS3GetPolicy('contributions-ticker', ['CODE/*']),
-				new AllowSqsSendPolicy(this, 'braze-emails'),
+				new AllowSqsSendPolicy(this, [
+					'braze-emails',
+					'supporter-product-data',
+				]),
 			],
 		});
 	}
 }
 
 class AllowSqsSendPolicy extends PolicyStatement {
-	constructor(scope: GuStack, queueName: SrQueueName) {
+	constructor(scope: GuStack, queueNames: SrQueueName[]) {
 		super({
 			actions: ['sqs:GetQueueUrl', 'sqs:SendMessage'],
-			resources: [
-				`arn:aws:sqs:${scope.region}:${scope.account}:${queueName}-CODE`,
-			],
+			resources: queueNames.map(
+				(queueName) =>
+					`arn:aws:sqs:${scope.region}:${scope.account}:${queueName}-CODE`,
+			),
 		});
 	}
 }


### PR DESCRIPTION
## What does this change?

Adds the `supporter-product-data-CODE` SQS queue to local dev policy.

This is needed when running the multiple-account-api integration tests locally.