### PR TITLE
Reduce maximum number of invites per subscription to 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/
 handlers/*/coverage
 # PII query result downloads from supporter-product-data-lambdas download-query-results
 select-active-rate-plans-*.csv
+.pnpm-store

--- a/handlers/multiple-account-api/src/createInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/createInvitationEndpoint.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { getOrCreateUserFromEmail } from '@modules/identity/idapi';
 import type { IdentityClient } from '@modules/identity/identityClient';
 import { logger } from '@modules/logger/logger';
+import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
 import { created } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
@@ -40,6 +41,7 @@ export const createInvitationEndpoint =
 	(
 		stage: Stage,
 		invitationRepository: InvitationRepository,
+		secondaryUserRepository: SecondaryUserRepository,
 		identityClient: IdentityClient,
 		zuoraCatalog: ZuoraCatalog,
 		productCatalog: ProductCatalog,
@@ -66,6 +68,7 @@ export const createInvitationEndpoint =
 
 		await validateInvitationInformation(
 			invitationRepository,
+			secondaryUserRepository,
 			subscriptionName,
 			secondaryIdentityId,
 		);

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -70,6 +70,7 @@ export const handler: Handler = Router([
 					return createInvitationEndpoint(
 						stage,
 						invitationRepository,
+						secondaryUserRepository,
 						identityClient,
 						await lazyZuoraCatalog.get(),
 						await lazyProductCatalog.get(),

--- a/handlers/multiple-account-api/src/validation.ts
+++ b/handlers/multiple-account-api/src/validation.ts
@@ -14,7 +14,7 @@ import type { ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import type { InvitationRepository } from './invitationRepository';
 
-const MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION = 3;
+const MAXIMUM_NUMBER_OF_INVITATIONS_AND_SECONDARY_USERS_PER_SUBSCRIPTION = 3;
 
 function productHasMultipleAccountsBenefit(productKey: ProductKey) {
 	return productBenefitMapping[productKey].includes('multipleAccounts');
@@ -80,14 +80,16 @@ export async function validateInvitationInformation(
 		);
 	}
 
-	// Check the subscription still has free invites
-	const subscriptionHasAvailableInvites =
+	// Check the subscription still has room for another invitation or secondary
+	// user, counting both pending invitations and already-accepted secondary
+	// users towards the limit.
+	const subscriptionHasAvailableSlots =
 		nonCancelledInvites.length + existingSecondaryUsers.length <
-		MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION;
+		MAXIMUM_NUMBER_OF_INVITATIONS_AND_SECONDARY_USERS_PER_SUBSCRIPTION;
 
-	if (!subscriptionHasAvailableInvites) {
+	if (!subscriptionHasAvailableSlots) {
 		throw new ValidationError(
-			'This subscription already has the maximum number of invites',
+			'This subscription already has the maximum number of invitations and secondary users',
 		);
 	}
 }

--- a/handlers/multiple-account-api/src/validation.ts
+++ b/handlers/multiple-account-api/src/validation.ts
@@ -4,6 +4,7 @@ import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-sub
 import { GuardianSubscriptionParser } from '@modules/guardian-subscription/guardianSubscriptionParser';
 import { SubscriptionFilter } from '@modules/guardian-subscription/subscriptionFilter';
 import { logger } from '@modules/logger/logger';
+import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { productBenefitMapping } from '@modules/product-benefits/productBenefit';
 import type {
 	ProductCatalog,
@@ -42,13 +43,31 @@ export function checkSubscriptionHasMultipleAccountsBenefit(
 }
 
 export async function validateInvitationInformation(
-	repo: InvitationRepository,
+	invitationRepository: InvitationRepository,
+	secondaryUserRepository: SecondaryUserRepository,
 	subscriptionName: string,
 	secondaryIdentityId: string,
 ) {
 	logger.log('Validating invitation information');
 
-	const nonCancelledInvites = await repo.listNonCancelled(subscriptionName);
+	const existingSecondaryUsers =
+		await secondaryUserRepository.listNonCancelledBySubscription(
+			subscriptionName,
+		);
+
+	// Check the secondary user is not already a secondary user for this subscription
+	const secondaryUserAlreadyExists = existingSecondaryUsers.find(
+		(user) => user.secondaryIdentityId === secondaryIdentityId,
+	);
+
+	if (secondaryUserAlreadyExists) {
+		throw new ValidationError(
+			'This user is already a secondary user for this subscription',
+		);
+	}
+
+	const nonCancelledInvites =
+		await invitationRepository.listNonCancelled(subscriptionName);
 
 	// Check the secondary user has not been invited already
 	const inviteAlreadyExistsForUser = nonCancelledInvites.find(
@@ -63,7 +82,8 @@ export async function validateInvitationInformation(
 
 	// Check the subscription still has free invites
 	const subscriptionHasAvailableInvites =
-		nonCancelledInvites.length < MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION;
+		nonCancelledInvites.length + existingSecondaryUsers.length <
+		MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION;
 
 	if (!subscriptionHasAvailableInvites) {
 		throw new ValidationError(

--- a/handlers/multiple-account-api/src/validation.ts
+++ b/handlers/multiple-account-api/src/validation.ts
@@ -13,7 +13,7 @@ import type { ZuoraSubscription } from '@modules/zuora/types';
 import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
 import type { InvitationRepository } from './invitationRepository';
 
-const MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION = 5;
+const MAXIMUM_NUMBER_OF_INVITES_PER_SUBSCRIPTION = 3;
 
 function productHasMultipleAccountsBenefit(productKey: ProductKey) {
 	return productBenefitMapping[productKey].includes('multipleAccounts');

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -43,6 +43,7 @@ beforeEach(async () => {
 	const endpoint = createInvitationEndpoint(
 		stage,
 		invitationRepository,
+		secondaryUserRepository,
 		identityClient,
 		zuoraCatalog,
 		productCatalog,

--- a/handlers/multiple-account-api/test/createInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/createInvitationIntegration.test.ts
@@ -5,6 +5,7 @@
  * @group integration
  */
 import { IdentityClient } from '@modules/identity/identityClient';
