### PR TITLE
Don't send an account verification email to secondary users

### DIFF
--- a/handlers/multiple-account-api/src/createInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/createInvitationEndpoint.ts
@@ -64,6 +64,7 @@ export const createInvitationEndpoint =
 		const secondaryIdentityId = await getOrCreateUserFromEmail(
 			identityClient,
 			body.secondaryUserEmail,
+			false,
 		);
 
 		await validateInvitationInformation(

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -148,6 +148,7 @@ describe('createInvitationHandler', () => {
 		expect(mockGetOrCreateUserFromEmail).toHaveBeenCalledWith(
 			mockIdentityClient,
 			'secondary@example.com',
+			false,
 		);
 
 		expect(mockSendEmail).toHaveBeenCalledWith(stage, {

--- a/modules/identity/src/idapi.ts
+++ b/modules/identity/src/idapi.ts
@@ -87,9 +87,10 @@ export const getUserByIdentityId = async (
 export const createGuestAccount = async (
 	client: IdentityClient,
 	email: string,
+	sendAccountVerificationEmail: boolean = true,
 ): Promise<string> => {
 	const response = await client.post(
-		`/guest?accountVerificationEmail=true`,
+		`/guest?accountVerificationEmail=${sendAccountVerificationEmail}`,
 		JSON.stringify({ primaryEmailAddress: email }),
 		guestAccountResponseSchema,
 	);
@@ -99,10 +100,11 @@ export const createGuestAccount = async (
 export const getOrCreateUserFromEmail = async (
 	client: IdentityClient,
 	email: string,
+	sendAccountVerificationEmail: boolean = true,
 ): Promise<string> => {
 	const user = await getUserByEmail(client, email);
 	if (user) {
 		return user.id;
 	}
-	return await createGuestAccount(client, email);
+	return await createGuestAccount(client, email, sendAccountVerificationEmail);
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The invitation email we send to prospective secondary users will have a link to an onboarding process where the user will complete their identity account, so we don't need to send them a separate email to ask them to do this.

Previously when we created a new guest user account in the create invitation endpoint we were using the `accountVerificationEmail=true` query param to trigger an email send, this PR sets the param to false for this endpoint.