### PR TITLE
Trigger email to primary user when secondary leaves subscription

### DIFF
--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -20,7 +20,7 @@ import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraAccount } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { sendLeaveSubscriptionEmail } from './emails/leaveSubcriptionEmail';
+import { sendLeaveSubscriptionEmailToSecondary } from './emails/leaveSubcriptionEmail';
 
 export const deleteSecondaryUserPathSchema = z.object({
 	subscriptionName: z.string(),
@@ -115,7 +115,7 @@ export const deleteSecondaryUserEndpoint = async (
 				throw new Error('Secondary user does not have email address');
 			}
 
-			await sendLeaveSubscriptionEmail(
+			await sendLeaveSubscriptionEmailToSecondary(
 				stage,
 				account.billToContact.firstName,
 				account.billToContact.workEmail,

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -20,7 +20,10 @@ import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraAccount } from '@modules/zuora/types';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
-import { sendLeaveSubscriptionEmailToSecondary } from './emails/leaveSubcriptionEmail';
+import {
+	sendLeaveSubscriptionEmailToPrimary,
+	sendLeaveSubscriptionEmailToSecondary,
+} from './emails/leaveSubcriptionEmail';
 
 export const deleteSecondaryUserPathSchema = z.object({
 	subscriptionName: z.string(),
@@ -115,13 +118,23 @@ export const deleteSecondaryUserEndpoint = async (
 				throw new Error('Secondary user does not have email address');
 			}
 
-			await sendLeaveSubscriptionEmailToSecondary(
-				stage,
-				account.billToContact.firstName,
-				account.billToContact.workEmail,
-				secondaryUserDetails.primaryEmailAddress,
-				secondaryIdentityId,
-			);
+			const primaryFirstName = account.billToContact.firstName;
+			const primaryEmail = account.billToContact.workEmail;
+			await Promise.all([
+				sendLeaveSubscriptionEmailToSecondary(
+					stage,
+					primaryFirstName,
+					primaryEmail,
+					secondaryUserDetails.primaryEmailAddress,
+					secondaryIdentityId,
+				),
+				sendLeaveSubscriptionEmailToPrimary(
+					stage,
+					primaryEmail,
+					secondaryUser.primaryIdentityId,
+					secondaryUserDetails.primaryEmailAddress,
+				),
+			]);
 		}
 
 		return {

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -121,18 +121,16 @@ export const deleteSecondaryUserEndpoint = async (
 			const primaryFirstName = account.billToContact.firstName;
 			const primaryEmail = account.billToContact.workEmail;
 			await Promise.all([
-				sendLeaveSubscriptionEmailToSecondary(
-					stage,
-					primaryFirstName,
-					primaryEmail,
-					secondaryUserDetails.primaryEmailAddress,
-					secondaryIdentityId,
-				),
-				sendLeaveSubscriptionEmailToPrimary(
-					stage,
-					primaryEmail,
-					secondaryUser.primaryIdentityId,
-				),
+				sendLeaveSubscriptionEmailToSecondary(stage, {
+					primaryUserFirstName: primaryFirstName,
+					primaryUserEmail: primaryEmail,
+					secondaryUserEmail: secondaryUserDetails.primaryEmailAddress,
+					secondaryUserIdentityId: secondaryIdentityId,
+				}),
+				sendLeaveSubscriptionEmailToPrimary(stage, {
+					primaryUserEmail: primaryEmail,
+					primaryUserIdentityId: secondaryUser.primaryIdentityId,
+				}),
 			]);
 		}
 

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -132,7 +132,6 @@ export const deleteSecondaryUserEndpoint = async (
 					stage,
 					primaryEmail,
 					secondaryUser.primaryIdentityId,
-					secondaryUserDetails.primaryEmailAddress,
 				),
 			]);
 		}

--- a/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
+++ b/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
@@ -26,3 +26,23 @@ export async function sendLeaveSubscriptionEmailToSecondary(
 	);
 	await sendEmail(stage, emailMessage);
 }
+
+export async function sendLeaveSubscriptionEmailToPrimary(
+	stage: Stage,
+	primaryUserEmail: string,
+	primaryUserIdentityId: string,
+	secondaryUserEmail: string,
+) {
+	const dataAttributes = {
+		secondary_user_email: secondaryUserEmail,
+	};
+
+	const emailMessage = buildEmailMessage(
+		primaryUserEmail,
+		DataExtensionNames.multipleAccountEmails.primaryUser
+			.secondaryUserLeftSubscription,
+		dataAttributes,
+		{ IdentityUserId: primaryUserIdentityId },
+	);
+	await sendEmail(stage, emailMessage);
+}

--- a/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
+++ b/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
@@ -5,7 +5,7 @@ import {
 } from '@modules/email/email';
 import type { Stage } from '@modules/stage';
 
-export async function sendLeaveSubscriptionEmail(
+export async function sendLeaveSubscriptionEmailToSecondary(
 	stage: Stage,
 	primaryUserFirstName: string,
 	primaryUserEmail: string,

--- a/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
+++ b/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
@@ -31,11 +31,8 @@ export async function sendLeaveSubscriptionEmailToPrimary(
 	stage: Stage,
 	primaryUserEmail: string,
 	primaryUserIdentityId: string,
-	secondaryUserEmail: string,
 ) {
-	const dataAttributes = {
-		secondary_user_email: secondaryUserEmail,
-	};
+	const dataAttributes = {};
 
 	const emailMessage = buildEmailMessage(
 		primaryUserEmail,

--- a/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
+++ b/handlers/multiple-account-api/src/emails/leaveSubcriptionEmail.ts
@@ -7,10 +7,17 @@ import type { Stage } from '@modules/stage';
 
 export async function sendLeaveSubscriptionEmailToSecondary(
 	stage: Stage,
-	primaryUserFirstName: string,
-	primaryUserEmail: string,
-	secondaryUserEmail: string,
-	secondaryUserIdentityId: string,
+	{
+		primaryUserFirstName,
+		primaryUserEmail,
+		secondaryUserEmail,
+		secondaryUserIdentityId,
+	}: {
+		primaryUserFirstName: string;
+		primaryUserEmail: string;
+		secondaryUserEmail: string;
+		secondaryUserIdentityId: string;
+	},
 ) {
 	const dataAttributes = {
 		primary_user_first_name: primaryUserFirstName,
@@ -29,8 +36,13 @@ export async function sendLeaveSubscriptionEmailToSecondary(
 
 export async function sendLeaveSubscriptionEmailToPrimary(
 	stage: Stage,
-	primaryUserEmail: string,
-	primaryUserIdentityId: string,
+	{
+		primaryUserEmail,
+		primaryUserIdentityId,
+	}: {
+		primaryUserEmail: string;
+		primaryUserIdentityId: string;
+	},
 ) {
 	const dataAttributes = {};
 

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -13,7 +13,7 @@ import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { deleteSecondaryUserEndpoint } from '../src/deleteSecondaryUserEndpoint';
-import { sendLeaveSubscriptionEmail } from '../src/emails/leaveSubcriptionEmail';
+import { sendLeaveSubscriptionEmailToSecondary } from '../src/emails/leaveSubcriptionEmail';
 import { makeAccount, makeSubscription } from './helpers';
 
 jest.mock('@modules/zuora/subscription', () => ({
@@ -29,7 +29,7 @@ jest.mock('@modules/identity/idapi', () => ({
 }));
 
 jest.mock('../src/emails/leaveSubcriptionEmail', () => ({
-	sendLeaveSubscriptionEmail: jest.fn(),
+	sendLeaveSubscriptionEmailToSecondary: jest.fn(),
 }));
 
 const stage = 'CODE';
@@ -192,7 +192,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 			secondaryIdentityId,
 			'secondary',
 		);
-		expect(sendLeaveSubscriptionEmail).toHaveBeenCalledWith(
+		expect(sendLeaveSubscriptionEmailToSecondary).toHaveBeenCalledWith(
 			stage,
 			'PrimaryFirstName',
 			primaryEmail,

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -196,19 +196,16 @@ describe('deleteSecondaryUserEndpoint', () => {
 			secondaryIdentityId,
 			'secondary',
 		);
-		expect(sendLeaveSubscriptionEmailToSecondary).toHaveBeenCalledWith(
-			stage,
-			'PrimaryFirstName',
-			primaryEmail,
-			secondaryEmail,
-			secondaryIdentityId,
-		);
-		expect(sendLeaveSubscriptionEmailToPrimary).toHaveBeenCalledWith(
-			stage,
-			primaryEmail,
-			primaryIdentityId,
-			secondaryEmail,
-		);
+		expect(sendLeaveSubscriptionEmailToSecondary).toHaveBeenCalledWith(stage, {
+			primaryUserFirstName: 'PrimaryFirstName',
+			primaryUserEmail: primaryEmail,
+			secondaryUserEmail: secondaryEmail,
+			secondaryUserIdentityId: secondaryIdentityId,
+		});
+		expect(sendLeaveSubscriptionEmailToPrimary).toHaveBeenCalledWith(stage, {
+			primaryUserEmail: primaryEmail,
+			primaryUserIdentityId: primaryIdentityId,
+		});
 	});
 
 	it('returns 404 when the secondary user record is not found', async () => {

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -13,7 +13,10 @@ import { getAccount } from '@modules/zuora/account';
 import { getSubscription } from '@modules/zuora/subscription';
 import type { ZuoraClient } from '@modules/zuora/zuoraClient';
 import { deleteSecondaryUserEndpoint } from '../src/deleteSecondaryUserEndpoint';
-import { sendLeaveSubscriptionEmailToSecondary } from '../src/emails/leaveSubcriptionEmail';
+import {
+	sendLeaveSubscriptionEmailToPrimary,
+	sendLeaveSubscriptionEmailToSecondary,
+} from '../src/emails/leaveSubcriptionEmail';
 import { makeAccount, makeSubscription } from './helpers';
 
 jest.mock('@modules/zuora/subscription', () => ({
@@ -30,6 +33,7 @@ jest.mock('@modules/identity/idapi', () => ({
 
 jest.mock('../src/emails/leaveSubcriptionEmail', () => ({
 	sendLeaveSubscriptionEmailToSecondary: jest.fn(),
+	sendLeaveSubscriptionEmailToPrimary: jest.fn(),
 }));
 
 const stage = 'CODE';
@@ -198,6 +202,12 @@ describe('deleteSecondaryUserEndpoint', () => {
 			primaryEmail,
 			secondaryEmail,
 			secondaryIdentityId,
+		);
+		expect(sendLeaveSubscriptionEmailToPrimary).toHaveBeenCalledWith(
+			stage,
+			primaryEmail,
+			primaryIdentityId,
+			secondaryEmail,
 		);
 	});
 

--- a/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserIntegration.test.ts
@@ -22,7 +22,7 @@ import { deleteSecondaryUserEndpoint } from '../src/deleteSecondaryUserEndpoint'
 import { InvitationRepository } from '../src/invitationRepository';
 
 const stage = 'CODE';
-const subscriptionName = 'A-S00974337';
+const subscriptionName = 'A-S01117027';
 const secondaryUserEmail = 'integration-test2+multiple-account@thegulocal.com';
 
 let invitationCode: string;


### PR DESCRIPTION
## What does this change?

Following on from #3766. When a secondary user leaves a subscription, trigger an email to the primary user.

## How has this change been tested?

I've tested by running the integration tests.