### PR TITLE
Return 410 Gone when accepting an already-accepted invitation

### DIFF
--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -8,6 +8,7 @@ import { getIfDefined } from '@modules/nullAndUndefined';
 import {
 	badRequest,
 	buildErrorResponse,
+	conflict,
 	notFound,
 	ok,
 } from '@modules/routing/apiGatewayResponses';
@@ -28,6 +29,19 @@ export const acceptInvitationEndpoint = async (
 		const invitation = await invitationRepository.get(invitationCode);
 
 		if (!invitation) {
+			// The invitation is hard-deleted once accepted, so if it's missing but a
+			// secondary user record already exists for this invitation code, the
+			// user has already accepted it previously.
+			const alreadyAccepted = (
+				await secondaryUserRepository.listByIdentity(signedInUserId)
+			).some(
+				(secondaryUser) => secondaryUser.invitationCode === invitationCode,
+			);
+
+			if (alreadyAccepted) {
+				return conflict('Invitation has already been accepted');
+			}
+
 			return notFound();
 		}
 

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -8,7 +8,7 @@ import { getIfDefined } from '@modules/nullAndUndefined';
 import {
 	badRequest,
 	buildErrorResponse,
-	conflict,
+	gone,
 	notFound,
 	ok,
 } from '@modules/routing/apiGatewayResponses';
@@ -39,7 +39,7 @@ export const acceptInvitationEndpoint = async (
 			);
 
 			if (alreadyAccepted) {
-				return conflict('Invitation has already been accepted');
+				return gone('Invitation has already been accepted');
 			}
 
 			return notFound();

--- a/handlers/multiple-account-api/test/acceptInvitationEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationEndpoint.test.ts
@@ -1,0 +1,107 @@
+import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import type { SecondaryUserRecord } from '@modules/multiple-account/secondaryUserRepository';
+import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
+import { acceptInvitationEndpoint } from '../src/acceptInvitationEndpoint';
+import type { InvitationRepository } from '../src/invitationRepository';
+
+const stage = 'CODE';
+const subscriptionName = 'A-S00974337';
+const secondaryIdentityId = 'secondary-id';
+const primaryIdentityId = 'primary-id';
+const invitationCode = 'RpwR62kMnAxe';
+
+const makeSecondaryUser = (
+	overrides: Partial<SecondaryUserRecord> = {},
+): SecondaryUserRecord => ({
+	subscriptionName,
+	secondaryIdentityId,
+	primaryIdentityId,
+	acceptedDate: '2026-06-12T00:00:00.000Z',
+	expiryDate: 1781218800,
+	invitationCode,
+	...overrides,
+});
+
+const makeInvitationRepository = (): {
+	repository: InvitationRepository;
+	mockGet: jest.Mock;
+} => {
+	const mockGet = jest.fn().mockResolvedValue(undefined);
+	const repository = {
+		get: mockGet,
+	} as unknown as InvitationRepository;
+	return { repository, mockGet };
+};
+
+const makeSecondaryUserRepository = (
+	secondaryUsers: SecondaryUserRecord[],
+): {
+	repository: SecondaryUserRepository;
+	mockListByIdentity: jest.Mock;
+} => {
+	const mockListByIdentity = jest.fn().mockResolvedValue(secondaryUsers);
+	const repository = {
+		listByIdentity: mockListByIdentity,
+	} as unknown as SecondaryUserRepository;
+	return { repository, mockListByIdentity };
+};
+
+const dynamoClient = {} as DynamoDBClient;
+
+describe('acceptInvitationEndpoint', () => {
+	it('returns 409 when the invitation has already been accepted by this user', async () => {
+		const { repository: invitationRepository, mockGet } =
+			makeInvitationRepository();
+		const { repository: secondaryUserRepository, mockListByIdentity } =
+			makeSecondaryUserRepository([makeSecondaryUser()]);
+
+		const result = await acceptInvitationEndpoint(
+			stage,
+			invitationRepository,
+			secondaryUserRepository,
+			dynamoClient,
+			secondaryIdentityId,
+			invitationCode,
+		);
+
+		expect(result.statusCode).toBe(409);
+		expect(mockGet).toHaveBeenCalledWith(invitationCode);
+		expect(mockListByIdentity).toHaveBeenCalledWith(secondaryIdentityId);
+	});
+
+	it('returns 404 when the invitation is not found and there is no matching secondary user record', async () => {
+		const { repository: invitationRepository } = makeInvitationRepository();
+		const { repository: secondaryUserRepository } = makeSecondaryUserRepository(
+			[],
+		);
+
+		const result = await acceptInvitationEndpoint(
+			stage,
+			invitationRepository,
+			secondaryUserRepository,
+			dynamoClient,
+			secondaryIdentityId,
+			invitationCode,
+		);
+
+		expect(result.statusCode).toBe(404);
+	});
+
+	it('returns 404 when the invitation is not found and the signed in user has other secondary user records but none matching this invitation code', async () => {
+		const { repository: invitationRepository } = makeInvitationRepository();
+		const { repository: secondaryUserRepository } = makeSecondaryUserRepository(
+			[makeSecondaryUser({ invitationCode: 'some-other-code' })],
+		);
+
+		const result = await acceptInvitationEndpoint(
+			stage,
+			invitationRepository,
+			secondaryUserRepository,
+			dynamoClient,
+			secondaryIdentityId,
+			invitationCode,
+		);
+
+		expect(result.statusCode).toBe(404);
+	});
+});

--- a/handlers/multiple-account-api/test/acceptInvitationEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationEndpoint.test.ts
@@ -49,7 +49,7 @@ const makeSecondaryUserRepository = (
 const dynamoClient = {} as DynamoDBClient;
 
 describe('acceptInvitationEndpoint', () => {
-	it('returns 409 when the invitation has already been accepted by this user', async () => {
+	it('returns 410 when the invitation has already been accepted by this user', async () => {
 		const { repository: invitationRepository, mockGet } =
 			makeInvitationRepository();
 		const { repository: secondaryUserRepository, mockListByIdentity } =
@@ -64,7 +64,7 @@ describe('acceptInvitationEndpoint', () => {
 			invitationCode,
 		);
 
-		expect(result.statusCode).toBe(409);
+		expect(result.statusCode).toBe(410);
 		expect(mockGet).toHaveBeenCalledWith(invitationCode);
 		expect(mockListByIdentity).toHaveBeenCalledWith(secondaryIdentityId);
 	});

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -23,6 +23,10 @@ export function notFound(): APIGatewayProxyResult {
 	return jsonResponse('Not Found', 404);
 }
 
+export function conflict(message: string): APIGatewayProxyResult {
+	return jsonResponse(message, 409);
+}
+
 /**
  * Return a 200 OK response with the provided body.
  * @param body

--- a/modules/routing/src/apiGatewayResponses.ts
+++ b/modules/routing/src/apiGatewayResponses.ts
@@ -23,8 +23,8 @@ export function notFound(): APIGatewayProxyResult {
 	return jsonResponse('Not Found', 404);
 }
 
-export function conflict(message: string): APIGatewayProxyResult {
-	return jsonResponse(message, 409);
+export function gone(message: string): APIGatewayProxyResult {
+	return jsonResponse(message, 410);
 }
 
 /**


### PR DESCRIPTION
## What
Previously, when a secondary user tried to accept a multiple-account invitation they had **already accepted**, the endpoint returned `404 Not Found` — because the invitation record is hard-deleted upon successful acceptance. This is misleading, since the invitation did exist and was successfully processed; a 404 implies the invitation code was invalid/unknown.

This PR changes that specific case to return `410 Gone` instead, while still returning `404` for genuinely unknown/invalid invitation codes.

## How
- Added a `gone(message)` helper (410) to `modules/routing/src/apiGatewayResponses.ts`, alongside the existing `notFound`/`badRequest` helpers.
- In `acceptInvitationEndpoint.ts`, when the invitation lookup returns nothing, we now check `secondaryUserRepository.listByIdentity(signedInUserId)` for an existing secondary-user record whose `invitationCode` matches the requested code. If found, we know the invitation was already accepted by this user, and return `410 Gone`. Otherwise we fall back to the existing `404 Not Found` behaviour.
- Added `test/acceptInvitationEndpoint.test.ts` with unit tests covering: 410 when already accepted, 404 when the invitation code is completely unknown, and 404 when the user has other secondary-user records but none matching this invitation code.

## Testing
- Added a new test to ensure correct behaviour