### PR TITLE
Soft-accept invitations

### DIFF
--- a/handlers/multiple-account-api/openapi.yaml
+++ b/handlers/multiple-account-api/openapi.yaml
@@ -392,7 +392,7 @@ paths:
       description: >-
         Returns an invitation by invitation code. Returns a 400 if the
         invitation has already been cancelled by the primary or secondary
-        user.
+        user, or a 410 if it has already been accepted.
       security:
         - apiKey: []
       parameters:
@@ -425,6 +425,13 @@ paths:
               schema:
                 type: string
                 example: Not Found
+        '410':
+          description: The invitation has already been accepted.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Invitation has already been accepted
         '500':
           description: Internal server error.
           content:
@@ -441,7 +448,8 @@ paths:
         secondary user of the invitation. Whether the invitation was cancelled
         by the primary or rejected by the secondary is derived from which of the
         two the identity id matches. An invitation that has already been
-        cancelled is treated as not found and cannot be cancelled again.
+        cancelled or accepted is treated as not found and cannot be cancelled
+        again.
       security:
         - apiKey: []
       parameters:
@@ -476,7 +484,7 @@ paths:
         '404':
           description: >-
             Invitation not found. Also returned when the invitation has already
-            been cancelled.
+            been cancelled or accepted.
           content:
             text/plain:
               schema:
@@ -496,7 +504,8 @@ paths:
       description: >-
         Accepts an invitation for the signed-in secondary user, linking them to
         the subscription. An invitation that has already been cancelled cannot
-        be accepted.
+        be accepted. An invitation that has already been accepted returns a
+        410.
       security:
         - bearerAuth: []
       parameters:
@@ -569,6 +578,13 @@ paths:
               schema:
                 type: string
                 example: Not Found
+        '410':
+          description: The invitation has already been accepted.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Invitation has already been accepted
         '500':
           description: Internal server error.
           content:

