### PR TITLE
Add regex for subscription id validation in digital-subscription-expiry

### DIFF
--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
@@ -7,7 +7,7 @@ import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayHandler.Operation
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.apigateway.ResponseModels.ApiResponse
-import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.reader.Types._
 import play.api.libs.json.{Json, Reads}
 
@@ -21,6 +21,14 @@ object UrlParams {
   implicit val urlParamsReads: Reads[UrlParams] = json => wireReads.reads(json).map(_.toUrlParams)
 }
 object DigitalSubscriptionExpirySteps extends Logging {
+
+  val subscriptionIdPatterns = List(
+    "^[A-Z0-9]+$".r, // upper case alphanumeric
+    "^[A-Z]-[A-Z0-9]+$".r, // this pattern: <upper case letter>-<upper case alphanumeric>
+  )
+
+  def isValidSubscriptionId(id: String): Boolean =
+    subscriptionIdPatterns.exists(_.pattern.matcher(id).matches())
 
   def apply(
       getEmergencyTokenExpiry: String => ApiGatewayOp[Unit],
@@ -38,6 +46,13 @@ object DigitalSubscriptionExpirySteps extends Logging {
         )
         _ <- getEmergencyTokenExpiry(expiryRequest.subscriberId)
         subscriptionId = SubscriptionId(expiryRequest.subscriberId.trim.dropWhile(_ == '0'))
+
+        _ <-
+          if (isValidSubscriptionId(subscriptionId.value))
+            ContinueProcessing(())
+          else
+            ReturnWithResponse(DigitalSubscriptionApiResponses.notFoundResponse)
+
         subscriptionResult <- getSubscription(subscriptionId)
         queryStringParameters <- apiGatewayRequest.queryParamsAsCaseClass[UrlParams]()
         _ <-

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/SetActivationDate.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/SetActivationDate.scala
@@ -7,13 +7,13 @@ import com.gu.digitalSubscriptionExpiry.zuora.GetSubscription.SubscriptionId
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.ClientFailableOp
 import com.typesafe.scalalogging.LazyLogging
-import play.api.libs.json.{JsSuccess, Json, Reads}
+import play.api.libs.json.{JsSuccess, Json, OWrites, Reads}
 
 object SetActivationDate extends LazyLogging {
 
   case class UpdateRequestBody(ActivationDate__c: String)
 
-  implicit val writes = Json.writes[UpdateRequestBody]
+  implicit val writes: OWrites[UpdateRequestBody] = Json.writes[UpdateRequestBody]
 
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryRequestTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryRequestTest.scala
@@ -32,5 +32,4 @@ class DigitalSubscriptionExpiryRequestTest extends AnyFlatSpec {
 
     event should be(expected)
   }
-
 }

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -16,8 +16,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class DigitalSubscriptionExpiryStepsTest extends AnyFlatSpec with Matchers {
-
-  // Date: September 2026
   
   // While adding server side validation for the subscription ids
   // https://github.com/guardian/support-service-lambdas/pull/3816

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -16,7 +16,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class DigitalSubscriptionExpiryStepsTest extends AnyFlatSpec with Matchers {
-  
+
   // While adding server side validation for the subscription ids
   // https://github.com/guardian/support-service-lambdas/pull/3816
   // We made a change in the legacy tests to use a Zuora subscription id
@@ -211,6 +211,38 @@ class DigitalSubscriptionExpiryStepsTest extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "not call getSubscription (regex gate) when subscriberId fails validation" in {
+    var getSubscriptionCalled = false
+
+    val steps = DigitalSubscriptionExpirySteps(
+      getEmergencyTokenExpiry = getTokenExpiry,
+      getSubscription = id => {
+        getSubscriptionCalled = true
+        getSubId(id)
+      },
+      setActivationDate = setActivationDate,
+      getAccountSummary = getAccount,
+      getSubscriptionExpiry = getSubExpiry,
+      skipActivationDateUpdate = skipActivationDateUpdate,
+    )
+
+    val request =
+      """{
+        |      "subscriberId" : "invalid id!"
+        |    }
+    """.stripMargin
+
+    val actual = steps.steps(ApiGatewayRequest(None, None, Some(request), None, None, None))
+
+    getSubscriptionCalled shouldBe false
+
+    verifyResponse(
+      actualResponse = actual,
+      expectedBody = expectedNotFoundResponseBody,
+      expectedStatus = "404",
+    )
+  }
+
   def verifyResponse(actualResponse: ApiResponse, expectedStatus: String, expectedBody: String) = {
     val expectedReponseBodyJson = Json.parse(expectedBody)
     val actualResponseBodyJson = Json.parse(actualResponse.body)
@@ -271,3 +303,4 @@ class SubscriptionIdValidationTest extends AnyFlatSpec with Matchers {
     DigitalSubscriptionExpirySteps.isValidSubscriptionId("feedback for the Guardian") should be(false) // we do not allow non alpha numerical, here the spaces
   }
 }
+

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -17,6 +17,14 @@ import org.scalatest.matchers.should.Matchers
 
 class DigitalSubscriptionExpiryStepsTest extends AnyFlatSpec with Matchers {
 
+  // Date: September 2026
+  
+  // While adding server side validation for the subscription ids
+  // https://github.com/guardian/support-service-lambdas/pull/3816
+  // We made a change in the legacy tests to use a Zuora subscription id
+  // only made of uppercase letters. This way the validation doesn't break
+  // the legacy tests.
+
   val validTokenResponse = {
     val expiry = Expiry(
       expiryDate = LocalDate.of(1985, 10, 26),
@@ -30,7 +38,7 @@ class DigitalSubscriptionExpiryStepsTest extends AnyFlatSpec with Matchers {
   val successfulResponseFromZuora = ApiResponse("123", "valid zuora response")
 
   def getSubId(s: SubscriptionId): ApiGatewayOp[SubscriptionResult] = {
-    if (s.value == "validZuoraSubId") {
+    if (s.value == "A-VALIDZUORASUBID") {
       val response = SubscriptionResult(
         id = s,
         name = SubscriptionName("someSubName"),
@@ -89,7 +97,7 @@ class DigitalSubscriptionExpiryStepsTest extends AnyFlatSpec with Matchers {
   it should "trim leading spaces and zeroes and return subscription from zuora" in {
     val request =
       """{
-    |      "subscriberId" : "   0000validZuoraSubId ",
+    |      "subscriberId" : "   0000A-VALIDZUORASUBID ",
     |      "password" : "somePassword"
     |    }
 
@@ -103,7 +111,7 @@ class DigitalSubscriptionExpiryStepsTest extends AnyFlatSpec with Matchers {
   it should "return not found for valid zuora id with no password provided" in {
     val request =
       """{
-    |      "subscriberId" : "validZuoraSubId"
+    |      "subscriberId" : "A-VALIDZUORASUBID"
     |    }
 
   """.stripMargin
@@ -249,5 +257,19 @@ class DeserialiserTest extends AnyFlatSpec with Matchers {
     val json = """{"apiToken": "a", "apiClientId": "b", "noActivation": "true"}"""
 
     Json.parse(json).validate[UrlParams] should be(JsSuccess(UrlParams(true)))
+  }
+}
+
+class SubscriptionIdValidationTest extends AnyFlatSpec with Matchers {
+  it should "perform correct subscription validation, accepting" in {
+    DigitalSubscriptionExpirySteps.isValidSubscriptionId("A-S00044160") should be(true)
+    DigitalSubscriptionExpirySteps.isValidSubscriptionId("A3F4DACDD") should be(true)
+    DigitalSubscriptionExpirySteps.isValidSubscriptionId("00044160") should be(true) // the leading `0` will be trimmed out
+  }
+  it should "perform correct subscription validation, rejecting" in {
+    DigitalSubscriptionExpirySteps.isValidSubscriptionId("AB-S00044160") should be(false)
+    DigitalSubscriptionExpirySteps.isValidSubscriptionId("a3f4dAccd") should be(false) // we do not allow lowercases
+    DigitalSubscriptionExpirySteps.isValidSubscriptionId("Luke@TheResistance") should be(false) // we do not allow non alpha numerical
+    DigitalSubscriptionExpirySteps.isValidSubscriptionId("feedback for the Guardian") should be(false) // we do not allow non alpha numerical, here the spaces
   }
 }


### PR DESCRIPTION
Add regex for subscription id validation, among other things will guard against people submitting emails addresses and some passwords