### PR TITLE
Add endpoint to get secondary users by identity id

### DIFF
--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -276,25 +276,27 @@ paths:
   /secondary-user/me:
     get:
       operationId: getSecondaryUserMe
-      summary: Get primary users for the signed-in secondary user
+      summary: Get primary user subscriptions for the signed-in secondary user
       description: >-
-        Returns the contact details of the primary user for each subscription
-        the signed-in secondary user is linked to. The secondary user is
-        identified by their Okta bearer token.
+        Returns, for each subscription the signed-in secondary user is linked
+        to, the subscription name and the contact details of that
+        subscription's primary user. The secondary user is identified by
+        their Okta bearer token.
       security:
         - bearerAuth: []
       responses:
         '200':
-          description: Primary users returned.
+          description: Subscriptions returned.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SecondaryUserMeResponse'
+                $ref: '#/components/schemas/SecondaryUserDetailsResponse'
               examples:
                 default:
                   value:
-                    primaryUsers:
-                      - firstName: Jane
+                    subscriptions:
+                      - subscriptionName: A-S00974337
+                        firstName: Jane
                         lastName: Smith
                         workEmail: jane.smith@example.com
         '401':
@@ -335,7 +337,101 @@ paths:
               schema:
                 type: string
                 example: Internal server error
+  /secondary-user/{identityId}:
+    get:
+      operationId: getSecondaryUserByIdentityId
+      summary: Get primary user subscriptions for a secondary user by identity id
+      description: >-
+        Returns, for each subscription the given secondary user is linked to,
+        the subscription name and the contact details of that subscription's
+        primary user. Intended for server-to-server use where the caller
+        already knows the secondary user's identity id.
+      security:
+        - apiKey: []
+      parameters:
+        - name: identityId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Identity id of the secondary user.
+          example: '30067890'
+      responses:
+        '200':
+          description: Subscriptions returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecondaryUserDetailsResponse'
+              examples:
+                default:
+                  value:
+                    subscriptions:
+                      - subscriptionName: A-S00974337
+                        firstName: Jane
+                        lastName: Smith
+                        workEmail: jane.smith@example.com
+        '404':
+          description: Route not found.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Not Found
+        '500':
+          description: Internal server error.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
   /invitation/{invitationCode}:
+    get:
+      operationId: getInvitation
+      summary: Get invitation
+      description: >-
+        Returns an invitation by invitation code. Returns a 400 if the
+        invitation has already been cancelled by the primary or secondary
+        user.
+      security:
+        - apiKey: []
+      parameters:
+        - name: invitationCode
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The invitation code to look up.
+      responses:
+        '200':
+          description: Invitation returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invitation'
+        '400':
+          description: The invitation has already been cancelled.
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                cancelled:
+                  value: The invitation has been cancelled by the primary user
+        '404':
+          description: Invitation not found.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Not Found
+        '500':
+          description: Internal server error.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
     delete:
       operationId: deleteInvitation
       summary: Delete invitation
@@ -546,6 +642,8 @@ components:
         - subscriptionName
         - invitationCode
         - primaryIdentityId
+        - primaryUserFirstName
+        - primaryUserEmail
         - secondaryUserEmail
         - secondaryIdentityId
         - invitedDate
@@ -560,6 +658,13 @@ components:
         primaryIdentityId:
           type: string
           example: '20012345'
+        primaryUserFirstName:
+          type: string
+          example: Jane
+        primaryUserEmail:
+          type: string
+          format: email
+          example: jane.smith@example.com
         secondaryUserEmail:
           type: string
           format: email
@@ -585,6 +690,13 @@ components:
             user. Absent for pending invitations, and never returned by the
             mma-primary summary (which excludes cancelled invitations).
           example: primary
+        cancelledDate:
+          type: string
+          format: date-time
+          description: >-
+            Present alongside 'cancelledBy' once the invitation has been
+            cancelled or rejected.
+          example: '2026-06-13T00:00:00.000Z'
     ListInvitationsResponse:
       type: object
       additionalProperties: false
@@ -603,6 +715,8 @@ components:
         - secondaryIdentityId
         - primaryIdentityId
         - acceptedDate
+        - expiryDate
+        - invitationCode
       properties:
         subscriptionName:
           type: string
@@ -617,45 +731,43 @@ components:
           type: string
           format: date-time
           example: '2026-06-12T00:00:00.000Z'