--- a/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/acceptInvitationEndpoint.ts
@@ -28,10 +28,18 @@ export const acceptInvitationEndpoint = async (
 	try {
 		const invitation = await invitationRepository.get(invitationCode);
 
+		// Invitations are soft-accepted, so they may still exist with an
+		// acceptedDate set.
+		if (invitation?.acceptedDate) {
+			return gone('Invitation has already been accepted');
+		}
+
 		if (!invitation) {
-			// The invitation is hard-deleted once accepted, so if it's missing but a
-			// secondary user record already exists for this invitation code, the
-			// user has already accepted it previously.
+			// The invitation may be missing because a soft-accepted invitation's
+			// retention period (used to allow time for export to the data
+			// platform) has expired and the record has been removed by DynamoDB's
+			// TTL. If a secondary user record already exists for this invitation
+			// code, the user has already accepted it previously.
 			const alreadyAccepted = (
 				await secondaryUserRepository.listByIdentity(signedInUserId)
 			).some(
@@ -77,19 +85,19 @@ export const acceptInvitationEndpoint = async (
 
 		const createSecondaryUserTransaction =
 			secondaryUserRepository.getPutTransaction(secondaryUserRecord);
-		const deleteInvitationTransaction =
-			invitationRepository.getDeleteTransaction(
+		const acceptInvitationTransaction =
+			invitationRepository.getAcceptTransaction(
 				invitation.subscriptionName,
 				invitationCode,
 			);
 
-		// Carry out the secondary user creation and deletion of the invitation
-		// in a transaction to keep them atomic
+		// Carry out the secondary user creation and soft-accepting of the
+		// invitation in a transaction to keep them atomic
 		await dynamoClient.send(
 			new TransactWriteItemsCommand({
 				TransactItems: [
 					createSecondaryUserTransaction,
-					deleteInvitationTransaction,
+					acceptInvitationTransaction,
 				],
 			}),
 		);

--- a/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteInvitationEndpoint.ts
@@ -20,7 +20,11 @@ export const deleteInvitationEndpoint = async (
 	try {
 		const invitation = await invitationRepository.get(invitationCode);
 
-		if (!invitation || invitation.cancelledBy !== undefined) {
+		if (
+			!invitation ||
+			invitation.cancelledBy !== undefined ||
+			invitation.acceptedDate !== undefined
+		) {
 			return notFound();
 		}
 

--- a/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
+++ b/handlers/multiple-account-api/src/deleteSecondaryUserEndpoint.ts
@@ -65,7 +65,7 @@ export const deleteSecondaryUserEndpoint = async (
 		logger.mutableAddContext(composedSubscriptionName);
 
 		const secondaryUser =
-			await secondaryUserRepository.getNonCancelledBySubscriptionAndIdentity(
+			await secondaryUserRepository.getActiveBySubscriptionAndIdentity(
 				subscriptionName,
 				secondaryIdentityId,
 			);

--- a/handlers/multiple-account-api/src/getInvitationEndpoint.ts
+++ b/handlers/multiple-account-api/src/getInvitationEndpoint.ts
@@ -8,10 +8,39 @@ import {
 	notFound,
 	ok,
 } from '@modules/routing/apiGatewayResponses';
+import type { InvitationRecord } from './invitationRepository';
 import {
+	activeInvitationRecordSchema,
 	type InvitationRepository,
-	nonCancelledInvitationRecordSchema,
 } from './invitationRepository';
+
+const invitationAlreadyAccepted = async (
+	invitation: InvitationRecord | undefined,
+	secondaryUserRepository: SecondaryUserRepository,
+	invitationCode: string,
+) => {
+	// Invitations are soft-accepted, so they may still exist with an acceptedDate set.
+	if (invitation?.acceptedDate) {
+		return true;
+	}
+
+	if (invitation) {
+		return false;
+	}
+
+	// Otherwise if the invitation is missing but a secondary user record exists for this
+	// invitation code, then it has already been accepted. This happens once a
+	// soft-accepted invitation's retention period (used to allow time for export
+	// to the data platform) has expired and the record has been removed by
+	// DynamoDB's TTL.
+
+	// We can't check the signed in user here since this endpoint is not authenticated,
+	// so we look up the secondary user record by invitation code instead.
+	const alreadyAccepted =
+		(await secondaryUserRepository.listByInvitationCode(invitationCode))
+			.length > 0;
+	return alreadyAccepted;
+};
 
 export const getInvitationEndpoint = async (
 	invitationRepository: InvitationRepository,
@@ -23,20 +52,17 @@ export const getInvitationEndpoint = async (
 	try {
 		const invitation = await invitationRepository.get(invitationCode);
 
+		if (
+			await invitationAlreadyAccepted(
+				invitation,
+				secondaryUserRepository,
+				invitationCode,
+			)
+		) {
+			return gone('Invitation has already been accepted');
+		}
+
 		if (!invitation) {
-			// The invitation is hard-deleted once accepted, so if it's missing but a
-			// secondary user record already exists for this invitation code, the
-			// invitation has already been accepted. We can't check the signed in
-			// user here since this endpoint is not authenticated, so we look up the
-			// secondary user record by invitation code instead.
-			const alreadyAccepted =
-				(await secondaryUserRepository.listByInvitationCode(invitationCode))
-					.length > 0;
-
-			if (alreadyAccepted) {
-				return gone('Invitation has already been accepted');
-			}
-
 			return notFound();
 		}
 
@@ -46,7 +72,7 @@ export const getInvitationEndpoint = async (
 			);
 		}
 
-		return ok(invitation, nonCancelledInvitationRecordSchema);
+		return ok(invitation, activeInvitationRecordSchema);
 	} catch (error) {
 		logger.error('Error retrieving invitation', error);
 		return internalServerError();

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -16,14 +16,15 @@ import {
 } from '@modules/multiple-account/cancelledBySchema';
 import type { Stage } from '@modules/stage';
 
-// When an invitation is cancelled/rejected we keep the
-// record for a short period (rather than hard deleting it) so we can tell who
-// cancelled it, then let DynamoDB's TTL (expiryDate) remove it automatically.
-export function invitationCancellationTTL(): number {
+// When an invitation is cancelled/rejected or accepted we keep the
+// record for a short period (rather than hard deleting it) to allow time for
+// the record to be exported to the data platform, then let
+// DynamoDB's TTL (expiryDate) remove it automatically.
+export function dataRetentionTTL(): number {
 	return dayjs().add(2, 'weeks').unix();
 }
 
-export const nonCancelledInvitationRecordSchema = z.object({
+export const activeInvitationRecordSchema = z.object({
 	subscriptionName: z.string(),
 	invitationCode: z.string(),
 	primaryIdentityId: z.string(),
@@ -35,12 +36,11 @@ export const nonCancelledInvitationRecordSchema = z.object({
 	expiryDate: z.number(),
 });
 
-export const invitationRecordSchema = nonCancelledInvitationRecordSchema.extend(
-	{
-		cancelledBy: cancelledBySchema.optional(),
-		cancelledDate: z.iso.datetime().optional(),
-	},
-);
+export const invitationRecordSchema = activeInvitationRecordSchema.extend({
+	cancelledBy: cancelledBySchema.optional(),
+	cancelledDate: z.iso.datetime().optional(),
+	acceptedDate: z.iso.datetime().optional(),
+});
 
 export type InvitationRecord = z.infer<typeof invitationRecordSchema>;
 
@@ -106,9 +106,11 @@ export class InvitationRepository {
 		);
 	}
 
-	async listNonCancelled(subscriptionName: string) {
+	async listActive(subscriptionName: string) {
 		return (await this.list(subscriptionName)).filter(
-			(invitation) => invitation.cancelledBy === undefined,
+			(invitation) =>
+				invitation.cancelledBy === undefined &&
+				invitation.acceptedDate === undefined,
 		);
 	}
 
@@ -142,12 +144,33 @@ export class InvitationRepository {
 				UpdateExpression:
 					'SET expiryDate = :expiryDate, cancelledBy = :cancelledBy, cancelledDate = :cancelledDate',
 				ExpressionAttributeValues: {
-					':expiryDate': { N: invitationCancellationTTL().toString() },
+					':expiryDate': { N: dataRetentionTTL().toString() },
 					':cancelledBy': { S: cancelledBy },
 					':cancelledDate': { S: dayjs().toISOString() },
 				},
 			}),
 		);
+	}
+
+	getAcceptTransaction(
+		subscriptionName: string,
+		invitationCode: string,
+	): TransactWriteItem {
+		return {
+			Update: {
+				TableName: this.tableName,
+				Key: {
+					subscriptionName: { S: subscriptionName },
+					invitationCode: { S: invitationCode },
+				},
+				UpdateExpression:
+					'SET expiryDate = :expiryDate, acceptedDate = :acceptedDate',
+				ExpressionAttributeValues: {
+					':expiryDate': { N: dataRetentionTTL().toString() },
+					':acceptedDate': { S: dayjs().toISOString() },
+				},
+			},
+		};
 	}
 
 	getDeleteTransaction(

--- a/handlers/multiple-account-api/src/invitationRepository.ts
+++ b/handlers/multiple-account-api/src/invitationRepository.ts
@@ -172,19 +172,4 @@ export class InvitationRepository {
 			},
 		};
 	}
-
-	getDeleteTransaction(
-		subscriptionName: string,
-		invitationCode: string,
-	): TransactWriteItem {
-		return {
-			Delete: {
-				TableName: this.tableName,
-				Key: {
-					subscriptionName: { S: subscriptionName },
-					invitationCode: { S: invitationCode },
-				},
-			},
-		};
-	}
 }

--- a/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
+++ b/handlers/multiple-account-api/src/listSecondaryUsersEndpoint.ts
@@ -9,9 +9,7 @@ export const listSecondaryUsersEndpoint = async (
 	try {
 		logger.mutableAddContext(subscriptionName);
 		const secondaryUsers =
-			await secondaryUserRepository.listNonCancelledBySubscription(
-				subscriptionName,
-			);
+			await secondaryUserRepository.listActiveBySubscription(subscriptionName);
 		return ok({ secondaryUsers });
 	} catch (error) {
 		return buildErrorResponse(error);

--- a/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
+++ b/handlers/multiple-account-api/src/mmaPrimarySummaryEndpoint.ts
@@ -10,12 +10,12 @@ import { secondaryUserRecordSchema } from '@modules/multiple-account/secondaryUs
 import { prettyPrint } from '@modules/prettyPrint';
 import { buildErrorResponse, ok } from '@modules/routing/apiGatewayResponses';
 import {
+	activeInvitationRecordSchema,
 	type InvitationRepository,
-	nonCancelledInvitationRecordSchema,
 } from './invitationRepository';
 
 export const mmaPrimarySummaryResponseSchema = z.object({
-	invitations: z.array(nonCancelledInvitationRecordSchema),
+	invitations: z.array(activeInvitationRecordSchema),
 	secondaryUsers: z.array(
 		secondaryUserRecordSchema.extend({
 			email: z.string().optional(),
@@ -32,20 +32,19 @@ export const mmaPrimarySummaryEndpoint = async (
 	try {
 		logger.mutableAddContext(subscriptionName);
 
-		const nonCancelledInvitations =
-			await invitationRepository.listNonCancelled(subscriptionName);
+		const activeInvitations =
+			await invitationRepository.listActive(subscriptionName);
 
-		const nonCancelledSecondaryUsers =
-			await getNonCancelledSecondaryUserListWithNames(
-				subscriptionName,
-				secondaryUserRepository,
-				identityClient,
-			);
+		const activeSecondaryUsers = await getActiveSecondaryUserListWithNames(
+			subscriptionName,
+			secondaryUserRepository,
+			identityClient,
+		);
 
 		return ok(
 			{
-				invitations: nonCancelledInvitations,
-				secondaryUsers: nonCancelledSecondaryUsers,
+				invitations: activeInvitations,
+				secondaryUsers: activeSecondaryUsers,
 			},
 			mmaPrimarySummaryResponseSchema,
 		);
@@ -54,15 +53,13 @@ export const mmaPrimarySummaryEndpoint = async (
 	}
 };
 
-const getNonCancelledSecondaryUserListWithNames = async (
+const getActiveSecondaryUserListWithNames = async (
 	subscriptionName: string,
 	secondaryUserRepository: SecondaryUserRepository,
 	identityClient: IdentityClient,
 ) => {
 	const secondaryUsers =
-		await secondaryUserRepository.listNonCancelledBySubscription(
-			subscriptionName,
-		);
+		await secondaryUserRepository.listActiveBySubscription(subscriptionName);
 
 	return Promise.all(
 		secondaryUsers.map(async (secondaryUser) =>

--- a/handlers/multiple-account-api/src/secondaryUserDetailsEndpoint.ts
+++ b/handlers/multiple-account-api/src/secondaryUserDetailsEndpoint.ts
@@ -31,7 +31,7 @@ export async function secondaryUserDetailsEndpoint(
 	zuoraClient: ZuoraClient,
 ): Promise<APIGatewayProxyResult> {
 	const secondaryUsers: SecondaryUserRecord[] =
-		await secondaryUserRepository.listNonCancelledByIdentity(identityId);
+		await secondaryUserRepository.listActiveByIdentity(identityId);
 
 	const subscriptionsWithPrimaryUserInformation = await Promise.all(
 		secondaryUsers.map(async (secondaryUser) =>

--- a/handlers/multiple-account-api/src/validation.ts
+++ b/handlers/multiple-account-api/src/validation.ts
@@ -51,9 +51,7 @@ export async function validateInvitationInformation(
 	logger.log('Validating invitation information');
 
 	const existingSecondaryUsers =
-		await secondaryUserRepository.listNonCancelledBySubscription(
-			subscriptionName,
-		);
+		await secondaryUserRepository.listActiveBySubscription(subscriptionName);
 
 	// Check the secondary user is not already a secondary user for this subscription
 	const secondaryUserAlreadyExists = existingSecondaryUsers.find(
@@ -67,7 +65,7 @@ export async function validateInvitationInformation(
 	}
 
 	const nonCancelledInvites =
-		await invitationRepository.listNonCancelled(subscriptionName);
+		await invitationRepository.listActive(subscriptionName);
 
 	// Check the secondary user has not been invited already
 	const inviteAlreadyExistsForUser = nonCancelledInvites.find(

--- a/handlers/multiple-account-api/test/acceptInvitationEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationEndpoint.test.ts
@@ -2,7 +2,10 @@ import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import type { SecondaryUserRecord } from '@modules/multiple-account/secondaryUserRepository';
 import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { acceptInvitationEndpoint } from '../src/acceptInvitationEndpoint';
-import type { InvitationRepository } from '../src/invitationRepository';
+import type {
+	InvitationRecord,
+	InvitationRepository,
+} from '../src/invitationRepository';
 
 const stage = 'CODE';
 const subscriptionName = 'A-S00974337';
@@ -22,11 +25,28 @@ const makeSecondaryUser = (
 	...overrides,
 });
 
-const makeInvitationRepository = (): {
+const makeInvitation = (
+	overrides: Partial<InvitationRecord> = {},
+): InvitationRecord => ({
+	subscriptionName,
+	invitationCode,
+	primaryIdentityId,
+	primaryUserFirstName: 'Joe',
+	primaryUserEmail: 'joe@example.com',
+	secondaryUserEmail: 'secondary@example.com',
+	secondaryIdentityId,
+	invitedDate: '2026-06-12T00:00:00.000Z',
+	expiryDate: 1781222400,
+	...overrides,
+});
+
+const makeInvitationRepository = (
+	invitation: InvitationRecord | undefined = undefined,
+): {
 	repository: InvitationRepository;
 	mockGet: jest.Mock;
 } => {
-	const mockGet = jest.fn().mockResolvedValue(undefined);
+	const mockGet = jest.fn().mockResolvedValue(invitation);
 	const repository = {
 		get: mockGet,
 	} as unknown as InvitationRepository;
@@ -49,7 +69,31 @@ const makeSecondaryUserRepository = (
 const dynamoClient = {} as DynamoDBClient;
 
 describe('acceptInvitationEndpoint', () => {
-	it('returns 410 when the invitation has already been accepted by this user', async () => {
+	it('returns 410 when the invitation has already been soft-accepted (acceptedDate is set)', async () => {
+		const { repository: invitationRepository, mockGet } =
+			makeInvitationRepository(
+				makeInvitation({ acceptedDate: '2026-06-12T00:00:00.000Z' }),
+			);
+		const { repository: secondaryUserRepository, mockListByIdentity } =
+			makeSecondaryUserRepository([]);
+
+		const result = await acceptInvitationEndpoint(
+			stage,
+			invitationRepository,
+			secondaryUserRepository,
+			dynamoClient,
+			secondaryIdentityId,
+			invitationCode,
+		);
+
+		expect(result.statusCode).toBe(410);
+		expect(mockGet).toHaveBeenCalledWith(invitationCode);
+		// The invitation itself already tells us it's accepted, so there's no
+		// need for the fallback secondary user record lookup.
+		expect(mockListByIdentity).not.toHaveBeenCalled();
+	});
+
+	it('returns 410 when the invitation record no longer exists (TTL-expired) but a secondary user record exists', async () => {
 		const { repository: invitationRepository, mockGet } =
 			makeInvitationRepository();
 		const { repository: secondaryUserRepository, mockListByIdentity } =

--- a/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
+++ b/handlers/multiple-account-api/test/acceptInvitationIntegration.test.ts
@@ -104,9 +104,11 @@ test('acceptInvitationEndpoint accepts an invitation and creates a secondary use
 	// data record to complete
 	await new Promise((resolve) => setTimeout(resolve, 10000));
 
-	// The invitation should have been deleted as part of accepting
+	// The invitation should have been soft-accepted (kept with an acceptedDate
+	// and a shortened expiryDate) rather than deleted as part of accepting
 	const invitation = await invitationRepository.get(invitationCode);
-	expect(invitation).toBeUndefined();
+	expect(invitation).toBeDefined();
+	expect(invitation?.acceptedDate).toBeDefined();
 
 	// A secondary user record should have been created
 	const secondaryUsers =

--- a/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/deleteSecondaryUserEndpoint.test.ts
@@ -73,26 +73,25 @@ const makeRepository = (
 	secondaryUser: SecondaryUserRecord | undefined,
 ): {
 	repository: SecondaryUserRepository;
-	mockGetNonCancelledBySubscriptionAndIdentity: jest.Mock<
+	mockGetActiveBySubscriptionAndIdentity: jest.Mock<
 		Promise<SecondaryUserRecord | undefined>,
 		[string, string]
 	>;
 	mockGetSoftDeleteTransaction: jest.Mock;
 } => {
-	const mockGetNonCancelledBySubscriptionAndIdentity = jest
+	const mockGetActiveBySubscriptionAndIdentity = jest
 		.fn<Promise<SecondaryUserRecord | undefined>, [string, string]>()
 		.mockResolvedValue(secondaryUser);
 	const mockGetSoftDeleteTransaction = jest
 		.fn()
 		.mockReturnValue(softDeleteTransactItem);
 	const repository = {
-		getNonCancelledBySubscriptionAndIdentity:
-			mockGetNonCancelledBySubscriptionAndIdentity,
+		getActiveBySubscriptionAndIdentity: mockGetActiveBySubscriptionAndIdentity,
 		getSoftDeleteTransaction: mockGetSoftDeleteTransaction,
 	} as unknown as SecondaryUserRepository;
 	return {
 		repository,
-		mockGetNonCancelledBySubscriptionAndIdentity,
+		mockGetActiveBySubscriptionAndIdentity,
 		mockGetSoftDeleteTransaction,
 	};
 };
@@ -241,7 +240,7 @@ describe('deleteSecondaryUserEndpoint', () => {
 	});
 
 	it('returns 404 when the secondary user record is already cancelled', async () => {
-		// The repository's getNonCancelledBySubscriptionAndIdentity filters out
+		// The repository's getActiveBySubscriptionAndIdentity filters out
 		// cancelled records, so it resolves undefined for an already-cancelled user.
 		const { repository, mockGetSoftDeleteTransaction } =
 			makeRepository(undefined);

--- a/handlers/multiple-account-api/test/getInvitationEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/getInvitationEndpoint.test.ts
@@ -1,7 +1,10 @@
 import type { SecondaryUserRecord } from '@modules/multiple-account/secondaryUserRepository';
 import type { SecondaryUserRepository } from '@modules/multiple-account/secondaryUserRepository';
 import { getInvitationEndpoint } from '../src/getInvitationEndpoint';
-import type { InvitationRepository } from '../src/invitationRepository';
+import type {
+	InvitationRecord,
+	InvitationRepository,
+} from '../src/invitationRepository';
 
 const subscriptionName = 'A-S00974337';
 const secondaryIdentityId = 'secondary-id';
@@ -20,11 +23,28 @@ const makeSecondaryUser = (
 	...overrides,
 });
 
-const makeInvitationRepository = (): {
+const makeInvitation = (
+	overrides: Partial<InvitationRecord> = {},
+): InvitationRecord => ({
+	subscriptionName,
+	invitationCode,
+	primaryIdentityId,
+	primaryUserFirstName: 'Joe',
+	primaryUserEmail: 'joe@example.com',
+	secondaryUserEmail: 'secondary@example.com',
+	secondaryIdentityId,
+	invitedDate: '2026-06-12T00:00:00.000Z',
+	expiryDate: 1781222400,
+	...overrides,
+});
+
+const makeInvitationRepository = (
+	invitation: InvitationRecord | undefined = undefined,
+): {
 	repository: InvitationRepository;
 	mockGet: jest.Mock;
 } => {
-	const mockGet = jest.fn().mockResolvedValue(undefined);
+	const mockGet = jest.fn().mockResolvedValue(invitation);
 	const repository = {
 		get: mockGet,
 	} as unknown as InvitationRepository;
@@ -45,7 +65,28 @@ const makeSecondaryUserRepository = (
 };
 
 describe('getInvitationEndpoint', () => {
-	it('returns 410 when the invitation has already been accepted', async () => {
+	it('returns 410 when the invitation has already been soft-accepted (acceptedDate is set)', async () => {
+		const { repository: invitationRepository, mockGet } =
+			makeInvitationRepository(
+				makeInvitation({ acceptedDate: '2026-06-12T00:00:00.000Z' }),
+			);
+		const { repository: secondaryUserRepository, mockListByInvitationCode } =
+			makeSecondaryUserRepository([]);
+
+		const result = await getInvitationEndpoint(
+			invitationRepository,
+			secondaryUserRepository,
+			invitationCode,
+		);
+
+		expect(result.statusCode).toBe(410);
+		expect(mockGet).toHaveBeenCalledWith(invitationCode);
+		// The invitation itself already tells us it's accepted, so there's no
+		// need for the fallback secondary user record lookup.
+		expect(mockListByInvitationCode).not.toHaveBeenCalled();
+	});
+
+	it('returns 410 when the invitation record no longer exists (TTL-expired) but a secondary user record exists', async () => {
 		const { repository: invitationRepository, mockGet } =
 			makeInvitationRepository();
 		const { repository: secondaryUserRepository, mockListByInvitationCode } =
@@ -75,5 +116,25 @@ describe('getInvitationEndpoint', () => {
 		);
 
 		expect(result.statusCode).toBe(404);
+	});
+
+	it('returns 200 with the invitation when it exists and has not been accepted or cancelled', async () => {
+		const invitation = makeInvitation();
+		const { repository: invitationRepository } =
+			makeInvitationRepository(invitation);
+		const { repository: secondaryUserRepository, mockListByInvitationCode } =
+			makeSecondaryUserRepository([]);
+
+		const result = await getInvitationEndpoint(
+			invitationRepository,
+			secondaryUserRepository,
+			invitationCode,
+		);
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual(invitation);
+		// No need for the fallback secondary user record lookup when the
+		// invitation itself was found.
+		expect(mockListByInvitationCode).not.toHaveBeenCalled();
 	});
 });

--- a/handlers/multiple-account-api/test/invitation.test.ts
+++ b/handlers/multiple-account-api/test/invitation.test.ts
@@ -78,18 +78,18 @@ const mockList = jest
 	.fn<Promise<InvitationRecord[]>, [string]>()
 	.mockResolvedValue(mockInvitations);
 
-const mockListNonCancelled = jest
+const mockListActive = jest
 	.fn<Promise<InvitationRecord[]>, [string]>()
 	.mockResolvedValue(mockInvitations);
 
 const mockInvitationRepo: InvitationRepository = {
 	save: mockSave,
 	list: mockList,
-	listNonCancelled: mockListNonCancelled,
+	listActive: mockListActive,
 } as unknown as InvitationRepository;
 
 const mockSecondaryUserRepo = {
-	listNonCancelledBySubscription: jest
+	listActiveBySubscription: jest
 		.fn<Promise<SecondaryUserRecord[]>, [string]>()
 		.mockResolvedValue(mockSecondaryUsers),
 } as unknown as SecondaryUserRepository;
@@ -104,7 +104,7 @@ describe('createInvitationHandler', () => {
 		);
 		mockSave.mockResolvedValue(undefined);
 		mockList.mockResolvedValue(mockInvitations);
-		mockListNonCancelled.mockResolvedValue(mockInvitations);
+		mockListActive.mockResolvedValue(mockInvitations);
 	});
 
 	it('saves an invitation record and returns 201 with invitationCode', async () => {

--- a/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/listSecondaryUsersEndpoint.test.ts
@@ -5,7 +5,7 @@ import type {
 import { listSecondaryUsersEndpoint } from '../src/listSecondaryUsersEndpoint';
 
 describe('listSecondaryUsersEndpoint', () => {
-	it('returns all non-cancelled secondary users for the subscription', async () => {
+	it('returns all active secondary users for the subscription', async () => {
 		const secondaryUsers: SecondaryUserRecord[] = [
 			{
 				subscriptionName: 'A-S00974337',
@@ -16,11 +16,11 @@ describe('listSecondaryUsersEndpoint', () => {
 				invitationCode: 'RpwR62kMnAxe',
 			},
 		];
-		const mockListNonCancelled = jest
+		const mockListActive = jest
 			.fn<Promise<SecondaryUserRecord[]>, [string]>()
 			.mockResolvedValue(secondaryUsers);
 		const secondaryUserRepository = {
-			listNonCancelledBySubscription: mockListNonCancelled,
+			listActiveBySubscription: mockListActive,
 		} as unknown as SecondaryUserRepository;
 
 		const result = await listSecondaryUsersEndpoint(
@@ -30,15 +30,15 @@ describe('listSecondaryUsersEndpoint', () => {
 
 		expect(result.statusCode).toBe(200);
 		expect(JSON.parse(result.body)).toEqual({ secondaryUsers });
-		expect(mockListNonCancelled).toHaveBeenCalledWith('A-S00974337');
+		expect(mockListActive).toHaveBeenCalledWith('A-S00974337');
 	});
 
 	it('returns a 500 response when listing fails', async () => {
-		const mockListNonCancelled = jest
+		const mockListActive = jest
 			.fn<Promise<SecondaryUserRecord[]>, [string]>()
 			.mockRejectedValue(new Error('dynamodb error'));
 		const secondaryUserRepository = {
-			listNonCancelledBySubscription: mockListNonCancelled,
+			listActiveBySubscription: mockListActive,
 		} as unknown as SecondaryUserRepository;
 
 		const result = await listSecondaryUsersEndpoint(

--- a/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
+++ b/handlers/multiple-account-api/test/secondaryUserMeEndpoint.test.ts
@@ -39,7 +39,7 @@ describe('secondaryUserMeEndpoint', () => {
 			get: jest
 				.fn<Promise<SecondaryUserRecord[]>, [string]>()
 				.mockResolvedValue(users),
-			listNonCancelledByIdentity: jest
+			listActiveByIdentity: jest
 				.fn<Promise<SecondaryUserRecord[]>, [string]>()
 				.mockResolvedValue(users),
 		}) as unknown as SecondaryUserRepository;

--- a/handlers/multiple-account-api/test/validation.test.ts
+++ b/handlers/multiple-account-api/test/validation.test.ts
@@ -144,20 +144,20 @@ describe('validateInvitationInformation', () => {
 
 	const buildRepositories = ({
 		existingSecondaryUsers = [],
-		nonCancelledInvites = [],
+		activeInvites = [],
 	}: {
 		existingSecondaryUsers?: SecondaryUserRecord[];
-		nonCancelledInvites?: InvitationRecord[];
+		activeInvites?: InvitationRecord[];
 	}) => {
 		const secondaryUserRepository = {
-			listNonCancelledBySubscription: jest
+			listActiveBySubscription: jest
 				.fn<Promise<SecondaryUserRecord[]>, [string]>()
 				.mockResolvedValue(existingSecondaryUsers),
 		} as unknown as SecondaryUserRepository;
 		const invitationRepository = {
-			listNonCancelled: jest
+			listActive: jest
 				.fn<Promise<InvitationRecord[]>, [string]>()
-				.mockResolvedValue(nonCancelledInvites),
+				.mockResolvedValue(activeInvites),
 		} as unknown as InvitationRepository;
 
 		return {
@@ -188,7 +188,7 @@ describe('validateInvitationInformation', () => {
 	it('throws a ValidationError when an invitation already exists for this user', async () => {
 		const { invitationRepository, secondaryUserRepository } = buildRepositories(
 			{
-				nonCancelledInvites: [buildInvitation('secondary-id')],
+				activeInvites: [buildInvitation('secondary-id')],
 			},
 		);
 
@@ -206,7 +206,7 @@ describe('validateInvitationInformation', () => {
 		const { invitationRepository, secondaryUserRepository } = buildRepositories(
 			{
 				existingSecondaryUsers: [buildSecondaryUser('secondary-id')],
-				nonCancelledInvites: [buildInvitation('secondary-id')],
+				activeInvites: [buildInvitation('secondary-id')],
 			},
 		);
 
@@ -226,7 +226,7 @@ describe('validateInvitationInformation', () => {
 		const { invitationRepository, secondaryUserRepository } = buildRepositories(
 			{
 				existingSecondaryUsers: [buildSecondaryUser('existing-1')],
-				nonCancelledInvites: [buildInvitation('existing-2')],
+				activeInvites: [buildInvitation('existing-2')],
 			},
 		);
 
@@ -243,7 +243,7 @@ describe('validateInvitationInformation', () => {
 	it('throws a ValidationError when the subscription has reached the maximum number of invitations', async () => {
 		const { invitationRepository, secondaryUserRepository } = buildRepositories(
 			{
-				nonCancelledInvites: [
+				activeInvites: [
 					buildInvitation('existing-1'),
 					buildInvitation('existing-2'),
 					buildInvitation('existing-3'),
@@ -267,7 +267,7 @@ describe('validateInvitationInformation', () => {
 		const { invitationRepository, secondaryUserRepository } = buildRepositories(
 			{
 				existingSecondaryUsers: [buildSecondaryUser('existing-1')],
-				nonCancelledInvites: [
+				activeInvites: [
 					buildInvitation('existing-2'),
 					buildInvitation('existing-3'),
 				],

--- a/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItemLambda.ts
+++ b/handlers/supporter-product-data-lambdas/src/handlers/processSupporterRatePlanItemLambda.ts
@@ -42,7 +42,7 @@ const buildDependencies = async (): Promise<ProcessItemDependencies> => {
 			subscriptionService.getSubscription(subscriptionName),
 		writePrimaryItem: (item) => dynamoService.writeItem(item),
 		getSecondaryUsers: (subscriptionName) =>
-			secondaryUserRepository.listNonCancelledBySubscription(subscriptionName),
+			secondaryUserRepository.listActiveBySubscription(subscriptionName),
 		writeSecondaryItem: async (primaryItem, secondaryUser) => {
 			// Create is an upsert, so if the secondary subscription already exists it will be updated
 			await createSecondarySubscription(

--- a/modules/multiple-account/src/secondaryUserRepository.ts
+++ b/modules/multiple-account/src/secondaryUserRepository.ts
@@ -81,7 +81,7 @@ export class SecondaryUserRepository {
 		);
 	}
 
-	async listNonCancelledByIdentity(
+	async listActiveByIdentity(
 		secondaryIdentityId: string,
 	): Promise<SecondaryUserRecord[]> {
 		return (await this.listByIdentity(secondaryIdentityId)).filter(
@@ -108,7 +108,7 @@ export class SecondaryUserRepository {
 		return secondaryUserRecordSchema.parse(unmarshall(result.Item));
 	}
 
-	async getNonCancelledBySubscriptionAndIdentity(
+	async getActiveBySubscriptionAndIdentity(
 		subscriptionName: string,
 		secondaryIdentityId: string,
 	): Promise<SecondaryUserRecord | undefined> {
@@ -160,7 +160,7 @@ export class SecondaryUserRepository {
 		);
 	}
 
-	async listNonCancelledBySubscription(
+	async listActiveBySubscription(
 		subscriptionName: string,
 	): Promise<SecondaryUserRecord[]> {
 		return (await this.listBySubscription(subscriptionName)).filter(


### PR DESCRIPTION
## What does this change?

Changes how invitation acceptance is handled: instead of hard-deleting the invitation record when it's accepted, we now **soft-accept** it — the record is kept for a short retention period (2 weeks, via the existing DynamoDB `expiryDate` TTL) with an `acceptedDate` set, the same pattern already used for cancelled/rejected invitations. This gives the data platform time to import the record before it's removed by TTL.

### Key changes
- `InvitationRepository.getAcceptTransaction` (an `Update` that sets `acceptedDate` and shortens `expiryDate`) replaces the previous `getDeleteTransaction` (hard `Delete`) call in `acceptInvitationEndpoint`.
- Renamed `invitationCancellationTTL` → `dataRetentionTTL` since it's now used for both cancellation and acceptance retention.
- Renamed `listNonCancelled*` / `getNonCancelledBySubscriptionAndIdentity` methods on `InvitationRepository` and `SecondaryUserRepository` to `listActive*` / `getActiveBySubscriptionAndIdentity`, since "active" now also excludes soft-accepted invitations, not just cancelled ones.
- `getInvitationEndpoint` and `acceptInvitationEndpoint` now check `invitation.acceptedDate` directly to return `410 Gone` for already-accepted invitations, with the existing secondary-user-record lookup kept as a fallback for the case where the invitation's retention period has since expired and the record has been removed by DynamoDB's TTL.
- `deleteInvitationEndpoint` now also treats an already-accepted invitation as not found (in addition to already-cancelled).

### Related PRs
- guardian/support-service-lambdas#3799 (Return 410 Gone when accepting an already-accepted invitation) — this PR changes the mechanism used to detect an already-accepted invitation, from relying on hard-deletion to using `acceptedDate`.
- guardian/support-service-lambdas#3801 (Return 410 for already accepted invitations from get invitation endpoint) — same mechanism update applied here.
- guardian/support-service-lambdas#3736 (Multiple accounts: Soft delete secondary users) — precedent for the soft-delete/soft-accept retention pattern used here.

## External documentation

See [this document](https://docs.google.com/document/d/1eqMn9zkg-iRK3Gi9ecmgGh8WWUYpLX6B3cOasTRYpns/edit?tab=t.0#heading=h.n725ldbma47t) for background on the multiple accounts feature.
