### PR TITLE
Migrate new-product-api to Zuora Orders

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddContribution.scala
@@ -67,6 +67,7 @@ class AddContribution(
       chargeOverride = ChargeOverride(Some(amountMinorUnits), planAndCharge.productRatePlanChargeId, None)
       zuoraCreateSubRequest = ZuoraCreateSubRequest(
         request = request,
+        accountNumber = account.accountNumber,
         acceptanceDate = acceptanceDate,
         ratePlans = List(
           ZuoraCreateSubRequestRatePlan(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddDigipackSub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddDigipackSub.scala
@@ -81,6 +81,7 @@ class AddDigipackSub(
 
     createSubRequest = ZuoraCreateSubRequest(
       request = request,
+      accountNumber = customerData.account.accountNumber,
       acceptanceDate = request.startDate,
       ratePlans = ratePlans,
     )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddGuardianWeeklySub.scala
@@ -61,6 +61,7 @@ class AddGuardianWeeklySub(
     ).toApiGatewayOp.toAsync
     createSubRequest <- createCreateSubRequest(
       request,
+      customerData.account.accountNumber,
       getZuoraRateplanId,
     ).toAsync
     subscriptionName <- createSubscription(createSubRequest).toAsyncApiGatewayOp("create guardian weekly subscription")
@@ -130,6 +131,7 @@ object AddGuardianWeeklySub {
 
   def createCreateSubRequest(
       request: AddSubscriptionRequest,
+      accountNumber: GetAccount.AccountNumber,
       getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
   ): ApiGatewayOp[ZuoraCreateSubRequest] = {
     for {
@@ -159,6 +161,7 @@ object AddGuardianWeeklySub {
         )
       createSubRequest = ZuoraCreateSubRequest(
         request = request,
+        accountNumber = accountNumber,
         acceptanceDate = request.startDate,
         ratePlans = ratePlans,
       )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddPaperSub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddPaperSub.scala
@@ -87,6 +87,7 @@ class AddPaperSub(
 
     createSubRequest = ZuoraCreateSubRequest(
       request = request,
+      accountNumber = customerData.account.accountNumber,
       acceptanceDate = request.startDate,
       ratePlans = ratePlans,
     )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSupporterPlus.scala
@@ -89,6 +89,7 @@ class AddSupporterPlus(
         )
       zuoraCreateSubRequest = ZuoraCreateSubRequest(
         request = request,
+        accountNumber = account.accountNumber,
         acceptanceDate = acceptanceDate,
         ratePlans = ratePlans,
       )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddTierThree.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddTierThree.scala
@@ -56,6 +56,7 @@ class AddTierThree(
     ).toApiGatewayOp.toAsync
     createSubRequest <- createCreateSubRequest(
       request,
+      customerData.account.accountNumber,
       getZuoraRateplanId,
     ).toAsync
     subscriptionName <- createSubscription(createSubRequest).toAsyncApiGatewayOp("create tier three subscription")
@@ -124,6 +125,7 @@ object AddTierThree {
 
   def createCreateSubRequest(
       request: AddSubscriptionRequest,
+      accountNumber: GetAccount.AccountNumber,
       getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
   ): ApiGatewayOp[ZuoraCreateSubRequest] = {
     for {
@@ -153,6 +155,7 @@ object AddTierThree {
         )
       createSubRequest = ZuoraCreateSubRequest(
         request = request,
+        accountNumber = accountNumber,
         acceptanceDate = request.startDate,
         ratePlans = ratePlans,
       )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -13,7 +13,10 @@ import com.gu.newproduct.api.addsubscription.validation.guardianweekly.{
 }
 import com.gu.newproduct.api.addsubscription.validation.paper.PaperAddressValidator
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.SubscriptionName
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{WireCreateRequest, WireSubscription}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{
+  WireCreateOrderRequest,
+  WireOrderResponse,
+}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAccount
 import com.gu.newproduct.api.addsubscription.zuora._
 import com.gu.newproduct.api.productcatalog.PlanId.{
@@ -116,7 +119,10 @@ object Steps {
           StartDateValidator.fromRule(validatorFor, plan.startDateRules)
         },
       )
-      createSubscription = CreateSubscription(zuoraClient.post[WireCreateRequest, WireSubscription], currentDate) _
+      createSubscription = CreateSubscription(
+        zuoraClient.post[WireCreateOrderRequest, WireOrderResponse],
+        currentDate,
+      ) _
 
       supporterPlusSteps = AddSupporterPlus.wireSteps(
         catalog,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccount.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccount.scala
@@ -5,6 +5,7 @@ import com.gu.newproduct.api.addsubscription.validation.Validation._
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount._
 
 case class ValidatedAccount(
+    accountNumber: AccountNumber,
     identityId: Option[IdentityId],
     sfContactId: Option[SfContactId],
     paymentMethodId: PaymentMethodId,
@@ -19,6 +20,7 @@ object ValidateAccount {
       _ <- account.autoPay.value orFailWith "Zuora account has autopay disabled"
       paymentMethodId <- account.paymentMethodId getOrFailWith "Zuora account has no default payment method"
     } yield ValidatedAccount(
+      account.accountNumber,
       account.identityId,
       account.sfContactId,
       paymentMethodId,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -3,92 +3,188 @@ package com.gu.newproduct.api.addsubscription.zuora
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import com.gu.newproduct.api.addsubscription._
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.AccountNumber
 import com.gu.newproduct.api.productcatalog.AmountMinorUnits
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.util.resthttp.ClientFailableOpLogging.LogImplicit2
 import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
-import com.gu.util.resthttp.Types.ClientFailableOp
-import play.api.libs.json.{Json, OWrites, Reads}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
+import play.api.libs.json.{JsObject, Json, OWrites, Reads}
 
 object CreateSubscription {
-  val SpecificDateTriggerEventId = "USD"
-
   object WireModel {
 
-    case class WireSubscription(subscriptionNumber: String)
+    case class WireOrderResponse(subscriptionNumbers: List[String])
 
-    implicit val readsResponse: Reads[WireSubscription] = Json.reads[WireSubscription]
+    implicit val readsResponse: Reads[WireOrderResponse] = Json.reads[WireOrderResponse]
 
-    case class ChargeOverrides(
-        price: Option[Double],
+    case class ChargeStartDate(triggerEvent: String, specificTriggerDate: String)
+
+    implicit val writesChargeStartDate: OWrites[ChargeStartDate] = Json.writes[ChargeStartDate]
+
+    case class RecurringFlatFee(listPrice: Double)
+
+    implicit val writesRecurringFlatFee: OWrites[RecurringFlatFee] = Json.writes[RecurringFlatFee]
+
+    case class Pricing(recurringFlatFee: RecurringFlatFee)
+
+    implicit val writesPricing: OWrites[Pricing] = Json.writes[Pricing]
+
+    case class ChargeOverride(
         productRatePlanChargeId: String,
-        triggerDate: Option[LocalDate],
-        triggerEvent: Option[String],
+        pricing: Option[Pricing],
+        startDate: Option[ChargeStartDate],
     )
 
-    implicit val writesCharge: OWrites[ChargeOverrides] = Json.writes[ChargeOverrides]
+    implicit val writesChargeOverride: OWrites[ChargeOverride] = OWrites { chargeOverride =>
+      Json.obj("productRatePlanChargeId" -> chargeOverride.productRatePlanChargeId) ++
+        chargeOverride.pricing.fold(JsObject.empty)(pricing => Json.obj("pricing" -> pricing)) ++
+        chargeOverride.startDate.fold(JsObject.empty)(startDate => Json.obj("startDate" -> startDate))
+    }
 
-    case class SubscribeToRatePlans(
-        productRatePlanId: String,
-        chargeOverrides: List[ChargeOverrides],
+    case class SubscribeToRatePlan(productRatePlanId: String, chargeOverrides: List[ChargeOverride])
+
+    implicit val writesSubscribeToRatePlan: OWrites[SubscribeToRatePlan] = Json.writes[SubscribeToRatePlan]
+
+    case class InitialTerm(termType: String, period: Int, periodType: String)
+
+    implicit val writesInitialTerm: OWrites[InitialTerm] = Json.writes[InitialTerm]
+
+    case class RenewalTerm(period: Int, periodType: String)
+
+    implicit val writesRenewalTerm: OWrites[RenewalTerm] = Json.writes[RenewalTerm]
+
+    case class Terms(
+        autoRenew: Boolean,
+        initialTerm: InitialTerm,
+        renewalSetting: String,
+        renewalTerms: List[RenewalTerm],
     )
 
-    implicit val writesSubscribe: OWrites[SubscribeToRatePlans] = Json.writes[SubscribeToRatePlans]
+    implicit val writesTerms: OWrites[Terms] = Json.writes[Terms]
 
-    case class WireCreateRequest(
-        accountKey: String,
-        autoRenew: Boolean = true,
-        contractEffectiveDate: String,
-        customerAcceptanceDate: String,
-        termType: String = "TERMED",
-        renewalTerm: Int = 12,
-        initialTerm: Int = 12,
-        subscribeToRatePlans: List[SubscribeToRatePlans],
-        AcquisitionCase__c: String,
-        AcquisitionSource__c: String,
-        CreatedByCSR__c: String,
-        DeliveryAgent__c: Option[String],
-        LastPlanAddedDate__c: String,
+    case class CreateSubscriptionAction(terms: Terms, subscribeToRatePlans: List[SubscribeToRatePlan])
+
+    implicit val writesCreateSubscriptionAction: OWrites[CreateSubscriptionAction] =
+      Json.writes[CreateSubscriptionAction]
+
+    case class TriggerDate(name: String, triggerDate: String)
+
+    implicit val writesTriggerDate: OWrites[TriggerDate] = Json.writes[TriggerDate]
+
+    case class OrderAction(
+        `type`: String,
+        triggerDates: List[TriggerDate],
+        createSubscription: CreateSubscriptionAction,
     )
 
-    implicit val writesRequest: OWrites[WireCreateRequest] = Json.writes[WireCreateRequest]
+    implicit val writesOrderAction: OWrites[OrderAction] = Json.writes[OrderAction]
+
+    case class SubscriptionCustomFields(
+        acquisitionCase: String,
+        acquisitionSource: String,
+        createdByCSR: String,
+        deliveryAgent: Option[String],
+        lastPlanAddedDate: String,
+    )
+
+    implicit val writesSubscriptionCustomFields: OWrites[SubscriptionCustomFields] = OWrites { customFields =>
+      Json.obj(
+        "AcquisitionCase__c" -> customFields.acquisitionCase,
+        "AcquisitionSource__c" -> customFields.acquisitionSource,
+        "CreatedByCSR__c" -> customFields.createdByCSR,
+        "LastPlanAddedDate__c" -> customFields.lastPlanAddedDate,
+      ) ++ customFields.deliveryAgent.fold(JsObject.empty)(deliveryAgent =>
+        Json.obj("DeliveryAgent__c" -> deliveryAgent),
+      )
+    }
+
+    case class OrderSubscription(orderActions: List[OrderAction], customFields: SubscriptionCustomFields)
+
+    implicit val writesOrderSubscription: OWrites[OrderSubscription] = Json.writes[OrderSubscription]
+
+    case class ProcessingOptions(runBilling: Boolean, collectPayment: Boolean)
+
+    implicit val writesProcessingOptions: OWrites[ProcessingOptions] = Json.writes[ProcessingOptions]
+
+    case class WireCreateOrderRequest(
+        orderDate: String,
+        existingAccountNumber: String,
+        subscriptions: List[OrderSubscription],
+        processingOptions: ProcessingOptions,
+    )
+
+    implicit val writesRequest: OWrites[WireCreateOrderRequest] = Json.writes[WireCreateOrderRequest]
   }
 
   import WireModel._
 
-  def createRequest(currentDate: LocalDate, createSubscription: ZuoraCreateSubRequest): WireCreateRequest = {
+  private val DateFormat = DateTimeFormatter.ISO_LOCAL_DATE
+
+  private def zuoraDate(date: LocalDate): String = date.format(DateFormat)
+
+  def createRequest(currentDate: LocalDate, createSubscription: ZuoraCreateSubRequest): WireCreateOrderRequest = {
     import createSubscription._
-    WireCreateRequest(
-      accountKey = accountId.value,
-      contractEffectiveDate = currentDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
-      customerAcceptanceDate = acceptanceDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
-      AcquisitionCase__c = acquisitionCase.value,
-      AcquisitionSource__c = acquisitionSource.value,
-      CreatedByCSR__c = createdByCSR.value,
-      DeliveryAgent__c = deliveryAgent.map(_.value),
-      LastPlanAddedDate__c = currentDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
-      subscribeToRatePlans = ratePlans.map { ratePlan =>
-        SubscribeToRatePlans(
-          productRatePlanId = ratePlan.productRatePlanId.value,
-          chargeOverrides = ratePlan.maybeChargeOverride.map { chargeOverride =>
-            ChargeOverrides(
-              price = chargeOverride.amountMinorUnits.map(_.value.toDouble / 100),
-              productRatePlanChargeId = chargeOverride.productRatePlanChargeId.value,
-              triggerDate = chargeOverride.triggerDate,
-              triggerEvent = chargeOverride.triggerDate.map(_ => SpecificDateTriggerEventId),
-            )
-          }.toList,
-        )
-      },
+    val contractEffectiveDate = zuoraDate(currentDate)
+
+    WireCreateOrderRequest(
+      orderDate = contractEffectiveDate,
+      existingAccountNumber = accountNumber.value,
+      subscriptions = List(
+        OrderSubscription(
+          orderActions = List(
+            OrderAction(
+              `type` = "CreateSubscription",
+              triggerDates = List(
+                TriggerDate("ContractEffective", contractEffectiveDate),
+                TriggerDate("CustomerAcceptance", zuoraDate(acceptanceDate)),
+              ),
+              createSubscription = CreateSubscriptionAction(
+                terms = Terms(
+                  autoRenew = true,
+                  initialTerm = InitialTerm("TERMED", 12, "Month"),
+                  renewalSetting = "RENEW_WITH_SPECIFIC_TERM",
+                  renewalTerms = List(RenewalTerm(12, "Month")),
+                ),
+                subscribeToRatePlans = ratePlans.map { ratePlan =>
+                  SubscribeToRatePlan(
+                    productRatePlanId = ratePlan.productRatePlanId.value,
+                    chargeOverrides = ratePlan.maybeChargeOverride.map { chargeOverride =>
+                      WireModel.ChargeOverride(
+                        productRatePlanChargeId = chargeOverride.productRatePlanChargeId.value,
+                        pricing = chargeOverride.amountMinorUnits.map(amount =>
+                          Pricing(RecurringFlatFee(amount.value.toDouble / 100)),
+                        ),
+                        startDate =
+                          chargeOverride.triggerDate.map(date => ChargeStartDate("SpecificDate", zuoraDate(date))),
+                      )
+                    }.toList,
+                  )
+                },
+              ),
+            ),
+          ),
+          customFields = SubscriptionCustomFields(
+            acquisitionCase = acquisitionCase.value,
+            acquisitionSource = acquisitionSource.value,
+            createdByCSR = createdByCSR.value,
+            deliveryAgent = deliveryAgent.map(_.value),
+            lastPlanAddedDate = contractEffectiveDate,
+          ),
+        ),
+      ),
+      processingOptions = ProcessingOptions(runBilling = true, collectPayment = true),
     )
   }
+
   case class ChargeOverride(
       amountMinorUnits: Option[AmountMinorUnits],
       productRatePlanChargeId: ProductRatePlanChargeId,
       triggerDate: Option[LocalDate],
   )
+
   case class ZuoraCreateSubRequest(
-      accountId: ZuoraAccountId,
+      accountNumber: AccountNumber,
       acceptanceDate: LocalDate,
       acquisitionCase: CaseId,
       acquisitionSource: AcquisitionSource,
@@ -105,10 +201,11 @@ object CreateSubscription {
   object ZuoraCreateSubRequest {
     def apply(
         request: AddSubscriptionRequest,
+        accountNumber: AccountNumber,
         acceptanceDate: LocalDate,
         ratePlans: List[ZuoraCreateSubRequestRatePlan],
     ): ZuoraCreateSubRequest = ZuoraCreateSubRequest(
-      accountId = request.zuoraAccountId,
+      accountNumber = accountNumber,
       acceptanceDate = acceptanceDate,
       acquisitionCase = request.acquisitionCase,
       acquisitionSource = request.acquisitionSource,
@@ -117,18 +214,19 @@ object CreateSubscription {
       ratePlans = ratePlans,
     )
   }
+
   case class SubscriptionName(value: String) extends AnyVal
 
   def apply(
-      post: RequestsPost[WireCreateRequest, WireSubscription],
+      post: RequestsPost[WireCreateOrderRequest, WireOrderResponse],
       currentDate: () => LocalDate,
-  )(createSubscription: ZuoraCreateSubRequest): ClientFailableOp[SubscriptionName] = {
-    val maybeWireSubscription = post(createRequest(currentDate(), createSubscription), s"subscriptions", WithCheck)
-    maybeWireSubscription
-      .map { wireSubscription =>
-        SubscriptionName(wireSubscription.subscriptionNumber)
+  )(createSubscription: ZuoraCreateSubRequest): ClientFailableOp[SubscriptionName] =
+    // https://developer.zuora.com/v1-api-reference/api/operation/POST_Order/
+    post(createRequest(currentDate(), createSubscription), "orders", WithCheck)
+      .flatMap {
+        case WireOrderResponse(subscriptionNumber :: Nil) => ClientSuccess(SubscriptionName(subscriptionNumber))
+        case WireOrderResponse(subscriptionNumbers) =>
+          GenericError(s"expected one subscription number from Zuora Orders, received ${subscriptionNumbers.size}")
       }
       .withLogging("created subscription")
-  }
-
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccount.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccount.scala
@@ -11,6 +11,7 @@ object GetAccount {
   object WireModel {
 
     case class ZuoraAccount(
+        AccountNumber: String,
         IdentityId__c: Option[String],
         sfContactId__c: Option[String],
         DefaultPaymentMethodId: Option[String],
@@ -26,6 +27,7 @@ object GetAccount {
         case Some(currency) =>
           ClientSuccess(
             Account(
+              AccountNumber(zuoraAccount.AccountNumber),
               zuoraAccount.IdentityId__c.map(IdentityId),
               zuoraAccount.sfContactId__c.map(SfContactId.apply),
               zuoraAccount.DefaultPaymentMethodId.map(PaymentMethodId),
@@ -46,6 +48,8 @@ object GetAccount {
 
   case class IdentityId(value: String) extends AnyVal
 
+  case class AccountNumber(value: String) extends AnyVal
+
   case class SfContactId(value: String) extends AnyVal
 
   case class PaymentMethodId(value: String) extends AnyVal
@@ -55,6 +59,7 @@ object GetAccount {
   case class AccountBalanceMinorUnits(value: Int) extends AnyVal
 
   case class Account(
+      accountNumber: AccountNumber,
       identityId: Option[IdentityId],
       sfContactId: Option[SfContactId],
       paymentMethodId: Option[PaymentMethodId],

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/TestData.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/TestData.scala
@@ -10,6 +10,7 @@ import com.gu.newproduct.api.addsubscription.validation.supporterplus.SupporterP
 import com.gu.newproduct.api.addsubscription.validation.tierthree.TierThreeCustomerData
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{
   AccountBalanceMinorUnits,
+  AccountNumber,
   AutoPay,
   IdentityId,
   PaymentMethodId,
@@ -29,6 +30,7 @@ import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
 
 object TestData {
   val validatedAccount = ValidatedAccount(
+    accountNumber = AccountNumber("A00000001"),
     identityId = Some(IdentityId("identityId")),
     paymentMethodId = PaymentMethodId("paymentMethodId"),
     autoPay = AutoPay(true),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -12,7 +12,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
   ZuoraCreateSubRequest,
   ZuoraCreateSubRequestRatePlan,
 }
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountNumber, SfContactId}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
@@ -46,7 +46,7 @@ class ContributionStepsTest extends AnyFlatSpec with Matchers {
     def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
 
     val expectedIn = ZuoraCreateSubRequest(
-      accountId = ZuoraAccountId("acccc"),
+      accountNumber = AccountNumber("A00000001"),
       acceptanceDate = LocalDate.of(2018, 7, 18),
       acquisitionCase = CaseId("case"),
       acquisitionSource = AcquisitionSource("CSR"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/GuardianWeeklyStepsTest.scala
@@ -12,7 +12,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
   ZuoraCreateSubRequest,
   ZuoraCreateSubRequestRatePlan,
 }
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountNumber, SfContactId}
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.{BillToAddress, SoldToAddress}
 import com.gu.newproduct.api.productcatalog.PlanId.{
   GuardianWeeklyPlusDomesticMonthly,
@@ -117,7 +117,7 @@ class GuardianWeeklyStepsTest extends AnyFlatSpec with Matchers {
         request: CreateSubscription.ZuoraCreateSubRequest,
     ): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
       request shouldBe ZuoraCreateSubRequest(
-        accountId = testZuoraAccountId,
+        accountNumber = AccountNumber("A00000001"),
         acceptanceDate = testFirstPaymentDate,
         acquisitionCase = testCaseId,
         acquisitionSource = testAcquistionSource,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/HealthCheckTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/HealthCheckTest.scala
@@ -15,6 +15,7 @@ class HealthCheckTest extends AnyFlatSpec with Matchers {
       requestedAccountId should be(ZuoraAccountId("accacc"))
       ClientSuccess(
         Account(
+          AccountNumber("A00000001"),
           Some(IdentityId("1313")),
           Some(SfContactId("1414")),
           None,
@@ -33,6 +34,7 @@ class HealthCheckTest extends AnyFlatSpec with Matchers {
     def getAccount(dontcare: ZuoraAccountId): Types.ClientFailableOp[Account] = {
       ClientSuccess(
         Account(
+          AccountNumber("A00000001"),
           Some(IdentityId("asdf")),
           Some(SfContactId("1414")),
           None,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/PaperStepsTest.scala
@@ -8,7 +8,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
   ZuoraCreateSubRequest,
   ZuoraCreateSubRequestRatePlan,
 }
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountNumber, SfContactId}
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts.SoldToAddress
 import com.gu.newproduct.api.productcatalog.PlanId.{NationalDeliveryWeekend, VoucherEveryDay}
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
@@ -130,7 +130,7 @@ class PaperStepsTest extends AnyFlatSpec with Matchers with Inside with DiffShou
     def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
 
     val expectedIn = ZuoraCreateSubRequest(
-      accountId = ZuoraAccountId("acccc"),
+      accountNumber = AccountNumber("A00000001"),
       acceptanceDate = LocalDate.of(2018, 7, 18),
       acquisitionCase = CaseId("case"),
       acquisitionSource = AcquisitionSource("CSR"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/SupporterPlusStepsTest.scala
@@ -13,7 +13,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
   ZuoraCreateSubRequest,
   ZuoraCreateSubRequestRatePlan,
 }
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountNumber, SfContactId}
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlySupporterPlus
 import com.gu.newproduct.api.productcatalog.RuleFixtures.testStartDateRules
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharges, ProductRatePlanChargeId, ProductRatePlanId}
@@ -46,7 +46,7 @@ class SupporterPlusStepsTest extends AnyFlatSpec with Matchers {
     def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
 
     val expectedIn = ZuoraCreateSubRequest(
-      accountId = ZuoraAccountId("acccc"),
+      accountNumber = AccountNumber("A00000001"),
       acceptanceDate = LocalDate.of(2018, 7, 18),
       acquisitionCase = CaseId("case"),
       acquisitionSource = AcquisitionSource("CSR"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccountTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccountTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class ValidateAccountTest extends AnyFlatSpec with Matchers {
 
   val validAccount = Account(
+    accountNumber = AccountNumber("A00000001"),
     identityId = Some(IdentityId("idAccount1")),
     sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = Some(PaymentMethodId("activePaymentMethod")),
@@ -17,6 +18,7 @@ class ValidateAccountTest extends AnyFlatSpec with Matchers {
   )
 
   val validatedAccount = ValidatedAccount(
+    accountNumber = AccountNumber("A00000001"),
     identityId = Some(IdentityId("idAccount1")),
     sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = PaymentMethodId("activePaymentMethod"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionAccountValidationTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionAccountValidationTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ContributionAccountValidationTest extends AnyFlatSpec with Matchers {
   val account = ValidatedAccount(
+    accountNumber = AccountNumber("A00000001"),
     identityId = Some(IdentityId("identityId")),
     sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = PaymentMethodId("id"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/digipack/DigipackAccountValidationTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/digipack/DigipackAccountValidationTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class DigipackAccountValidationTest extends AnyFlatSpec with Matchers {
   val account = ValidatedAccount(
+    accountNumber = AccountNumber("A00000001"),
     identityId = Some(IdentityId("identityId")),
     sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = PaymentMethodId("id"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAccountValidationTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/guardianweekly/GuardianWeeklyAccountValidationTest.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed, ValidatedAccount}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{
   AccountBalanceMinorUnits,
+  AccountNumber,
   AutoPay,
   IdentityId,
   PaymentMethodId,
@@ -13,6 +14,7 @@ import org.scalatest.matchers.should.Matchers
 
 class GuardianWeeklyAccountValidationTest extends AnyFlatSpec with Matchers {
   val account = ValidatedAccount(
+    accountNumber = AccountNumber("A00000001"),
     identityId = Some(IdentityId("1234")),
     sfContactId = None,
     paymentMethodId = PaymentMethodId("id"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/supporterplus/SupporterPlusAccountValidationTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/supporterplus/SupporterPlusAccountValidationTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class SupporterPlusAccountValidationTest extends AnyFlatSpec with Matchers {
   val account = ValidatedAccount(
+    accountNumber = AccountNumber("A00000001"),
     identityId = Some(IdentityId("identityId")),
     sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = PaymentMethodId("id"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/voucher/PaperAccountValidationTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/voucher/PaperAccountValidationTest.scala
@@ -5,6 +5,7 @@ import com.gu.newproduct.api.addsubscription.validation.paper.PaperAccountValida
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed, ValidatedAccount}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{
   AccountBalanceMinorUnits,
+  AccountNumber,
   AutoPay,
   PaymentMethodId,
   SfContactId,
@@ -14,6 +15,7 @@ import org.scalatest.matchers.should.Matchers
 
 class PaperAccountValidationTest extends AnyFlatSpec with Matchers {
   val account = ValidatedAccount(
+    accountNumber = AccountNumber("A00000001"),
     identityId = None,
     sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = PaymentMethodId("id"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -6,6 +6,7 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel._
 import com.gu.newproduct.api.addsubscription._
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, ZuoraCreateSubRequestRatePlan}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAccount
 import com.gu.newproduct.api.productcatalog.AmountMinorUnits
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.test.EffectsTest
@@ -22,36 +23,38 @@ class CreateSubscriptionEffectsTest extends AnyFlatSpec with Matchers {
   def currentDate = () => LocalDate.of(2024, 2, 10)
   it should "create subscription in account" taggedAs EffectsTest in {
     val validCaseIdToAvoidCausingSFErrors = CaseId("5006E000005b5cf")
-    val request = CreateSubscription.ZuoraCreateSubRequest(
-      ZuoraAccountId(
-        "8ad095dd82f7aaa50182f96de24d3ddb",
-      ), // code https://apisandbox.zuora.com/apps/CustomerAccount.do?method=view&id=8ad095dd82f7aaa50182f96de24d3ddb
-      currentDate().plusDays(2),
-      validCaseIdToAvoidCausingSFErrors,
-      AcquisitionSource("sourcesource"),
-      CreatedByCSR("csrcsr"),
-      None,
-      List(
-        ZuoraCreateSubRequestRatePlan(
-          productRatePlanId = monthlyContribution.productRatePlanId,
-          maybeChargeOverride = Some(
-            ChargeOverride(
-              amountMinorUnits = Some(AmountMinorUnits(100)),
-              productRatePlanChargeId = monthlyContribution.productRatePlanChargeId,
-              triggerDate = None,
-            ),
-          ),
-        ),
-        ZuoraCreateSubRequestRatePlan(
-          productRatePlanId = ProductRatePlanId("71a1018d1c18b3c6af44b8dbb5720000"),
-          maybeChargeOverride = None,
-        ),
-      ),
-    )
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
-      post: RequestsPost[WireCreateRequest, WireSubscription] = zuoraDeps.post[WireCreateRequest, WireSubscription]
+      account <- GetAccount(zuoraDeps.get[ZuoraAccount])(
+        ZuoraAccountId("8ad095dd82f7aaa50182f96de24d3ddb"),
+      ).toDisjunction
+      request = CreateSubscription.ZuoraCreateSubRequest(
+        account.accountNumber,
+        currentDate().plusDays(2),
+        validCaseIdToAvoidCausingSFErrors,
+        AcquisitionSource("sourcesource"),
+        CreatedByCSR("csrcsr"),
+        None,
+        List(
+          ZuoraCreateSubRequestRatePlan(
+            productRatePlanId = monthlyContribution.productRatePlanId,
+            maybeChargeOverride = Some(
+              ChargeOverride(
+                amountMinorUnits = Some(AmountMinorUnits(100)),
+                productRatePlanChargeId = monthlyContribution.productRatePlanChargeId,
+                triggerDate = None,
+              ),
+            ),
+          ),
+          ZuoraCreateSubRequestRatePlan(
+            productRatePlanId = ProductRatePlanId("71a1018d1c18b3c6af44b8dbb5720000"),
+            maybeChargeOverride = None,
+          ),
+        ),
+      )
+      post: RequestsPost[WireCreateOrderRequest, WireOrderResponse] =
+        zuoraDeps.post[WireCreateOrderRequest, WireOrderResponse]
       res <- CreateSubscription(post, currentDate)(request).toDisjunction
     } yield res
     withClue(actual) {
@@ -63,31 +66,32 @@ class CreateSubscriptionEffectsTest extends AnyFlatSpec with Matchers {
   it should "create digipack in account with a discount" taggedAs EffectsTest in {
     val validCaseIdToAvoidCausingSFErrors = CaseId("5006E000005b5cf")
     val monthlyTestRatePlanZuoraId = ProductRatePlanId("2c92c0f84bbfec8b014bc655f4852d9d")
-    val request = CreateSubscription.ZuoraCreateSubRequest(
-      ZuoraAccountId(
-        "8ad095dd82f7aaa50182f96de24d3ddb",
-      ), // code https://apisandbox.zuora.com/apps/CustomerAccount.do?method=view&id=8ad095dd82f7aaa50182f96de24d3ddb
-      currentDate().plusDays(2),
-      validCaseIdToAvoidCausingSFErrors,
-      AcquisitionSource("sourcesource"),
-      CreatedByCSR("csrcsr"),
-      None,
-      List(
-        ZuoraCreateSubRequestRatePlan(
-          productRatePlanId = monthlyTestRatePlanZuoraId,
-          maybeChargeOverride = None,
-        ),
-        ZuoraCreateSubRequestRatePlan(
-          productRatePlanId = ProductRatePlanId("2c92c0f97421eeff017425ad4ef7522b"),
-          maybeChargeOverride = None,
-        ),
-      ),
-    )
-
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("CODE"), GetFromS3.fetchString).load[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
-      post: RequestsPost[WireCreateRequest, WireSubscription] = zuoraDeps.post[WireCreateRequest, WireSubscription]
+      account <- GetAccount(zuoraDeps.get[ZuoraAccount])(
+        ZuoraAccountId("8ad095dd82f7aaa50182f96de24d3ddb"),
+      ).toDisjunction
+      request = CreateSubscription.ZuoraCreateSubRequest(
+        account.accountNumber,
+        currentDate().plusDays(2),
+        validCaseIdToAvoidCausingSFErrors,
+        AcquisitionSource("sourcesource"),
+        CreatedByCSR("csrcsr"),
+        None,
+        List(
+          ZuoraCreateSubRequestRatePlan(
+            productRatePlanId = monthlyTestRatePlanZuoraId,
+            maybeChargeOverride = None,
+          ),
+          ZuoraCreateSubRequestRatePlan(
+            productRatePlanId = ProductRatePlanId("2c92c0f97421eeff017425ad4ef7522b"),
+            maybeChargeOverride = None,
+          ),
+        ),
+      )
+      post: RequestsPost[WireCreateOrderRequest, WireOrderResponse] =
+        zuoraDeps.post[WireCreateOrderRequest, WireOrderResponse]
       res <- CreateSubscription(post, currentDate)(request).toDisjunction
     } yield res
     withClue(actual) {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -3,10 +3,8 @@ package com.gu.newproduct.api.addsubscription.zuora
 import java.time.LocalDate
 
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{
-  ChargeOverrides,
-  SubscribeToRatePlans,
-  WireCreateRequest,
-  WireSubscription,
+  WireCreateOrderRequest,
+  WireOrderResponse,
 }
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
   ChargeOverride,
@@ -14,6 +12,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{
   ZuoraCreateSubRequest,
   ZuoraCreateSubRequestRatePlan,
 }
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.AccountNumber
 import com.gu.newproduct.api.addsubscription._
 import com.gu.newproduct.api.productcatalog.AmountMinorUnits
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
@@ -21,55 +20,24 @@ import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
 import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
 
 class CreateSubscriptionTest extends AnyFlatSpec with Matchers {
 
-  def currentDate = () => LocalDate.of(2018, 7, 2)
-  it should "get account as object" in {
+  private val currentDate = () => LocalDate.of(2018, 7, 2)
 
+  it should "build a create subscription order" in {
     val ids = PlanAndCharge(
       productRatePlanId = ProductRatePlanId("hiProductRatePlanId"),
       productRatePlanChargeId = ProductRatePlanChargeId("hiProductRatePlanChargeId"),
     )
-    val expectedReq = WireCreateRequest(
-      accountKey = "zac",
-      autoRenew = true,
-      contractEffectiveDate = "2018-07-02",
-      customerAcceptanceDate = "2018-07-27",
-      termType = "TERMED",
-      renewalTerm = 12,
-      initialTerm = 12,
-      AcquisitionCase__c = "casecase",
-      AcquisitionSource__c = "sourcesource",
-      CreatedByCSR__c = "csrcsr",
-      DeliveryAgent__c = None,
-      LastPlanAddedDate__c = "2018-07-02",
-      subscribeToRatePlans = List(
-        SubscribeToRatePlans(
-          productRatePlanId = "hiProductRatePlanId",
-          chargeOverrides = List(
-            ChargeOverrides(
-              price = Some(1.25),
-              productRatePlanChargeId = "hiProductRatePlanChargeId",
-              triggerDate = Some(LocalDate.of(2020, 1, 1)),
-              triggerEvent = Some("USD"),
-            ),
-          ),
-        ),
-      ),
-    )
-    val accF: RequestsPost[WireCreateRequest, WireSubscription] = {
-      case (req, "subscriptions", WithCheck) if req == expectedReq =>
-        ClientSuccess(WireSubscription("a-s123"))
-      case in => GenericError(s"bad request: $in")
-    }
-    val createReq = ZuoraCreateSubRequest(
-      accountId = ZuoraAccountId("zac"),
+    val createRequest = ZuoraCreateSubRequest(
+      accountNumber = AccountNumber("A00012345"),
       acceptanceDate = LocalDate.of(2018, 7, 27),
       acquisitionCase = CaseId("casecase"),
       acquisitionSource = AcquisitionSource("sourcesource"),
       createdByCSR = CreatedByCSR("csrcsr"),
-      deliveryAgent = None,
+      deliveryAgent = Some(DeliveryAgent("deliveryagent")),
       ratePlans = List(
         ZuoraCreateSubRequestRatePlan(
           productRatePlanId = ids.productRatePlanId,
@@ -83,7 +51,87 @@ class CreateSubscriptionTest extends AnyFlatSpec with Matchers {
         ),
       ),
     )
-    val actual = CreateSubscription(accF, currentDate)(createReq)
-    actual shouldBe ClientSuccess(SubscriptionName("a-s123"))
+    val expectedJson = Json.parse("""
+      {
+        "orderDate":"2018-07-02",
+        "existingAccountNumber":"A00012345",
+        "subscriptions":[{
+          "orderActions":[{
+            "type":"CreateSubscription",
+            "triggerDates":[
+              {"name":"ContractEffective","triggerDate":"2018-07-02"},
+              {"name":"CustomerAcceptance","triggerDate":"2018-07-27"}
+            ],
+            "createSubscription":{
+              "terms":{
+                "autoRenew":true,
+                "initialTerm":{"termType":"TERMED","period":12,"periodType":"Month"},
+                "renewalSetting":"RENEW_WITH_SPECIFIC_TERM",
+                "renewalTerms":[{"period":12,"periodType":"Month"}]
+              },
+              "subscribeToRatePlans":[{
+                "productRatePlanId":"hiProductRatePlanId",
+                "chargeOverrides":[{
+                  "productRatePlanChargeId":"hiProductRatePlanChargeId",
+                  "pricing":{"recurringFlatFee":{"listPrice":1.25}},
+                  "startDate":{"triggerEvent":"SpecificDate","specificTriggerDate":"2020-01-01"}
+                }]
+              }]
+            }
+          }],
+          "customFields":{
+            "AcquisitionCase__c":"casecase",
+            "AcquisitionSource__c":"sourcesource",
+            "CreatedByCSR__c":"csrcsr",
+            "DeliveryAgent__c":"deliveryagent",
+            "LastPlanAddedDate__c":"2018-07-02"
+          }
+        }],
+        "processingOptions":{"runBilling":true,"collectPayment":true}
+      }
+    """)
+
+    Json.toJson(CreateSubscription.createRequest(currentDate(), createRequest)) shouldBe expectedJson
+  }
+
+  it should "create a subscription through orders" in {
+    val createRequest = ZuoraCreateSubRequest(
+      accountNumber = AccountNumber("A00012345"),
+      acceptanceDate = LocalDate.of(2018, 7, 27),
+      acquisitionCase = CaseId("casecase"),
+      acquisitionSource = AcquisitionSource("sourcesource"),
+      createdByCSR = CreatedByCSR("csrcsr"),
+      deliveryAgent = Some(DeliveryAgent("deliveryagent")),
+      ratePlans = List(
+        ZuoraCreateSubRequestRatePlan(
+          productRatePlanId = ProductRatePlanId("hiProductRatePlanId"),
+          maybeChargeOverride = None,
+        ),
+      ),
+    )
+    val post: RequestsPost[WireCreateOrderRequest, WireOrderResponse] = {
+      case (_, "orders", WithCheck) => ClientSuccess(WireOrderResponse(List("A-S00012345")))
+      case input => GenericError(s"bad request: $input")
+    }
+
+    CreateSubscription(post, currentDate)(createRequest) shouldBe ClientSuccess(SubscriptionName("A-S00012345"))
+  }
+
+  it should "fail when Zuora returns anything other than one subscription" in {
+    val createRequest = ZuoraCreateSubRequest(
+      accountNumber = AccountNumber("A00012345"),
+      acceptanceDate = LocalDate.of(2018, 7, 27),
+      acquisitionCase = CaseId("casecase"),
+      acquisitionSource = AcquisitionSource("sourcesource"),
+      createdByCSR = CreatedByCSR("csrcsr"),
+      deliveryAgent = None,
+      ratePlans = Nil,
+    )
+    val post: RequestsPost[WireCreateOrderRequest, WireOrderResponse] = {
+      case (_, "orders", WithCheck) => ClientSuccess(WireOrderResponse(Nil))
+      case input => GenericError(s"bad request: $input")
+    }
+
+    CreateSubscription(post, currentDate)(createRequest).isFailure shouldBe true
   }
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountEffectsTest.scala
@@ -19,14 +19,16 @@ class GetAccountEffectsTest extends AnyFlatSpec with Matchers {
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       res <- GetAccount(zuoraDeps.get[ZuoraAccount])(ZuoraAccountId("8ad095dd82f7aaa50182f96de24d3ddb")).toDisjunction
     } yield res
-    val expected = Account(
-      identityId = Some(IdentityId("200045767")),
-      sfContactId = Some(SfContactId("0039E00001cEWmcQAG")),
-      paymentMethodId = Some(PaymentMethodId("8ad095dd82f7aaa50182f96de2883de1")),
-      autoPay = AutoPay(true),
-      accountBalanceMinorUnits = AccountBalanceMinorUnits(0),
-      currency = GBP,
-    )
-    actual shouldBe Right(expected)
+    actual match {
+      case Right(account) =>
+        account.accountNumber.value should not be empty
+        account.identityId shouldBe Some(IdentityId("200045767"))
+        account.sfContactId shouldBe Some(SfContactId("0039E00001cEWmcQAG"))
+        account.paymentMethodId shouldBe Some(PaymentMethodId("8ad095dd82f7aaa50182f96de2883de1"))
+        account.autoPay shouldBe AutoPay(true)
+        account.accountBalanceMinorUnits shouldBe AccountBalanceMinorUnits(0)
+        account.currency shouldBe GBP
+      case Left(error) => fail(error.toString)
+    }
   }
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountTest.scala
@@ -12,6 +12,7 @@ import org.scalatest.matchers.should.Matchers
 class GetAccountTest extends AnyFlatSpec with Matchers {
 
   val acc: ZuoraAccount = ZuoraAccount(
+    AccountNumber = "A00000001",
     IdentityId__c = Some("6002"),
     DefaultPaymentMethodId = Some("2c92c0f8649cc8a60164a2bfd475000c"),
     AutoPay = false,
@@ -28,6 +29,7 @@ class GetAccountTest extends AnyFlatSpec with Matchers {
     val actual = GetAccount(accF)(ZuoraAccountId("2c92c0f9624bbc5f016253e573970b16"))
     actual shouldBe ClientSuccess(
       Account(
+        AccountNumber("A00000001"),
         Some(IdentityId("6002")),
         Some(SfContactId("sfContactId")),
         Some(PaymentMethodId("2c92c0f8649cc8a60164a2bfd475000c")),
@@ -47,6 +49,7 @@ class GetAccountTest extends AnyFlatSpec with Matchers {
     val actual = GetAccount(accF)(ZuoraAccountId("missingFieldsAccount"))
     actual shouldBe ClientSuccess(
       Account(
+        AccountNumber("A00000001"),
         None,
         None,
         None,


### PR DESCRIPTION
## What does this change?

Moves new-product-api from the legacy subscriptions endpoint to the synchronous Zuora Orders API.

It preserves the existing rate plans, prices, acceptance date, term settings, acquisition fields, optional delivery agent and billing options. The existing account lookup now retains the account number required by Orders.

Asana: https://app.asana.com/1/1210045093164357/project/1213012175670365/task/1218098873407925?focus=true

The request is covered by an exact JSON contract test. For example:

```json
{
  "orderDate": "2018-07-02",
  "existingAccountNumber": "A00012345",
  "subscriptions": [
    {
      "orderActions": [
        {
          "type": "CreateSubscription",
          "triggerDates": [
            { "name": "ContractEffective", "triggerDate": "2018-07-02" },
            { "name": "CustomerAcceptance", "triggerDate": "2018-07-27" }
          ],
          "createSubscription": {
            "terms": {
              "autoRenew": true,
              "initialTerm": { "termType": "TERMED", "period": 12, "periodType": "Month" },
              "renewalSetting": "RENEW_WITH_SPECIFIC_TERM",
              "renewalTerms": [{ "period": 12, "periodType": "Month" }]
            },
            "subscribeToRatePlans": [
              {
                "productRatePlanId": "hiProductRatePlanId",
                "chargeOverrides": [
                  {
                    "productRatePlanChargeId": "hiProductRatePlanChargeId",
                    "pricing": { "recurringFlatFee": { "listPrice": 1.25 } },
                    "startDate": {
                      "triggerEvent": "SpecificDate",
                      "specificTriggerDate": "2020-01-01"
                    }
                  }
                ]
              }
            ]
          }
        }
      ],
      "customFields": {
        "AcquisitionCase__c": "casecase",
        "AcquisitionSource__c": "sourcesource",
        "CreatedByCSR__c": "csrcsr",
        "DeliveryAgent__c": "deliveryagent",
        "LastPlanAddedDate__c": "2018-07-02"
      }
    }
  ],
  "processingOptions": {
    "runBilling": true,
    "collectPayment": true
  }
}
```

## How has this change been tested?

Ran Scala formatting, 150 tests, JAR assembly and the CDK package locally. The request builder is tested against the complete Orders payload, including optional custom fields and an unexpected Orders response.

This has not yet been deployed to CODE.

## How can we measure success?

A subscription created in CODE should return one subscription number and retain the expected rate plans, prices, dates, term settings and custom fields in Zuora.

## Have we considered potential risks?

The Orders request must preserve the legacy subscription creation behaviour. The exact payload test covers the request contract; CODE testing should compare the created subscription and charges before a production deployment.