+import { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
@@ -25,6 +26,7 @@ test('createInvitationEndpoint saves invitation data and returns invitation code
 	const zuoraCatalog = await getZuoraCatalogFromS3(stage);
 	const productCatalog = await getProductCatalogFromApi(stage);
 	const invitationRepository = InvitationRepository.create(stage);
+	const secondaryUserRepository = SecondaryUserRepository.create(stage);
 	const identityClient = await IdentityClient.create(
 		stage,
 		`/${stage}/support/multiple-account-api/identity-client-access-token`,
@@ -34,6 +36,7 @@ test('createInvitationEndpoint saves invitation data and returns invitation code
 	const endpoint = createInvitationEndpoint(
 		stage,
 		invitationRepository,
+		secondaryUserRepository,
 		identityClient,
 		zuoraCatalog,
 		productCatalog,

--- a/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
@@ -46,6 +46,7 @@ beforeEach(async () => {
 	const createEndpoint = createInvitationEndpoint(
 		stage,
 		invitationRepository,
+		secondaryUserRepository,
 		identityClient,
 		zuoraCatalog,
 		productCatalog,

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -2,6 +2,10 @@ import dayjs from 'dayjs';
 import * as email from 'email/src/email';
 import * as identity from '@modules/identity/idapi';
 import type { IdentityClient } from '@modules/identity/identityClient';
+import type {
+	SecondaryUserRecord,
+	SecondaryUserRepository,
+} from '@modules/multiple-account/secondaryUserRepository';
 import { generateProductCatalog } from '@modules/product-catalog/generateProductCatalog';
 import type {
 	ZuoraAccount,
@@ -60,6 +64,8 @@ const mockInvitations: InvitationRecord[] = [
 	},
 ];
 
+const mockSecondaryUsers: SecondaryUserRecord[] = [];
+
 const stage = 'CODE';
 const zuoraCatalog = zuoraCatalogSchema.parse(code);
 const productCatalog = generateProductCatalog(zuoraCatalog);
@@ -76,11 +82,17 @@ const mockListNonCancelled = jest
 	.fn<Promise<InvitationRecord[]>, [string]>()
 	.mockResolvedValue(mockInvitations);
 
-const mockRepo: InvitationRepository = {
+const mockInvitationRepo: InvitationRepository = {
 	save: mockSave,
 	list: mockList,
 	listNonCancelled: mockListNonCancelled,
 } as unknown as InvitationRepository;
+
+const mockSecondaryUserRepo = {
+	listNonCancelledBySubscription: jest
+		.fn<Promise<SecondaryUserRecord[]>, [string]>()
+		.mockResolvedValue(mockSecondaryUsers),
+} as unknown as SecondaryUserRepository;
 
 const mockIdentityClient = {} as IdentityClient;
 
@@ -101,7 +113,8 @@ describe('createInvitationHandler', () => {
 
 		const handler = createInvitationEndpoint(
 			stage,
-			mockRepo,
+			mockInvitationRepo,
+			mockSecondaryUserRepo,
 			mockIdentityClient,
 			zuoraCatalog,
 			productCatalog,
@@ -165,7 +178,8 @@ describe('createInvitationHandler', () => {
 		const now = dayjs().add(1, 'month').toDate().getTime();
 		const handler = createInvitationEndpoint(
 			stage,
-			mockRepo,
+			mockInvitationRepo,
+			mockSecondaryUserRepo,
 			mockIdentityClient,
 			zuoraCatalog,
 			productCatalog,
@@ -192,7 +206,8 @@ describe('createInvitationHandler', () => {
 
 		const handler = createInvitationEndpoint(
 			stage,
-			mockRepo,
+			mockInvitationRepo,
+			mockSecondaryUserRepo,
 			mockIdentityClient,
 			zuoraCatalog,
 			productCatalog,

--- a/handlers/multiple-account-api/test/validation.test.ts
+++ b/handlers/multiple-account-api/test/validation.test.ts
@@ -1,0 +1,288 @@
+import { ValidationError } from '@modules/errors';
+import { getSinglePlanFlattenedSubscriptionOrThrow } from '@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow';
+import { GuardianSubscriptionParser } from '@modules/guardian-subscription/guardianSubscriptionParser';
+import { SubscriptionFilter } from '@modules/guardian-subscription/subscriptionFilter';
+import type {
+	SecondaryUserRecord,
+	SecondaryUserRepository,
+} from '@modules/multiple-account/secondaryUserRepository';
+import type { ProductCatalog } from '@modules/product-catalog/productCatalog';
+import type { ZuoraSubscription } from '@modules/zuora/types';
+import type { ZuoraCatalog } from '@modules/zuora-catalog/zuoraCatalogSchema';
+import type {
+	InvitationRecord,
+	InvitationRepository,
+} from '../src/invitationRepository';
+import {
+	checkSubscriptionHasMultipleAccountsBenefit,
+	validateInvitationInformation,
+} from '../src/validation';
+
+jest.mock('@modules/guardian-subscription/guardianSubscriptionParser', () => ({
+	GuardianSubscriptionParser: jest.fn(),
+}));
+
+jest.mock('@modules/guardian-subscription/subscriptionFilter', () => ({
+	SubscriptionFilter: {
+		activeNonEndedSubscriptionFilter: jest.fn(),
+	},
+}));
+
+jest.mock(
+	'@modules/guardian-subscription/getSinglePlanFlattenedSubscriptionOrThrow',
+	() => ({
+		getSinglePlanFlattenedSubscriptionOrThrow: jest.fn(),
+	}),
+);
+
+describe('checkSubscriptionHasMultipleAccountsBenefit', () => {
+	const mockGuardianSubscriptionParser = jest.mocked(
+		GuardianSubscriptionParser,
+	);
+	const mockActiveNonEndedSubscriptionFilter =
+		jest.mocked(SubscriptionFilter).activeNonEndedSubscriptionFilter;
+	const mockGetSinglePlan = jest.mocked(
+		getSinglePlanFlattenedSubscriptionOrThrow,
+	);
+
+	const toGuardianSubscriptionMock = jest.fn();
+	const filterSubscriptionMock = jest.fn();
+
+	const zuoraSubscription = {
+		subscriptionNumber: 'A-S00974337',
+	} as unknown as ZuoraSubscription;
+	const zuoraCatalog = { catalog: 'zuora' } as unknown as ZuoraCatalog;
+	const productCatalog = { catalog: 'product' } as unknown as ProductCatalog;
+
+	const rawGuardianSubscription = { raw: 'guardianSubscription' };
+	const filteredGuardianSubscription = { filtered: 'guardianSubscription' };
+
+	const mockProductKey = (
+		productKey: string,
+	): ReturnType<typeof getSinglePlanFlattenedSubscriptionOrThrow> =>
+		({
+			ratePlan: { productKey },
+		}) as unknown as ReturnType<
+			typeof getSinglePlanFlattenedSubscriptionOrThrow
+		>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockGuardianSubscriptionParser.mockImplementation(
+			() =>
+				({
+					toGuardianSubscription: toGuardianSubscriptionMock,
+				}) as unknown as GuardianSubscriptionParser,
+		);
+		toGuardianSubscriptionMock.mockReturnValue(rawGuardianSubscription);
+
+		mockActiveNonEndedSubscriptionFilter.mockReturnValue({
+			filterSubscription: filterSubscriptionMock,
+		} as unknown as SubscriptionFilter);
+		filterSubscriptionMock.mockReturnValue(filteredGuardianSubscription);
+	});
+
+	it('does not throw when the subscription has the multiple accounts benefit', () => {
+		mockGetSinglePlan.mockReturnValue(mockProductKey('HomeDelivery'));
+
+		expect(() =>
+			checkSubscriptionHasMultipleAccountsBenefit(
+				zuoraSubscription,
+				zuoraCatalog,
+				productCatalog,
+			),
+		).not.toThrow();
+	});
+
+	it('throws a ValidationError naming the subscription when it does not have the multiple accounts benefit', () => {
+		mockGetSinglePlan.mockReturnValue(mockProductKey('GuardianAdLite'));
+
+		let caughtError: unknown;
+		try {
+			checkSubscriptionHasMultipleAccountsBenefit(
+				zuoraSubscription,
+				zuoraCatalog,
+				productCatalog,
+			);
+		} catch (error) {
+			caughtError = error;
+		}
+
+		expect(caughtError).toBeInstanceOf(ValidationError);
+		expect((caughtError as Error).message).toBe(
+			'A-S00974337 does not have multiple accounts benefit',
+		);
+	});
+});
+
+describe('validateInvitationInformation', () => {
+	const subscriptionName = 'A-S00974337';
+
+	const buildSecondaryUser = (
+		secondaryIdentityId: string,
+	): SecondaryUserRecord => ({
+		subscriptionName,
+		secondaryIdentityId,
+		primaryIdentityId: 'primary-id',
+		acceptedDate: '2026-06-12T00:00:00.000Z',
+		expiryDate: 1781218800,
+		invitationCode: 'RpwR62kMnAxe',
+	});
+
+	const buildInvitation = (secondaryIdentityId: string): InvitationRecord => ({
+		subscriptionName,
+		invitationCode: 'RpwR62kMnAxe',
+		primaryIdentityId: 'primary-id',
+		primaryUserFirstName: 'Joe',
+		primaryUserEmail: 'joe@example.com',
+		secondaryUserEmail: 'secondary@example.com',
+		secondaryIdentityId,
+		invitedDate: '2026-06-12T00:00:00.000Z',
+		expiryDate: 1781222400000,
+	});
+
+	const buildRepositories = ({
+		existingSecondaryUsers = [],
+		nonCancelledInvites = [],
+	}: {
+		existingSecondaryUsers?: SecondaryUserRecord[];
+		nonCancelledInvites?: InvitationRecord[];
+	}) => {
+		const secondaryUserRepository = {
+			listNonCancelledBySubscription: jest
+				.fn<Promise<SecondaryUserRecord[]>, [string]>()
+				.mockResolvedValue(existingSecondaryUsers),
+		} as unknown as SecondaryUserRepository;
+		const invitationRepository = {
+			listNonCancelled: jest
+				.fn<Promise<InvitationRecord[]>, [string]>()
+				.mockResolvedValue(nonCancelledInvites),
+		} as unknown as InvitationRepository;
+
+		return {
+			secondaryUserRepository,
+			invitationRepository,
+		};
+	};
+
+	it('throws a ValidationError when the secondary user already exists for this subscription', async () => {
+		const { invitationRepository, secondaryUserRepository } = buildRepositories(
+			{
+				existingSecondaryUsers: [buildSecondaryUser('secondary-id')],
+			},
+		);
+
+		await expect(
+			validateInvitationInformation(
+				invitationRepository,
+				secondaryUserRepository,
+				subscriptionName,
+				'secondary-id',
+			),
+		).rejects.toThrow(
+			'This user is already a secondary user for this subscription',
+		);
+	});
+
+	it('throws a ValidationError when an invitation already exists for this user', async () => {
+		const { invitationRepository, secondaryUserRepository } = buildRepositories(
+			{
+				nonCancelledInvites: [buildInvitation('secondary-id')],
+			},
+		);
+
+		await expect(
+			validateInvitationInformation(
+				invitationRepository,
+				secondaryUserRepository,
+				subscriptionName,
+				'secondary-id',
+			),
+		).rejects.toThrow('An invitation already exists for this subscription');
+	});
+
+	it('checks for an existing secondary user before checking for an existing invitation', async () => {
+		const { invitationRepository, secondaryUserRepository } = buildRepositories(
+			{
+				existingSecondaryUsers: [buildSecondaryUser('secondary-id')],
+				nonCancelledInvites: [buildInvitation('secondary-id')],
+			},
+		);
+
+		await expect(
+			validateInvitationInformation(
+				invitationRepository,
+				secondaryUserRepository,
+				subscriptionName,
+				'secondary-id',
+			),
+		).rejects.toThrow(
+			'This user is already a secondary user for this subscription',
+		);
+	});
+
+	it('allows an invite when the subscription has exactly two existing invites/secondary users', async () => {
+		const { invitationRepository, secondaryUserRepository } = buildRepositories(
+			{
+				existingSecondaryUsers: [buildSecondaryUser('existing-1')],
+				nonCancelledInvites: [buildInvitation('existing-2')],
+			},
+		);
+
+		await expect(
+			validateInvitationInformation(
+				invitationRepository,
+				secondaryUserRepository,
+				subscriptionName,
+				'new-secondary-id',
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it('throws a ValidationError when the subscription has reached the maximum number of invitations', async () => {
+		const { invitationRepository, secondaryUserRepository } = buildRepositories(
+			{
+				nonCancelledInvites: [
+					buildInvitation('existing-1'),
+					buildInvitation('existing-2'),
+					buildInvitation('existing-3'),
+				],
+			},
+		);
+
+		await expect(
+			validateInvitationInformation(
+				invitationRepository,
+				secondaryUserRepository,
+				subscriptionName,
+				'new-secondary-id',
+			),
+		).rejects.toThrow(
+			'This subscription already has the maximum number of invitations and secondary users',
+		);
+	});
+
+	it('throws a ValidationError when the maximum is reached via a mix of invites and secondary users', async () => {
+		const { invitationRepository, secondaryUserRepository } = buildRepositories(
+			{
+				existingSecondaryUsers: [buildSecondaryUser('existing-1')],
+				nonCancelledInvites: [
+					buildInvitation('existing-2'),
+					buildInvitation('existing-3'),
+				],
+			},
+		);
+
+		await expect(
+			validateInvitationInformation(
+				invitationRepository,
+				secondaryUserRepository,
+				subscriptionName,
+				'new-secondary-id',
+			),
+		).rejects.toThrow(
+			'This subscription already has the maximum number of invitations and secondary users',
+		);
+	});
+});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR fixes two issues with the validation of the create invitation step in multiple-account API:
- Change the number of invitations allowed per subscription from 5 to 3 (this is the final agreed amount)
- Take account of already accepted invitations when calculating the number of invitations left. Previously we weren't doing this so a user could potentially continue creating more invitations after users had accepted them.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217869353043631