### PR TITLE
Alarms for multiple-account-api should go to Portfolio

### DIFF
--- a/handlers/alarms-handler/src/alarmMappings.ts
+++ b/handlers/alarms-handler/src/alarmMappings.ts
@@ -80,6 +80,7 @@ const teamToAppMappings: Record<Team, string[]> = {
 		'user-benefits',
 		'mobile-purchases-to-supporter-product-data',
 		'supporter-product-data-lambdas',
+		'multiple-account-api',
 	],
 	PLATFORM: [
 		// fulfilment


### PR DESCRIPTION
## What does this change?

Map alarms for multiple-account-api to Portfolio team alarms channel.