-    SecondaryUserWithName:
-      type: object
-      additionalProperties: false
-      required:
-        - subscriptionName
-        - secondaryIdentityId
-        - primaryIdentityId
-        - acceptedDate
-        - displayName
-        - firstName
-        - lastName
-        - email
-      properties:
-        subscriptionName:
+        expiryDate:
+          type: number
+          example: 1781222400000
+        invitationCode:
           type: string
-          example: A-S00974337
-        secondaryIdentityId:
+          description: The invitation code that was accepted to create this secondary user.
+          example: RpwR62kMnAxe
+        cancelledBy:
           type: string
-          example: '30067890'
-        primaryIdentityId:
-          type: string
-          example: '20012345'
-        acceptedDate:
+          enum:
+            - primary
+            - secondary
+          description: >-
+            Present once the secondary user has been removed by the primary
+            user or has removed themselves. Absent while the secondary user
+            is active, and never returned by list-secondary-users or the
+            mma-primary summary (which both exclude removed secondary users).
+          example: primary
+        cancelledDate:
           type: string
           format: date-time
-          example: '2026-06-12T00:00:00.000Z'
-        displayName:
-          type: string
-          example: jsmith92
-        firstName:
-          type: string
-          example: Jane
-        lastName:
-          type: string
-          example: Smith
-        email:
-          type: string
-          format: email
-          example: jane.smith@example.com
+          description: >-
+            Present alongside 'cancelledBy' once the secondary user has been
+            removed.
+          example: '2026-06-13T00:00:00.000Z'
+    SecondaryUserWithEmail:
+      description: >-
+        A secondary user together with their email address, as returned by
+        the mma-primary summary endpoint.
+      allOf:
+        - $ref: '#/components/schemas/SecondaryUser'
+        - type: object
+          properties:
+            email:
+              type: string
+              format: email
+              example: jane.smith@example.com
     MmaPrimarySummaryResponse:
       type: object
       additionalProperties: false
@@ -670,7 +782,7 @@ components:
         secondaryUsers:
           type: array
           items:
-            $ref: '#/components/schemas/SecondaryUserWithName'
+            $ref: '#/components/schemas/SecondaryUserWithEmail'
     ListSecondaryUsersResponse:
       type: object
       additionalProperties: false
@@ -681,14 +793,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SecondaryUser'
-    PrimaryUser:
+    SubscriptionWithPrimaryUser:
       type: object
       additionalProperties: false
       required:
+        - subscriptionName
         - firstName
         - lastName
         - workEmail
       properties:
+        subscriptionName:
+          type: string
+          example: A-S00974337
         firstName:
           type: string
           example: Jane
@@ -699,16 +815,16 @@ components:
           type: string
           format: email
           example: jane.smith@example.com
-    SecondaryUserMeResponse:
+    SecondaryUserDetailsResponse:
       type: object
       additionalProperties: false
       required:
-        - primaryUsers
+        - subscriptions
       properties:
-        primaryUsers:
+        subscriptions:
           type: array
           items:
-            $ref: '#/components/schemas/PrimaryUser'
+            $ref: '#/components/schemas/SubscriptionWithPrimaryUser'
     ParserError:
       type: object
       additionalProperties: true

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -28,8 +28,12 @@ import { InvitationRepository } from './invitationRepository';
 import { listInvitationsEndpoint } from './listInvitationsEndpoint';
 import { listSecondaryUsersEndpoint } from './listSecondaryUsersEndpoint';
 import { mmaPrimarySummaryEndpoint } from './mmaPrimarySummaryEndpoint';
-import { invitationPathSchema, subscriptionPathSchema } from './schemas';
-import { secondaryUserMeEndpoint } from './secondaryUserMeEndpoint';
+import {
+	identityIdPathSchema,
+	invitationPathSchema,
+	subscriptionPathSchema,
+} from './schemas';
+import { secondaryUserDetailsEndpoint } from './secondaryUserDetailsEndpoint';
 
 const stage = stageFromEnvironment();
 const authenticate = buildAuthenticate(stage, []);
