### PR TITLE
Return 410 for already accepted invitations from get invitation endpoint

### DIFF
--- a/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/multiple-account-api.test.ts.snap
@@ -1089,6 +1089,10 @@ exports[`The Multiple account api stack matches the snapshot 1`] = `
             "AttributeName": "secondaryIdentityId",
             "AttributeType": "S",
           },
+          {
+            "AttributeName": "invitationCode",
+            "AttributeType": "S",
+          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
         "GlobalSecondaryIndexes": [
@@ -1097,6 +1101,18 @@ exports[`The Multiple account api stack matches the snapshot 1`] = `
             "KeySchema": [
               {
                 "AttributeName": "secondaryIdentityId",
+                "KeyType": "HASH",
+              },
+            ],
+            "Projection": {
+              "ProjectionType": "ALL",
+            },
+          },
+          {
+            "IndexName": "invitationCode-index",
+            "KeySchema": [
+              {
+                "AttributeName": "invitationCode",
                 "KeyType": "HASH",
               },
             ],
@@ -2406,6 +2422,10 @@ exports[`The Multiple account api stack matches the snapshot 2`] = `
             "AttributeName": "secondaryIdentityId",
             "AttributeType": "S",
           },
+          {
+            "AttributeName": "invitationCode",
+            "AttributeType": "S",
+          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
         "GlobalSecondaryIndexes": [
@@ -2414,6 +2434,18 @@ exports[`The Multiple account api stack matches the snapshot 2`] = `
             "KeySchema": [
               {
                 "AttributeName": "secondaryIdentityId",
+                "KeyType": "HASH",
+              },
+            ],
+            "Projection": {
+              "ProjectionType": "ALL",
+            },
+          },
+          {
+            "IndexName": "invitationCode-index",
+            "KeySchema": [
+              {
+                "AttributeName": "invitationCode",
                 "KeyType": "HASH",
               },
             ],

--- a/cdk/lib/multiple-account-api.ts
+++ b/cdk/lib/multiple-account-api.ts
@@ -88,6 +88,11 @@ export class MultipleAccountApi extends SrStack {
 			partitionKey: { name: 'secondaryIdentityId', type: AttributeType.STRING },
 		});
 
+		secondaryUserTable.addGlobalSecondaryIndex({
+			indexName: 'invitationCode-index',
+			partitionKey: { name: 'invitationCode', type: AttributeType.STRING },
+		});
+
 		secondaryUserTable.grantFullAccess(lambda);
 	}
 }

