### PR TITLE
Send invitation redeemed email to primary user

### DIFF
--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -13,7 +13,7 @@ import {
 } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 import { getSupporterRatePlan } from '@modules/supporter-product-data/supporterProductData';
-import { sendAcceptInvitationEmail } from './emails/acceptInvitationEmail';
+import { sendInvitationRedeemedEmail } from './emails/acceptInvitationEmail';
 import type { InvitationRepository } from './invitationRepository';
 
 export const acceptInvitationEndpoint = async (
@@ -89,13 +89,15 @@ export const acceptInvitationEndpoint = async (
 			today,
 		);
 
-		await sendAcceptInvitationEmail(
+		await sendInvitationRedeemedEmail(
 			stage,
+			primaryIdentityId,
 			invitation.primaryUserFirstName,
 			invitation.primaryUserEmail,
 			invitation.secondaryUserEmail,
 			invitation.secondaryIdentityId,
 		);
+
 		return ok({
 			identityId: secondaryIdentityId,
 			secondarySubscriptionName,

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -89,14 +89,13 @@ export const acceptInvitationEndpoint = async (
 			today,
 		);
 
-		await sendInvitationRedeemedEmail(
-			stage,
-			primaryIdentityId,
-			invitation.primaryUserFirstName,
-			invitation.primaryUserEmail,
-			invitation.secondaryUserEmail,
-			invitation.secondaryIdentityId,
-		);
+		await sendInvitationRedeemedEmail(stage, {
+			primaryUserIdentityId: primaryIdentityId,
+			primaryUserFirstName: invitation.primaryUserFirstName,
+			primaryUserEmail: invitation.primaryUserEmail,
+			secondaryUserEmail: invitation.secondaryUserEmail,
+			secondaryUserIdentityId: invitation.secondaryIdentityId,
+		});
 
 		return ok({
 			identityId: secondaryIdentityId,

--- a/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
+++ b/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
@@ -7,11 +7,19 @@ import type { Stage } from '@modules/stage';
 
 export async function sendInvitationRedeemedEmail(
 	stage: Stage,
-	primaryUserIdentityId: string,
-	primaryUserFirstName: string,
-	primaryUserEmail: string,
-	secondaryUserEmail: string,
-	secondaryUserIdentityId: string,
+	{
+		primaryUserIdentityId,
+		primaryUserFirstName,
+		primaryUserEmail,
+		secondaryUserEmail,
+		secondaryUserIdentityId,
+	}: {
+		primaryUserIdentityId: string;
+		primaryUserFirstName: string;
+		primaryUserEmail: string;
+		secondaryUserEmail: string;
+		secondaryUserIdentityId: string;
+	},
 ) {
 	const dataAttributes = {
 		primary_user_first_name: primaryUserFirstName,

--- a/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
+++ b/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
@@ -5,8 +5,9 @@ import {
 } from '@modules/email/email';
 import type { Stage } from '@modules/stage';
 
-export async function sendAcceptInvitationEmail(
+export async function sendInvitationRedeemedEmail(
 	stage: Stage,
+	primaryUserIdentityId: string,
 	primaryUserFirstName: string,
 	primaryUserEmail: string,
 	secondaryUserEmail: string,
@@ -17,11 +18,20 @@ export async function sendAcceptInvitationEmail(
 		primary_user_email: primaryUserEmail,
 	};
 
-	const emailMessage = buildEmailMessage(
+	const secondaryUserEmailMessage = buildEmailMessage(
 		secondaryUserEmail,
 		DataExtensionNames.multipleAccountEmails.secondaryUser.invitationRedeemed,
 		dataAttributes,
 		{ IdentityUserId: secondaryUserIdentityId },
 	);
-	await sendEmail(stage, emailMessage);
+
+	const primaryUserEmailMessage = buildEmailMessage(
+		primaryUserEmail,
+		DataExtensionNames.multipleAccountEmails.primaryUser.invitationRedeemed,
+		{},
+		{ IdentityUserId: primaryUserIdentityId },
+	);
+
+	await sendEmail(stage, secondaryUserEmailMessage);
+	await sendEmail(stage, primaryUserEmailMessage);
 }

--- a/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
+++ b/handlers/multiple-account-api/src/emails/acceptInvitationEmail.ts
@@ -40,6 +40,8 @@ export async function sendInvitationRedeemedEmail(
 		{ IdentityUserId: primaryUserIdentityId },
 	);
 
-	await sendEmail(stage, secondaryUserEmailMessage);
-	await sendEmail(stage, primaryUserEmailMessage);
+	await Promise.all([
+		sendEmail(stage, secondaryUserEmailMessage),
+		sendEmail(stage, primaryUserEmailMessage),
+	]);
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds a new send email event for the primary user when a invitation  is redeemed.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
Added test coverage and run tests locally

[Trigger email for primary user when an invitation has been redeemed](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1218106672862358?focus=true)