@@ -204,11 +208,22 @@ export const handler: Handler = Router([
 				return maybeAuthenticatedEvent.response;
 			}
 
-			return secondaryUserMeEndpoint(
+			return secondaryUserDetailsEndpoint(
 				maybeAuthenticatedEvent.userDetails.identityId,
 				secondaryUserRepository,
 				await lazyZuoraClient.get(),
 			);
 		},
+	},
+	{
+		httpMethod: 'GET',
+		path: '/secondary-user/{identityId}',
+		handler: withPathParser(identityIdPathSchema, async (event, path) => {
+			return secondaryUserDetailsEndpoint(
+				path.identityId,
+				secondaryUserRepository,
+				await lazyZuoraClient.get(),
+			);
+		}),
 	},
 ]);

--- a/handlers/multiple-account-api/src/schemas.ts
+++ b/handlers/multiple-account-api/src/schemas.ts
@@ -7,3 +7,7 @@ export const invitationPathSchema = z.object({
 export const subscriptionPathSchema = z.object({
 	subscriptionName: z.string(),
 });
+
+export const identityIdPathSchema = z.object({
+	identityId: z.string(),
+});

--- a/handlers/multiple-account-api/src/secondaryUserDetailsEndpoint.ts
+++ b/handlers/multiple-account-api/src/secondaryUserDetailsEndpoint.ts
@@ -25,7 +25,7 @@ const responseSchema = z.object({
 	subscriptions: z.array(subscriptionWithPrimaryUserInformationSchema),
 });
 
-export async function secondaryUserMeEndpoint(
+export async function secondaryUserDetailsEndpoint(
 	identityId: string,
 	secondaryUserRepository: SecondaryUserRepository,
 	zuoraClient: ZuoraClient,

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -6,7 +6,7 @@ import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraAccount, ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { secondaryUserMeEndpoint } from '../src/secondaryUserMeEndpoint';
+import { secondaryUserDetailsEndpoint } from '../src/secondaryUserDetailsEndpoint';
 
 jest.mock('@modules/zuora/subscription', () => ({
 	getSubscription: jest.fn(),
@@ -39,16 +39,16 @@ describe('secondaryUserMeEndpoint', () => {
 		subscriptionName,
 		secondaryIdentityId: 'secondary-id',
 		primaryIdentityId: 'primary-id',
-		acceptedDate: '2026-06-12T00:00:00.000Z',
+		acceptedDate: '2026-06-12',
 		expiryDate: 1781218800,
-		invitationCode: 'RpwR62kMnAxe',
+		invitationCode: 'INVITATION-CODE',
 	});
 
 	const makeRepository = (
 		users: SecondaryUserRecord[],
 	): SecondaryUserRepository =>
 		({
-			listNonCancelledByIdentity: jest
+			get: jest
 				.fn<Promise<SecondaryUserRecord[]>, [string]>()
 				.mockResolvedValue(users),
 		}) as unknown as SecondaryUserRepository;
@@ -69,7 +69,7 @@ describe('secondaryUserMeEndpoint', () => {
 			.mockResolvedValueOnce(makeAccount('Ada', 'Lovelace', 'ada@example.com'))
 			.mockResolvedValueOnce(makeAccount('Alan', 'Turing', 'alan@example.com'));
 
-		const result = await secondaryUserMeEndpoint(
+		const result = await secondaryUserDetailsEndpoint(
 			'secondary-id',
 			makeRepository(secondaryUsers),
 			zuoraClient,
@@ -77,15 +77,13 @@ describe('secondaryUserMeEndpoint', () => {
 
 		expect(result.statusCode).toBe(200);
 		expect(JSON.parse(result.body)).toEqual({
-			subscriptions: [
+			primaryUsers: [
 				{
-					subscriptionName: 'A-S00000001',
 					firstName: 'Ada',
 					lastName: 'Lovelace',
 					workEmail: 'ada@example.com',
 				},
 				{
-					subscriptionName: 'A-S00000002',
 					firstName: 'Alan',
 					lastName: 'Turing',
 					workEmail: 'alan@example.com',
@@ -105,54 +103,23 @@ describe('secondaryUserMeEndpoint', () => {
 	});
 
 	it('returns an empty primaryUsers list when there are no secondary users', async () => {
-		const result = await secondaryUserMeEndpoint(
+		const result = await secondaryUserDetailsEndpoint(
 			'secondary-id',
 			makeRepository([]),
 			zuoraClient,
 		);
 
 		expect(result.statusCode).toBe(200);
-		expect(JSON.parse(result.body)).toEqual({ subscriptions: [] });
+		expect(JSON.parse(result.body)).toEqual({ primaryUsers: [] });
 		expect(mockGetSubscription).not.toHaveBeenCalled();
 		expect(mockGetAccount).not.toHaveBeenCalled();
-	});
-
-	it('only requests details for the non-cancelled records returned by the repository', async () => {
-		const activeUser = makeSecondaryUser('A-S00000001');
-		mockGetSubscription.mockResolvedValueOnce(makeSubscription('A00000001'));
-		mockGetAccount.mockResolvedValueOnce(
-			makeAccount('Ada', 'Lovelace', 'ada@example.com'),
-		);
-
-		const result = await secondaryUserMeEndpoint(
-			'secondary-id',
-			makeRepository([activeUser]),
-			zuoraClient,
-		);
-
-		expect(result.statusCode).toBe(200);
-		expect(JSON.parse(result.body)).toEqual({
-			subscriptions: [
-				{
-					subscriptionName: 'A-S00000001',
-					firstName: 'Ada',
-					lastName: 'Lovelace',
-					workEmail: 'ada@example.com',
-				},
-			],
-		});
-		expect(mockGetSubscription).toHaveBeenCalledTimes(1);
-		expect(mockGetSubscription).toHaveBeenCalledWith(
-			zuoraClient,
-			'A-S00000001',
-		);
 	});
 
 	it('propagates errors thrown while fetching from Zuora', async () => {
 		mockGetSubscription.mockRejectedValue(new Error('Zuora unavailable'));
 
 		await expect(
-			secondaryUserMeEndpoint(
+			secondaryUserDetailsEndpoint(
 				'secondary-id',
 				makeRepository([makeSecondaryUser('A-S00000001')]),
 				zuoraClient,

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -51,6 +51,9 @@ describe('secondaryUserMeEndpoint', () => {
 			get: jest
 				.fn<Promise<SecondaryUserRecord[]>, [string]>()
 				.mockResolvedValue(users),
+			listNonCancelledByIdentity: jest
+				.fn<Promise<SecondaryUserRecord[]>, [string]>()
+				.mockResolvedValue(users),
 		}) as unknown as SecondaryUserRepository;
 
 	beforeEach(() => {
@@ -77,16 +80,18 @@ describe('secondaryUserMeEndpoint', () => {
 
 		expect(result.statusCode).toBe(200);
 		expect(JSON.parse(result.body)).toEqual({
-			primaryUsers: [
+			subscriptions: [
 				{
 					firstName: 'Ada',
 					lastName: 'Lovelace',
 					workEmail: 'ada@example.com',
+					subscriptionName: 'A-S00000001',
 				},
 				{
 					firstName: 'Alan',
 					lastName: 'Turing',
 					workEmail: 'alan@example.com',
+					subscriptionName: 'A-S00000002',
 				},
 			],
 		});
@@ -102,7 +107,7 @@ describe('secondaryUserMeEndpoint', () => {
 		expect(mockGetAccount).toHaveBeenCalledWith(zuoraClient, 'A00000002');
 	});
 
-	it('returns an empty primaryUsers list when there are no secondary users', async () => {
+	it('returns an empty subscriptions list when there are no secondary users', async () => {
 		const result = await secondaryUserDetailsEndpoint(
 			'secondary-id',
 			makeRepository([]),
@@ -110,7 +115,7 @@ describe('secondaryUserMeEndpoint', () => {
 		);
 
 		expect(result.statusCode).toBe(200);
-		expect(JSON.parse(result.body)).toEqual({ primaryUsers: [] });
+		expect(JSON.parse(result.body)).toEqual({ subscriptions: [] });
 		expect(mockGetSubscription).not.toHaveBeenCalled();
 		expect(mockGetAccount).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a new endpoint to the multiple-account API which enables the retrieval of secondary user subscriptions for any identity ID.

## Usage:
```shell
curl --location 'https://multiple-account-api-code.support.guardianapis.com/secondary-user/200712934' \
--header 'x-api-key: [API_KEY]'
```

```json
{
    "subscriptions": [
        {
            "subscriptionName": "A-S01115245",
            "firstName": "test",
            "lastName": "user",
            "workEmail": "test.user@theguardian.com"
        }
    ]
}
```

## Details
This endpoint shares almost all its code with the `secondary-user/me` endpoint. The only difference is that it takes the identity from the path rather than an Okta token.