### PR TITLE
Route support-backend alarms to Portfolio

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -70,6 +70,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'workers',
 		'payment-api',
 		'supporter-product-data',
+		'support-backend',
 
 		// support-service-lambdas
 		'catalog-service',


### PR DESCRIPTION
## What does this change?

Route support-backend alarms to the Portfolio alarms channel.