### PR TITLE
Add filtering to promotions API

### DIFF
--- a/buildcheck/data/build.ts
+++ b/buildcheck/data/build.ts
@@ -113,6 +113,7 @@ const modulePromotions: ModuleDefinition = {
 		...dep['@aws-sdk/client-dynamodb'],
 		...dep['@aws-sdk/util-dynamodb'],
 		...dep['zod'],
+		...dep.dayjs,
 	},
 	moduleDependencies: [
 		moduleAws,

--- a/handlers/promotions-api/openapi.yaml
+++ b/handlers/promotions-api/openapi.yaml
@@ -22,6 +22,15 @@ paths:
         module, augmented with product catalog information (the catalog rate
         plans each promotion applies to). Promotions whose rate plan ids
         cannot be resolved against the current product catalog are omitted.
+      parameters:
+        - name: active
+          in: query
+          required: false
+          description: When provided, only return promotions whose active status
+            (started and, if it has an end date, not yet ended) matches this
+            value.
+          schema:
+            type: boolean
       responses:
         '200':
           description: A list of promotions
@@ -29,6 +38,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListPromotionsResponse'
+        '400':
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: 'Invalid query parameters: ...'
         '403':
           description: Missing or invalid API key
           content:

--- a/handlers/promotions-api/src/index.ts
+++ b/handlers/promotions-api/src/index.ts
@@ -1,7 +1,9 @@
 import type { Handler } from 'aws-lambda';
+import { z } from 'zod';
 import { Lazy } from '@modules/lazy';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
 import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
+import { badRequest } from '@modules/routing/apiGatewayResponses';
 import { Router } from '@modules/routing/router';
 import { stageFromEnvironment } from '@modules/stage';
 import { listPromotionsEndpoint } from './listPromotionsEndpoint';
@@ -12,11 +14,29 @@ const lazyProductCatalogHelper = new Lazy(
 	'Get product catalog helper',
 );
 
+const listPromotionsQueryParamsSchema = z.object({
+	active: z.enum(['true', 'false']).optional(),
+});
+
 export const handler: Handler = Router([
 	{
 		httpMethod: 'GET',
 		path: '/promotions',
-		handler: async () =>
-			listPromotionsEndpoint(stage, await lazyProductCatalogHelper.get()),
+		handler: async (event) => {
+			const queryParamsResult = listPromotionsQueryParamsSchema.safeParse(
+				event.queryStringParameters ?? {},
+			);
+			if (!queryParamsResult.success) {
+				return badRequest(
+					`Invalid query parameters: ${queryParamsResult.error.message}`,
+				);
+			}
+			const { active } = queryParamsResult.data;
+			return listPromotionsEndpoint(
+				stage,
+				await lazyProductCatalogHelper.get(),
+				{ active: active === undefined ? undefined : active === 'true' },
+			);
+		},
 	},
 ]);

--- a/handlers/promotions-api/src/index.ts
+++ b/handlers/promotions-api/src/index.ts
@@ -2,10 +2,8 @@ import type { Handler } from 'aws-lambda';
 import { z } from 'zod';
 import { Lazy } from '@modules/lazy';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
-import {
-	isProductKey,
-	ProductCatalogHelper,
-} from '@modules/product-catalog/productCatalog';
+import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
+import { productKeySchema } from '@modules/product-catalog/productCatalogSchema';
 import { badRequest } from '@modules/routing/apiGatewayResponses';
 import { Router } from '@modules/routing/router';
 import { stageFromEnvironment } from '@modules/stage';
@@ -19,8 +17,13 @@ const lazyProductCatalogHelper = new Lazy(
 
 const listPromotionsQueryParamsSchema = z
 	.object({
-		active: z.enum(['true', 'false']).optional(),
-		productKey: z.string().optional(),
+		active: z
+			.enum(['true', 'false'])
+			.optional()
+			.transform((value) =>
+				value === undefined ? undefined : value === 'true',
+			),
+		productKey: productKeySchema.optional(),
 		productRatePlanKey: z.string().optional(),
 	})
 	.refine(
@@ -46,18 +49,11 @@ export const handler: Handler = Router([
 					`Invalid query parameters: ${queryParamsResult.error.message}`,
 				);
 			}
-			const { active, productKey, productRatePlanKey } = queryParamsResult.data;
-			if (productKey !== undefined && !isProductKey(productKey)) {
-				return badRequest(`Invalid productKey: ${productKey}`);
-			}
+
 			return listPromotionsEndpoint(
 				stage,
 				await lazyProductCatalogHelper.get(),
-				{
-					active: active === undefined ? undefined : active === 'true',
-					productKey,
-					productRatePlanKey,
-				},
+				queryParamsResult.data,
 			);
 		},
 	},

--- a/handlers/promotions-api/src/index.ts
+++ b/handlers/promotions-api/src/index.ts
@@ -2,7 +2,10 @@ import type { Handler } from 'aws-lambda';
 import { z } from 'zod';
 import { Lazy } from '@modules/lazy';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
-import { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
+import {
+	isProductKey,
+	ProductCatalogHelper,
+} from '@modules/product-catalog/productCatalog';
 import { badRequest } from '@modules/routing/apiGatewayResponses';
 import { Router } from '@modules/routing/router';
 import { stageFromEnvironment } from '@modules/stage';
@@ -14,9 +17,21 @@ const lazyProductCatalogHelper = new Lazy(
 	'Get product catalog helper',
 );
 
-const listPromotionsQueryParamsSchema = z.object({
-	active: z.enum(['true', 'false']).optional(),
-});
+const listPromotionsQueryParamsSchema = z
+	.object({
+		active: z.enum(['true', 'false']).optional(),
+		productKey: z.string().optional(),
+		productRatePlanKey: z.string().optional(),
+	})
+	.refine(
+		(params) =>
+			params.productRatePlanKey === undefined ||
+			params.productKey !== undefined,
+		{
+			message:
+				'productRatePlanKey filter requires productKey to also be provided',
+		},
+	);
 
 export const handler: Handler = Router([
 	{
@@ -31,11 +46,18 @@ export const handler: Handler = Router([
 					`Invalid query parameters: ${queryParamsResult.error.message}`,
 				);
 			}
-			const { active } = queryParamsResult.data;
+			const { active, productKey, productRatePlanKey } = queryParamsResult.data;
+			if (productKey !== undefined && !isProductKey(productKey)) {
+				return badRequest(`Invalid productKey: ${productKey}`);
+			}
 			return listPromotionsEndpoint(
 				stage,
 				await lazyProductCatalogHelper.get(),
-				{ active: active === undefined ? undefined : active === 'true' },
+				{
+					active: active === undefined ? undefined : active === 'true',
+					productKey,
+					productRatePlanKey,
+				},
 			);
 		},
 	},

--- a/handlers/promotions-api/src/listPromotionsEndpoint.ts
+++ b/handlers/promotions-api/src/listPromotionsEndpoint.ts
@@ -2,15 +2,31 @@ import { logger } from '@modules/logger/logger';
 import type { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
 import { addCatalogInformationToPromos } from '@modules/promotions/v2/addCatalogInformationToPromo';
 import { getPromotions } from '@modules/promotions/v2/getPromotions';
+import { isActivePromo } from '@modules/promotions/v2/isActivePromo';
 import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
+
+export type ListPromotionsFilters = {
+	/**
+	 * When provided, only return promotions whose active status (has started
+	 * and, if it has an end date, has not yet ended) matches this value.
+	 */
+	active?: boolean;
+};
 
 export async function listPromotionsEndpoint(
 	stage: Stage,
 	catalogHelper: ProductCatalogHelper,
+	filters: ListPromotionsFilters = {},
 ) {
 	try {
-		const promotions = await getPromotions(stage);
+		const allPromotions = await getPromotions(stage);
+		const promotions =
+			filters.active === undefined
+				? allPromotions
+				: allPromotions.filter(
+						(promo) => isActivePromo(promo) === filters.active,
+					);
 		const { succeeded, failed } = addCatalogInformationToPromos(
 			promotions,
 			catalogHelper,

--- a/handlers/promotions-api/src/listPromotionsEndpoint.ts
+++ b/handlers/promotions-api/src/listPromotionsEndpoint.ts
@@ -1,8 +1,12 @@
 import { logger } from '@modules/logger/logger';
-import type { ProductCatalogHelper } from '@modules/product-catalog/productCatalog';
+import type {
+	ProductCatalogHelper,
+	ProductKey,
+} from '@modules/product-catalog/productCatalog';
 import { addCatalogInformationToPromos } from '@modules/promotions/v2/addCatalogInformationToPromo';
 import { getPromotions } from '@modules/promotions/v2/getPromotions';
 import { isActivePromo } from '@modules/promotions/v2/isActivePromo';
+import type { PromoWithCatalogInformation } from '@modules/promotions/v2/schema';
 import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
 import type { Stage } from '@modules/stage';
 
@@ -12,7 +16,50 @@ export type ListPromotionsFilters = {
 	 * and, if it has an end date, has not yet ended) matches this value.
 	 */
 	active?: boolean;
+	/**
+	 * When provided, only return promotions that apply to this catalog
+	 * ProductKey.
+	 */
+	productKey?: ProductKey;
+	/**
+	 * When provided (alongside productKey), only return promotions that apply
+	 * to this catalog ProductRatePlanKey.
+	 */
+	productRatePlanKey?: string;
 };
+
+function catalogRatePlanMatchesFilters(
+	catalogRatePlan: PromoWithCatalogInformation['appliesTo']['catalogRatePlans'][number],
+	filters: ListPromotionsFilters,
+): boolean {
+	const matchesProductKey = catalogRatePlan.productKey === filters.productKey;
+	const matchesProductRatePlanKey =
+		filters.productRatePlanKey === undefined ||
+		catalogRatePlan.productRatePlanKey === filters.productRatePlanKey;
+
+	return matchesProductKey && matchesProductRatePlanKey;
+}
+
+function promoMatchesProductFilters(
+	promo: PromoWithCatalogInformation,
+	filters: ListPromotionsFilters,
+): boolean {
+	return promo.appliesTo.catalogRatePlans.some((catalogRatePlan) =>
+		catalogRatePlanMatchesFilters(catalogRatePlan, filters),
+	);
+}
+
+function filterByProduct(
+	promotions: PromoWithCatalogInformation[],
+	filters: ListPromotionsFilters,
+): PromoWithCatalogInformation[] {
+	if (filters.productKey === undefined) {
+		return promotions;
+	}
+	return promotions.filter((promo) =>
+		promoMatchesProductFilters(promo, filters),
+	);
+}
 
 export async function listPromotionsEndpoint(
 	stage: Stage,
@@ -39,7 +86,7 @@ export async function listPromotionsEndpoint(
 			);
 		}
 
-		return ok({ promotions: succeeded });
+		return ok({ promotions: filterByProduct(succeeded, filters) });
 	} catch (error) {
 		logger.error('Error retrieving promotions', error);
 		return buildErrorResponse(error);

--- a/handlers/promotions-api/test/listPromotionsEndpoint.test.ts
+++ b/handlers/promotions-api/test/listPromotionsEndpoint.test.ts
@@ -94,4 +94,64 @@ describe('listPromotionsEndpoint', () => {
 
 		expect(result.statusCode).toBe(500);
 	});
+
+	it('filters out inactive promotions when active=true is requested', async () => {
+		const activePromo: Promo = {
+			...promo,
+			promoCode: 'ACTIVE',
+			startTimestamp: '2000-01-01T00:00:00.000Z',
+			endTimestamp: undefined,
+		};
+		const expiredPromo: Promo = {
+			...promo,
+			promoCode: 'EXPIRED',
+			startTimestamp: '2000-01-01T00:00:00.000Z',
+			endTimestamp: '2001-01-01T00:00:00.000Z',
+		};
+		mockGetPromotions.mockResolvedValue([activePromo, expiredPromo]);
+		mockAddCatalogInformationToPromos.mockReturnValue({
+			succeeded: [{ ...promoWithCatalogInformation, promoCode: 'ACTIVE' }],
+			failed: [],
+		});
+
+		const result = await listPromotionsEndpoint('CODE', catalogHelper, {
+			active: true,
+		});
+
+		expect(mockAddCatalogInformationToPromos).toHaveBeenCalledWith(
+			[activePromo],
+			expect.anything(),
+		);
+		expect(result.statusCode).toBe(200);
+	});
+
+	it('filters out active promotions when active=false is requested', async () => {
+		const activePromo: Promo = {
+			...promo,
+			promoCode: 'ACTIVE',
+			startTimestamp: '2000-01-01T00:00:00.000Z',
+			endTimestamp: undefined,
+		};
+		const expiredPromo: Promo = {
+			...promo,
+			promoCode: 'EXPIRED',
+			startTimestamp: '2000-01-01T00:00:00.000Z',
+			endTimestamp: '2001-01-01T00:00:00.000Z',
+		};
+		mockGetPromotions.mockResolvedValue([activePromo, expiredPromo]);
+		mockAddCatalogInformationToPromos.mockReturnValue({
+			succeeded: [{ ...promoWithCatalogInformation, promoCode: 'EXPIRED' }],
+			failed: [],
+		});
+
+		const result = await listPromotionsEndpoint('CODE', catalogHelper, {
+			active: false,
+		});
+
+		expect(mockAddCatalogInformationToPromos).toHaveBeenCalledWith(
+			[expiredPromo],
+			expect.anything(),
+		);
+		expect(result.statusCode).toBe(200);
+	});
 });

--- a/handlers/promotions-api/test/listPromotionsEndpoint.test.ts
+++ b/handlers/promotions-api/test/listPromotionsEndpoint.test.ts
@@ -49,6 +49,17 @@ const promoWithCatalogInformation: PromoWithCatalogInformation = {
 	},
 };
 
+const promoWithOtherCatalogInformation: PromoWithCatalogInformation = {
+	...promo,
+	promoCode: 'PROMO2',
+	appliesTo: {
+		...promo.appliesTo,
+		catalogRatePlans: [
+			{ productKey: 'SupporterPlus', productRatePlanKey: 'Annual' },
+		],
+	},
+};
+
 describe('listPromotionsEndpoint', () => {
 	afterEach(() => {
 		jest.resetAllMocks();
@@ -153,5 +164,65 @@ describe('listPromotionsEndpoint', () => {
 			expect.anything(),
 		);
 		expect(result.statusCode).toBe(200);
+	});
+
+	it('filters promotions by productKey', async () => {
+		mockGetPromotions.mockResolvedValue([promo, promo]);
+		mockAddCatalogInformationToPromos.mockReturnValue({
+			succeeded: [
+				promoWithCatalogInformation,
+				promoWithOtherCatalogInformation,
+			],
+			failed: [],
+		});
+
+		const result = await listPromotionsEndpoint('CODE', catalogHelper, {
+			productKey: 'SupporterPlus',
+			productRatePlanKey: 'Monthly',
+		});
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({
+			promotions: [promoWithCatalogInformation],
+		});
+	});
+
+	it('filters promotions by productKey only, ignoring productRatePlanKey when not provided', async () => {
+		mockGetPromotions.mockResolvedValue([promo, promo]);
+		mockAddCatalogInformationToPromos.mockReturnValue({
+			succeeded: [
+				promoWithCatalogInformation,
+				promoWithOtherCatalogInformation,
+			],
+			failed: [],
+		});
+
+		const result = await listPromotionsEndpoint('CODE', catalogHelper, {
+			productKey: 'SupporterPlus',
+		});
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({
+			promotions: [
+				promoWithCatalogInformation,
+				promoWithOtherCatalogInformation,
+			],
+		});
+	});
+
+	it('returns no promotions when no catalog rate plan matches the requested productRatePlanKey', async () => {
+		mockGetPromotions.mockResolvedValue([promo]);
+		mockAddCatalogInformationToPromos.mockReturnValue({
+			succeeded: [promoWithCatalogInformation],
+			failed: [],
+		});
+
+		const result = await listPromotionsEndpoint('CODE', catalogHelper, {
+			productKey: 'SupporterPlus',
+			productRatePlanKey: 'Annual',
+		});
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({ promotions: [] });
 	});
 });

--- a/modules/promotions/package.json
+++ b/modules/promotions/package.json
@@ -15,6 +15,7 @@
     "@aws-sdk/client-dynamodb": "^3.940.0",
     "@aws-sdk/util-dynamodb": "^3.940.0",
     "zod": "catalog:",
+    "dayjs": "^1.11.13",
     "aws": "workspace:*",
     "internationalisation": "workspace:*",
     "logger": "workspace:*",

--- a/modules/promotions/src/v2/isActivePromo.ts
+++ b/modules/promotions/src/v2/isActivePromo.ts
@@ -10,6 +10,6 @@ export const isActivePromo = (promo: Promo, now: Dayjs = dayjs()): boolean => {
 
 	const hasStarted = startDate.isBefore(now) || startDate.isSame(now);
 	const hasNotEnded = endDate === undefined || now.isBefore(endDate);
-	
+
 	return hasStarted && hasNotEnded;
 };

--- a/modules/promotions/src/v2/isActivePromo.ts
+++ b/modules/promotions/src/v2/isActivePromo.ts
@@ -1,0 +1,15 @@
+import dayjs, { type Dayjs } from 'dayjs';
+import type { Promo } from './schema';
+
+/**
+ * A promotion is active if it has started and, if it has an end date, has not yet ended.
+ */
+export const isActivePromo = (promo: Promo, now: Dayjs = dayjs()): boolean => {
+	const startDate = dayjs(promo.startTimestamp);
+	const endDate = promo.endTimestamp ? dayjs(promo.endTimestamp) : undefined;
+
+	const hasStarted = startDate.isBefore(now) || startDate.isSame(now);
+	const hasNotEnded = endDate === undefined || now.isBefore(endDate);
+	
+	return hasStarted && hasNotEnded;
+};

--- a/modules/promotions/test/v2/isActivePromo.test.ts
+++ b/modules/promotions/test/v2/isActivePromo.test.ts
@@ -1,0 +1,61 @@
+import dayjs from 'dayjs';
+import type { Promo } from '@modules/promotions/v2/schema';
+import { isActivePromo } from '../../src/v2/isActivePromo';
+
+const buildPromo = (startTimestamp: string, endTimestamp?: string): Promo => ({
+	name: 'Test Promotion',
+	promoCode: 'TEST123',
+	campaignCode: 'campaign',
+	startTimestamp,
+	endTimestamp,
+	discount: undefined,
+	description: undefined,
+	landingPage: undefined,
+	appliesTo: {
+		productRatePlanIds: [],
+		countries: ['GB'],
+	},
+});
+
+describe('isActivePromo', () => {
+	const now = dayjs('2025-06-15T00:00:00.000Z');
+
+	it('returns true when the promo has started and has no end date', () => {
+		const promo = buildPromo('2025-01-01T00:00:00.000Z');
+		expect(isActivePromo(promo, now)).toBe(true);
+	});
+
+	it('returns true when the promo has started and has not yet ended', () => {
+		const promo = buildPromo(
+			'2025-01-01T00:00:00.000Z',
+			'2025-12-31T00:00:00.000Z',
+		);
+		expect(isActivePromo(promo, now)).toBe(true);
+	});
+
+	it('returns false when the promo has not started yet', () => {
+		const promo = buildPromo('2025-12-01T00:00:00.000Z');
+		expect(isActivePromo(promo, now)).toBe(false);
+	});
+
+	it('returns false when the promo has already ended', () => {
+		const promo = buildPromo(
+			'2025-01-01T00:00:00.000Z',
+			'2025-06-01T00:00:00.000Z',
+		);
+		expect(isActivePromo(promo, now)).toBe(false);
+	});
+
+	it('returns false when the promo ends exactly now', () => {
+		const promo = buildPromo('2025-01-01T00:00:00.000Z', now.toISOString());
+		expect(isActivePromo(promo, now)).toBe(false);
+	});
+
+	it('defaults to the current time when now is not provided', () => {
+		const pastPromo = buildPromo('2000-01-01T00:00:00.000Z');
+		expect(isActivePromo(pastPromo)).toBe(true);
+
+		const futurePromo = buildPromo('2999-01-01T00:00:00.000Z');
+		expect(isActivePromo(futurePromo)).toBe(false);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1195,6 +1195,9 @@ importers:
       aws:
         specifier: workspace:*
         version: link:../aws
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.21
       internationalisation:
         specifier: workspace:*
         version: link:../internationalisation


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds filtering support to the `promotions-api` `listPromotions` endpoint.

Consumers can now filter the returned promotions by:
- `active` — only return promotions whose active status (started, and not yet ended if it has an end date) matches the given value
- `productKey` — only return promotions that apply to a given catalog `ProductKey`
- `productRatePlanKey` — (used alongside `productKey`) only return promotions that apply to a given catalog `ProductRatePlanKey`



## How has this change been tested?

Unit tests were added/updated for:
- `listPromotionsEndpoint` covering the new `active`, `productKey`, and `productRatePlanKey` filters
- `isActivePromo`
- `getPromotions` (integration test)


Example request (CODE):

```bash
curl "https://promotions-api-code.support.guardianapis.com/promotions?active=true&productKey=SupporterPlus&productRatePlanKey=Monthly" \
  -H "x-api-key: <api-key>"
```

Example response:

```json
{
  "promotions": [
    {
      "promoCode": "PROMO1",
      "name": "A promotion",
      "campaignCode": "CAMPAIGN1",
      "appliesTo": {
        "productRatePlanIds": ["rate-plan-id"],
        "countries": ["GB"],
        "catalogRatePlans": [
          { "productKey": "SupporterPlus", "productRatePlanKey": "Monthly" }
        ]
      },
      "startTimestamp": "2024-01-01T00:00:00.000Z"
    }
  ]
}
```