--- a/handlers/multiple-account-api/src/getInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/getInvitationEndpoint.ts
@@ -1,7 +1,9 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { logger } from '@modules/logger/logger';
+import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import {
 	badRequest,
+	gone,
 	internalServerError,
 	notFound,
 	ok,
@@ -13,6 +15,7 @@ import {
 
 export const getInvitationEndpoint = async (
 	invitationRepository: InvitationRepository,
+	secondaryUserRepository: SecondaryUserRepository,
 	invitationCode: string,
 ): Promise<APIGatewayProxyResult> => {
 	logger.mutableAddContext(invitationCode);
@@ -21,6 +24,19 @@ export const getInvitationEndpoint = async (
 		const invitation = await invitationRepository.get(invitationCode);
 
 		if (!invitation) {
+			// The invitation is hard-deleted once accepted, so if it's missing but a
+			// secondary user record already exists for this invitation code, the
+			// invitation has already been accepted. We can't check the signed in
+			// user here since this endpoint is not authenticated, so we look up the
+			// secondary user record by invitation code instead.
+			const alreadyAccepted =
+				(await secondaryUserRepository.listByInvitationCode(invitationCode))
+					.length > 0;
+
+			if (alreadyAccepted) {
+				return gone('Invitation has already been accepted');
+			}
+
 			return notFound();
 		}
 

--- a/handlers/multiple-account-api/src/index.ts
+++ b/handlers/multiple-account-api/src/index.ts
@@ -84,7 +84,11 @@ export const handler: Handler = Router([
 		httpMethod: 'GET',
 		path: '/invitation/{invitationCode}',
 		handler: withPathParser(invitationPathSchema, async (_event, path) =>
-			getInvitationEndpoint(invitationRepository, path.invitationCode),
+			getInvitationEndpoint(
+				invitationRepository,
+				secondaryUserRepository,
+				path.invitationCode,
+			),
 		),
 	},
 	{

--- a/handlers/multiple-account-api/test/getInvitationEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/getInvitationEndpoint.test.ts
@@ -1,0 +1,79 @@
+import type { SecondaryUserRecord } from '@modules/multiple-account/secondaryUserRepository';
+import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
+import { getInvitationEndpoint } from '../src/getInvitationEndpoint';
+import type { InvitationRepository } from '../src/invitationRepository';
+
+const subscriptionName = 'A-S00974337';
+const secondaryIdentityId = 'secondary-id';
+const primaryIdentityId = 'primary-id';
+const invitationCode = 'RpwR62kMnAxe';
+
+const makeSecondaryUser = (
+	overrides: Partial<SecondaryUserRecord> = {},
+): SecondaryUserRecord => ({
+	subscriptionName,
+	secondaryIdentityId,
+	primaryIdentityId,
+	acceptedDate: '2026-06-12T00:00:00.000Z',
+	expiryDate: 1781218800,
+	invitationCode,
+	...overrides,
+});
+
+const makeInvitationRepository = (): {
+	repository: InvitationRepository;
+	mockGet: jest.Mock;
+} => {
+	const mockGet = jest.fn().mockResolvedValue(undefined);
+	const repository = {
+		get: mockGet,
+	} as unknown as InvitationRepository;
+	return { repository, mockGet };
+};
+
+const makeSecondaryUserRepository = (
+	secondaryUsers: SecondaryUserRecord[],
+): {
+	repository: SecondaryUserRepository;
+	mockListByInvitationCode: jest.Mock;
+} => {
+	const mockListByInvitationCode = jest.fn().mockResolvedValue(secondaryUsers);
+	const repository = {
+		listByInvitationCode: mockListByInvitationCode,
+	} as unknown as SecondaryUserRepository;
+	return { repository, mockListByInvitationCode };
+};
+
+describe('getInvitationEndpoint', () => {
+	it('returns 410 when the invitation has already been accepted', async () => {
+		const { repository: invitationRepository, mockGet } =
+			makeInvitationRepository();
+		const { repository: secondaryUserRepository, mockListByInvitationCode } =
+			makeSecondaryUserRepository([makeSecondaryUser()]);
+
+		const result = await getInvitationEndpoint(
+			invitationRepository,
+			secondaryUserRepository,
+			invitationCode,
+		);
+
+		expect(result.statusCode).toBe(410);
+		expect(mockGet).toHaveBeenCalledWith(invitationCode);
+		expect(mockListByInvitationCode).toHaveBeenCalledWith(invitationCode);
+	});
+
+	it('returns 404 when the invitation is not found and there is no matching secondary user record', async () => {
+		const { repository: invitationRepository } = makeInvitationRepository();
+		const { repository: secondaryUserRepository } = makeSecondaryUserRepository(
+			[],
+		);
+
+		const result = await getInvitationEndpoint(
+			invitationRepository,
+			secondaryUserRepository,
+			invitationCode,
+		);
+
+		expect(result.statusCode).toBe(404);
+	});
+});

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import * as email from 'email/src/email';
+import * as email from '@modules/email/email';
 import * as identity from '@modules/identity/idapi';
 import type { IdentityClient } from '@modules/identity/identityClient';
 import type {

--- a/modules/multiple-account/src/secondaryUserRepository.ts
+++ b/modules/multiple-account/src/secondaryUserRepository.ts
@@ -122,6 +122,24 @@ export class SecondaryUserRepository {
 		return secondaryUser;
 	}
 
+	async listByInvitationCode(
+		invitationCode: string,
+	): Promise<SecondaryUserRecord[]> {
+		const result = await this.client.send(
+			new QueryCommand({
+				TableName: this.tableName,
+				IndexName: 'invitationCode-index',
+				KeyConditionExpression: 'invitationCode = :invitationCode',
+				ExpressionAttributeValues: {
+					':invitationCode': { S: invitationCode },
+				},
+			}),
+		);
+		return (result.Items ?? []).map((item) =>
+			secondaryUserRecordSchema.parse(unmarshall(item)),
+		);
+	}
+
 	async listBySubscription(
 		subscriptionName: string,
 	): Promise<SecondaryUserRecord[]> {


### PR DESCRIPTION
## What
Updates `getInvitationEndpoint.ts` (GET `/invitation/{invitationCode}`) to return `410 Gone` when an invitation has already been accepted, matching the existing behaviour of `acceptInvitationEndpoint.ts`.

Since this endpoint is not authenticated by user, it cannot check the signed-in user like the accept endpoint does. Instead, it looks up whether any secondary-user record exists for the given invitation code (via a new DynamoDB GSI) to determine "already accepted" status.

## Deployment notes
Adding the GSI is a standard, non-disruptive CloudFormation change — DynamoDB automatically backfills the new index for existing items, so no manual migration is required. The stack update may take slightly longer while the GSI becomes `ACTIVE`.