### PR TITLE
Add isIntroductoryPricing field to v2 promo schema

### DIFF
--- a/handlers/promotions-api/openapi.yaml
+++ b/handlers/promotions-api/openapi.yaml
@@ -118,6 +118,9 @@ components:
           description: A human-readable description of the promotion.
         landingPage:
           $ref: '#/components/schemas/LandingPage'
+        isIntroductoryPricing:
+          type: boolean
+          description: Whether this promotion offers introductory pricing.
 
     AppliesTo:
       type: object

--- a/modules/promotions/src/v2/schema.ts
+++ b/modules/promotions/src/v2/schema.ts
@@ -49,6 +49,7 @@ export const promoSchema = z.object({
 	discount: optionalDropNulls(discountDetailsSchema),
 	description: optionalDropNulls(z.string()),
 	landingPage: optionalDropNulls(landingPageSchema),
+	isIntroductoryPricing: optionalDropNulls(z.boolean()),
 });
 
 export type Promo = z.infer<typeof promoSchema>;


### PR DESCRIPTION
## Summary
Adds an optional `isIntroductoryPricing` boolean field to the v2 promo schema. This value is sourced directly from Dynamo, so it is defined as optional and drops nulls, consistent with other optional Dynamo-sourced fields (`description`, `landingPage`).

Also documents the new field in the `promotions-api` OpenAPI spec.

## Testing
- `tsc --noEmit`, `eslint --fix`, `prettier` and `jest` all pass for both the `promotions` module and `promotions-api` handler.