### PR TITLE
Migrate stripe-disputes to Zuora Orders API

### DIFF
--- a/handlers/stripe-disputes/src/consumer.ts
+++ b/handlers/stripe-disputes/src/consumer.ts
@@ -1,4 +1,4 @@
-import type { SQSEvent } from 'aws-lambda';
+import type { Context, SQSEvent } from 'aws-lambda';
 import { Logger } from '@modules/logger/logger';
 import type {
 	ListenDisputeClosedRequestBody,
@@ -18,7 +18,10 @@ interface DisputeEventMessage {
 	disputeId: string;
 }
 
-export const handler = async (event: SQSEvent): Promise<void> => {
+export const handler = async (
+	event: SQSEvent,
+	context?: Context,
+): Promise<void> => {
 	logger.log(`Input: ${JSON.stringify(event)}`);
 	logger.log(`Processing ${event.Records.length} SQS dispute events`);
 
@@ -47,6 +50,9 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 						logger,
 						message.webhookData as ListenDisputeClosedRequestBody,
 						message.disputeId,
+						context === undefined
+							? undefined
+							: () => context.getRemainingTimeInMillis(),
 					);
 					break;
 				}

--- a/handlers/stripe-disputes/src/services/cancelSubscriptionService.ts
+++ b/handlers/stripe-disputes/src/services/cancelSubscriptionService.ts
@@ -7,12 +7,34 @@ import {
 import type { Logger } from '@modules/logger/logger';
 import { stageFromEnvironment } from '@modules/stage';
 import { getAccount } from '@modules/zuora/account';
-import {
-	cancelSubscription,
-	updateSubscription,
-} from '@modules/zuora/subscription';
+import { cancelSubscriptionWithOrder } from '@modules/zuora/orders/cancelSubscription';
+import { updateSubscription } from '@modules/zuora/subscription';
 import type { ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+
+/**
+ * Reserve two of the consumer Lambda's five minutes for the Stripe rejection,
+ * invoice write-offs and cancellation email after the Zuora Order has finished.
+ */
+const postOrderWorkBufferInMilliseconds = 120_000;
+const minimumOrderDurationInMilliseconds = 10_000;
+const maximumOrderDurationInMilliseconds = 180_000;
+
+export const orderDuration = (
+	getRemainingTimeInMillis: (() => number) | undefined,
+): number => {
+	const remainingTimeInMilliseconds =
+		getRemainingTimeInMillis?.() ??
+		maximumOrderDurationInMilliseconds + postOrderWorkBufferInMilliseconds;
+	const availableDuration =
+		remainingTimeInMilliseconds - postOrderWorkBufferInMilliseconds;
+	if (availableDuration < minimumOrderDurationInMilliseconds) {
+		throw new Error(
+			'Not enough Lambda time remains to safely submit the Zuora cancellation order',
+		);
+	}
+	return Math.min(availableDuration, maximumOrderDurationInMilliseconds);
+};
 
 export interface CancelSubscriptionResult {
 	cancelled: boolean;
@@ -23,6 +45,8 @@ export async function cancelSubscriptionService(
 	logger: Logger,
 	zuoraClient: ZuoraClient,
 	subscription: ZuoraSubscription,
+	disputeId: string,
+	getRemainingTimeInMillis?: () => number,
 ): Promise<CancelSubscriptionResult> {
 	if (subscription.status !== 'Active') {
 		logger.log(
@@ -35,15 +59,20 @@ export async function cancelSubscriptionService(
 		`Canceling active subscription: ${subscription.subscriptionNumber}`,
 	);
 
-	const cancelResponse = await cancelSubscription(
+	const today = dayjs();
+	const negativeInvoiceId = await cancelSubscriptionWithOrder(
 		zuoraClient,
-		subscription.subscriptionNumber,
-		dayjs(),
-		true,
+		{
+			accountNumber: subscription.accountNumber,
+			subscriptionNumber: subscription.subscriptionNumber,
+			orderDate: today,
+			cancellationEffectiveDate: today,
+		},
+		orderDuration(getRemainingTimeInMillis),
+		`stripe-dispute-cancellation-${disputeId}`,
 	);
 
-	const negativeInvoiceId = cancelResponse.invoiceId;
-	if (negativeInvoiceId) {
+	if (negativeInvoiceId !== undefined) {
 		logger.log(`Cancellation generated negative invoice: ${negativeInvoiceId}`);
 	}
 

--- a/handlers/stripe-disputes/src/sqs-consumers/listenDisputeClosed.ts
+++ b/handlers/stripe-disputes/src/sqs-consumers/listenDisputeClosed.ts
@@ -18,6 +18,7 @@ export async function handleListenDisputeClosed(
 	logger: Logger,
 	webhookData: ListenDisputeClosedRequestBody,
 	disputeId: string,
+	getRemainingTimeInMillis?: () => number,
 ): Promise<SalesforceUpsertResponse | null> {
 	logger.log(`Processing dispute closure for dispute ${disputeId}`);
 
@@ -61,6 +62,8 @@ export async function handleListenDisputeClosed(
 			logger,
 			zuoraClient,
 			subscription,
+			disputeId,
+			getRemainingTimeInMillis,
 		);
 
 		// Step 3: Reject payment - may fail if already refunded

--- a/handlers/stripe-disputes/test/consumer.test.ts
+++ b/handlers/stripe-disputes/test/consumer.test.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/order -- the other import must come after the mocks
-import type { SQSEvent } from 'aws-lambda';
+import type { Context, SQSEvent } from 'aws-lambda';
 
 const mockLogger = {
 	log: jest.fn(),
@@ -114,7 +114,24 @@ describe('Consumer Handler', () => {
 				mockLogger,
 				expect.objectContaining({ data: { object: { id: 'du_2' } } }),
 				'du_2',
+				undefined,
 			);
+		});
+
+		it('passes the Lambda time budget to dispute closures', async () => {
+			const event = createMockSqsEvent('dispute.closed', 'du_test123');
+			const getRemainingTimeInMillis = jest.fn(() => 300_000);
+
+			await handler(event, { getRemainingTimeInMillis } as unknown as Context);
+
+			expect(mockHandleListenDisputeClosed).toHaveBeenCalledWith(
+				mockLogger,
+				expect.objectContaining({ data: { object: { id: 'du_test123' } } }),
+				'du_test123',
+				expect.any(Function),
+			);
+			const timeBudget = mockHandleListenDisputeClosed.mock.calls[0]?.[3];
+			expect(timeBudget()).toBe(300_000);
 		});
 	});
 });

--- a/handlers/stripe-disputes/test/services/cancelSubscriptionService.test.ts
+++ b/handlers/stripe-disputes/test/services/cancelSubscriptionService.test.ts
@@ -2,13 +2,16 @@ import { sendEmail } from '@modules/email/email';
 import type { Logger } from '@modules/logger/logger';
 import { stageFromEnvironment } from '@modules/stage';
 import { getAccount } from '@modules/zuora/account';
-import { cancelSubscription } from '@modules/zuora/subscription';
+import { cancelSubscriptionWithOrder } from '@modules/zuora/orders/cancelSubscription';
 import type { ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { cancelSubscriptionService } from '../../src/services/cancelSubscriptionService';
+import {
+	cancelSubscriptionService,
+	orderDuration,
+} from '../../src/services/cancelSubscriptionService';
 
 jest.mock('@modules/zuora/account');
-jest.mock('@modules/zuora/subscription');
+jest.mock('@modules/zuora/orders/cancelSubscription');
 jest.mock('@modules/email/email');
 jest.mock('@modules/stage');
 jest.mock('dayjs', () =>
@@ -27,6 +30,7 @@ describe('cancelSubscriptionService', () => {
 	} as unknown as jest.Mocked<Logger>;
 
 	const mockZuoraClient = {} as ZuoraClient;
+	const disputeId = 'dp_123';
 
 	const createMockSubscription = (
 		status: 'Active' | 'Cancelled',
@@ -63,29 +67,35 @@ describe('cancelSubscriptionService', () => {
 		jest.clearAllMocks();
 		(stageFromEnvironment as jest.Mock).mockReturnValue('TEST');
 		(getAccount as jest.Mock).mockResolvedValue(mockAccount);
-		(cancelSubscription as jest.Mock).mockResolvedValue({
-			invoiceId: 'INV-NEG-001',
-		});
+		(cancelSubscriptionWithOrder as jest.Mock).mockResolvedValue('INV-NEG-001');
 	});
 
-	it('should cancel active subscription with SpecificDate policy and runBilling=true', async () => {
+	it('cancels active subscriptions with a billing order', async () => {
 		const mockSubscription = createMockSubscription('Active');
 
 		const result = await cancelSubscriptionService(
 			mockLogger,
 			mockZuoraClient,
 			mockSubscription,
+			disputeId,
 		);
 
 		expect(result).toEqual({
 			cancelled: true,
 			negativeInvoiceId: 'INV-NEG-001',
 		});
-		expect(cancelSubscription).toHaveBeenCalledWith(
+		expect(cancelSubscriptionWithOrder).toHaveBeenCalledWith(
 			mockZuoraClient,
-			'SUB-12345',
-			expect.objectContaining({ format: expect.any(Function) }),
-			true,
+			expect.objectContaining({
+				accountNumber: 'ACC-12345',
+				subscriptionNumber: 'SUB-12345',
+				orderDate: expect.objectContaining({ format: expect.any(Function) }),
+				cancellationEffectiveDate: expect.objectContaining({
+					format: expect.any(Function),
+				}),
+			}),
+			180_000,
+			'stripe-dispute-cancellation-dp_123',
 		);
 	});
 
@@ -96,25 +106,25 @@ describe('cancelSubscriptionService', () => {
 			mockLogger,
 			mockZuoraClient,
 			mockSubscription,
+			disputeId,
 		);
 
 		expect(result).toEqual({ cancelled: false });
 		expect(mockLogger.log).toHaveBeenCalledWith(
 			'Subscription already inactive (Cancelled), skipping cancellation',
 		);
-		expect(cancelSubscription).not.toHaveBeenCalled();
+		expect(cancelSubscriptionWithOrder).not.toHaveBeenCalled();
 	});
 
 	it('should return negativeInvoiceId from cancel response', async () => {
 		const mockSubscription = createMockSubscription('Active');
-		(cancelSubscription as jest.Mock).mockResolvedValue({
-			invoiceId: 'INV-NEG-789',
-		});
+		(cancelSubscriptionWithOrder as jest.Mock).mockResolvedValue('INV-NEG-789');
 
 		const result = await cancelSubscriptionService(
 			mockLogger,
 			mockZuoraClient,
 			mockSubscription,
+			disputeId,
 		);
 
 		expect(result.negativeInvoiceId).toBe('INV-NEG-789');
@@ -123,27 +133,49 @@ describe('cancelSubscriptionService', () => {
 		);
 	});
 
-	it('should handle cancel response without invoiceId', async () => {
+	it('continues when the cancellation order does not generate an invoice', async () => {
 		const mockSubscription = createMockSubscription('Active');
-		(cancelSubscription as jest.Mock).mockResolvedValue({});
+		(cancelSubscriptionWithOrder as jest.Mock).mockResolvedValue(undefined);
 
-		const result = await cancelSubscriptionService(
-			mockLogger,
-			mockZuoraClient,
-			mockSubscription,
+		await expect(
+			cancelSubscriptionService(
+				mockLogger,
+				mockZuoraClient,
+				mockSubscription,
+				disputeId,
+			),
+		).resolves.toEqual({ cancelled: true, negativeInvoiceId: undefined });
+		expect(mockLogger.log).not.toHaveBeenCalledWith(
+			'Cancellation generated negative invoice: undefined',
 		);
-
-		expect(result).toEqual({ cancelled: true, negativeInvoiceId: undefined });
 	});
 
 	it('should propagate errors when ZuoraClient throws', async () => {
 		const mockSubscription = createMockSubscription('Active');
 		const error = new Error('Zuora API error: Subscription not found');
-		(cancelSubscription as jest.Mock).mockRejectedValue(error);
+		(cancelSubscriptionWithOrder as jest.Mock).mockRejectedValue(error);
 
 		await expect(
-			cancelSubscriptionService(mockLogger, mockZuoraClient, mockSubscription),
+			cancelSubscriptionService(
+				mockLogger,
+				mockZuoraClient,
+				mockSubscription,
+				disputeId,
+			),
 		).rejects.toThrow('Zuora API error: Subscription not found');
+	});
+
+	describe('orderDuration', () => {
+		it('leaves two minutes for the remaining dispute processing', () => {
+			expect(orderDuration(() => 300_000)).toBe(180_000);
+			expect(orderDuration(() => 210_000)).toBe(90_000);
+		});
+
+		it('does not submit an order without enough time left', () => {
+			expect(() => orderDuration(() => 129_999)).toThrow(
+				'Not enough Lambda time remains',
+			);
+		});
 	});
 
 	describe('email sending', () => {
@@ -155,6 +187,7 @@ describe('cancelSubscriptionService', () => {
 				mockLogger,
 				mockZuoraClient,
 				mockSubscription,
+				disputeId,
 			);
 
 			expect(result.cancelled).toBe(true);
@@ -190,6 +223,7 @@ describe('cancelSubscriptionService', () => {
 				mockLogger,
 				mockZuoraClient,
 				mockSubscription,
+				disputeId,
 			);
 
 			expect(result.cancelled).toBe(true);
@@ -207,6 +241,7 @@ describe('cancelSubscriptionService', () => {
 				mockLogger,
 				mockZuoraClient,
 				mockSubscription,
+				disputeId,
 			);
 
 			expect(result.cancelled).toBe(true);
@@ -226,6 +261,7 @@ describe('cancelSubscriptionService', () => {
 				mockLogger,
 				mockZuoraClient,
 				mockSubscription,
+				disputeId,
 			);
 
 			expect(result.cancelled).toBe(true);
@@ -243,6 +279,7 @@ describe('cancelSubscriptionService', () => {
 				mockLogger,
 				mockZuoraClient,
 				mockSubscription,
+				disputeId,
 			);
 
 			expect(sendEmail).not.toHaveBeenCalled();

--- a/handlers/stripe-disputes/test/sqs-consumers/listenDisputeClosed.test.ts
+++ b/handlers/stripe-disputes/test/sqs-consumers/listenDisputeClosed.test.ts
@@ -170,6 +170,8 @@ describe('handleListenDisputeClosed', () => {
 				status: 'Active',
 				subscriptionNumber: 'SUB-12345',
 			}),
+			'du_test456',
+			undefined,
 		);
 
 		expect(mockRejectPayment).toHaveBeenCalledWith(

--- a/modules/zuora/src/orders/asyncOrderRequests.ts
+++ b/modules/zuora/src/orders/asyncOrderRequests.ts
@@ -1,0 +1,201 @@
+import { z } from 'zod';
+import { logger } from '@modules/logger/logger';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import type { OrderRequest } from './orderRequests';
+
+const pollIntervalInMilliseconds = 2_000;
+const readTimeoutInMilliseconds = 120_000;
+const lockingContentionRetryDelayInMilliseconds = 60_000;
+const lockingContentionCode = '[40000050]';
+
+const asyncOrderSubmissionSchema = z.union([
+	z.object({ success: z.literal(true), jobId: z.string().min(1) }),
+	z.object({ success: z.literal(false) }),
+]);
+
+const orderStatusSchema = z.enum([
+	'Draft',
+	'Pending',
+	'Completed',
+	'Cancelled',
+	'Scheduled',
+	'Executing',
+	'Failed',
+]);
+
+const asyncOrderJobReportSchema = z.object({
+	success: z.boolean().optional().default(true),
+	status: z.enum(['Processing', 'Failed', 'Completed']),
+	errors: z.string().nullable().optional().default(null),
+	result: z
+		.object({
+			status: orderStatusSchema,
+			orderNumber: z.string().optional(),
+			invoiceNumbers: z.array(z.string()).optional(),
+		})
+		.nullable()
+		.optional()
+		.default(null),
+});
+
+export type AsyncOrderResult = NonNullable<
+	z.infer<typeof asyncOrderJobReportSchema>['result']
+>;
+
+type AsyncOrderClient = Pick<ZuoraClient, 'get' | 'post'>;
+
+type Wait = (milliseconds: number) => Promise<void>;
+type Now = () => number;
+
+export type AsyncOrderOptions = {
+	now?: Now;
+	wait?: Wait;
+	idempotencyKey?: string;
+};
+
+class LockingContention extends Error {}
+
+const wait = (milliseconds: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const remainingDuration = (deadline: number, now: Now): number =>
+	deadline - now();
+
+const requestTimeout = (deadline: number, now: Now): number =>
+	Math.min(remainingDuration(deadline, now), readTimeoutInMilliseconds);
+
+const waitForNextPoll = async (
+	deadline: number,
+	now: Now,
+	pause: Wait,
+): Promise<boolean> => {
+	const remaining = remainingDuration(deadline, now);
+	if (remaining <= 0) {
+		return false;
+	}
+	await pause(Math.min(remaining, pollIntervalInMilliseconds));
+	return true;
+};
+
+const waitForCompletion = async (
+	zuoraClient: AsyncOrderClient,
+	jobId: string,
+	deadline: number,
+	now: Now,
+	pause: Wait,
+): Promise<AsyncOrderResult> => {
+	while (remainingDuration(deadline, now) > 0) {
+		let job: z.infer<typeof asyncOrderJobReportSchema>;
+		try {
+			job = await zuoraClient.get(
+				`/v1/async-jobs/${jobId}`,
+				asyncOrderJobReportSchema,
+				undefined,
+				requestTimeout(deadline, now),
+			);
+		} catch (error) {
+			logger.log(
+				`Could not read Zuora order job ${jobId}: ${String(error)}. Retrying.`,
+			);
+			if (await waitForNextPoll(deadline, now, pause)) {
+				continue;
+			}
+			break;
+		}
+		if (!job.success) {
+			throw new Error(
+				`Zuora order job ${jobId} failed: ${job.errors ?? 'no reason returned'}`,
+			);
+		}
+
+		switch (job.status) {
+			case 'Processing':
+				if (await waitForNextPoll(deadline, now, pause)) {
+					continue;
+				}
+				break;
+			case 'Failed':
+				if (job.errors?.includes(lockingContentionCode)) {
+					throw new LockingContention(
+						`Zuora order job ${jobId} failed because the subscription is locked`,
+					);
+				}
+				throw new Error(
+					`Zuora order job ${jobId} failed: ${job.errors ?? 'no reason returned'}`,
+				);
+			case 'Completed':
+				if (job.result?.status === 'Completed') {
+					return job.result;
+				}
+				throw new Error(
+					`Zuora order job ${jobId} completed with order status ${job.result?.status ?? 'missing'}`,
+				);
+		}
+	}
+	throw new Error(`Timed out waiting for Zuora order job ${jobId}`);
+};
+
+export const createOrderAsynchronously = async (
+	zuoraClient: AsyncOrderClient,
+	orderRequest: OrderRequest,
+	maximumDurationInMilliseconds: number,
+	{
+		now = Date.now,
+		wait: pause = wait,
+		idempotencyKey,
+	}: AsyncOrderOptions = {},
+): Promise<AsyncOrderResult> => {
+	if (maximumDurationInMilliseconds <= 0) {
+		throw new Error('The Zuora order time budget must be positive');
+	}
+
+	const deadline = now() + maximumDurationInMilliseconds;
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		const remaining = remainingDuration(deadline, now);
+		if (remaining <= 0) {
+			throw new Error('Timed out before submitting the Zuora order');
+		}
+
+		const submission = await zuoraClient.post(
+			'/v1/async/orders',
+			JSON.stringify(orderRequest),
+			asyncOrderSubmissionSchema,
+			idempotencyKey === undefined
+				? undefined
+				: { 'idempotency-key': `${idempotencyKey}-${attempt}` },
+			Math.min(remaining, readTimeoutInMilliseconds),
+		);
+		if (!submission.success) {
+			throw new Error('Zuora did not accept the order');
+		}
+
+		logger.log(`Submitted Zuora order job ${submission.jobId}`);
+		try {
+			const result = await waitForCompletion(
+				zuoraClient,
+				submission.jobId,
+				deadline,
+				now,
+				pause,
+			);
+			logger.log(`Zuora order job ${submission.jobId} completed`);
+			return result;
+		} catch (error) {
+			if (
+				error instanceof LockingContention &&
+				attempt === 0 &&
+				remainingDuration(deadline, now) >
+					lockingContentionRetryDelayInMilliseconds
+			) {
+				logger.log(
+					`Retrying the Zuora order after locking contention: ${error.message}`,
+				);
+				await pause(lockingContentionRetryDelayInMilliseconds);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	throw new Error('The Zuora order could not be completed');
+};

--- a/modules/zuora/src/orders/cancelSubscription.ts
+++ b/modules/zuora/src/orders/cancelSubscription.ts
@@ -1,0 +1,82 @@
+import type { Dayjs } from 'dayjs';
+import { getInvoice } from '@modules/zuora/invoice';
+import { zuoraDateFormat } from '@modules/zuora/utils';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { createOrderAsynchronously } from './asyncOrderRequests';
+import type { CancelSubscriptionOrderAction } from './orderActions';
+import type { CreateOrderRequest } from './orderRequests';
+
+export type CancellationOrderInput = {
+	accountNumber: string;
+	subscriptionNumber: string;
+	orderDate: Dayjs;
+	cancellationEffectiveDate: Dayjs;
+};
+
+const cancellationAction = (
+	cancellationEffectiveDate: Dayjs,
+): CancelSubscriptionOrderAction => {
+	const effectiveDate = zuoraDateFormat(cancellationEffectiveDate);
+	return {
+		type: 'CancelSubscription',
+		triggerDates: [
+			{
+				name: 'ContractEffective',
+				triggerDate: effectiveDate,
+			},
+		],
+		cancelSubscription: {
+			cancellationPolicy: 'SpecificDate',
+			cancellationEffectiveDate: effectiveDate,
+		},
+	};
+};
+
+export const buildCancellationOrderRequest = (
+	input: CancellationOrderInput,
+): CreateOrderRequest => ({
+	orderDate: zuoraDateFormat(input.orderDate),
+	existingAccountNumber: input.accountNumber,
+	subscriptions: [
+		{
+			subscriptionNumber: input.subscriptionNumber,
+			orderActions: [cancellationAction(input.cancellationEffectiveDate)],
+		},
+	],
+	processingOptions: {
+		runBilling: true,
+		collectPayment: false,
+	},
+});
+
+export const zeroOrOneInvoiceNumber = (
+	invoiceNumbers: string[] | undefined,
+): string | undefined => {
+	if (invoiceNumbers === undefined || invoiceNumbers.length === 0) {
+		return undefined;
+	}
+	if (invoiceNumbers.length > 1) {
+		throw new Error(
+			'Zuora generated more than one invoice for a single subscription cancellation',
+		);
+	}
+	return invoiceNumbers[0];
+};
+
+export const cancelSubscriptionWithOrder = async (
+	zuoraClient: ZuoraClient,
+	input: CancellationOrderInput,
+	maximumDurationInMilliseconds: number,
+	idempotencyKey: string,
+): Promise<string | undefined> => {
+	const orderResult = await createOrderAsynchronously(
+		zuoraClient,
+		buildCancellationOrderRequest(input),
+		maximumDurationInMilliseconds,
+		{ idempotencyKey },
+	);
+	const invoiceNumber = zeroOrOneInvoiceNumber(orderResult.invoiceNumbers);
+	return invoiceNumber === undefined
+		? undefined
+		: (await getInvoice(zuoraClient, invoiceNumber)).id;
+};

--- a/modules/zuora/src/orders/orderActions.ts
+++ b/modules/zuora/src/orders/orderActions.ts
@@ -25,7 +25,8 @@ export type OrderActionType =
 	| 'UpdateProduct'
 	| 'CreateSubscription'
 	| 'AddProduct'
-	| 'RemoveProduct';
+	| 'RemoveProduct'
+	| 'CancelSubscription';
 
 type BaseOrderAction = {
 	type: OrderActionType;
@@ -90,6 +91,19 @@ export type TermsAndConditionsOrderAction = BaseOrderAction & {
 		};
 	};
 };
+export type CancelSubscriptionOrderAction = {
+	type: 'CancelSubscription';
+	triggerDates: [
+		{
+			name: 'ContractEffective';
+			triggerDate: string;
+		},
+	];
+	cancelSubscription: {
+		cancellationPolicy: 'SpecificDate';
+		cancellationEffectiveDate: string;
+	};
+};
 type SubscribeToProductRatePlan = {
 	productRatePlanId: string;
 	chargeOverrides?: Array<{
@@ -150,7 +164,8 @@ export type OrderAction =
 	| UpdateProductOrderAction
 	| DiscountOrderAction
 	| RemoveProductOrderAction
-	| CreateSubscriptionOrderAction;
+	| CreateSubscriptionOrderAction
+	| CancelSubscriptionOrderAction;
 
 export function singleTriggerDate(applyFromDate: Dayjs): TriggerDates {
 	return [

--- a/modules/zuora/test/orders/asyncOrderRequests.test.ts
+++ b/modules/zuora/test/orders/asyncOrderRequests.test.ts
@@ -1,0 +1,185 @@
+import { createOrderAsynchronously } from '@modules/zuora/orders/asyncOrderRequests';
+import type { OrderRequest } from '@modules/zuora/orders/orderRequests';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+
+const orderRequest: OrderRequest = {
+	orderDate: '2026-08-25',
+	existingAccountNumber: 'A01234567',
+	subscriptions: [],
+};
+
+const completedJob = {
+	success: true,
+	status: 'Completed',
+	errors: null,
+	result: { status: 'Completed', orderNumber: 'O-01234567' },
+} as const;
+
+const processingJob = {
+	success: true,
+	status: 'Processing',
+	errors: null,
+	result: null,
+} as const;
+
+const createClock = () => {
+	let milliseconds = 0;
+	return {
+		now: () => milliseconds,
+		wait: (duration: number) => {
+			milliseconds += duration;
+			return Promise.resolve();
+		},
+	};
+};
+
+const createZuoraClient = ({
+	post,
+	get,
+}: {
+	post: jest.Mock;
+	get: jest.Mock;
+}): ZuoraClient => ({ post, get }) as unknown as ZuoraClient;
+
+test('waits for both the job and order to complete', async () => {
+	const clock = createClock();
+	const post = jest.fn().mockResolvedValue({ success: true, jobId: 'job-1' });
+	const get = jest
+		.fn()
+		.mockResolvedValueOnce(processingJob)
+		.mockResolvedValueOnce(completedJob);
+
+	const result = await createOrderAsynchronously(
+		createZuoraClient({ post, get }),
+		orderRequest,
+		20_000,
+		clock,
+	);
+
+	expect(result).toEqual(completedJob.result);
+	expect(post).toHaveBeenCalledTimes(1);
+	expect(get).toHaveBeenCalledTimes(2);
+});
+
+test('retries a temporary failure while reading the same job', async () => {
+	const clock = createClock();
+	const post = jest.fn().mockResolvedValue({ success: true, jobId: 'job-1' });
+	const get = jest
+		.fn()
+		.mockRejectedValueOnce(new Error('temporary network failure'))
+		.mockResolvedValueOnce(completedJob);
+
+	await createOrderAsynchronously(
+		createZuoraClient({ post, get }),
+		orderRequest,
+		20_000,
+		clock,
+	);
+
+	expect(post).toHaveBeenCalledTimes(1);
+	expect(get).toHaveBeenCalledTimes(2);
+});
+
+test('retries once after explicit locking contention', async () => {
+	const clock = createClock();
+	const post = jest
+		.fn()
+		.mockResolvedValueOnce({ success: true, jobId: 'job-1' })
+		.mockResolvedValueOnce({ success: true, jobId: 'job-2' });
+	const get = jest
+		.fn()
+		.mockResolvedValueOnce({
+			success: true,
+			status: 'Failed',
+			errors: '[40000050] subscription is locked',
+			result: null,
+		})
+		.mockResolvedValueOnce(completedJob);
+
+	await createOrderAsynchronously(
+		createZuoraClient({ post, get }),
+		orderRequest,
+		70_000,
+		{ ...clock, idempotencyKey: 'stripe-dispute-cancellation-du_123' },
+	);
+
+	expect(post).toHaveBeenCalledTimes(2);
+	expect(get).toHaveBeenCalledTimes(2);
+	expect(post).toHaveBeenNthCalledWith(
+		1,
+		'/v1/async/orders',
+		expect.any(String),
+		expect.anything(),
+		{ 'idempotency-key': 'stripe-dispute-cancellation-du_123-0' },
+		expect.any(Number),
+	);
+	expect(post).toHaveBeenNthCalledWith(
+		2,
+		'/v1/async/orders',
+		expect.any(String),
+		expect.anything(),
+		{ 'idempotency-key': 'stripe-dispute-cancellation-du_123-1' },
+		expect.any(Number),
+	);
+});
+
+test('does not re-submit an order when submission fails', async () => {
+	const clock = createClock();
+	const post = jest.fn().mockRejectedValue(new Error('request timed out'));
+	const get = jest.fn();
+
+	await expect(
+		createOrderAsynchronously(
+			createZuoraClient({ post, get }),
+			orderRequest,
+			20_000,
+			clock,
+		),
+	).rejects.toThrow('request timed out');
+
+	expect(post).toHaveBeenCalledTimes(1);
+	expect(get).not.toHaveBeenCalled();
+});
+
+test('fails when Zuora reports an unsuccessful job', async () => {
+	const clock = createClock();
+	const post = jest.fn().mockResolvedValue({ success: true, jobId: 'job-1' });
+	const get = jest.fn().mockResolvedValue({
+		success: false,
+		status: 'Failed',
+		errors: 'invalid order',
+		result: null,
+	});
+
+	await expect(
+		createOrderAsynchronously(
+			createZuoraClient({ post, get }),
+			orderRequest,
+			20_000,
+			clock,
+		),
+	).rejects.toThrow('Zuora order job job-1 failed: invalid order');
+
+	expect(post).toHaveBeenCalledTimes(1);
+	expect(get).toHaveBeenCalledTimes(1);
+});
+
+test('rejects a completed job without a completed order', async () => {
+	const clock = createClock();
+	const post = jest.fn().mockResolvedValue({ success: true, jobId: 'job-1' });
+	const get = jest.fn().mockResolvedValue({
+		success: true,
+		status: 'Completed',
+		errors: null,
+		result: null,
+	});
+
+	await expect(
+		createOrderAsynchronously(
+			createZuoraClient({ post, get }),
+			orderRequest,
+			20_000,
+			clock,
+		),
+	).rejects.toThrow('completed with order status missing');
+});

--- a/modules/zuora/test/orders/cancelSubscription.test.ts
+++ b/modules/zuora/test/orders/cancelSubscription.test.ts
@@ -1,0 +1,127 @@
+import dayjs from 'dayjs';
+import { getInvoice } from '@modules/zuora/invoice';
+import { createOrderAsynchronously } from '@modules/zuora/orders/asyncOrderRequests';
+import {
+	buildCancellationOrderRequest,
+	cancelSubscriptionWithOrder,
+	zeroOrOneInvoiceNumber,
+} from '@modules/zuora/orders/cancelSubscription';
+import type { ZuoraClient } from '@modules/zuora/zuoraClient';
+
+jest.mock('@modules/zuora/invoice');
+jest.mock('@modules/zuora/orders/asyncOrderRequests');
+
+const input = {
+	accountNumber: 'A01234567',
+	subscriptionNumber: 'A-S01234567',
+	orderDate: dayjs('2026-08-21'),
+	cancellationEffectiveDate: dayjs('2026-08-21'),
+};
+
+describe('buildCancellationOrderRequest', () => {
+	it('builds a billing cancellation order', () => {
+		expect(buildCancellationOrderRequest(input)).toEqual({
+			orderDate: '2026-08-21',
+			existingAccountNumber: 'A01234567',
+			subscriptions: [
+				{
+					subscriptionNumber: 'A-S01234567',
+					orderActions: [
+						{
+							type: 'CancelSubscription',
+							triggerDates: [
+								{
+									name: 'ContractEffective',
+									triggerDate: '2026-08-21',
+								},
+							],
+							cancelSubscription: {
+								cancellationPolicy: 'SpecificDate',
+								cancellationEffectiveDate: '2026-08-21',
+							},
+						},
+					],
+				},
+			],
+			processingOptions: {
+				runBilling: true,
+				collectPayment: false,
+			},
+		});
+	});
+});
+
+describe('zeroOrOneInvoiceNumber', () => {
+	it('returns the only invoice number', () => {
+		expect(zeroOrOneInvoiceNumber(['INV-000001'])).toBe('INV-000001');
+	});
+
+	it.each([undefined, []])(
+		'returns undefined when the cancellation does not generate an invoice',
+		(invoiceNumbers) => {
+			expect(zeroOrOneInvoiceNumber(invoiceNumbers)).toBeUndefined();
+		},
+	);
+
+	it('rejects a cancellation order that generated multiple invoices', () => {
+		expect(() => zeroOrOneInvoiceNumber(['INV-000001', 'INV-000002'])).toThrow(
+			'more than one invoice for a single subscription cancellation',
+		);
+	});
+});
+
+describe('cancelSubscriptionWithOrder', () => {
+	const zuoraClient = {} as ZuoraClient;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('looks up the invoice id returned by the completed order', async () => {
+		jest.mocked(createOrderAsynchronously).mockResolvedValue({
+			status: 'Completed',
+			invoiceNumbers: ['INV-000001'],
+		});
+		jest.mocked(getInvoice).mockResolvedValue({
+			id: '8a123',
+			amount: -10,
+			amountWithoutTax: -10,
+			balance: -10,
+			accountId: '8a456',
+		});
+
+		await expect(
+			cancelSubscriptionWithOrder(
+				zuoraClient,
+				input,
+				180_000,
+				'stripe-dispute-cancellation-dp_123',
+			),
+		).resolves.toBe('8a123');
+
+		expect(createOrderAsynchronously).toHaveBeenCalledWith(
+			zuoraClient,
+			buildCancellationOrderRequest(input),
+			180_000,
+			{ idempotencyKey: 'stripe-dispute-cancellation-dp_123' },
+		);
+		expect(getInvoice).toHaveBeenCalledWith(zuoraClient, 'INV-000001');
+	});
+
+	it('does not look up an invoice when the cancellation order does not generate one', async () => {
+		jest.mocked(createOrderAsynchronously).mockResolvedValue({
+			status: 'Completed',
+		});
+
+		await expect(
+			cancelSubscriptionWithOrder(
+				zuoraClient,
+				input,
+				180_000,
+				'stripe-dispute-cancellation-dp_123',
+			),
+		).resolves.toBeUndefined();
+
+		expect(getInvoice).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What does this change?

Stripe disputes now cancel active subscriptions through the Zuora Orders API rather than the legacy cancellation endpoint. The SQS consumer waits for the asynchronous Order within a three minute budget, leaving two minutes for the payment rejection, invoice write-offs and cancellation email.

The request is idempotent for each dispute. A lost submission response can therefore be recovered on SQS redelivery without creating another cancellation. A negative invoice remains optional, as it was with the previous endpoint.

## How has this change been tested?

Unit tests cover the Order payload, job completion, temporary status-read failures, locking contention, idempotency and the existing dispute flow. Type-checking, linting and formatting pass for stripe-disputes and the shared Zuora module.

## How can we measure success?

Completed lost disputes should create Zuora Orders and continue to complete without consumer errors or messages reaching the DLQ.

## Have we considered potential risks?

Zuora can take time to complete an asynchronous Order. The consumer stops waiting after three minutes so the remaining work can still run within its five minute Lambda timeout. An unsuccessful message remains available for the existing SQS retry and DLQ handling.