### PR TITLE
Remove unused taxEngineId property from Zuora response schema

### DIFF
--- a/handlers/sales-tax-api/test/fixtures.ts
+++ b/handlers/sales-tax-api/test/fixtures.ts
@@ -14,7 +14,6 @@ export const supporterPlusTaxEngineId = '8ad095dd81de1cf00181de66e7404253';
 
 export const zuoraTaxCodeSupporterPlus: ZuoraTaxCode = {
 	id: supporterPlusTaxCodeId,
-	taxEngineId: '2c92c0f94568f996014570f746f75c52',
 	active: true,
 	name: 'Supporter Plus',
 	description: '',

--- a/handlers/sales-tax-api/test/index.test.ts
+++ b/handlers/sales-tax-api/test/index.test.ts
@@ -39,7 +39,6 @@ describe('SalesTax API', () => {
 		taxCodes: [
 			{
 				id: supporterPlusTaxCodeId,
-				taxEngineId: '2c92c0f94568f996014570f746f75c52',
 				active: true,
 				name: 'Supporter Plus Global Tax',
 				description: '',

--- a/modules/zuora/src/types/objects/tax.ts
+++ b/modules/zuora/src/types/objects/tax.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 export const zuoraTaxCodeSchema = z.object({
 	id: z.string(),
-	taxEngineId: z.string(),
 	active: z.boolean(),
 	name: z.string(),
 	description: z.string(),


### PR DESCRIPTION
## What does this change?

Remove unused taxEngineId property from Zuora response schema.

There's a case in Zuora sandbox where this isn't set and it's causing the sales-tax-api to return errors due to a schema validation failure. Looking at the code, I don't think we need it, so just remove it from the schema.

## How has this change been tested?

Ran the sales-tax-api integration tests before and after this change and they went from red to green.